### PR TITLE
Timeslice processes using systick

### DIFF
--- a/src/arch/cortex-m4/ctx_switch.S
+++ b/src/arch/cortex-m4/ctx_switch.S
@@ -7,9 +7,11 @@
 .global SVC_Handler
 .globl switch_to_user
 .globl generic_isr
+.globl systick_handler
 
 .extern INTERRUPT_TABLE
 .extern SYSCALL_FIRED
+.extern OVERFLOW_FIRED
 
 .thumb_func
 SVC_Handler:
@@ -22,6 +24,7 @@ to_kernel:
   ldr r0, =SYSCALL_FIRED
   mov r1, #1
   str r1, [r0, #0]
+
   movw LR, #0xFFF9
   movt LR, #0xFFFF
   bx lr
@@ -69,7 +72,6 @@ generic_isr:
     /* Push non-hardware-stacked registers onto Process stack */
     /* r0 points to user stack (see to_kernel) */
     stmdb r0, {r4-r11}
-
 _generic_isr_no_stacking:
     /* Find the ISR number by looking at the low byte of the IPSR registers */
     mrs r0, IPSR
@@ -88,6 +90,25 @@ _generic_isr_no_stacking:
     blx r0
     pop {lr}
 
+    movw LR, #0xFFF9
+    movt LR, #0xFFFF
+    bx lr
+
+.thumb_func
+systick_handler:
+    /* Skip saving process state if not coming from user-space */
+    cmp lr, #0xfffffffd
+    bne _systick_handler_no_stacking
+
+    mrs r0, PSP /* PSP into r0 */
+
+    /* Push non-hardware-stacked registers onto Process stack */
+    /* r0 points to user stack (see to_kernel) */
+    stmdb r0, {r4-r11}
+_systick_handler_no_stacking:
+    ldr r0, =OVERFLOW_FIRED
+    mov r1, #1
+    str r1, [r0, #0]
     movw LR, #0xFFF9
     movt LR, #0xFFFF
     bx lr

--- a/src/chips/sam4l/lib.rs
+++ b/src/chips/sam4l/lib.rs
@@ -51,6 +51,7 @@ extern {
 
     // Defined in src/arch/cortex-m4/ctx_switch.S
     fn SVC_Handler();
+    fn systick_handler();
 
     fn generic_isr();
 
@@ -75,7 +76,7 @@ pub static BASE_VECTORS: [unsafe extern fn(); 16] = [
     /* DebugMon */      unhandled_interrupt,
     unhandled_interrupt,
     /* PendSV */        unhandled_interrupt,
-    /* SysTick */       unhandled_interrupt
+    /* SysTick */       systick_handler
 ];
 
 #[link_section=".vectors"]

--- a/src/platform/nrf_pca10001/lib.rs
+++ b/src/platform/nrf_pca10001/lib.rs
@@ -8,6 +8,8 @@ extern crate hil;
 extern crate nrf51822;
 extern crate support;
 
+pub mod systick;
+
 pub struct Firestorm {
     gpio: &'static drivers::gpio::GPIO<'static, nrf51822::gpio::GPIOPin>,
 }

--- a/src/platform/nrf_pca10001/systick.rs
+++ b/src/platform/nrf_pca10001/systick.rs
@@ -1,0 +1,26 @@
+/// Stub implementation of a systick timer since the NRF doesn't have the
+/// Cortex-M0 Systick. This will need to be replaced with one of the other
+/// timers on the NRF, or maybe we don't care if only one process will ever run
+/// on the NRF51
+
+
+static mut VAL : usize = 0;
+
+pub unsafe fn reset() {
+    VAL = 0;
+}
+
+pub unsafe fn set_timer(val: usize) {
+    VAL = val;
+}
+
+pub unsafe fn enable(_: bool) {
+}
+
+pub unsafe fn overflowed() -> bool {
+    false
+}
+
+pub unsafe fn value() -> usize {
+    VAL
+}

--- a/src/platform/storm/lib.rs
+++ b/src/platform/storm/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "platform"]
 #![crate_type = "rlib"]
 #![no_std]
-#![feature(const_fn,lang_items)]
+#![feature(core_intrinsics,const_fn,lang_items)]
 
 extern crate common;
 extern crate drivers;
@@ -18,6 +18,8 @@ use drivers::virtual_i2c::{MuxI2C, I2CDevice};
 
 #[macro_use]
 pub mod io;
+
+pub mod systick;
 
 // HAL unit tests. To enable a particular unit test, uncomment
 // the module here and uncomment the call to start the test in

--- a/src/platform/storm/systick.rs
+++ b/src/platform/storm/systick.rs
@@ -1,0 +1,67 @@
+use core::intrinsics;
+
+struct SysTick {
+    control:     u32,
+    reload:      u32,
+    value:       u32,
+    calibration: u32
+}
+
+const BASE_ADDR : *mut SysTick = 0xE000E010 as *mut SysTick;
+
+/// Sets the timer as close as possible to the given interval in milliseconds.
+/// The clock is 24-bits wide and specific timing is dependent on the driving
+/// clock. Increments of 10ms are most accurate and, in practice 466ms is the
+/// approximate maximum.
+pub unsafe fn set_timer(ms: u32) {
+    let systick : &mut SysTick = &mut *BASE_ADDR;
+
+    let tenms = intrinsics::volatile_load(&systick.calibration) & 0xffffff;
+    let reload = tenms * ms / 10;
+
+    intrinsics::volatile_store(&mut systick.value, 0);
+    intrinsics::volatile_store(&mut systick.reload, reload);
+}
+
+/// Returns the time left in approximate microseconds
+pub unsafe fn value() -> u32 {
+    let systick : &SysTick = &*BASE_ADDR;
+
+    let tenms = intrinsics::volatile_load(&systick.calibration) & 0xffffff;
+    let value = intrinsics::volatile_load(&systick.value) & 0xffffff;
+
+    value * 10000 / tenms
+}
+
+pub unsafe fn overflowed() -> bool {
+    let systick : &SysTick = &*BASE_ADDR;
+    intrinsics::volatile_load(&systick.control) & 1 << 16 != 0
+}
+
+pub unsafe fn reset() {
+    let systick : &mut SysTick = &mut *BASE_ADDR;
+
+    intrinsics::volatile_store(&mut systick.control, 0);
+    intrinsics::volatile_store(&mut systick.reload, 0);
+    intrinsics::volatile_store(&mut systick.value, 0);
+    intrinsics::volatile_store(&mut OVERFLOW_FIRED, 0);
+}
+
+#[inline(never)]
+pub unsafe fn enable(with_interrupt: bool) {
+    let systick : &mut SysTick = &mut *BASE_ADDR;
+
+    if with_interrupt {
+        intrinsics::volatile_store(&mut systick.control, 0b111);
+    } else {
+        intrinsics::volatile_store(&mut systick.control, 0b101);
+    }
+}
+
+#[no_mangle]
+pub static mut OVERFLOW_FIRED : usize = 0;
+
+pub unsafe fn overflow_fired() -> bool {
+    intrinsics::volatile_load(&OVERFLOW_FIRED) == 1
+}
+

--- a/src/process/process.rs
+++ b/src/process/process.rs
@@ -273,7 +273,7 @@ impl<'a> Process<'a> {
     }
 
     /// Context switch to the process.
-    pub unsafe fn switch_to_callback(&mut self, callback: Callback) {
+    pub unsafe fn push_callback(&mut self, callback: Callback) {
         // Fill in initial stack expected by SVC handler
         // Top minus 8 u32s for r0-r3, r12, lr, pc and xPSR
         let stack_bottom = (self.cur_stack as *mut usize).offset(-8);
@@ -289,7 +289,6 @@ impl<'a> Process<'a> {
         volatile_store(stack_bottom.offset(3), callback.r3);
 
         self.cur_stack = stack_bottom as *mut u8;
-        self.switch_to();
     }
 
     pub unsafe fn syscall_fired(&self) -> bool {


### PR DESCRIPTION
  * Implements systick for the cortex-m4

  * Limits each processes to 10ms at a time before yielding to other processes