### PR TITLE
GPIO interrupts in the SAM4L HAL.

### DIFF
--- a/src/chips/sam4l/chip.rs
+++ b/src/chips/sam4l/chip.rs
@@ -5,6 +5,7 @@ use dma;
 use nvic;
 use usart;
 use spi;
+use gpio;
 
 pub struct Sam4l;
 
@@ -31,10 +32,26 @@ impl Sam4l {
         INTERRUPT_QUEUE.as_mut().unwrap().dequeue().map(|interrupt| {
             match interrupt {
                 ASTALARM => ast::AST.handle_interrupt(),
+
                 USART3   => usart::USART3.handle_interrupt(),
+
                 PDCA0   => dma::DMAChannels[0].handle_interrupt(),
                 PDCA1   => dma::DMAChannels[1].handle_interrupt(),
                 PDCA2   => dma::DMAChannels[2].handle_interrupt(),
+
+                GPIO0 => gpio::PA.handle_interrupt(),
+                GPIO1 => gpio::PA.handle_interrupt(),
+                GPIO2 => gpio::PA.handle_interrupt(),
+                GPIO3 => gpio::PA.handle_interrupt(),
+                GPIO4 => gpio::PB.handle_interrupt(),
+                GPIO5 => gpio::PB.handle_interrupt(),
+                GPIO6 => gpio::PB.handle_interrupt(),
+                GPIO7 => gpio::PB.handle_interrupt(),
+                GPIO8 => gpio::PC.handle_interrupt(),
+                GPIO9 => gpio::PC.handle_interrupt(),
+                GPIO10 => gpio::PC.handle_interrupt(),
+                GPIO11 => gpio::PC.handle_interrupt(),
+
                 //NvicIdx::ADCIFE   => self.adc.handle_interrupt(),
                 _ => {}
             }

--- a/src/hil/gpio.rs
+++ b/src/hil/gpio.rs
@@ -1,7 +1,22 @@
+pub enum InputMode {
+    PullUp,
+    PullDown
+}
+
+pub enum InterruptMode {
+    Change,
+    RisingEdge,
+    FallingEdge
+}
+
 pub trait GPIOPin {
     fn enable_output(&self);
+    fn enable_input(&self, mode: InputMode);
+    fn disable(&self);
     fn set(&self);
     fn clear(&self);
     fn toggle(&self);
     fn read(&self) -> bool;
+    fn set_interrupt_mode(&self, mode: InterruptMode);
 }
+

--- a/src/hil/gpio.rs
+++ b/src/hil/gpio.rs
@@ -20,3 +20,7 @@ pub trait GPIOPin {
     fn set_interrupt_mode(&self, mode: InterruptMode);
 }
 
+pub trait Client {
+    fn fired(&self);
+}
+

--- a/src/hil/gpio.rs
+++ b/src/hil/gpio.rs
@@ -17,10 +17,10 @@ pub trait GPIOPin {
     fn clear(&self);
     fn toggle(&self);
     fn read(&self) -> bool;
-    fn set_interrupt_mode(&self, mode: InterruptMode);
+    fn enable_interrupt(&self, identifier: usize, mode: InterruptMode);
 }
 
 pub trait Client {
-    fn fired(&self);
+    fn fired(&self, identifier: usize);
 }
 

--- a/src/platform/storm/gpio_dummy.rs
+++ b/src/platform/storm/gpio_dummy.rs
@@ -1,0 +1,31 @@
+///! A dummy GPIO client to test the GPIO interrupt implementation
+
+use sam4l::gpio;
+use hil;
+
+static GPIO_CLIENT : DummyGPIO = DummyGPIO;
+
+struct DummyGPIO;
+
+impl hil::gpio::Client for DummyGPIO {
+    fn fired(&self, _pin: usize) {
+        let led : &hil::gpio::GPIOPin = unsafe { &gpio::PC[10] };
+        led.toggle();
+    }
+}
+
+pub fn gpio_dummy_test() {
+    use hil::gpio::GPIOPin;
+
+    let led : &hil::gpio::GPIOPin = unsafe { &gpio::PC[10] };
+    led.enable_output();
+
+    let int_pin : &'static mut hil::gpio::GPIOPin = unsafe {
+        gpio::PA[13].set_client(&GPIO_CLIENT);
+        &mut gpio::PA[13]
+    };
+
+    int_pin.enable_input(hil::gpio::InputMode::PullDown);
+    int_pin.enable_interrupt(0, hil::gpio::InterruptMode::Change);
+}
+

--- a/src/platform/storm/lib.rs
+++ b/src/platform/storm/lib.rs
@@ -11,7 +11,10 @@ extern crate sam4l;
 use hil::Controller;
 use hil::timer::*;
 
-// Uncomment to test SPI with commented out code block in `init`
+// Uncomment each module to test with respective commented out code block in
+// `init`
+//
+//mod gpio_dummy;
 //mod spi_dummy;
 
 pub struct Firestorm {
@@ -126,6 +129,11 @@ pub unsafe fn init<'a>() -> &'a mut Firestorm {
     // Uncommenting the following line will cause the device to write
     // [7, 6, 5, 4, 3, 2, 1, 0] repeatedly over SPI peripheral 1.
     //spi_dummy::spi_dummy_test();
+
+    // Uncommenting the following line will toggle the LED whenever the value of
+    // Firestorm's pin 8 changes value (e.g., connect a push button to pin 8 and
+    // press toggle it).
+    //gpio_dummy::gpio_dummy_test();
 
     firestorm.console.initialize();
 


### PR DESCRIPTION
Add support for GPIO interrupts in the SAM4L HAL.

The SAM4L groups pins into _ports_ (of 32 pins each). When an interrupt is recieved, the only way to tell which pin changed is to check the IFR register on the port (which has a bit for each pin). Therefore, we need to explicitly group pins in the code so we can map an offset in the port to an actual pin data structure. Fortunately, this has no real effect on code outside of the gpio module.

In contrast to my reading of the SAM4L user guide, it seems (from experience) that the a pin's output must be disabled to read the value of the pin. So, for now, a pin can only be in output or input mode, not both.