### PR TITLE
Timer overhaul

### DIFF
--- a/src/chips/sam4l/ast.rs
+++ b/src/chips/sam4l/ast.rs
@@ -67,8 +67,6 @@ impl Controller for Ast {
         self.set_prescalar(0); // 32Khz / (2^(0 + 1)) = 16Khz
         self.enable_alarm_wake();
         self.clear_alarm();
-
-        self.enable();
     }
 }
 
@@ -138,6 +136,13 @@ impl Ast {
         unsafe {
             let cr = intrinsics::volatile_load(&(*self.regs).cr) | 1;
             intrinsics::volatile_store(&mut (*self.regs).cr, cr);
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        while self.busy() {}
+        unsafe {
+            intrinsics::volatile_load(&(*self.regs).cr) & 1 == 1
         }
     }
 
@@ -248,6 +253,10 @@ impl Alarm for Ast {
 
     fn disable_alarm(&self) {
         self.disable_alarm_irq();
+    }
+
+    fn is_armed(&self) -> bool {
+        self.is_enabled()
     }
 
     fn set_alarm(&self, tics: u32) {

--- a/src/chips/sam4l/ast.rs
+++ b/src/chips/sam4l/ast.rs
@@ -240,6 +240,7 @@ impl Alarm for Ast {
     type Frequency = Freq16Khz;
 
     fn now(&self) -> u32 {
+        while self.busy() {}
         unsafe {
             intrinsics::volatile_load(&(*self.regs).cv)
         }
@@ -261,6 +262,7 @@ impl Alarm for Ast {
     }
 
     fn get_alarm(&self) -> u32 {
+        while self.busy() {}
         unsafe {
             intrinsics::volatile_load(&(*self.regs).ar0)
         }

--- a/src/drivers/timer.rs
+++ b/src/drivers/timer.rs
@@ -2,78 +2,7 @@ use core::cell::Cell;
 use process::{AppId, Container, Callback};
 use hil::Driver;
 use hil::alarm::{Alarm, AlarmClient, Frequency};
-use hil::timer::{Timer, TimerClient};
-
-#[derive(Copy, Clone)]
-enum Schedule {
-    Oneshot,
-    Repeating { interval: u32 }
-}
-
-pub struct AlarmToTimer<'a, Alrm: Alarm + 'a> {
-    schedule: Cell<Schedule>,
-    alarm: &'a Alrm,
-    client: Cell<Option<&'a TimerClient>>
-}
-
-impl<'a, Alrm: Alarm> AlarmToTimer<'a, Alrm> {
-    pub const fn new(alarm: &'a Alrm) -> AlarmToTimer<'a, Alrm> {
-        AlarmToTimer {
-            schedule: Cell::new(Schedule::Oneshot),
-            alarm: alarm,
-            client: Cell::new(None)
-        }
-    }
-
-    pub fn set_client(&self, client: &'a TimerClient) {
-        self.client.set(Some(client));
-    }
-}
-
-impl<'a, Alrm: Alarm> Timer for AlarmToTimer<'a, Alrm> {
-    fn now(&self) -> u32 {
-        self.alarm.now()
-    }
-
-    fn oneshot(&self, interval_ms: u32) {
-        let interval = interval_ms * <Alrm::Frequency>::frequency() / 1000;
-
-        self.schedule.set(Schedule::Oneshot);
-
-        let when = interval.wrapping_add(self.alarm.now());
-        self.alarm.set_alarm(when);
-    }
-
-    fn repeat(&self, interval_ms: u32) {
-        let interval = interval_ms * <Alrm::Frequency>::frequency() / 1000;
-
-        self.schedule.set(Schedule::Repeating {interval: interval});
-
-        let when = interval.wrapping_add(self.alarm.now());
-        self.alarm.set_alarm(when);
-    }
-
-    fn stop(&self) {
-        self.alarm.disable_alarm();
-    }
-}
-
-impl<'a, Alrm: Alarm> AlarmClient for AlarmToTimer<'a, Alrm> {
-    fn fired(&self) {
-        let now = self.now();
-
-        match self.schedule.get() {
-            Schedule::Oneshot => self.alarm.disable_alarm(),
-
-            Schedule::Repeating { interval } => {
-                let when = interval.wrapping_add(now);
-                self.alarm.set_alarm(when);
-            }
-        }
-
-        self.client.get().map(|client| client.fired(now) );
-    }
-}
+use hil::timer::{Timer};
 
 #[derive(Copy, Clone)]
 pub struct TimerData {
@@ -89,22 +18,47 @@ impl Default for TimerData {
     }
 }
 
-pub struct TimerDriver<'a, T: Timer + 'a> {
-    timer: &'a T,
+pub struct TimerDriver<'a, A: Alarm + 'a> {
+    alarm: &'a A,
+    num_armed: Cell<usize>,
     app_timer: Container<TimerData>
 }
 
-impl<'a, T: Timer> TimerDriver<'a, T> {
-    pub const fn new(timer: &'a T, container: Container<TimerData>)
-            -> TimerDriver<'a, T> {
+impl<'a, A: Alarm + 'a> TimerDriver<'a, A> {
+    pub const fn new(alarm: &'a A, container: Container<TimerData>)
+            -> TimerDriver<'a, A> {
         TimerDriver {
-            timer: timer,
+            alarm: alarm,
+            num_armed: Cell::new(0),
             app_timer: container
+        }
+    }
+
+    fn reset_active_timer(&self) {
+        let now = self.alarm.now();
+        let mut next_alarm = u32::max_value();
+        let mut next_dist = u32::max_value();
+        for timer in self.app_timer.iter() {
+            timer.enter(|timer, _| {
+                if timer.interval > 0 {
+                    let native_int =
+                        timer.interval * <A::Frequency>::frequency() / 1000;
+                    let t_alarm = timer.t0.wrapping_add(native_int);
+                    let t_dist = t_alarm.wrapping_sub(now);
+                    if next_dist > t_dist {
+                        next_alarm = t_alarm;
+                        next_dist = t_dist;
+                    }
+                }
+            });
+        }
+        if next_alarm != u32::max_value() {
+            self.alarm.set_alarm(next_alarm);
         }
     }
 }
 
-impl<'a, T: Timer> Driver for TimerDriver<'a, T> {
+impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
     fn subscribe(&self, _: usize, callback: Callback) -> isize {
         self.app_timer.enter(callback.app_id(), |td, _allocator| {
             td.callback = Some(callback);
@@ -115,44 +69,81 @@ impl<'a, T: Timer> Driver for TimerDriver<'a, T> {
     fn command(&self, cmd_type: usize, interval: usize, caller_id: AppId)
             -> isize {
         let interval = interval as u32;
-        self.app_timer.enter(caller_id, |td, _allocator| {
+        let (res, reset) = self.app_timer.enter(caller_id, |td, _allocator| {
             match cmd_type {
-                0 /* Oneshot */ => {
-                    td.t0 = self.timer.now();
-                    td.interval = interval;
-                    td.repeating = false;
-                    self.timer.oneshot(interval);
-                    0
-                },
-                1 /* Repeating */ => {
-                    td.t0 = self.timer.now();
-                    td.interval = interval;
-                    td.repeating = true;
-                    self.timer.repeat(interval);
-                    0
-                },
                 2 /* Stop */ => {
-                    td.interval = 0;
-                    td.t0 = 0;
-                    self.timer.stop();
-                    0
+                    if td.interval > 0 {
+                        td.interval = 0;
+                        td.t0 = 0;
+                        let num_armed = self.num_armed.get();
+                        self.num_armed.set(num_armed - 1);
+                        if num_armed == 1 {
+                            self.alarm.disable_alarm();
+                            (0, false)
+                        } else {
+                            (0, true)
+                        }
+                    } else {
+                        (-2, false)
+                    }
                 },
-                _ => -1
+                /* 0 for Oneshot, 1 for Repeat */
+                cmd_type if cmd_type <= 1 => {
+                    if interval == 0 {
+                        return (-2, false);
+                    }
+
+                    if td.interval == 0 {
+                        self.num_armed.set(self.num_armed.get() + 1);
+                    }
+
+                    td.t0 = self.alarm.now();
+                    td.interval = interval;
+
+                    // Repeat if cmd_type was 1
+                    td.repeating = cmd_type == 1;
+                    if self.alarm.is_armed() {
+                        (0, true)
+                    } else {
+                        let interval =
+                            interval * <A::Frequency>::frequency() / 1000;
+                        self.alarm.set_alarm(td.t0.wrapping_add(interval));
+                        (0, false)
+                    }
+                },
+                _ => (-1, false)
             }
-        }).unwrap_or(-2)
+        }).unwrap_or((-3, false));
+        if reset {
+            self.reset_active_timer();        
+        }
+        res
     }
 }
 
-impl<'a, T: Timer> TimerClient for TimerDriver<'a, T> {
-    fn fired(&self, now: u32) {
+impl<'a, A: Alarm> AlarmClient for TimerDriver<'a, A> {
+    fn fired(&self) {
+        let now = self.alarm.now();
+
         self.app_timer.each(|timer| {
             let elapsed = now.wrapping_sub(timer.t0);
-            if elapsed >= timer.interval {
+            if timer.interval > 0 && elapsed >= timer.interval {
+                if timer.repeating {
+                    timer.t0 = now;
+                } else {
+                    timer.interval = 0;
+                    self.num_armed.set(self.num_armed.get() - 1);
+                }
                 timer.callback.map(|mut cb| {
                     cb.schedule(now as usize, 0, 0);
                 });
             }
         });
+        if self.num_armed.get() > 0 {
+            self.reset_active_timer();
+        } else {
+            self.alarm.disable_alarm();
+        }
     }
 }
 

--- a/src/drivers/virtual_alarm.rs
+++ b/src/drivers/virtual_alarm.rs
@@ -3,7 +3,7 @@ use hil::alarm::{Alarm, AlarmClient};
 use common::{List, ListLink, ListNode};
 
 pub struct VirtualMuxAlarm<'a, Alrm: Alarm + 'a> {
-    alarm: &'a MuxAlarm<'a, Alrm>,
+    mux: &'a MuxAlarm<'a, Alrm>,
     when: Cell<u32>,
     armed: Cell<bool>,
     next: ListLink<'a, VirtualMuxAlarm<'a, Alrm>>,
@@ -19,7 +19,7 @@ impl<'a, A: Alarm + 'a> ListNode<'a, VirtualMuxAlarm<'a, A>> for VirtualMuxAlarm
 impl<'a, Alrm: Alarm> VirtualMuxAlarm<'a, Alrm> {
     pub fn new(mux_alarm: &'a MuxAlarm<'a, Alrm>) -> VirtualMuxAlarm<'a, Alrm> {
         VirtualMuxAlarm {
-            alarm: mux_alarm,
+            mux: mux_alarm,
             when: Cell::new(0),
             armed: Cell::new(false),
             next: ListLink::empty(),
@@ -28,7 +28,7 @@ impl<'a, Alrm: Alarm> VirtualMuxAlarm<'a, Alrm> {
     }
 
     pub fn set_client(&'a self, client: &'a AlarmClient) {
-        self.alarm.virtual_alarms.push_head(self);
+        self.mux.virtual_alarms.push_head(self);
         self.when.set(0);
         self.armed.set(false);
         self.client.set(Some(client));
@@ -40,20 +40,31 @@ impl<'a, Alrm: Alarm> Alarm for VirtualMuxAlarm<'a, Alrm> {
     type Frequency = Alrm::Frequency;
 
     fn now(&self) -> u32 {
-        self.alarm.alarm.now()
+        self.mux.alarm.now()
     }
 
     fn set_alarm(&self, when: u32) {
-        let enabled = self.alarm.enabled.get();
-        self.alarm.enabled.set(enabled + 1);
+        let enabled = self.mux.enabled.get();
 
-        // If there are no other virtual alarms enabled, set the underlying
-        // alarm
-        if enabled == 0 {
-            self.alarm.prev.set(self.alarm.alarm.now());
-            self.alarm.alarm.set_alarm(when);
+        if !self.is_armed() {
+            self.mux.enabled.set(enabled + 1);
+            self.armed.set(true);
+
         }
-        self.armed.set(true);
+
+        if enabled > 0 {
+            let cur_alarm = self.mux.alarm.get_alarm();
+            let now = self.now();
+
+            if cur_alarm.wrapping_sub(now) > when.wrapping_sub(now) {
+                self.mux.prev.set(self.mux.alarm.now());
+                self.mux.alarm.set_alarm(when);
+            }
+        } else {
+            self.mux.prev.set(self.mux.alarm.now());
+            self.mux.alarm.set_alarm(when);
+        }
+
         self.when.set(when);
     }
 
@@ -68,16 +79,24 @@ impl<'a, Alrm: Alarm> Alarm for VirtualMuxAlarm<'a, Alrm> {
 
         self.armed.set(false);
 
-        let enabled = self.alarm.enabled.get() - 1;
-        self.alarm.enabled.set(enabled);
+        let enabled = self.mux.enabled.get() - 1;
+        self.mux.enabled.set(enabled);
 
         // If there are not more enabled alarms, disable the underlying alarm
         // completely.
         if enabled == 0 {
-            self.alarm.alarm.disable_alarm();
+            self.mux.alarm.disable_alarm();
         }
     }
 }
+
+impl <'a, Alrm: Alarm> AlarmClient for VirtualMuxAlarm<'a, Alrm> {
+    fn fired(&self) {
+        self.client.get().map(|client| client.fired() );
+    }
+}
+
+/* MuxAlarm */
 
 pub struct MuxAlarm<'a, Alrm: Alarm + 'a> {
     virtual_alarms: List<'a, VirtualMuxAlarm<'a, Alrm>>,
@@ -97,14 +116,8 @@ impl<'a, Alrm: Alarm> MuxAlarm<'a, Alrm> {
     }
 }
 
-impl <'a, Alrm: Alarm> AlarmClient for VirtualMuxAlarm<'a, Alrm> {
-    fn fired(&self) {
-        self.client.get().map(|client| client.fired() );
-    }
-}
-
 fn past_from_base(cur: u32, now: u32, prev: u32) -> bool {
-    cur.wrapping_sub(now) <= cur.wrapping_sub(prev)
+    now.wrapping_sub(prev) >= cur.wrapping_sub(prev)
 }
 
 impl <'a, Alrm: Alarm> AlarmClient for MuxAlarm<'a, Alrm> {
@@ -114,17 +127,21 @@ impl <'a, Alrm: Alarm> AlarmClient for MuxAlarm<'a, Alrm> {
         self.alarm.disable_alarm();
 
         let now = self.alarm.now();
-        let mut next = None;
-        let mut min_distance : u32 = u32::max_value();
 
         for cur in self.virtual_alarms.iter() {
             let should_fire = past_from_base(cur.when.get(),
-                                         now, self.prev.get());
+                                         now + 100, self.prev.get());
             if cur.armed.get() && should_fire {
                 cur.armed.set(false);
                 self.enabled.set(self.enabled.get() - 1);
                 cur.fired();
-            } else {
+            }
+        }
+
+        let mut next = None;
+        let mut min_distance : u32 = u32::max_value();
+        for cur in self.virtual_alarms.iter() {
+            if cur.armed.get() {
                 let distance = cur.when.get().wrapping_sub(now);
                 if cur.armed.get() && distance < min_distance {
                     min_distance = distance;

--- a/src/drivers/virtual_alarm.rs
+++ b/src/drivers/virtual_alarm.rs
@@ -88,6 +88,10 @@ impl<'a, Alrm: Alarm> Alarm for VirtualMuxAlarm<'a, Alrm> {
             self.mux.alarm.disable_alarm();
         }
     }
+
+    fn is_armed(&self) -> bool {
+        self.armed.get()
+    }
 }
 
 impl <'a, Alrm: Alarm> AlarmClient for VirtualMuxAlarm<'a, Alrm> {

--- a/src/hil/alarm.rs
+++ b/src/hil/alarm.rs
@@ -48,6 +48,9 @@ pub trait Alarm {
     /// Disables the alarm.
     fn disable_alarm(&self);
 
+    /// Returns true if the alarm is armed
+    fn is_armed(&self) -> bool;
+
     /// Returns the value set in [`set_alarm`](#tymethod.set_alarm)
     fn get_alarm(&self) -> u32;
 }

--- a/src/platform/storm/lib.rs
+++ b/src/platform/storm/lib.rs
@@ -13,7 +13,6 @@ extern crate process;
 use hil::Controller;
 use hil::spi_master::SpiMaster;
 use hil::gpio::GPIOPin;
-use drivers::timer::AlarmToTimer;
 use drivers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use drivers::virtual_i2c::{MuxI2C, I2CDevice};
 
@@ -34,8 +33,8 @@ pub struct Firestorm {
     chip: sam4l::chip::Sam4l,
     console: &'static drivers::console::Console<'static, sam4l::usart::USART>,
     gpio: &'static drivers::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
-    timer: &'static drivers::timer::TimerDriver<'static, AlarmToTimer<'static,
-                                VirtualMuxAlarm<'static, sam4l::ast::Ast>>>,
+    timer: &'static drivers::timer::TimerDriver<'static,
+                VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
     tmp006: &'static drivers::tmp006::TMP006<'static>,
     isl29035: &'static drivers::isl29035::Isl29035<'static>,
     spi: &'static drivers::spi::Spi<'static, sam4l::spi::Spi>,
@@ -320,15 +319,11 @@ pub unsafe fn init<'a>() -> &'a mut Firestorm {
 
     static_init!(virtual_alarm1 : VirtualMuxAlarm<'static, sam4l::ast::Ast> =
                     VirtualMuxAlarm::new(mux_alarm));
-    static_init!(vtimer1 : AlarmToTimer<'static,
+    static_init!(timer : drivers::timer::TimerDriver<'static,
                                 VirtualMuxAlarm<'static, sam4l::ast::Ast>> =
-                            AlarmToTimer::new(virtual_alarm1));
-    virtual_alarm1.set_client(vtimer1);
-    static_init!(timer : drivers::timer::TimerDriver<AlarmToTimer<'static,
-                                VirtualMuxAlarm<'static, sam4l::ast::Ast>>> =
-                            drivers::timer::TimerDriver::new(vtimer1,
+                            drivers::timer::TimerDriver::new(virtual_alarm1,
                                             process::Container::create()));
-    vtimer1.set_client(timer);
+    virtual_alarm1.set_client(timer);
 
     // Initialize and enable SPI HAL
     static_init!(spi: drivers::spi::Spi<'static, sam4l::spi::Spi> =


### PR DESCRIPTION
Fixes major (and some minor) issues throughout the virtual timer stack. The high bits:

  * The SAM4L AST capsule wasn't waiting on the busy bit to before reading the current timer value and the alarm registers. This resulted in alarms appearing to fire before the alarm that was set (because `now` was reading stale values)

  * The `virtual_alarm` capsule wasn't properly accounting for enabled and disabled virtual alarms.

  * The `TimerDriver` (virtual timer for processes) was not consistently translating from milliseconds (which is the unit the driver accepts) to native clock frequency (in the case of SAM4L's AST 16Khz), resulting in basically all virtual timers being fired almost every time.
