### PR TITLE
Use MPU to isolate applications

### DIFF
--- a/src/arch/cortex-m4/Makefile.mk
+++ b/src/arch/cortex-m4/Makefile.mk
@@ -1,2 +1,7 @@
 $(BUILD_PLATFORM_DIR)/ctx_switch.o: $(SRC_DIR)arch/$(ARCH)/ctx_switch.S | $(BUILD_PLATFORM_DIR)
 	@$(TOOLCHAIN)as -mcpu=cortex-m4 -mthumb $^ -o $@
+
+$(BUILD_PLATFORM_DIR)/libcortexm4.rlib: $(call rwildcard,$(SRC_DIR)arch/cortex-m4,*.rs) $(BUILD_PLATFORM_DIR)/libcore.rlib | $(BUILD_PLATFORM_DIR)
+	@echo "Building $@"
+	@$(RUSTC) $(RUSTC_FLAGS) --out-dir $(BUILD_PLATFORM_DIR) $(SRC_DIR)arch/cortex-m4/lib.rs
+

--- a/src/arch/cortex-m4/ctx_switch.S
+++ b/src/arch/cortex-m4/ctx_switch.S
@@ -17,6 +17,11 @@
 SVC_Handler:
   cmp lr, #0xfffffff9
   bne to_kernel
+
+  /* Set thread mode to unprivileged */
+  mov r0, #1
+  msr CONTROL, r0
+
   movw lr, #0xfffd
   movt lr, #0xffff
   bx lr
@@ -24,6 +29,10 @@ to_kernel:
   ldr r0, =SYSCALL_FIRED
   mov r1, #1
   str r1, [r0, #0]
+
+  /* Set thread mode to privileged */
+  mov r0, #0
+  msr CONTROL, r0
 
   movw LR, #0xFFF9
   movt LR, #0xFFFF
@@ -90,6 +99,10 @@ _generic_isr_no_stacking:
     blx r0
     pop {lr}
 
+    /* Set thread mode to privileged */
+    mov r0, #0
+    msr CONTROL, r0
+
     movw LR, #0xFFF9
     movt LR, #0xFFFF
     bx lr
@@ -109,6 +122,11 @@ _systick_handler_no_stacking:
     ldr r0, =OVERFLOW_FIRED
     mov r1, #1
     str r1, [r0, #0]
+
+    /* Set thread mode to privileged */
+    mov r0, #0
+    msr CONTROL, r0
+
     movw LR, #0xFFF9
     movt LR, #0xFFFF
     bx lr

--- a/src/arch/cortex-m4/lib.rs
+++ b/src/arch/cortex-m4/lib.rs
@@ -1,0 +1,41 @@
+#![crate_name = "cortexm4"]
+#![crate_type = "rlib"]
+#![feature(core_intrinsics,const_fn)]
+#![no_std]
+
+pub mod mpu {
+
+    use core::intrinsics;
+
+    /// Constructor field is private to limit who can create a new MPU
+    pub struct MPU(());
+
+    impl MPU {
+
+        pub const unsafe fn new() -> MPU {
+            MPU(())
+        }
+
+        pub fn enable_mpu(&mut self) {
+            unsafe {
+                let ctrl = 0xE000ED94 as *mut usize;
+                intrinsics::volatile_store(ctrl, 0b101);
+            }
+        }
+
+        pub fn set_mpu(&mut self, region_num: usize,
+                              start_addr: usize, len: usize,
+                              execute: bool, ap: usize) {
+            unsafe {
+                let rbar = 0xE000ED9C as *mut usize;
+                let rasr = 0xE000EDA0 as *mut usize;
+
+                intrinsics::volatile_store(rbar, region_num | 1 << 4 | start_addr);
+                let xn = if execute { 0 } else { 1 };
+                intrinsics::volatile_store(rasr, 1 | len << 1 | ap << 24 | xn << 28);
+            }
+        }
+
+    }
+}
+

--- a/src/arch/cortex-m4/lib.rs
+++ b/src/arch/cortex-m4/lib.rs
@@ -3,39 +3,5 @@
 #![feature(core_intrinsics,const_fn)]
 #![no_std]
 
-pub mod mpu {
-
-    use core::intrinsics;
-
-    /// Constructor field is private to limit who can create a new MPU
-    pub struct MPU(());
-
-    impl MPU {
-
-        pub const unsafe fn new() -> MPU {
-            MPU(())
-        }
-
-        pub fn enable_mpu(&mut self) {
-            unsafe {
-                let ctrl = 0xE000ED94 as *mut usize;
-                intrinsics::volatile_store(ctrl, 0b101);
-            }
-        }
-
-        pub fn set_mpu(&mut self, region_num: usize,
-                              start_addr: usize, len: usize,
-                              execute: bool, ap: usize) {
-            unsafe {
-                let rbar = 0xE000ED9C as *mut usize;
-                let rasr = 0xE000EDA0 as *mut usize;
-
-                intrinsics::volatile_store(rbar, region_num | 1 << 4 | start_addr);
-                let xn = if execute { 0 } else { 1 };
-                intrinsics::volatile_store(rasr, 1 | len << 1 | ap << 24 | xn << 28);
-            }
-        }
-
-    }
-}
+pub mod mpu;
 

--- a/src/arch/cortex-m4/lib.rs
+++ b/src/arch/cortex-m4/lib.rs
@@ -1,7 +1,9 @@
 #![crate_name = "cortexm4"]
 #![crate_type = "rlib"]
-#![feature(core_intrinsics,const_fn)]
+#![feature(const_fn)]
 #![no_std]
+
+extern crate common;
 
 pub mod mpu;
 

--- a/src/arch/cortex-m4/mpu.rs
+++ b/src/arch/cortex-m4/mpu.rs
@@ -1,33 +1,106 @@
-use core::intrinsics;
+use common::volatile_cell::VolatileCell;
+
+/// Indicates whether the MPU is present and, if so, how many regions it
+/// supports.
+#[repr(C,packed)]
+pub struct MpuType {
+    /// Indicates whether the processor support unified (0) or separate
+    /// (1) instruction and data regions. Always reads 0 on the
+    /// Cortex-M4.
+    pub is_separate: VolatileCell<u8>,
+
+    /// The number of data regions supported. Always reads 8.
+    pub data_regions: VolatileCell<u8>,
+
+    /// The number of instructions regions supported. Always reads 0.
+    pub instruction_regions: VolatileCell<u8>,
+
+    _reserved: u8
+}
+
+#[repr(C,packed)]
+pub struct Registers {
+    pub mpu_type: VolatileCell<MpuType>,
+
+    /// The control register:
+    ///   * Enables the MPU (bit 0).
+    ///   * Enables MPU in hard-fault, non-maskable interrupt (NMI) and
+    ///     FAULTMASK escalated handlers (bit 1).
+    ///   * Enables the default memory map background region in privileged mode
+    ///     (bit 2).
+    pub control: VolatileCell<u32>,
+
+
+    /// Selects the region number (zero-indexed) referenced by the region base
+    /// address and region attribute and size registers.
+    pub region_number: VolatileCell<u32>,
+
+    /// Defines the base address of the currently selected MPU region.
+    ///
+    /// When writing, the first 3 bits select a new region if bit-4 is set.
+    ///
+    /// The top bits set the base address of the register, with the bottom 32-N
+    /// bits masked based on the region size (set in the region attribute and
+    /// size register) according to:
+    ///
+    ///   N = Log2(Region size in bytes)
+    ///
+    pub region_base_address: VolatileCell<u32>,
+
+    /// Defines the region size and memory attributes of the selected MPU
+    /// region. The bits are defined as in 4.5.5 of the Cortex-M4 user guide:
+    ///
+    /// Bit   | Name   | Function
+    /// ----- | ------ | -----------------------------
+    /// 0     | ENABLE | Region enable
+    /// 5:1   | SIZE   | Region size is 2^(SIZE+1) (minimum 3)
+    /// 7:6   |        | Unused
+    /// 15:8  | SRD    | Subregion disable bits (0 is enable, 1 is disable)
+    /// 16    | B      | Memory access attribute
+    /// 17    | C      | Memory access attribute
+    /// 18    | S      | Shareable
+    /// 21:19 | TEX    | Memory access attribute
+    /// 23:22 |        | Unused
+    /// 26:24 | AP     | Access permission field
+    /// 27    |        | Unused
+    /// 28    | XN     | Instruction access disable
+    pub region_attributes_and_size: VolatileCell<u32>
+}
+
+const MPU_BASE_ADDRESS: *const Registers = 0xE000ED90 as *const Registers;
 
 /// Constructor field is private to limit who can create a new MPU
-pub struct MPU(());
+pub struct MPU(*const Registers);
 
 impl MPU {
 
     pub const unsafe fn new() -> MPU {
-        MPU(())
+        MPU(MPU_BASE_ADDRESS)
     }
 
+    /// Enables MPU, allowing privileged software access to the default memory
+    /// map.
     pub fn enable_mpu(&mut self) {
-        unsafe {
-            let ctrl = 0xE000ED94 as *mut usize;
-            intrinsics::volatile_store(ctrl, 0b101);
-        }
+        let regs = unsafe { &*self.0 };
+        regs.control.set(0b101);
     }
 
-    pub fn set_mpu(&mut self, region_num: usize,
-                          start_addr: usize, len: usize,
-                          execute: bool, ap: usize) {
-        unsafe {
-            let rbar = 0xE000ED9C as *mut usize;
-            let rasr = 0xE000EDA0 as *mut usize;
-
-            intrinsics::volatile_store(rbar, region_num | 1 << 4 | start_addr);
-            let xn = if execute { 0 } else { 1 };
-            intrinsics::volatile_store(rasr, 1 | len << 1 | ap << 24 | xn << 28);
-        }
+    /// Sets the base address, size and access attributes of the given MPU
+    /// region number.
+    ///
+    /// `region_num`: an MPU region number 0-7
+    /// `start_addr`: the region base address. Lower bits will be masked
+    ///               according to the region size. 
+    /// `len`       : region size as a function 2^(len + 1)
+    /// `execute`   : whether to enable code execution from this region
+    /// `ap`        : access permissions as defined in Table 4.47 of the user
+    ///               guide.
+    pub fn set_mpu(&mut self, region_num: u32, start_addr: u32, len: u32,
+                  execute: bool, ap: u32) {
+        let regs = unsafe { &*self.0 };
+        regs.region_base_address.set(region_num | 1 << 4 | start_addr);
+        let xn = if execute { 0 } else { 1 };
+        regs.region_attributes_and_size.set(1 | len << 1 | ap << 24 | xn << 28);
     }
-
 }
 

--- a/src/arch/cortex-m4/mpu.rs
+++ b/src/arch/cortex-m4/mpu.rs
@@ -1,0 +1,33 @@
+use core::intrinsics;
+
+/// Constructor field is private to limit who can create a new MPU
+pub struct MPU(());
+
+impl MPU {
+
+    pub const unsafe fn new() -> MPU {
+        MPU(())
+    }
+
+    pub fn enable_mpu(&mut self) {
+        unsafe {
+            let ctrl = 0xE000ED94 as *mut usize;
+            intrinsics::volatile_store(ctrl, 0b101);
+        }
+    }
+
+    pub fn set_mpu(&mut self, region_num: usize,
+                          start_addr: usize, len: usize,
+                          execute: bool, ap: usize) {
+        unsafe {
+            let rbar = 0xE000ED9C as *mut usize;
+            let rasr = 0xE000EDA0 as *mut usize;
+
+            intrinsics::volatile_store(rbar, region_num | 1 << 4 | start_addr);
+            let xn = if execute { 0 } else { 1 };
+            intrinsics::volatile_store(rasr, 1 | len << 1 | ap << 24 | xn << 28);
+        }
+    }
+
+}
+

--- a/src/chips/sam4l/Makefile.mk
+++ b/src/chips/sam4l/Makefile.mk
@@ -14,7 +14,7 @@ LDFLAGS += -T$(LOADER) -lm
 OBJDUMP_FLAGS := --disassemble --source --disassembler-options=force-thumb
 OBJDUMP_FLAGS += -C --section-headers
 
-$(BUILD_PLATFORM_DIR)/libsam4l.rlib: $(call rwildcard,$(SRC_DIR)chips/sam4l,*.rs) $(BUILD_PLATFORM_DIR)/libcore.rlib $(BUILD_PLATFORM_DIR)/libhil.rlib $(BUILD_PLATFORM_DIR)/libcommon.rlib | $(BUILD_PLATFORM_DIR)
+$(BUILD_PLATFORM_DIR)/libsam4l.rlib: $(call rwildcard,$(SRC_DIR)chips/sam4l,*.rs) $(BUILD_PLATFORM_DIR)/libcortexm4.rlib $(BUILD_PLATFORM_DIR)/libcore.rlib $(BUILD_PLATFORM_DIR)/libhil.rlib $(BUILD_PLATFORM_DIR)/libcommon.rlib | $(BUILD_PLATFORM_DIR)
 	@echo "Building $@"
 	@$(RUSTC) $(RUSTC_FLAGS) --out-dir $(BUILD_PLATFORM_DIR) $(SRC_DIR)chips/sam4l/lib.rs
 

--- a/src/chips/sam4l/chip.rs
+++ b/src/chips/sam4l/chip.rs
@@ -1,5 +1,5 @@
-use core::intrinsics;
 use common::{RingBuffer,Queue};
+use cortexm4;
 use ast;
 //use adc;
 use dma;
@@ -9,7 +9,9 @@ use spi;
 use gpio;
 use i2c;
 
-pub struct Sam4l;
+pub struct Sam4l {
+    pub mpu: cortexm4::mpu::MPU
+}
 
 const IQ_SIZE: usize = 100;
 static mut IQ_BUF : [nvic::NvicIdx; IQ_SIZE] =
@@ -34,7 +36,9 @@ impl Sam4l {
         i2c::I2C2.set_dma(&dma::DMAChannels[4]);
         dma::DMAChannels[4].client = Some(&mut i2c::I2C2);
 
-        Sam4l
+        Sam4l {
+            mpu: cortexm4::mpu::MPU::new()
+        }
     }
 
     pub unsafe fn service_pending_interrupts(&mut self) {

--- a/src/chips/sam4l/lib.rs
+++ b/src/chips/sam4l/lib.rs
@@ -5,6 +5,7 @@
 
 #[macro_use]
 extern crate common;
+extern crate cortexm4;
 extern crate hil;
 extern crate process;
 

--- a/src/main/sched.rs
+++ b/src/main/sched.rs
@@ -19,6 +19,12 @@ pub unsafe fn do_process(platform: &mut Firestorm, process: &mut Process,
 
         match process.state {
             process::State::Running => {
+                let (data_start, data_len, text_start, text_len) =
+                        process.memory_regions();
+                // Data segment read/write/execute
+                platform.set_mpu(0, data_start, data_len, true, 0b011);
+                // Text segment read/execute (no write)
+                platform.set_mpu(1, text_start, text_len, true, 0b111);
                 systick::enable(true);
                 process.switch_to();
                 systick::enable(false);

--- a/src/main/sched.rs
+++ b/src/main/sched.rs
@@ -22,9 +22,9 @@ pub unsafe fn do_process(platform: &mut Firestorm, process: &mut Process,
                 let (data_start, data_len, text_start, text_len) =
                         process.memory_regions();
                 // Data segment read/write/execute
-                platform.set_mpu(0, data_start, data_len, true, 0b011);
+                platform.mpu().set_mpu(0, data_start, data_len, true, 0b011);
                 // Text segment read/execute (no write)
-                platform.set_mpu(1, text_start, text_len, true, 0b111);
+                platform.mpu().set_mpu(1, text_start, text_len, true, 0b111);
                 systick::enable(true);
                 process.switch_to();
                 systick::enable(false);

--- a/src/main/sched.rs
+++ b/src/main/sched.rs
@@ -22,9 +22,11 @@ pub unsafe fn do_process(platform: &mut Firestorm, process: &mut Process,
                 let (data_start, data_len, text_start, text_len) =
                         process.memory_regions();
                 // Data segment read/write/execute
-                platform.mpu().set_mpu(0, data_start, data_len, true, 0b011);
+                platform.mpu().set_mpu(
+                    0, data_start as u32, data_len as u32, true, 0b011);
                 // Text segment read/execute (no write)
-                platform.mpu().set_mpu(1, text_start, text_len, true, 0b111);
+                platform.mpu().set_mpu(
+                    1, text_start as u32, text_len as u32, true, 0b111);
                 systick::enable(true);
                 process.switch_to();
                 systick::enable(false);

--- a/src/platform/nrf_pca10001/lib.rs
+++ b/src/platform/nrf_pca10001/lib.rs
@@ -17,7 +17,7 @@ pub struct Firestorm {
 pub struct DummyMPU;
 
 impl DummyMPU {
-    pub fn set_mpu(&mut self, _: usize, _: usize, _: usize, _: bool, _: usize) {
+    pub fn set_mpu(&mut self, _: u32, _: u32, _: u32, _: bool, _: u32) {
     }
 }
 

--- a/src/platform/nrf_pca10001/lib.rs
+++ b/src/platform/nrf_pca10001/lib.rs
@@ -14,6 +14,13 @@ pub struct Firestorm {
     gpio: &'static drivers::gpio::GPIO<'static, nrf51822::gpio::GPIOPin>,
 }
 
+pub struct DummyMPU;
+
+impl DummyMPU {
+    pub fn set_mpu(&mut self, _: usize, _: usize, _: usize, _: bool, _: usize) {
+    }
+}
+
 impl Firestorm {
     pub unsafe fn service_pending_interrupts(&mut self) {
     }
@@ -22,6 +29,10 @@ impl Firestorm {
         // FIXME: The wfi call from main() blocks forever if no interrupts are generated. For now,
         // pretend we have interrupts to avoid blocking.
         true
+    }
+
+    pub fn mpu(&mut self) -> DummyMPU {
+        DummyMPU
     }
 
     #[inline(never)]

--- a/src/platform/storm/lib.rs
+++ b/src/platform/storm/lib.rs
@@ -52,6 +52,24 @@ impl Firestorm {
         self.chip.has_pending_interrupts()
     }
 
+    pub unsafe fn enable_mpu(&mut self) {
+        use core::intrinsics;
+        let ctrl = 0xE000ED94 as *mut usize;
+        intrinsics::volatile_store(ctrl, 0b101);
+    }
+
+    pub unsafe fn set_mpu(&mut self, region_num: usize,
+                          start_addr: usize, len: usize,
+                          execute: bool, ap: usize) {
+        use core::intrinsics;
+        let rbar = 0xE000ED9C as *mut usize;
+        let rasr = 0xE000EDA0 as *mut usize;
+
+        intrinsics::volatile_store(rbar, region_num | 1 << 4 | start_addr);
+        let xn = if execute { 0 } else { 1 };
+        intrinsics::volatile_store(rasr, 1 | len << 1 | ap << 24 | xn << 28);
+    }
+
     pub fn with_driver<F, R>(&mut self, driver_num: usize, f: F) -> R where
             F: FnOnce(Option<&hil::Driver>) -> R {
 
@@ -414,6 +432,9 @@ pub unsafe fn init<'a>() -> &'a mut Firestorm {
 
     firestorm.console.initialize();
     firestorm.nrf51822.initialize();
+
+    firestorm.enable_mpu();
+
     firestorm
 }
 

--- a/tools/elf2tbf/src/main.rs
+++ b/tools/elf2tbf/src/main.rs
@@ -115,7 +115,13 @@ fn do_work(input: &elf::File, output: &mut Write) {
         text.data.len() +
         got.data.len() +
         data.data.len()) as u32;
-    let pad = (4 - (total_len % 4)) % 4;
+
+    let pad = if total_len.count_ones() > 1 {
+        let power2len = 1 << (32 - total_len.leading_zeros());
+        power2len - total_len
+    } else {
+        0
+    };
     total_len = total_len + pad;
 
     let total_len_buf : &[u8; 4] = unsafe {


### PR DESCRIPTION
We have a new crate for the cortex-m4, containing Rust code that's general to the cortex (i.e. not sam4l specific). This patch adds the MPU implementation for the m4 to that crate (the systick belongs there too, but that's for another PR).

This patch sets up an MPU with two regions:

  * A region for the application code section, marked read and execute (not write).

  * A region for the application memory marked read/write/execute.

The default region is disabled for unprivileged code, which means by default unprivileged code cannot access anything not explicitly enabled by another region.

TODO:

  -  [x] Stub for NRF

  - [x] Cleanup MPU implementation

  - [x] Documentation