### PR TITLE
Add sample "c_blinky" app

### DIFF
--- a/src/apps/c_blinky/Makefile.mk
+++ b/src/apps/c_blinky/Makefile.mk
@@ -1,0 +1,14 @@
+$(BUILD_DIR)/apps/c_blinky.elf: $(call rwildcard,$(SRC_DIR)apps/c_blinky/,*.c) $(BUILD_DIR)/arch.o $(BUILD_DIR)/apps/firestorm.o $(BUILD_DIR)/apps/tock.o $(BUILD_DIR)/apps/crt1.o $(BUILD_DIR)/apps/sys.o $(APP_LIBC)
+	@mkdir -p $(BUILD_DIR)/apps
+	@echo "Building $@"
+	@$(CC) $(LDFLAGS) $(CFLAGS_APPS) -g -Os -T $(SRC_DIR)apps/c_blinky/loader.ld -o $@ -ffreestanding -nostdlib $^
+
+$(BUILD_DIR)/apps/c_blinky.bin: $(BUILD_DIR)/apps/c_blinky.elf
+	@echo "Extracting binary $@"
+	@$(OBJCOPY) --gap-fill 0xff -O binary $< $@
+
+$(BUILD_DIR)/apps/c_blinky.bin.o: $(BUILD_DIR)/apps/c_blinky.bin
+	@echo "Linking $@"
+	@$(LD) -r -b binary -o $@ $<
+	@$(OBJCOPY) --rename-section .data=.app.2 $@
+

--- a/src/apps/c_blinky/loader.ld
+++ b/src/apps/c_blinky/loader.ld
@@ -1,0 +1,56 @@
+ENTRY(_start)
+
+MEMORY {
+    FLASH (rx) : ORIGIN = 0x80000000, LENGTH = 0x00080000
+    SRAM (RWX) : ORIGIN = 0x00000000, LENGTH = 0x00002000
+}
+
+SECTIONS {
+/* Load information, used by runtime to load app */
+    .load_info :
+    {
+        KEEP(*(.load_info))
+    } > FLASH =0xFF
+
+/* Text section, Code! */
+    .text :
+    {
+        _text = .;
+        KEEP (*(.start))
+        *(.text*)
+        *(.rodata*)
+        KEEP (*(.syscalls))
+        _etext = .;
+    } > FLASH =0xFF
+
+/* Global Offset Table */
+    .got :
+    {
+        _got = .;
+        *(.got*)
+        _egot = .;
+        _plt = .;
+        *(.got.plt*)
+        _eplt = .;
+    } > SRAM AT > FLASH
+
+/* Data section, static initialized variables
+ *  Note: This is placed in Flash after the text section, but needs to be
+ *  moved to SRAM at runtime
+ */
+    .data :
+    {
+        _data = .;
+        *(.data*)
+        _edata = .;
+    } > SRAM AT > FLASH
+
+/* BSS section, static uninitialized variables */
+    .bss :
+    {
+        _bss = .;
+        *(.bss*)
+        *(COMMON)
+        _ebss = .;
+    } > SRAM
+}

--- a/src/apps/c_blinky/main.c
+++ b/src/apps/c_blinky/main.c
@@ -1,0 +1,64 @@
+#include <firestorm.h>
+
+#define LED_0 18
+#define LED_1 19
+
+/* FIXME: These delay functions are Cortex-M0 specific (and calibrated for a
+ * 16MHz CPU clock), therefore should be moved to platform specific location.
+ * */
+
+/* Delay for for the given microseconds (approximately).
+ *
+ * For a 16 MHz CPU, 1us == 16 instructions (assuming each instruction takes
+ * one cycle). */
+static void delay_us(int duration)
+{
+	// The inner loop instructions are: 14 NOPs + 1 SUBS/ADDS + 1 CMP
+	while (duration-- != 0) {
+		__asm volatile (
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+			"nop\n"
+		);
+	}
+}
+
+/* Delay for for the given milliseconds (approximately).
+ *
+ * Note that this is not precise as there are 2 extra instructions on the inner
+ * loop. Therefore, there is 1us added every 8 iterations. */
+static void delay_ms(int duration)
+{
+	while (duration-- != 0) {
+		delay_us(1000);
+	}
+}
+
+void main(void)
+{
+	gpio_enable(LED_0);
+	gpio_enable(LED_1);
+
+	while (1) {
+		gpio_clear(LED_0);
+		gpio_set(LED_1);
+
+		delay_ms(500);
+
+		gpio_clear(LED_1);
+		gpio_set(LED_0);
+
+		delay_ms(500);
+	}
+}


### PR DESCRIPTION
This application alternately blinks LEDs #0 and #1 of the nRF51822
PCA10001 board.

Parts specific to this board (which may require refactoring into specific vs. common parts:

* Memory layout on the linker script (loader.ld)
* delay functions based on NOPs (implementation similar to the Nordic SDK)
* Pin assignments to LED_0 and LED_1
