### PR TITLE
Initial support for nRF51822

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,7 @@ before_install:
   - sudo apt-get install -qq gcc-arm-none-eabi
   - mkdir -p build/apps
 
-script: make build/main.elf
+script:
+  - make build/main.elf
+  - make clean-all
+  - make PLATFORM=nrf_pca10001 CHIP=nrf51822 APPS=c_blinky

--- a/src/arch/cortex-m0/Makefile.mk
+++ b/src/arch/cortex-m0/Makefile.mk
@@ -1,0 +1,2 @@
+$(BUILD_DIR)/arch.o: $(SRC_DIR)arch/$(ARCH)/ctx_switch.S $(SRC_DIR)arch/$(ARCH)/syscalls.S
+	@$(TOOLCHAIN)as -mcpu=$(ARCH) -mthumb $^ -o $@

--- a/src/arch/cortex-m0/ctx_switch.S
+++ b/src/arch/cortex-m0/ctx_switch.S
@@ -1,0 +1,55 @@
+.cpu cortex-m0
+.syntax unified
+.thumb
+.text
+
+/* Exported functions */
+.global SVC_Handler
+.globl switch_to_user
+
+.thumb_func
+SVC_Handler:
+  ldr r0, EXC_RETURN_MSP
+  cmp lr, r0
+  bne to_kernel
+  ldr r1, EXC_RETURN_PSP
+  bx r1
+
+to_kernel:
+  mrs r0, PSP /* PSP into r0 */
+  str r0, [sp, #0] /* PSP into Master stack r0 */
+  ldr r1, EXC_RETURN_MSP
+  bx r1
+
+EXC_RETURN_MSP:
+  .word 0xFFFFFFF9
+EXC_RETURN_PSP:
+  .word 0xFFFFFFFD
+
+.thumb_func
+/* r0 is top of user stack, r1 is heap base */
+switch_to_user:
+  /* Load bottom of stack into Process Stack Pointer */
+  msr psp, r0
+
+  /* Cortex-M0 can only push registers R0-R7 directly, so move R8-R11 to R0-R3.
+   * This is equivalent to the 32-bit "push {r4-r11}" instruction. */
+  push {r4-r7}
+  mov r4,  r8
+  mov r5,  r9
+  mov r6, r10
+  mov r7, r11
+  push {r4-r7}
+
+  mov r9, r1
+  svc 0xff
+
+  /* These instructions are equivalent to the 32-bit "pop {r4-r11}" */
+  pop {r4-r7}
+  mov  r8, r4
+  mov  r9, r5
+  mov r10, r6
+  mov r11, r7
+  pop {r4-r7}
+
+  bx lr

--- a/src/arch/cortex-m0/syscalls.S
+++ b/src/arch/cortex-m0/syscalls.S
@@ -1,0 +1,34 @@
+.cpu cortex-m0
+.syntax unified
+.thumb
+.text
+
+.section .syscalls
+
+/* Cortex-M0 can only push/pop registers R0-R7 directly, so move R8-R11 to/from
+ * R0-R3. This is equivalent to the 32-bit "push/pop {r4-r11}" instructions. */
+
+.macro SYSCALL NAME, NUM
+.global \NAME
+.thumb_func
+\NAME :
+  push {r4-r7}
+  mov r4,  r8
+  mov r5,  r9
+  mov r6, r10
+  mov r7, r11
+  push {r4-r7}
+  svc \NUM
+  pop {r4-r7}
+  mov  r8, r4
+  mov  r9, r5
+  mov r10, r6
+  mov r11, r7
+  pop {r4-r7}
+  bx lr
+.endm
+
+SYSCALL __wait, 0
+SYSCALL __subscribe, 1
+SYSCALL __command, 2
+SYSCALL __allow, 3

--- a/src/chips/nrf51822/Makefile.mk
+++ b/src/chips/nrf51822/Makefile.mk
@@ -1,0 +1,19 @@
+ARCH = cortex-m0
+
+RUSTC_FLAGS += -C opt-level=3 -Z no-landing-pads
+RUSTC_FLAGS += --target $(SRC_DIR)chips/$(CHIP)/target.json
+RUSTC_FLAGS += -Ctarget-cpu=$(ARCH) -C relocation_model=static
+RUSTC_FLAGS += -g -C no-stack-check
+
+CFLAGS += -g -O3 -std=gnu99 -mcpu=$(ARCH) -mthumb -nostdlib -T$(SRC_DIR)chips/$(CHIP)/loader.ld
+LDFLAGS += -mcpu=$(ARCH) -mthumb
+LOADER = $(SRC_DIR)chips/$(CHIP)/loader.ld
+
+$(BUILD_DIR)/lib$(CHIP).rlib: $(call rwildcard,$(SRC_DIR)chips/$(CHIP),*.rs) $(BUILD_DIR)/libcore.rlib $(BUILD_DIR)/libhil.rlib $(BUILD_DIR)/libcommon.rlib
+	@echo "Building $@"
+	@$(RUSTC) $(RUSTC_FLAGS) --out-dir $(BUILD_DIR) $(SRC_DIR)chips/$(CHIP)/lib.rs
+
+$(BUILD_DIR)/crt1.o: $(SRC_DIR)chips/$(CHIP)/crt1.c
+	@echo "Building $@"
+	@$(CC) $(CFLAGS) -c $< -o $@ -lc -lgcc
+

--- a/src/chips/nrf51822/crt1.c
+++ b/src/chips/nrf51822/crt1.c
@@ -1,0 +1,148 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2014, Michael Andersen <m.andersen@eecs.berkeley.edu>
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+/* Symbols defined in the linker file */
+extern uint32_t _estack;
+extern uint32_t _etext;
+extern uint32_t _szero;
+extern uint32_t _ezero;
+extern uint32_t _srelocate;
+extern uint32_t _erelocate;
+
+int main(void);
+
+void Dummy_Handler(void)
+{
+	while (1) {
+	}
+}
+
+void Reset_Handler(void);
+void NMI_Handler(void) __attribute__ ((weak, alias("Dummy_Handler")));
+void HardFault_Handler(void)
+    __attribute__ ((weak, alias("Dummy_Handler")));
+void SVC_Handler(void) __attribute__ ((weak, alias("Dummy_Handler")));
+void PendSV_Handler(void) __attribute__ ((weak, alias("Dummy_Handler")));
+void SysTick_Handler(void) __attribute__ ((weak, alias("Dummy_Handler")));
+
+typedef void (*interrupt_function_t) (void);
+
+__attribute__ ((section(".vectors")))
+interrupt_function_t interrupt_table[] = {
+	(interrupt_function_t) (&_estack),
+	Reset_Handler,
+	NMI_Handler,
+	HardFault_Handler,
+	0, 0, 0, 0, 0, 0, 0,	/* Reserved */
+	SVC_Handler,
+	0, 0,			/* Reserved */
+	PendSV_Handler,
+	SysTick_Handler,
+};
+
+void Reset_Handler(void)
+{
+	uint32_t *pSrc, *pDest;
+
+	/* Move the relocate segment
+	 * This assumes it is located after the
+	 * text segment, which is where the storm
+	 * linker file puts it
+	 */
+	pSrc = &_etext;
+	pDest = &_srelocate;
+
+	if (pSrc != pDest) {
+		for (; pDest < &_erelocate;) {
+			*pDest++ = *pSrc++;
+		}
+	}
+
+	/* Clear the zero segment */
+	for (pDest = &_szero; pDest < &_ezero;) {
+		*pDest++ = 0;
+	}
+
+	/* Branch to main function */
+	main();
+}
+
+// IMPORTANT!! __aeabi_memset has count and value arguments reversed from ANSI
+// memset. TODO(alevy): Why does arm-none-eabi's libc not have __aeabi_memset?
+__attribute__ ((weak))
+void __aeabi_memset(void *dest, size_t count, int value)
+{
+	memset(dest, value, count);
+}
+
+__attribute__ ((weak))
+extern void __aeabi_memcpy(void *dest, void *src, unsigned int n)
+{
+	memcpy(dest, src, n);
+}
+
+__attribute__ ((weak))
+extern void __aeabi_memcpy4(void *dest, void *src, unsigned int n)
+{
+	memcpy(dest, src, n);
+}
+
+__attribute__ ((weak))
+extern void __aeabi_memcpy8(void *dest, void *src, unsigned int n)
+{
+	memcpy(dest, src, n);
+}
+
+__attribute__ ((weak))
+extern void __aeabi_memclr(void *dest, size_t n)
+{
+	memset(dest, 0, n);
+}
+
+__attribute__ ((weak))
+extern void __aeabi_memclr4(void *dest, size_t n)
+{
+	memset(dest, 0, n);
+}
+
+__attribute__ ((weak))
+extern void __aeabi_memclr8(void *dest, size_t n)
+{
+	memset(dest, 0, n);
+}
+
+/* Based on reference code from GCC documentation, see "Legacy __sync Built-in
+ * Functions for Atomic Memory Access" */
+
+__attribute__ ((weak))
+extern uint32_t __sync_fetch_and_add_4(uint32_t * ptr, uint32_t val)
+{
+	uint32_t tmp = *ptr;
+	*ptr += val;
+	return tmp;
+}
+
+__attribute__ ((weak))
+extern uint32_t __sync_fetch_and_sub_4(uint32_t * ptr, uint32_t val)
+{
+	uint32_t tmp = *ptr;
+	*ptr -= val;
+	return tmp;
+}

--- a/src/chips/nrf51822/crt1.c
+++ b/src/chips/nrf51822/crt1.c
@@ -61,6 +61,11 @@ void Reset_Handler(void)
 {
 	uint32_t *pSrc, *pDest;
 
+	/* Power on RAM blocks manually (see nRF51822-PAN v2.4, PAN #16). Note
+	 * that xxAA/xxAB variants have only two RAM blocks. For xxAC, change
+	 * to 0x0F. */
+	*((uint32_t volatile * ) 0x40000524) = 0x03;
+
 	/* Move the relocate segment
 	 * This assumes it is located after the
 	 * text segment, which is where the storm

--- a/src/chips/nrf51822/gpio.rs
+++ b/src/chips/nrf51822/gpio.rs
@@ -1,0 +1,121 @@
+use core::mem;
+use core::ops::{Index, IndexMut};
+use hil;
+
+// Source: https://github.com/hackndev/zinc/tree/master/volatile_cell
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct VolatileCell<T> {
+    value: T,
+}
+
+#[allow(dead_code)]
+impl<T> VolatileCell<T> {
+    #[inline]
+    pub fn get(&self) -> T {
+        unsafe {
+            ::core::intrinsics::volatile_load(&self.value)
+        }
+    }
+
+    #[inline]
+    pub fn set(&self, value: T) {
+        unsafe {
+            ::core::intrinsics::volatile_store(&self.value as *const T as *mut T, value)
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+struct GPIO {
+    _pad0: [u8; 1284],
+    pub OUT: VolatileCell<u32>,
+    pub OUTSET: VolatileCell<u32>,
+    pub OUTCLR: VolatileCell<u32>,
+    pub IN: VolatileCell<u32>,
+    pub DIR: VolatileCell<u32>,
+    pub DIRSET: VolatileCell<u32>,
+    pub DIRCLR: VolatileCell<u32>,
+    _pad1: [u8; 480],
+    pub PIN_CNF: [VolatileCell<u32>; 32],
+}
+
+#[allow(non_snake_case)]
+fn GPIO() -> &'static GPIO {
+    unsafe { mem::transmute(0x50000000 as usize) }
+}
+
+pub struct GPIOPin {
+    pin: u8,
+}
+
+impl GPIOPin {
+    const fn new(pin: u8) -> GPIOPin {
+        GPIOPin { pin: pin }
+    }
+}
+
+impl hil::gpio::GPIOPin for GPIOPin {
+    fn enable_output(&self) {
+        GPIO().PIN_CNF[self.pin as usize].set((1 << 0) | (1 << 1) | (0 << 2) | (0 << 8) | (0 << 16));
+    }
+
+    fn enable_input(&self, _mode: hil::gpio::InputMode) {
+        unimplemented!();
+    }
+
+    fn disable(&self) {
+        unimplemented!();
+    }
+
+    fn set(&self) {
+        GPIO().OUTSET.set(1 << self.pin);
+    }
+
+    fn clear(&self) {
+        GPIO().OUTCLR.set(1 << self.pin);
+    }
+
+    fn toggle(&self) {
+        unimplemented!();
+    }
+
+    fn read(&self) -> bool {
+        unimplemented!();
+    }
+
+    fn enable_interrupt(&self, _identifier: usize, _mode: hil::gpio::InterruptMode) {
+        unimplemented!();
+    }
+}
+
+pub struct Port {
+    pins: [GPIOPin; 32]
+}
+
+impl Index<usize> for Port {
+    type Output = GPIOPin;
+
+    fn index(&self, index: usize) -> &GPIOPin {
+        &self.pins[index]
+    }
+}
+
+impl IndexMut<usize> for Port {
+    fn index_mut(&mut self, index: usize) -> &mut GPIOPin {
+        &mut self.pins[index]
+    }
+}
+
+pub static mut PA : Port = Port {
+    pins: [
+        GPIOPin::new(0), GPIOPin::new(1), GPIOPin::new(2), GPIOPin::new(3),
+        GPIOPin::new(4), GPIOPin::new(5), GPIOPin::new(6), GPIOPin::new(7),
+        GPIOPin::new(8), GPIOPin::new(9), GPIOPin::new(10), GPIOPin::new(11),
+        GPIOPin::new(12), GPIOPin::new(13), GPIOPin::new(14), GPIOPin::new(15),
+        GPIOPin::new(16), GPIOPin::new(17), GPIOPin::new(18), GPIOPin::new(19),
+        GPIOPin::new(20), GPIOPin::new(21), GPIOPin::new(22), GPIOPin::new(23),
+        GPIOPin::new(24), GPIOPin::new(25), GPIOPin::new(26), GPIOPin::new(27),
+        GPIOPin::new(28), GPIOPin::new(29), GPIOPin::new(30), GPIOPin::new(31),
+    ],
+};

--- a/src/chips/nrf51822/lib.rs
+++ b/src/chips/nrf51822/lib.rs
@@ -1,4 +1,7 @@
 #![crate_name = "nrf51822"]
 #![crate_type = "rlib"]
-#![feature(asm,concat_idents,const_fn)]
+#![feature(asm,core_intrinsics,concat_idents,const_fn)]
 #![no_std]
+
+extern crate hil;
+pub mod gpio;

--- a/src/chips/nrf51822/lib.rs
+++ b/src/chips/nrf51822/lib.rs
@@ -1,0 +1,4 @@
+#![crate_name = "nrf51822"]
+#![crate_type = "rlib"]
+#![feature(asm,concat_idents,const_fn)]
+#![no_std]

--- a/src/chips/nrf51822/loader.ld
+++ b/src/chips/nrf51822/loader.ld
@@ -1,0 +1,146 @@
+/*
+ * This file is part of StormLoader, the Storm Bootloader
+ *
+ * StormLoader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StormLoader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2014, Michael Andersen <m.andersen@eecs.berkeley.edu>
+ *
+ * This file is largely copied from the Atmel supplied linker scripts
+ */
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+SEARCH_DIR(.) 
+
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x00000000, LENGTH = 256K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 16K
+}
+
+__stack_size__ = DEFINED(__stack_size__) ? __stack_size__ : 0x1000;
+__ram_end__ = ORIGIN(ram) + LENGTH(ram) - 4;
+
+/* Section Definitions */
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        _textstart = .;
+        KEEP(*(.vectors .vectors.*))
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+
+        KEEP (*(.syscalls))
+
+
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        . = ALIGN(4);
+        _efixed = .;            /* End of text section */
+    } > rom
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > rom
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+    . = ALIGN(4);
+    _etext = .;
+    _textend = .;
+
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+
+        . = ALIGN(4);
+        _sapps = .;
+        *(.app.*)
+        _eapps = .;
+
+        . = ALIGN(4);
+        _erelocate = .;
+    } > ram
+
+    /* .bss section which is used for uninitialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        _szero = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+
+        . = ALIGN(8);
+        *(.app_memory)
+
+        _ezero = .;
+    } > ram
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+         _sstack = .;
+        . = . + __stack_size__;
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
+    . = ALIGN(4);
+    _end = . ;
+}

--- a/src/chips/nrf51822/target.json
+++ b/src/chips/nrf51822/target.json
@@ -1,0 +1,14 @@
+{
+    "llvm-target": "thumbv6m-none-eabi",
+    "target-endian": "little",
+    "target-pointer-width": "32",
+    "os": "none",
+    "env": "eabi",
+    "vendor": "unknown",
+    "arch": "arm",
+
+    "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "cpu": "cortex-m0",
+    "executables": true,
+    "relocation-model": "static"
+}

--- a/src/platform/nrf_pca10001/Makefile.mk
+++ b/src/platform/nrf_pca10001/Makefile.mk
@@ -1,3 +1,8 @@
+JLINK_OPTIONS = -device nrf51822 -if swd -speed 1000
+JLINK = JLinkExe
+
+all: $(BUILD_DIR)/main.bin
+
 $(BUILD_DIR)/libplatform.rlib: $(call rwildcard,$(SRC_DIR)platform/$(PLATFORM),*.rs) $(BUILD_DIR)/libcore.rlib $(BUILD_DIR)/libhil.rlib $(BUILD_DIR)/lib$(CHIP).rlib $(BUILD_DIR)/libdrivers.rlib
 	@echo "Building $@"
 	@$(RUSTC) $(RUSTC_FLAGS) --out-dir $(BUILD_DIR) $(SRC_DIR)platform/$(PLATFORM)/lib.rs
@@ -7,14 +12,42 @@ $(BUILD_DIR)/main.elf: $(BUILD_DIR)/crt1.o $(BUILD_DIR)/arch.o $(BUILD_DIR)/main
 	@$(CC) $(LDFLAGS) -T$(LOADER) $^ -o $@ -ffreestanding -nostdlib -lc -lgcc
 	@$(TOOLCHAIN)size $@
 
-all: $(BUILD_DIR)/main.elf
+$(BUILD_DIR)/main.bin: $(BUILD_DIR)/main.elf
+	@echo "Generating $@"
+	@$(OBJCOPY) -Obinary $< $@
 
 .PHONY: rebuild-apps
 rebuild-apps: $(BUILD_DIR)/crt1.o $(BUILD_DIR)/arch.o $(BUILD_DIR)/main.o $(APP_BINS)
 	@echo "Relinking with APPS=\"$(APPS)\""
 	@$(CC) $(LDFLAGS) -T$(LOADER) $^ -o $(BUILD_DIR)/main.elf -ffreestanding -nostdlib -lc -lgcc
 
-# FIXME: implement "program" target using J-Link
-#.PHONY: program
-#program: $(BUILD_DIR)/main.hex
-#	...
+# "Flash" process:
+# 1) set NVMC.CONFIG to 1 (Write enabled)
+# 2) write firmware at address 0
+# 3) set NVMC.CONFIG to 0 (Read only access)
+.PHONY: program
+program: $(BUILD_DIR)/main.bin
+	echo \
+	connect\\n\
+	w4 4001e504 1\\n\
+	loadbin $< 0\\n\
+	w4 4001e504 0\\n\
+	r\\n\
+	g\\n\
+	exit | $(JLINK) $(JLINK_OPTIONS)
+
+# "Erase all" process:
+# 1) set NVMC.CONFIG to 2 (Erase enabled)
+# 2) set NVMC.ERASEALL to 1 (Start chip erase)
+# 3) wait some time for erase to finish
+# 4) set NVMC.CONFIG to 0 (Read only access)
+.PHONY: erase-all
+erase-all:
+	echo \
+	connect\\n\
+	w4 4001e504 2\\n\
+	w4 4001e50c 1\\n\
+	sleep 100\\n\
+	w4 4001e504 0\\n\
+	r\\n\
+	exit | $(JLINK) $(JLINK_OPTIONS)

--- a/src/platform/nrf_pca10001/Makefile.mk
+++ b/src/platform/nrf_pca10001/Makefile.mk
@@ -1,0 +1,20 @@
+$(BUILD_DIR)/libplatform.rlib: $(call rwildcard,$(SRC_DIR)platform/$(PLATFORM),*.rs) $(BUILD_DIR)/libcore.rlib $(BUILD_DIR)/libhil.rlib $(BUILD_DIR)/lib$(CHIP).rlib $(BUILD_DIR)/libdrivers.rlib
+	@echo "Building $@"
+	@$(RUSTC) $(RUSTC_FLAGS) --out-dir $(BUILD_DIR) $(SRC_DIR)platform/$(PLATFORM)/lib.rs
+
+$(BUILD_DIR)/main.elf: $(BUILD_DIR)/crt1.o $(BUILD_DIR)/arch.o $(BUILD_DIR)/main.o $(APP_BINS)
+	@echo "Linking $@"
+	@$(CC) $(LDFLAGS) -T$(LOADER) $^ -o $@ -ffreestanding -nostdlib -lc -lgcc
+	@$(TOOLCHAIN)size $@
+
+all: $(BUILD_DIR)/main.elf
+
+.PHONY: rebuild-apps
+rebuild-apps: $(BUILD_DIR)/crt1.o $(BUILD_DIR)/arch.o $(BUILD_DIR)/main.o $(APP_BINS)
+	@echo "Relinking with APPS=\"$(APPS)\""
+	@$(CC) $(LDFLAGS) -T$(LOADER) $^ -o $(BUILD_DIR)/main.elf -ffreestanding -nostdlib -lc -lgcc
+
+# FIXME: implement "program" target using J-Link
+#.PHONY: program
+#program: $(BUILD_DIR)/main.hex
+#	...

--- a/src/platform/nrf_pca10001/lib.rs
+++ b/src/platform/nrf_pca10001/lib.rs
@@ -2,22 +2,29 @@
 #![crate_type = "rlib"]
 #![no_std]
 
+extern crate drivers;
 extern crate hil;
+extern crate nrf51822;
 
-pub struct Firestorm;
+pub struct Firestorm {
+    gpio: &'static drivers::gpio::GPIO<[&'static hil::gpio::GPIOPin; 32]>,
+}
 
 impl Firestorm {
     pub unsafe fn service_pending_interrupts(&mut self) {
     }
 
     pub unsafe fn has_pending_interrupts(&mut self) -> bool {
-        false
+        // FIXME: The wfi call from main() blocks forever if no interrupts are generated. For now,
+        // pretend we have interrupts to avoid blocking.
+        true
     }
 
     #[inline(never)]
     pub fn with_driver<F, R>(&mut self, driver_num: usize, f: F) -> R where
             F: FnOnce(Option<&hil::Driver>) -> R {
         match driver_num {
+            1 => f(Some(self.gpio)),
             _ => f(None)
         }
     }
@@ -25,10 +32,28 @@ impl Firestorm {
 
 pub unsafe fn init<'a>() -> &'a mut Firestorm {
     use core::mem;
+    use nrf51822::gpio::PA;
 
     static mut FIRESTORM_BUF : [u8; 1024] = [0; 1024];
+    static mut GPIO_BUF : [u8; 1024] = [0; 1024];
+
+    let gpio : &mut drivers::gpio::GPIO<[&'static hil::gpio::GPIOPin; 32]> = mem::transmute(&mut GPIO_BUF);
+
+    *gpio = drivers::gpio::GPIO::new([
+        &mut PA[0], &mut PA[1], &mut PA[2], &mut PA[3],
+        &mut PA[4], &mut PA[5], &mut PA[6], &mut PA[7],
+        &mut PA[8], &mut PA[9], &mut PA[10], &mut PA[11],
+        &mut PA[12], &mut PA[13], &mut PA[14], &mut PA[15],
+        &mut PA[16], &mut PA[17], &mut PA[18], &mut PA[19],
+        &mut PA[20], &mut PA[21], &mut PA[22], &mut PA[23],
+        &mut PA[24], &mut PA[25], &mut PA[26], &mut PA[27],
+        &mut PA[28], &mut PA[29], &mut PA[30], &mut PA[31],
+    ]);
 
     let firestorm : &'static mut Firestorm = mem::transmute(&mut FIRESTORM_BUF);
+    *firestorm = Firestorm {
+        gpio: gpio,
+    };
 
     firestorm
 }

--- a/src/platform/nrf_pca10001/lib.rs
+++ b/src/platform/nrf_pca10001/lib.rs
@@ -1,0 +1,34 @@
+#![crate_name = "platform"]
+#![crate_type = "rlib"]
+#![no_std]
+
+extern crate hil;
+
+pub struct Firestorm;
+
+impl Firestorm {
+    pub unsafe fn service_pending_interrupts(&mut self) {
+    }
+
+    pub unsafe fn has_pending_interrupts(&mut self) -> bool {
+        false
+    }
+
+    #[inline(never)]
+    pub fn with_driver<F, R>(&mut self, driver_num: usize, f: F) -> R where
+            F: FnOnce(Option<&hil::Driver>) -> R {
+        match driver_num {
+            _ => f(None)
+        }
+    }
+}
+
+pub unsafe fn init<'a>() -> &'a mut Firestorm {
+    use core::mem;
+
+    static mut FIRESTORM_BUF : [u8; 1024] = [0; 1024];
+
+    let firestorm : &'static mut Firestorm = mem::transmute(&mut FIRESTORM_BUF);
+
+    firestorm
+}


### PR DESCRIPTION
Add support for the PCA10001 board with the nRF51822 SoC. This initial support contains just the minimal support for the "blinky" app to work:

* Context switching to/from kernel
* GPIO output pins
* Programming using JLink Debugger
