### PR TITLE
Timer

### DIFF
--- a/src/chips/sam4l/ast.rs
+++ b/src/chips/sam4l/ast.rs
@@ -1,11 +1,15 @@
+/* chips::sam4l::ast -- Implementation of a single hardware timer.
+ *
+ * Author: Amit Levy <alevy@stanford.edu>
+ * Author: Philip Levis <pal@cs.stanford.edu>
+ * Date: 7/16/15
+ */
+
 use core::prelude::*;
 use core::intrinsics;
 use nvic;
-use hil::Controller;
-use hil::timer::{Timer, TimerReceiver};
+use hil::alarm::{Alarm, Request};
 use chip;
-
-pub static mut INTERRUPT : bool = false;
 
 #[repr(C, packed)]
 #[allow(missing_copy_implementations)]
@@ -40,7 +44,7 @@ pub const AST_BASE: isize = 0x400F0800;
 #[allow(missing_copy_implementations)]
 pub struct Ast {
     regs: &'static mut AstRegisters,
-    receiver: Option<&'static mut TimerReceiver>
+    callback: Option<&'static mut Request>
 }
 
 #[repr(usize)]
@@ -52,26 +56,11 @@ pub enum Clock {
     Clock1K = 4
 }
 
-impl Controller for Ast {
-    type Config = &'static mut TimerReceiver;
-    
-    fn configure(&mut self, receiver: &'static mut TimerReceiver) {
-        self.receiver = Some(receiver);
-
-        // These should probably be parameters to `configure`
-        self.select_clock(Clock::ClockRCSys);
-        self.set_prescalar(0);
-
-        self.clear_alarm();
-    }
-
-}
-
 impl Ast {
     pub fn new() -> Ast {
         Ast {
             regs: unsafe { intrinsics::transmute(AST_BASE)},
-            receiver: None
+            callback: None
         }
     }
 
@@ -112,13 +101,14 @@ impl Ast {
     pub fn select_clock(&mut self, clock: Clock) {
         unsafe {
           // Disable clock by setting first bit to zero
-          let enb = intrinsics::volatile_load(&(*self.regs).clock) ^ 1;
+          while self.clock_busy() {}
+          let enb = intrinsics::volatile_load(&(*self.regs).clock) & !1;
           intrinsics::volatile_store(&mut (*self.regs).clock, enb);
           while self.clock_busy() {}
 
           // Select clock
           intrinsics::volatile_store(&mut (*self.regs).clock, (clock as u32) << 8);
-          while self.clock_busy() {}
+	  while self.clock_busy() {}
 
           // Re-enable clock
           let enb = intrinsics::volatile_load(&(*self.regs).clock) | 1;
@@ -214,34 +204,41 @@ impl Ast {
     #[inline(never)]
     pub fn handle_interrupt(&mut self) {
         self.clear_alarm();
-        self.receiver.as_mut().map(|r| {
-            r.alarm_fired();
-        });
+        let opt = self.callback.take();
+        let copt: &'static mut Request = opt.unwrap();
+        copt.fired();
     }
 
 }
 
-impl Timer for Ast {
+impl Alarm for Ast {
     fn now(&self) -> u32 {
         unsafe {
             intrinsics::volatile_load(&(*self.regs).cv)
         }
     }
 
-    fn disable_alarm(&mut self) {
+    fn disable_alarm(&'static mut self) {
         self.disable();
         self.clear_alarm();
     }
 
-    fn set_alarm(&mut self, tics: u32) {
+    fn set_alarm(&'static mut self, tics: u32, req: &'static mut Request) {
         self.disable();
         while self.busy() {}
+        self.callback = Some(req);
         unsafe {
             intrinsics::volatile_store(&mut (*self.regs).ar0, tics);
         }
         self.clear_alarm();
         self.enable_alarm_irq();
         self.enable();
+    }
+
+    fn get_alarm(&'static mut self) -> u32 {
+        unsafe { 
+            intrinsics::volatile_load(&(*self.regs).ar0)
+        }
     }
 }
 

--- a/src/chips/sam4l/ast.rs
+++ b/src/chips/sam4l/ast.rs
@@ -218,12 +218,12 @@ impl Alarm for Ast {
         }
     }
 
-    fn disable_alarm(&'static mut self) {
+    fn disable_alarm(&mut self) {
         self.disable();
         self.clear_alarm();
     }
 
-    fn set_alarm(&'static mut self, tics: u32, req: &'static mut Request) {
+    fn set_alarm(&mut self, tics: u32, req: &'static mut Request) {
         self.disable();
         while self.busy() {}
         self.callback = Some(req);
@@ -235,7 +235,7 @@ impl Alarm for Ast {
         self.enable();
     }
 
-    fn get_alarm(&'static mut self) -> u32 {
+    fn get_alarm(&mut self) -> u32 {
         unsafe { 
             intrinsics::volatile_load(&(*self.regs).ar0)
         }

--- a/src/chips/sam4l/ast.rs
+++ b/src/chips/sam4l/ast.rs
@@ -1,6 +1,6 @@
 /* chips::sam4l::ast -- Implementation of a single hardware timer.
  *
- * Author: Amit Levy <alevy@stanford.edu>
+ * Author: Amit Levy <levya@cs.stanford.edu>
  * Author: Philip Levis <pal@cs.stanford.edu>
  * Date: 7/16/15
  */

--- a/src/hil/alarm.rs
+++ b/src/hil/alarm.rs
@@ -1,3 +1,9 @@
+/**
+ * alarm.rs - Trait for a hardware timer based on a counter. Assumes 32 bits.
+ *
+ * Author: Amit Levy <alevy@stanford.edu>
+ * Date: 7/15/15
+ */ 
 pub trait Request {
     fn fired(&'static mut self);
 }

--- a/src/hil/alarm.rs
+++ b/src/hil/alarm.rs
@@ -1,7 +1,7 @@
 /**
  * alarm.rs - Trait for a hardware timer based on a counter. Assumes 32 bits.
  *
- * Author: Amit Levy <alevy@stanford.edu>
+ * Author: Amit Levy <levya@cs.stanford.edu>
  * Date: 7/15/15
  */
 pub trait Request {

--- a/src/hil/alarm.rs
+++ b/src/hil/alarm.rs
@@ -1,0 +1,12 @@
+pub trait Request {
+    fn fired(&'static mut self);
+}
+
+pub trait Alarm {
+    fn now(&self) -> u32;
+    fn set_alarm(&'static mut self, when: u32, request: &'static mut Request);
+    fn disable_alarm(&'static mut self);
+    fn get_alarm(&'static mut self) -> u32;
+}
+
+

--- a/src/hil/alarm.rs
+++ b/src/hil/alarm.rs
@@ -3,16 +3,16 @@
  *
  * Author: Amit Levy <alevy@stanford.edu>
  * Date: 7/15/15
- */ 
+ */
 pub trait Request {
     fn fired(&'static mut self);
 }
 
 pub trait Alarm {
     fn now(&self) -> u32;
-    fn set_alarm(&'static mut self, when: u32, request: &'static mut Request);
-    fn disable_alarm(&'static mut self);
-    fn get_alarm(&'static mut self) -> u32;
+    fn set_alarm(&mut self, when: u32, request: &'static mut Request);
+    fn disable_alarm(&mut self);
+    fn get_alarm(&mut self) -> u32;
 }
 
 

--- a/src/hil/led.rs
+++ b/src/hil/led.rs
@@ -1,0 +1,79 @@
+/**
+ *  led.rs -- Drivers for LEDs that abstract away polarity and pin.
+ *
+ * Author: Philip Levis <pal@cs.stanford.edu>
+ * Date: 7/31/15
+ */ 
+
+use gpio;
+
+pub trait Led {
+    fn init(&mut self);
+    fn on(&mut self);
+    fn off(&mut self);
+    fn toggle(&mut self);
+    fn read(&self) -> bool;
+}
+
+/* For LEDs in which on is when GPIO is high. */
+pub struct LedHigh {
+  pub pin: &'static mut gpio::GPIOPin
+}
+
+/* For LEDs in which on is when GPIO is low. */
+pub struct LedLow {
+  pub pin: &'static mut gpio::GPIOPin
+}
+
+impl LedHigh {
+  pub fn new(p: &'static mut gpio::GPIOPin) -> LedHigh {
+    LedHigh {
+      pin: p
+    }
+  }
+}
+
+impl LedLow {
+  pub fn new(p: &'static mut gpio::GPIOPin) -> LedLow {
+    LedLow {
+      pin: p
+    }
+  }
+}
+
+impl Led for LedHigh {
+  fn init(&mut self) {
+    self.pin.enable_output();
+  }
+  fn on(&mut self) {
+    self.pin.set();
+  }
+  fn off(&mut self) {
+    self.pin.clear();
+  }
+  fn toggle(&mut self) {
+    self.pin.toggle();
+  }
+  fn read(&self) -> bool {
+    self.pin.read()
+  }
+}
+
+impl Led for LedLow {
+  fn init(&mut self) {
+    self.pin.enable_output();
+  }
+  fn on(&mut self) {
+    self.pin.clear();
+  }
+  fn off(&mut self) {
+    self.pin.set();
+  }
+  fn toggle(&mut self) {
+    self.pin.toggle();
+  }
+  fn read(&self) -> bool {
+    !self.pin.read()
+  }
+}
+

--- a/src/hil/led.rs
+++ b/src/hil/led.rs
@@ -15,65 +15,73 @@ pub trait Led {
     fn read(&self) -> bool;
 }
 
-/* For LEDs in which on is when GPIO is high. */
+/// For LEDs in which on is when GPIO is high.
 pub struct LedHigh {
-  pub pin: &'static mut gpio::GPIOPin
+    pub pin: &'static mut gpio::GPIOPin
 }
 
-/* For LEDs in which on is when GPIO is low. */
+/// For LEDs in which on is when GPIO is low.
 pub struct LedLow {
-  pub pin: &'static mut gpio::GPIOPin
+    pub pin: &'static mut gpio::GPIOPin
 }
 
 impl LedHigh {
-  pub fn new(p: &'static mut gpio::GPIOPin) -> LedHigh {
-    LedHigh {
-      pin: p
+    pub fn new(p: &'static mut gpio::GPIOPin) -> LedHigh {
+        LedHigh {
+            pin: p
+        }
     }
-  }
 }
 
 impl LedLow {
-  pub fn new(p: &'static mut gpio::GPIOPin) -> LedLow {
-    LedLow {
-      pin: p
+    pub fn new(p: &'static mut gpio::GPIOPin) -> LedLow {
+        LedLow {
+            pin: p
+        }
     }
-  }
 }
 
 impl Led for LedHigh {
-  fn init(&mut self) {
-    self.pin.enable_output();
-  }
-  fn on(&mut self) {
-    self.pin.set();
-  }
-  fn off(&mut self) {
-    self.pin.clear();
-  }
-  fn toggle(&mut self) {
-    self.pin.toggle();
-  }
-  fn read(&self) -> bool {
-    self.pin.read()
-  }
+    fn init(&mut self) {
+        self.pin.enable_output();
+      }
+
+    fn on(&mut self) {
+        self.pin.set();
+    }
+
+    fn off(&mut self) {
+        self.pin.clear();
+    }
+
+    fn toggle(&mut self) {
+        self.pin.toggle();
+    }
+
+    fn read(&self) -> bool {
+        self.pin.read()
+    }
 }
 
 impl Led for LedLow {
-  fn init(&mut self) {
-    self.pin.enable_output();
-  }
-  fn on(&mut self) {
-    self.pin.clear();
-  }
-  fn off(&mut self) {
-    self.pin.set();
-  }
-  fn toggle(&mut self) {
-    self.pin.toggle();
-  }
-  fn read(&self) -> bool {
-    !self.pin.read()
-  }
+    fn init(&mut self) {
+        self.pin.enable_output();
+    }
+
+    fn on(&mut self) {
+        self.pin.clear();
+    }
+
+    fn off(&mut self) {
+        self.pin.set();
+    }
+
+    fn toggle(&mut self) {
+        self.pin.toggle();
+    }
+
+    fn read(&self) -> bool {
+        !self.pin.read()
+    }
 }
 

--- a/src/hil/lib.rs
+++ b/src/hil/lib.rs
@@ -6,6 +6,7 @@
 extern crate core;
 extern crate process;
 
+pub mod led;
 pub mod alarm;
 pub mod gpio;
 pub mod i2c;

--- a/src/hil/lib.rs
+++ b/src/hil/lib.rs
@@ -6,6 +6,7 @@
 extern crate core;
 extern crate process;
 
+pub mod alarm;
 pub mod gpio;
 pub mod i2c;
 pub mod timer;

--- a/src/hil/timer.rs
+++ b/src/hil/timer.rs
@@ -1,11 +1,243 @@
+/* hil::timer -- Traits and structures for software timers.
+ *
+ * Author: Philip Levis <pal@cs.stanford.edu>
+ * Date: 7/16/15
+ */
+#![allow(dead_code)]
+
+use core::prelude::*;
+use alarm;
+
+pub trait TimerCB {
+  fn fired(&'static mut self, &'static mut TimerRequest, now: u32);
+}
+
 pub trait Timer {
-    fn now(&self) -> u32;
-    fn set_alarm(&mut self, u32);
-    fn disable_alarm(&mut self);
+  fn now(&'static mut self) -> u32;
+  fn cancel(&'static mut self, &'static mut TimerRequest);
+  fn oneshot(&'static mut self, interval: u32, &'static mut TimerRequest);
+  fn repeat(&'static mut self, interval: u32, &'static mut TimerRequest);
+
 }
 
-pub trait TimerReceiver {
-    fn alarm_fired(&mut self) {
+pub struct TimerRequest {
+  pub next: Option<&'static mut TimerRequest>,
+  pub is_active: bool,
+  pub is_repeat: bool,
+  pub when: u32,
+  pub interval: u32,
+  pub last: u32,
+  pub callback: Option<&'static mut TimerCB>
+}
+
+impl TimerRequest {
+  pub fn new(cb: &'static mut TimerCB) -> TimerRequest {
+    TimerRequest {
+      next:      None,
+      is_active: false,
+      is_repeat: false,
+      when:      0,
+      interval:  0,
+      last:      0,
+      callback:  Some(cb)
     }
+  }
 }
 
+pub struct TimerMux {
+  request: Option<&'static mut TimerRequest>,
+  internal: Option<&'static mut alarm::Alarm>
+}
+
+impl TimerMux {
+  pub fn new(internal: &'static mut alarm::Alarm) -> TimerMux {
+    TimerMux {
+      request: None,
+      internal: Some(internal)
+    }
+  }
+
+  fn add(&'static mut self, request: &'static mut TimerRequest) -> bool {
+    let changed = self.insert(request);
+    if changed {
+      self.start_request();
+    }
+    changed
+  }
+
+  fn remove(&'static mut self, request: &'static mut TimerRequest) -> bool {
+    let changed = self.delete(request);
+    if changed {
+      self.start_request();
+    }
+    changed
+  }
+
+  // Returns whether hardware clock has to be recalculated (inserted
+  // timer is now first timer)
+  fn insert(&'static mut self, request: &'static mut TimerRequest) -> bool {
+    if request.next.is_some() { // Already on a list, this is an error!
+      false
+    }
+    else if self.request.is_none() {
+      self.request = Some(request);
+      true
+    } else {
+      let mut first = true;
+      let mut done = false;
+      let mut copt = &mut self.request;
+      while !done {
+        let mycopt = copt.take();
+        let mut curr = mycopt.unwrap();
+        // 'request' is earlier than current element, insert here by making
+        // the current Option point to 'request' and have 'request''s next
+        // Option point to the element the current Option held.
+        if request.when < curr.when {
+           request.next = Some(curr);
+           *copt = Some(request);
+           done = true;
+        } else {
+           // We need to insert later. We therefore are not inserting in
+           // the first element. There are two cases:
+           //   1. last element and we need to insert at the end, or
+           //   2. we need to traverse the next hop.
+           first = false;
+           if curr.next.is_none() {
+             // Reached end of list, insert here
+             curr.next = Some(request);
+             *copt = Some(curr);
+             done = true;
+           } else {
+             let mut nopt = &mut curr.next;
+             *copt = Some(curr);
+             copt = nopt;
+           }
+
+        }
+      }
+      first
+    }
+  }
+
+  // Returns whether hardware clock has to be recalculated (removed first
+  // timer)
+  fn delete(&'static mut self, request: &'static mut TimerRequest) -> bool {
+    if self.request.is_none() {return false;}
+
+    let mut done = false;
+    let mut copt = &mut self.request;
+    let mut first = true;
+    while !done {
+      let mycopt = copt.take();
+      let mut curr = mycopt.unwrap();
+      let cptr: *const TimerRequest = curr;
+      let rptr: *const TimerRequest = request;
+      if cptr == rptr {
+        *copt = curr.next.take();
+        done = true;
+      } else if curr.next.is_none() {
+        *copt = Some(curr);
+        first = false;
+        done = true;
+      } else {
+        let mut nopt = &mut curr.next;
+        *copt = Some(curr);
+        copt = nopt;
+        first = false;
+      }
+    }
+    first
+  }
+
+  fn start_request(&'static mut self) {
+    if self.request.is_none() {return;}
+
+    let aopt: Option<&'static mut alarm::Alarm> = self.internal.take();
+    let alarm: &'static mut alarm::Alarm = aopt.unwrap();
+    let ropt = self.request.take();
+    let request: &'static mut TimerRequest = ropt.unwrap();
+    let mut when = request.when;
+
+    let curr = alarm.now();
+    let delay = request.when - curr;
+    if delay > (0x80000000) {
+      when = (curr + 5) | 1;
+      request.when = when;
+    }
+    alarm.set_alarm(when, self);// as &mut alarm::Request);
+
+    self.internal = Some(alarm);
+    self.request = Some(request);
+
+  }
+
+}
+
+impl alarm::Request for TimerMux {
+  fn fired(&'static mut self) {
+    if self.request.is_none() {return;}
+    let curr = self.now();
+    let ropt = self.request.take();
+    let request: &'static mut TimerRequest = ropt.unwrap();
+    // The timer did not fire early
+    if (request.when - curr) < 20 {
+      self.request = request.next.take();
+
+      // Note this implementation is inefficient: if the repeat timer
+      // would be at the head of the queue again, we recalculate the
+      // timer, then re-insert so recalculate a second time.
+      // A better implementation would check this and conditionally
+      // remove/insert. -pal 7/22/15
+      let cbopt = request.callback.take();
+      let cb: &'static mut TimerCB = cbopt.unwrap();
+      request.callback = Some(cb);
+      if request.is_repeat {
+        request.last = request.when;
+        request.when = request.when + request.interval;
+        self.add(request);
+      } else {
+        request.is_active = false;
+      }
+      self.start_request();
+      cb.fired(request, curr);
+    } else { // Timer fired early?!?!? Not sure why this happens,
+            // But it does -pal 7/28/15
+      self.request = Some(request);
+      self.start_request();
+    }
+  }
+}
+
+impl Timer for TimerMux {
+  fn now(&'static mut self) -> u32 {
+     let alarm = self.internal.as_mut().unwrap();
+     let val = alarm.now();
+     self.internal = Some(*alarm);
+     val
+  }
+
+  fn cancel(&'static mut self, request: &'static mut TimerRequest) {
+    if !request.is_active {return;}
+
+    request.is_active = false;
+    self.remove(request);
+  }
+
+  fn oneshot(&'static mut self, interval: u32, request: &'static mut TimerRequest) {
+    request.interval = interval;
+    request.is_active = true;
+    request.when = self.now() + interval;
+    request.last = request.when;
+    request.is_repeat = false;
+    self.add(request);
+  }
+
+  fn repeat(&'static mut self, interval: u32, request: &'static mut TimerRequest) {
+    request.interval = interval;
+    request.is_active = true;
+    request.when = self.now() + interval;
+    request.last = request.when;
+    request.is_repeat = true;
+    self.add(request);
+  }
+}

--- a/src/hil/timer.rs
+++ b/src/hil/timer.rs
@@ -32,252 +32,254 @@ use alarm;
 const LATE_DELAY: u32 = 5;
 
 pub trait TimerCB {
-  fn fired(&'static mut self, &'static mut TimerRequest, now: u32);
+    fn fired(&'static mut self, &'static mut TimerRequest, now: u32);
 }
 
 pub trait Timer {
-  fn now(&'static mut self) -> u32;
-  fn cancel(&'static mut self, &'static mut TimerRequest);
-  fn oneshot(&'static mut self, interval: u32, &'static mut TimerRequest);
-  fn repeat(&'static mut self, interval: u32, &'static mut TimerRequest);
-
+    fn now(&'static mut self) -> u32;
+    fn cancel(&'static mut self, &'static mut TimerRequest);
+    fn oneshot(&'static mut self, interval: u32, &'static mut TimerRequest);
+    fn repeat(&'static mut self, interval: u32, &'static mut TimerRequest);
 }
 
 pub struct TimerRequest {
-  pub next: Option<&'static mut TimerRequest>,
-  pub is_active: bool,
-  pub is_repeat: bool,
-  pub when: u32,
-  pub interval: u32,
-  pub callback: Option<&'static mut TimerCB>
+    pub next: Option<&'static mut TimerRequest>,
+    pub is_active: bool,
+    pub is_repeat: bool,
+    pub when: u32,
+    pub interval: u32,
+    pub callback: Option<&'static mut TimerCB>
 }
 
 impl TimerRequest {
-  pub fn new(cb: &'static mut TimerCB) -> TimerRequest {
-    TimerRequest {
-      next:      None,
-      is_active: false,
-      is_repeat: false,
-      when:      0,
-      interval:  0,
-      callback:  Some(cb)
+    pub fn new(cb: &'static mut TimerCB) -> TimerRequest {
+        TimerRequest {
+            next:      None,
+            is_active: false,
+            is_repeat: false,
+            when:      0,
+            interval:  0,
+            callback:  Some(cb)
+        }
     }
-  }
 }
 
 pub struct TimerMux {
-  request: Option<&'static mut TimerRequest>,
-  internal: Option<&'static mut alarm::Alarm>
+    request: Option<&'static mut TimerRequest>,
+    internal: Option<&'static mut alarm::Alarm>
 }
 
 impl TimerMux {
-  pub fn new(internal: &'static mut alarm::Alarm) -> TimerMux {
-    TimerMux {
-      request: None,
-      internal: Some(internal)
-    }
-  }
-  /*
-   * There are two pairs of functions for manipulating the ordered
-   * linked list of outstanding timers
-   *
-   *  insert/delete: operate on list, inserting or deleting an entry
-   *  add/remove: operate on list, and reconfigure underlying hardware
-   *              alarm if first element of list changes
-   *
-   * add/remove are wrappers around insert/delete.
-   */
-
-  /* Insert a TimerRequest into the linked list, reconfiguring the
-   * hardware alarm if it is inserted as the first element. */
-  fn add(&'static mut self, request: &'static mut TimerRequest) -> bool {
-    let changed = self.insert(request);
-    if changed {
-      self.start_request();
-    }
-    changed
-  }
-
-  /* Remove a TimerRequest into the linked list, reconfiguring the
-   * hardware alarm if it was the first element. */
-  fn remove(&'static mut self, request: &'static mut TimerRequest) -> bool {
-    let changed = self.delete(request);
-    if changed {
-      self.start_request();
-    }
-    changed
-  }
-
-  /* Insert a TimerRequest into the linked list. Returns whether hardware 
-   * clock has to be recalculated (inserted timer is now first timer) */
-  fn insert(&'static mut self, request: &'static mut TimerRequest) -> bool {
-    if request.next.is_some() { // Already on a list, this is an error!
-      false
-    }
-    else if self.request.is_none() {
-      self.request = Some(request);
-      true
-    } else {
-      let mut first = true;
-      let mut done = false;
-      let mut copt = &mut self.request;
-      while !done {
-        let mycopt = copt.take();
-        let mut curr = mycopt.unwrap();
-        // 'request' is earlier than current element, insert here by making
-        // the current Option point to 'request' and have 'request''s next
-        // Option point to the element the current Option held.
-        if request.when < curr.when {
-           request.next = Some(curr);
-           *copt = Some(request);
-           done = true;
-        } else {
-           // We need to insert later. We therefore are not inserting in
-           // the first element. There are two cases:
-           //   1. last element and we need to insert at the end, or
-           //   2. we need to traverse the next hop.
-           first = false;
-           if curr.next.is_none() {
-             // Reached end of list, insert here
-             curr.next = Some(request);
-             *copt = Some(curr);
-             done = true;
-           } else {
-             let mut nopt = &mut curr.next;
-             *copt = Some(curr);
-             copt = nopt;
-           }
-
+    pub fn new(internal: &'static mut alarm::Alarm) -> TimerMux {
+        TimerMux {
+            request: None,
+            internal: Some(internal)
         }
-      }
-      first
-    }
   }
 
-  /* Delete a TimerRequest from the linked list. Returns whether hardware 
-   * clock has to be recalculated (removed first timer) */
-  fn delete(&'static mut self, request: &'static mut TimerRequest) -> bool {
-    if self.request.is_none() {return false;}
+    /*
+     * There are two pairs of functions for manipulating the ordered
+     * linked list of outstanding timers
+     *
+     *  insert/delete: operate on list, inserting or deleting an entry
+     *  add/remove: operate on list, and reconfigure underlying hardware
+     *              alarm if first element of list changes
+     *
+     * add/remove are wrappers around insert/delete.
+     */
 
-    let mut done = false;
-    let mut copt = &mut self.request;
-    let mut first = true;
-    while !done {
-      let mycopt = copt.take();
-      let mut curr = mycopt.unwrap();
-      let cptr: *const TimerRequest = curr;
-      let rptr: *const TimerRequest = request;
-      if cptr == rptr {
-        *copt = curr.next.take();
-        done = true;
-      } else if curr.next.is_none() {
-        *copt = Some(curr);
-        first = false;
-        done = true;
-      } else {
-        let mut nopt = &mut curr.next;
-        *copt = Some(curr);
-        copt = nopt;
-        first = false;
-      }
+    /* Insert a TimerRequest into the linked list, reconfiguring the
+     * hardware alarm if it is inserted as the first element. */
+    fn add(&'static mut self, request: &'static mut TimerRequest) -> bool {
+        let changed = self.insert(request);
+        if changed {
+            self.start_request();
+        }
+        changed
     }
-    first
-  }
 
-  /* Schedule the hardware alarm based on the first TimerRequest.
-     Assumes that timers are at most 2^31 in the future. If the
-     duration until a timer is > 2^31, assumes this means the
-     timer has passed (is late) and so fires immediately (in LATE_DELAY
-     ticks). */
-  fn start_request(&'static mut self) {
-    if self.request.is_none() {return;}
-
-    let aopt: Option<&'static mut alarm::Alarm> = self.internal.take();
-    let alarm: &'static mut alarm::Alarm = aopt.unwrap();
-    let ropt = self.request.take();
-    let request: &'static mut TimerRequest = ropt.unwrap();
-    let mut when = request.when;
-
-    let curr = alarm.now();
-    let delay = request.when - curr;
-    if delay > (0x80000000) {
-      when = curr + LATE_DELAY;
-      request.when = when;
+    /* Remove a TimerRequest into the linked list, reconfiguring the
+     * hardware alarm if it was the first element. */
+    fn remove(&'static mut self, request: &'static mut TimerRequest) -> bool {
+        let changed = self.delete(request);
+        if changed {
+            self.start_request();
+        }
+        changed
     }
-    alarm.set_alarm(when, self);
 
-    self.internal = Some(alarm);
-    self.request = Some(request);
-  }
+    /* Insert a TimerRequest into the linked list. Returns whether hardware 
+    * clock has to be recalculated (inserted timer is now first timer) */
+    fn insert(&'static mut self, request: &'static mut TimerRequest) -> bool {
+        if request.next.is_some() { // Already on a list, this is an error!
+            false
+        } else if self.request.is_none() {
+            self.request = Some(request);
+            true
+        } else {
+            let mut first = true;
+            let mut done = false;
+            let mut copt = &mut self.request;
+            while !done {
+                let mycopt = copt.take();
+                let mut curr = mycopt.unwrap();
+                // 'request' is earlier than current element, insert here by making
+                // the current Option point to 'request' and have 'request''s next
+                // Option point to the element the current Option held.
+                if request.when < curr.when {
+                   request.next = Some(curr);
+                   *copt = Some(request);
+                   done = true;
+                } else {
+                   // We need to insert later. We therefore are not inserting in
+                   // the first element. There are two cases:
+                   //   1. last element and we need to insert at the end, or
+                   //   2. we need to traverse the next hop.
+                   first = false;
+                   if curr.next.is_none() {
+                     // Reached end of list, insert here
+                     curr.next = Some(request);
+                     *copt = Some(curr);
+                     done = true;
+                   } else {
+                     let mut nopt = &mut curr.next;
+                     *copt = Some(curr);
+                     copt = nopt;
+                   }
+
+                }
+            }
+            first
+        }
+    }
+
+    /* Delete a TimerRequest from the linked list. Returns whether hardware 
+     * clock has to be recalculated (removed first timer) */
+    fn delete(&'static mut self, request: &'static mut TimerRequest) -> bool {
+        if self.request.is_none() {return false;}
+
+        let mut done = false;
+        let mut copt = &mut self.request;
+        let mut first = true;
+        while !done {
+            let mycopt = copt.take();
+            let mut curr = mycopt.unwrap();
+            let cptr: *const TimerRequest = curr;
+            let rptr: *const TimerRequest = request;
+            if cptr == rptr {
+                *copt = curr.next.take();
+                done = true;
+            } else if curr.next.is_none() {
+                *copt = Some(curr);
+                first = false;
+                done = true;
+            } else {
+                let mut nopt = &mut curr.next;
+                *copt = Some(curr);
+                copt = nopt;
+                first = false;
+            }
+        }
+        first
+    }
+
+    /* Schedule the hardware alarm based on the first TimerRequest.
+     * Assumes that timers are at most 2^31 in the future. If the
+     * duration until a timer is > 2^31, assumes this means the
+     * timer has passed (is late) and so fires immediately (in LATE_DELAY
+     * ticks).
+     */
+    fn start_request(&'static mut self) {
+        if self.request.is_none() {return;}
+
+        let aopt: Option<&'static mut alarm::Alarm> = self.internal.take();
+        let alarm: &'static mut alarm::Alarm = aopt.unwrap();
+        let ropt = self.request.take();
+        let request: &'static mut TimerRequest = ropt.unwrap();
+        let mut when = request.when;
+
+        let curr = alarm.now();
+        let delay = request.when - curr;
+        if delay > (0x80000000) {
+            when = curr + LATE_DELAY;
+            request.when = when;
+        }
+        alarm.set_alarm(when, self);
+
+        self.internal = Some(alarm);
+        self.request = Some(request);
+    }
 
 }
 
 impl alarm::Request for TimerMux {
 
-  // The hardware alarm fired. If its firing matches the expected
-  // firing time, invoke the next software timer and schedule the
-  // following one.
-  fn fired(&'static mut self) {
-    if self.request.is_none() {return;}
-    let curr = self.now();
-    let ropt = self.request.take();
-    let request: &'static mut TimerRequest = ropt.unwrap();
-    // The timer did not fire early
-    if (request.when - curr) < 20 {
-      self.request = request.next.take();
+    // The hardware alarm fired. If its firing matches the expected
+    // firing time, invoke the next software timer and schedule the
+    // following one.
+    fn fired(&'static mut self) {
+        if self.request.is_none() {return;}
+        let curr = self.now();
+        let ropt = self.request.take();
+        let request: &'static mut TimerRequest = ropt.unwrap();
+        // The timer did not fire early
+        if (request.when - curr) < 20 {
+            self.request = request.next.take();
 
-      // Note this implementation is inefficient: if the repeat timer
-      // would be at the head of the queue again, we recalculate the
-      // timer, then re-insert so recalculate a second time.
-      // A better implementation would check this and conditionally
-      // remove/insert. -pal 7/22/15
-      let cbopt = request.callback.take();
-      let cb: &'static mut TimerCB = cbopt.unwrap();
-      request.callback = Some(cb);
-      if request.is_repeat {
-        request.when = request.when + request.interval;
-        self.add(request);
-      } else {
-        request.is_active = false;
-      }
-      self.start_request();
-      cb.fired(request, curr);
-    } else { // Timer fired early. Not sure why this happens,
+            // Note this implementation is inefficient: if the repeat timer
+            // would be at the head of the queue again, we recalculate the
+            // timer, then re-insert so recalculate a second time.
+            // A better implementation would check this and conditionally
+            // remove/insert. -pal 7/22/15
+            let cbopt = request.callback.take();
+            let cb: &'static mut TimerCB = cbopt.unwrap();
+            request.callback = Some(cb);
+            if request.is_repeat {
+                request.when = request.when + request.interval;
+                self.add(request);
+            } else {
+                request.is_active = false;
+            }
+            self.start_request();
+            cb.fired(request, curr);
+        } else {
+            // Timer fired early. Not sure why this happens,
             // But it does -pal 7/28/15
-      self.request = Some(request);
-      self.start_request();
+            self.request = Some(request);
+            self.start_request();
+        }
     }
-  }
 }
 
 impl Timer for TimerMux {
-  fn now(&'static mut self) -> u32 {
-     let alarm = self.internal.as_mut().unwrap();
-     let val = alarm.now();
-     self.internal = Some(*alarm);
-     val
-  }
+    fn now(&'static mut self) -> u32 {
+        let alarm = self.internal.as_mut().unwrap();
+        let val = alarm.now();
+        self.internal = Some(*alarm);
+        val
+    }
 
-  fn cancel(&'static mut self, request: &'static mut TimerRequest) {
-    if !request.is_active {return;}
+    fn cancel(&'static mut self, request: &'static mut TimerRequest) {
+        if !request.is_active {return;}
 
-    request.is_active = false;
-    self.remove(request);
-  }
+        request.is_active = false;
+        self.remove(request);
+    }
 
-  fn oneshot(&'static mut self, interval: u32, request: &'static mut TimerRequest) {
-    request.interval = interval;
-    request.is_active = true;
-    request.when = self.now() + interval;
-    request.is_repeat = false;
-    self.add(request);
-  }
+    fn oneshot(&'static mut self, interval: u32, request: &'static mut TimerRequest) {
+        request.interval = interval;
+        request.is_active = true;
+        request.when = self.now() + interval;
+        request.is_repeat = false;
+        self.add(request);
+    }
 
-  fn repeat(&'static mut self, interval: u32, request: &'static mut TimerRequest) {
-    request.interval = interval;
-    request.is_active = true;
-    request.when = self.now() + interval;
-    request.is_repeat = true;
-    self.add(request);
-  }
+    fn repeat(&'static mut self, interval: u32, request: &'static mut TimerRequest) {
+        request.interval = interval;
+        request.is_active = true;
+        request.when = self.now() + interval;
+        request.is_repeat = true;
+        self.add(request);
+    }
 }
+

--- a/src/platform/storm/lib.rs
+++ b/src/platform/storm/lib.rs
@@ -22,6 +22,7 @@ pub struct Firestorm {
     gpio: drivers::gpio::GPIO<[&'static mut hil::gpio::GPIOPin; 14]>,
     tmp006: drivers::tmp006::TMP006<sam4l::i2c::I2CDevice>,
     timer: hil::timer::TimerMux,
+    led: hil::led::LedHigh
 }
 
 impl Firestorm {
@@ -62,7 +63,8 @@ pub unsafe fn init() -> &'static mut Firestorm {
             , &mut chip.pa13, &mut chip.pa11, &mut chip.pa10
             , &mut chip.pa12, &mut chip.pc09]),
         tmp006: drivers::tmp006::TMP006::new(&mut chip.i2c[2]),
-        timer: hil::timer::TimerMux::new(&mut chip.ast)
+        timer: hil::timer::TimerMux::new(&mut chip.ast),
+        led: hil::led::LedHigh::new(&mut chip.pc10)
     });
 
     let firestorm : &'static mut Firestorm = FIRESTORM.as_mut().unwrap();

--- a/src/platform/storm/lib.rs
+++ b/src/platform/storm/lib.rs
@@ -15,6 +15,7 @@ use sam4l::*;
 
 pub static mut FIRESTORM : Option<Firestorm> = None;
 
+#[allow(dead_code)]
 pub struct Firestorm {
     chip: &'static mut chip::Sam4l,
     console: drivers::console::Console<sam4l::usart::USART>,
@@ -42,12 +43,14 @@ impl Firestorm {
             _ => None
         })
     }
-
 }
 
 pub unsafe fn init() -> &'static mut Firestorm {
     chip::CHIP = Some(chip::Sam4l::new());
     let chip = chip::CHIP.as_mut().unwrap();
+    chip.ast.select_clock(sam4l::ast::Clock::ClockRCSys);
+    chip.ast.set_prescalar(0);
+    chip.ast.clear_alarm();
 
     FIRESTORM = Some(Firestorm {
         chip: chip,


### PR DESCRIPTION
There are three updates:
1. Renames the Timer trait to Alarm; Alarm is now a hardware counter compare interrupt, while Timer is a virtualized software timer
1. Adds Led to hil/. This presents an on-off abstraction of on-board LEDs, so a platform user doesn't have to know which GPIO is which LED and whether high is on or low is on.
1. Adds a software virtualized timer, called TimerMux, in hil/timer.rs.

The platform library for the Storm (platform/storm/lib.rs) demonstrates the timer toggling the LED.