### PR TITLE
Makefile - set a chip according to a platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,12 @@ BUILD_APP_DIR ?= $(BUILD_DIR)/apps
 
 # Default platform is the Storm (http://storm.rocks). Change to any platform in
 # the `platform` directory.
-PLATFORM ?= storm
-CHIP ?= sam4l
+ifeq ($(PLATFORM), nrf_pca10001)
+	CHIP = nrf51822
+else
+	PLATFORM = storm
+	CHIP = sam4l
+endif
 
 # Dummy all. The real one is in platform-specific Makefiles.
 all:	$(BUILD_DIR) $(BUILD_APP_DIR)


### PR DESCRIPTION
A platform should define a chip. Thus for build tools, all it can be required is just a platform. I consider a platform is unique name (=identifier).

```
# works as before , the default platform + chip set
make APPS=c_blinky
# for nrf_pca10001 platform, set chip nrf51822
make PLATFORM=nrf_pca10001 APPS=c_blinky
```