### PR TITLE
Prioritize IRQs over user-space processes

### DIFF
--- a/src/arch/cortex-m0/ctx_switch.S
+++ b/src/arch/cortex-m0/ctx_switch.S
@@ -7,6 +7,8 @@
 .global SVC_Handler
 .globl switch_to_user
 
+.extern SYSCALL_FIRED
+
 .thumb_func
 SVC_Handler:
   ldr r0, EXC_RETURN_MSP
@@ -16,8 +18,9 @@ SVC_Handler:
   bx r1
 
 to_kernel:
-  mrs r0, PSP /* PSP into r0 */
-  str r0, [sp, #0] /* PSP into Master stack r0 */
+  ldr r0, =SYSCALL_FIRED
+  movs r1, #1
+  str r1, [r0, #0]
   ldr r1, EXC_RETURN_MSP
   bx r1
 
@@ -54,6 +57,10 @@ switch_to_user:
     /* Set PIC base pointer to the Process GOT */
     mov r9, r1
 
+    ldr r0, =SYSCALL_FIRED
+    movs r1, #0
+    str r1, [r0, #0]
+
     /* SWITCH */
     svc 0xff /* It doesn't matter which SVC number we use here */
 
@@ -62,6 +69,8 @@ switch_to_user:
      * easier to address hardware-stacked registers in the rest of the kernel.
      * This is fine since we just account for that above.
      */
+
+    mrs r0, PSP /* PSP into r0 */
 
     subs r0, #32 // We actually store r4-r11 below the process stack
     str r4, [r0, #16]

--- a/src/arch/cortex-m4/ctx_switch.S
+++ b/src/arch/cortex-m4/ctx_switch.S
@@ -9,6 +9,7 @@
 .globl generic_isr
 
 .extern INTERRUPT_TABLE
+.extern SYSCALL_FIRED
 
 .thumb_func
 SVC_Handler:
@@ -18,8 +19,9 @@ SVC_Handler:
   movt lr, #0xffff
   bx lr
 to_kernel:
-  mrs r0, PSP /* PSP into r0 */
-  str r0, [sp, #0] /* PSP into Master stack r0 */
+  ldr r0, =SYSCALL_FIRED
+  mov r1, #1
+  str r1, [r0, #0]
   movw LR, #0xFFF9
   movt LR, #0xFFFF
   bx lr
@@ -38,8 +40,14 @@ switch_to_user:
     /* Set PIC base pointer to the Process GOT */
     mov r9, r1
 
+    ldr r0, =SYSCALL_FIRED
+    mov r1, #0
+    str r1, [r0, #0]
+
     /* SWITCH */
     svc 0xff /* It doesn't matter which SVC number we use here */
+
+    mrs r0, PSP /* PSP into r0 */
 
     /* Push non-hardware-stacked registers onto Process stack */
     /* r0 points to user stack (see to_kernel) */
@@ -69,5 +77,7 @@ generic_isr:
     blx r0
     pop {lr}
 
+    movw LR, #0xFFF9
+    movt LR, #0xFFFF
     bx lr
 

--- a/src/arch/cortex-m4/ctx_switch.S
+++ b/src/arch/cortex-m4/ctx_switch.S
@@ -60,6 +60,17 @@ switch_to_user:
 /* All ISRs are caught by this handler which indirects to a custom handler by
  * indexing into `INTERRUPT_TABLE` based on the ISR number. */
 generic_isr:
+    /* Skip saving process state if not coming from user-space */
+    cmp lr, #0xfffffffd
+    bne _generic_isr_no_stacking
+
+    mrs r0, PSP /* PSP into r0 */
+
+    /* Push non-hardware-stacked registers onto Process stack */
+    /* r0 points to user stack (see to_kernel) */
+    stmdb r0, {r4-r11}
+
+_generic_isr_no_stacking:
     /* Find the ISR number by looking at the low byte of the IPSR registers */
     mrs r0, IPSR
     and r0, #0xff

--- a/src/chips/sam4l/chip.rs
+++ b/src/chips/sam4l/chip.rs
@@ -1,3 +1,4 @@
+use core::intrinsics;
 use common::{RingBuffer,Queue};
 use ast;
 //use adc;
@@ -38,7 +39,9 @@ impl Sam4l {
 
     pub unsafe fn service_pending_interrupts(&mut self) {
         use nvic::NvicIdx::*;
-        INTERRUPT_QUEUE.as_mut().unwrap().dequeue().map(|interrupt| {
+
+        let iq = INTERRUPT_QUEUE.as_mut().unwrap();
+        while let Some(interrupt) = iq.dequeue() {
             match interrupt {
                 ASTALARM => ast::AST.handle_interrupt(),
 
@@ -74,7 +77,7 @@ impl Sam4l {
                 _ => {}
             }
             nvic::enable(interrupt);
-       });
+       }
     }
 
     pub unsafe fn has_pending_interrupts(&mut self) -> bool {

--- a/src/main/main.rs
+++ b/src/main/main.rs
@@ -38,6 +38,9 @@ pub extern fn main() {
                 p.as_mut().map(|process| {
                     sched::do_process(platform, process, AppId::new(i));
                 });
+                if platform.has_pending_interrupts() {
+                    break;
+                }
             }
 
             support::atomic(|| {

--- a/src/main/sched.rs
+++ b/src/main/sched.rs
@@ -22,6 +22,11 @@ pub unsafe fn do_process(platform: &mut Firestorm, process: &mut Process,
                 }
             }
         }
+
+        if !process.syscall_fired() {
+            break;
+        }
+
         match process.svc_number() {
             Some(syscall::MEMOP) => {
                 let brk_type = process.r0();

--- a/src/main/sched.rs
+++ b/src/main/sched.rs
@@ -48,7 +48,9 @@ pub unsafe fn do_process(platform: &mut Firestorm, process: &mut Process,
             Some(syscall::WAIT) => {
                 process.state = process::State::Waiting;
                 process.pop_syscall_stack();
-                break;
+
+                // There might be already enqueued callbacks
+                continue;
             },
             Some(syscall::SUBSCRIBE) => {
                 let driver_num = process.r0();

--- a/src/process/process.rs
+++ b/src/process/process.rs
@@ -1,10 +1,13 @@
 use core::intrinsics::{breakpoint, volatile_load, volatile_store};
-use core::mem;
+use core::{mem,ptr,intrinsics};
 use core::raw::{Repr,Slice};
 
 use common::{RingBuffer, Queue};
 
 use container;
+
+#[no_mangle]
+pub static mut SYSCALL_FIRED : usize = 0;
 
 #[allow(improper_ctypes)]
 extern {
@@ -140,7 +143,7 @@ impl<'a> Process<'a> {
                     len: num_ctrs
                 });
                 for opt in opts.iter_mut() {
-                    *opt = ::core::ptr::null()
+                    *opt = ptr::null()
                 }
                 res
             };
@@ -287,6 +290,10 @@ impl<'a> Process<'a> {
 
         self.cur_stack = stack_bottom as *mut u8;
         self.switch_to();
+    }
+
+    pub unsafe fn syscall_fired(&self) -> bool {
+        intrinsics::volatile_load(&SYSCALL_FIRED) != 0
     }
 
     /// Context switch to the process.


### PR DESCRIPTION
When a hardware interrupt comes in, switch immediately to the kernel instead of returning to user-space, prioritizing all kernel code over user-space.

  * Generic ISR saves process state in the same way as `switch_to_user`, but only if coming from a process.

  * The process scheduler breaks out of the process if `switch_to_user` returns but a syscall wasn't fired

Resolves: #63 