### PR TITLE
Ensure build/ and build/apps/ exist when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,20 @@
 # indiviual subdirectories and README for more specific explanation.
 
 BUILD_DIR ?= build
+BUILD_APP_DIR ?= $(BUILD_DIR)/apps
 
 # Default platform is the Storm (http://storm.rocks). Change to any platform in
 # the `platform` directory.
 PLATFORM ?= storm
 
 # Dummy all. The real one is in platform-specific Makefiles.
-all:	$(BUILD_DIR)
+all:	$(BUILD_DIR) $(BUILD_APP_DIR)
 
 $(BUILD_DIR):
-	@mkdir -p $@/apps
+	@mkdir -p $@
+
+$(BUILD_APP_DIR):
+	@mkdir -p $@
 
 # Common functions and variables
 include Common.mk
@@ -33,6 +37,7 @@ include src/Makefile.mk
 # Removes compilation artifacts for Tock, but not external dependencies.
 clean:
 	rm -Rf $(BUILD_DIR)/*.*
+	rm -Rf $(BUILD_APP_DIR)/*.*
 
 # Remove all compilation artifacts, including for external dependencies.
 clean-all:

--- a/src/apps/app1/Makefile.mk
+++ b/src/apps/app1/Makefile.mk
@@ -1,9 +1,9 @@
-#APPS += $(BUILD_DIR)/apps/libapp1.rlib
+#APPS += $(BUILD_APP_DIR)/libapp1.rlib
 
-$(BUILD_DIR)/apps/app1.o: $(call rwildcard,$(SRC_DIR)apps/app1/,*.rs) $(BUILD_DIR)/libcore.rlib $(BUILD_DIR)/libsupport.rlib
+$(BUILD_APP_DIR)/app1.o: $(call rwildcard,$(SRC_DIR)apps/app1/,*.rs) $(BUILD_DIR)/libcore.rlib $(BUILD_DIR)/libsupport.rlib | $(BUILD_APP_DIR)
 	@echo "Building $@"
 	@$(RUSTC) $(RUSTC_FLAGS) -C llvm-args="-llc-relocation-model=pic" -C lto --emit obj -o $@ $(SRC_DIR)apps/app1/main.rs
 
-$(BUILD_DIR)/apps/app1.elf: $(BUILD_DIR)/apps/app1.o $(BUILD_DIR)/arch.o
+$(BUILD_APP_DIR)/app1.elf: $(BUILD_APP_DIR)/app1.o $(BUILD_DIR)/arch.o
 	@echo "Building $@"
 	$(CC) $(LDFLAGS) -fpic -mpic-register=r6 $^ -o $@ -ffreestanding -nostdlib -lc -lgcc

--- a/src/apps/c_hello/Makefile.mk
+++ b/src/apps/c_hello/Makefile.mk
@@ -1,13 +1,12 @@
-$(BUILD_DIR)/apps/c_hello.elf: $(call rwildcard,$(SRC_DIR)apps/c_hello/,*.c) $(BUILD_DIR)/arch.o $(BUILD_DIR)/apps/firestorm.o $(BUILD_DIR)/apps/tock.o $(BUILD_DIR)/apps/crt1.o $(BUILD_DIR)/apps/sys.o $(APP_LIBC)
-	@mkdir -p $(BUILD_DIR)/apps
+$(BUILD_APP_DIR)/c_hello.elf: $(call rwildcard,$(SRC_DIR)apps/c_hello/,*.c) $(BUILD_DIR)/arch.o $(BUILD_APP_DIR)/firestorm.o $(BUILD_APP_DIR)/tock.o $(BUILD_APP_DIR)/crt1.o $(BUILD_APP_DIR)/sys.o $(APP_LIBC)
 	@echo "Building $@"
 	@$(CC) $(LDFLAGS) $(CFLAGS_APPS) -g -Os -T $(SRC_DIR)apps/c_hello/loader.ld -o $@ -ffreestanding -nostdlib $^
 
-$(BUILD_DIR)/apps/c_hello.bin: $(BUILD_DIR)/apps/c_hello.elf
+$(BUILD_APP_DIR)/c_hello.bin: $(BUILD_APP_DIR)/c_hello.elf
 	@echo "Extracting binary $@"
 	@$(OBJCOPY) --gap-fill 0xff -O binary $< $@ 
 
-$(BUILD_DIR)/apps/c_hello.bin.o: $(BUILD_DIR)/apps/c_hello.bin
+$(BUILD_APP_DIR)/c_hello.bin.o: $(BUILD_APP_DIR)/c_hello.bin
 	@echo "Linking $@"
 	@$(LD) -r -b binary -o $@ $<
 	@$(OBJCOPY) --rename-section .data=.app.2 $@

--- a/src/apps/c_sync/Makefile.mk
+++ b/src/apps/c_sync/Makefile.mk
@@ -1,13 +1,12 @@
-$(BUILD_DIR)/apps/c_sync.elf: $(call rwildcard,$(SRC_DIR)apps/c_sync/,*.c) $(BUILD_DIR)/arch.o $(BUILD_DIR)/apps/firestorm.o $(BUILD_DIR)/apps/tock.o $(BUILD_DIR)/apps/crt1.o $(BUILD_DIR)/apps/sys.o $(APP_LIBC)
-	@mkdir -p $(BUILD_DIR)/apps
+$(BUILD_APP_DIR)/c_sync.elf: $(call rwildcard,$(SRC_DIR)apps/c_sync/,*.c) $(BUILD_DIR)/arch.o $(BUILD_APP_DIR)/firestorm.o $(BUILD_APP_DIR)/tock.o $(BUILD_APP_DIR)/crt1.o $(BUILD_APP_DIR)/sys.o $(APP_LIBC)
 	@echo "Building $@"
 	@$(CC) $(LDFLAGS) $(CFLAGS_APPS) -g -Os -T $(SRC_DIR)apps/c_sync/loader.ld -o $@ -ffreestanding -nostdlib $^
 
-$(BUILD_DIR)/apps/c_sync.bin: $(BUILD_DIR)/apps/c_sync.elf
+$(BUILD_APP_DIR)/c_sync.bin: $(BUILD_APP_DIR)/c_sync.elf
 	@echo "Extracting binary $@"
 	@$(OBJCOPY) --gap-fill 0xff -O binary $< $@ 
 
-$(BUILD_DIR)/apps/c_sync.bin.o: $(BUILD_DIR)/apps/c_sync.bin
+$(BUILD_APP_DIR)/c_sync.bin.o: $(BUILD_APP_DIR)/c_sync.bin
 	@echo "Linking $@"
 	@$(LD) -r -b binary -o $@ $<
 	@$(OBJCOPY) --rename-section .data=.app.2 $@

--- a/src/apps/cpp_hello/Makefile.mk
+++ b/src/apps/cpp_hello/Makefile.mk
@@ -1,13 +1,12 @@
-$(BUILD_DIR)/apps/cpp_hello.elf: $(call rwildcard,$(SRC_DIR)apps/cpp_hello/,*.cc) $(BUILD_DIR)/arch.o $(BUILD_DIR)/apps/firestorm.o $(BUILD_DIR)/apps/tock.o $(BUILD_DIR)/apps/crt1.o $(BUILD_DIR)/apps/sys.o | $(APP_LIBC)
-	@mkdir -p $(BUILD_DIR)/apps
+$(BUILD_APP_DIR)/cpp_hello.elf: $(call rwildcard,$(SRC_DIR)apps/cpp_hello/,*.cc) $(BUILD_DIR)/arch.o $(BUILD_APP_DIR)/firestorm.o $(BUILD_APP_DIR)/tock.o $(BUILD_APP_DIR)/crt1.o $(BUILD_APP_DIR)/sys.o | $(APP_LIBC)
 	@echo "Building $@"
 	$(CPP) $(LDFLAGS) $(CFLAGS_APPS) -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections -mfloat-abi=soft -g -Os -T $(SRC_DIR)apps/cpp_hello/loader.ld -o $@ -nostdlib -nostartfiles -ffreestanding $^ -lstdc++ $(APP_LIBC) -lgcc
 
-$(BUILD_DIR)/apps/cpp_hello.bin: $(BUILD_DIR)/apps/cpp_hello.elf
+$(BUILD_APP_DIR)/cpp_hello.bin: $(BUILD_APP_DIR)/cpp_hello.elf
 	@echo "Extracting binary $@"
 	@$(OBJCOPY) --gap-fill 0xff -O binary $< $@ 
 
-$(BUILD_DIR)/apps/cpp_hello.bin.o: $(BUILD_DIR)/apps/cpp_hello.bin
+$(BUILD_APP_DIR)/cpp_hello.bin.o: $(BUILD_APP_DIR)/cpp_hello.bin
 	@echo "Linking $@"
 	@$(LD) -r -b binary -o $@ $<
 	@$(OBJCOPY) --rename-section .data=.app.2 $@

--- a/src/apps/libs/Makefile.mk
+++ b/src/apps/libs/Makefile.mk
@@ -1,18 +1,18 @@
-LIBFIRESTORM = $(BUILD_DIR)/apps/firestorm.o
-LIBTOCK = $(BUILD_DIR)/apps/tock.o
+LIBFIRESTORM = $(BUILD_APP_DIR)/firestorm.o
+LIBTOCK = $(BUILD_APP_DIR)/tock.o
 
-$(LIBFIRESTORM): $(SRC_DIR)apps/libs/firestorm.c $(SRC_DIR)apps/libs/firestorm.h
-	@echo "Building libfirestorm"
+$(LIBFIRESTORM): $(SRC_DIR)apps/libs/firestorm.c $(SRC_DIR)apps/libs/firestorm.h | $(BUILD_APP_DIR)
+	@echo "Building libfirestorm for apps"
 	@$(CC) $(LDFLAGS) $(CFLAGS_APPS) -c -g -Os -o $@ -ffreestanding -nostdlib $<
 
-$(LIBTOCK): $(SRC_DIR)apps/libs/tock.c $(SRC_DIR)apps/libs/tock.h
-	@echo "Building libtock"
+$(LIBTOCK): $(SRC_DIR)apps/libs/tock.c $(SRC_DIR)apps/libs/tock.h | $(BUILD_APP_DIR)
+	@echo "Building libtock for apps"
 	@$(CC) $(LDFLAGS) $(CFLAGS_APPS) -c -g -Os -o $@ -ffreestanding -nostdlib $<
 
-$(BUILD_DIR)/apps/crt1.o: $(SRC_DIR)apps/libs/crt1.c
-	@echo "Building app crt1.o"
+$(BUILD_APP_DIR)/crt1.o: $(SRC_DIR)apps/libs/crt1.c | $(BUILD_APP_DIR)
+	@echo "Building crt1 for apps"
 	@$(CC) $(LDFLAGS) $(CFLAGS_APPS) -c -g -Os -o $@ -ffreestanding -nostdlib $<
 
-$(BUILD_DIR)/apps/sys.o: $(SRC_DIR)apps/libs/sys.c
-	@echo "Building apps libc compat"
+$(BUILD_APP_DIR)/sys.o: $(SRC_DIR)apps/libs/sys.c | $(BUILD_APP_DIR)
+	@echo "Building libc stubs for apps"
 	@$(CC) $(LDFLAGS) $(CFLAGS_APPS) -c -g -Os -o $@ -ffreestanding -nostdlib $<

--- a/src/arch/cortex-m4/Makefile.mk
+++ b/src/arch/cortex-m4/Makefile.mk
@@ -1,2 +1,2 @@
-$(BUILD_DIR)/arch.o: $(SRC_DIR)arch/cortex-m4/ctx_switch.S $(SRC_DIR)arch/cortex-m4/syscalls.S
+$(BUILD_DIR)/arch.o: $(SRC_DIR)arch/cortex-m4/ctx_switch.S $(SRC_DIR)arch/cortex-m4/syscalls.S | $(BUILD_DIR)
 	@$(TOOLCHAIN)as -mcpu=cortex-m4 -mthumb $^ -o $@

--- a/src/chips/sam4l/Makefile.mk
+++ b/src/chips/sam4l/Makefile.mk
@@ -13,7 +13,7 @@ $(BUILD_DIR)/libsam4l.rlib: $(call rwildcard,$(SRC_DIR)chips/sam4l,*.rs) $(BUILD
 	@echo "Building $@"
 	@$(RUSTC) $(RUSTC_FLAGS) --out-dir $(BUILD_DIR) $(SRC_DIR)chips/sam4l/lib.rs
 
-$(BUILD_DIR)/crt1.o: $(SRC_DIR)chips/sam4l/crt1.c
+$(BUILD_DIR)/crt1.o: $(SRC_DIR)chips/sam4l/crt1.c | $(BUILD_DIR)
 	@echo "Building $@"
 	@$(CC) $(CFLAGS) -c $< -o $@ -lc -lgcc
 


### PR DESCRIPTION
I ran into a problem where the build/apps/ folder wasn't being automatically created even though it was needed, so I added some dependencies to make the makefiles a little more robust.

This branch has a Travis CI error that doesn't seem to be my fault.