### PR TITLE
Properly account for enable/disable in virtual I2C

### DIFF
--- a/src/drivers/isl29035.rs
+++ b/src/drivers/isl29035.rs
@@ -105,6 +105,7 @@ impl<'a> I2CClient for Isl29035<'a> {
                 self.state.set(State::Disabling(lux));
             },
             State::Disabling(lux) => {
+                self.i2c.disable();
                 self.state.set(State::Disabled);
                 self.buffer.replace(buffer);
                 self.callback.get().map(|mut cb| cb.schedule(lux, 0, 0));

--- a/src/drivers/virtual_i2c.rs
+++ b/src/drivers/virtual_i2c.rs
@@ -28,9 +28,10 @@ impl<'a> MuxI2C<'a> {
             inflight: TakeCell::empty()
         }
     }
+
     fn enable(&self) {
         let enabled = self.enabled.get();
-        self.enabled.set(enabled);
+        self.enabled.set(enabled + 1);
         if enabled == 0 {
             self.i2c.enable();
         }
@@ -123,12 +124,14 @@ impl<'a> ListNode<'a, I2CDevice<'a>> for I2CDevice<'a> {
 impl<'a> i2c::I2CDevice for I2CDevice<'a> {
     fn enable(&self) {
         if !self.enabled.get() {
+            self.enabled.set(true);
             self.mux.enable();
         }
     }
 
     fn disable(&self) {
         if self.enabled.get() {
+            self.enabled.set(false);
             self.mux.disable();
         }
     }


### PR DESCRIPTION
We were just allowing enable/disable to go through unaccounted for on `I2CDevice` (virtual I2C devices) and `MuxI2C`. This manifested as a particularly nefarious bug where if the TMP and ISL drivers where operating simultaneously (e.g. in the `sensors` app), and the TMP happened to disable the I2C while the ISL was in the middle of a multi-transaction operationg (e.g. preparing and reading the sensor), the bus would get block forever.