### PR TITLE
Use same units in systick's set_timer and value

### DIFF
--- a/src/main/sched.rs
+++ b/src/main/sched.rs
@@ -8,7 +8,7 @@ use syscall;
 pub unsafe fn do_process(platform: &mut Firestorm, process: &mut Process,
                   appid: AppId) {
     systick::reset();
-    systick::set_timer(10);
+    systick::set_timer(10000);
     systick::enable(true);
 
     loop {

--- a/src/platform/storm/systick.rs
+++ b/src/platform/storm/systick.rs
@@ -9,15 +9,15 @@ struct SysTick {
 
 const BASE_ADDR : *mut SysTick = 0xE000E010 as *mut SysTick;
 
-/// Sets the timer as close as possible to the given interval in milliseconds.
+/// Sets the timer as close as possible to the given interval in microseconds.
 /// The clock is 24-bits wide and specific timing is dependent on the driving
 /// clock. Increments of 10ms are most accurate and, in practice 466ms is the
 /// approximate maximum.
-pub unsafe fn set_timer(ms: u32) {
+pub unsafe fn set_timer(us: u32) {
     let systick : &mut SysTick = &mut *BASE_ADDR;
 
     let tenms = intrinsics::volatile_load(&systick.calibration) & 0xffffff;
-    let reload = tenms * ms / 10;
+    let reload = tenms * us / 10000;
 
     intrinsics::volatile_store(&mut systick.value, 0);
     intrinsics::volatile_store(&mut systick.reload, reload);


### PR DESCRIPTION
There is no good reason that `set_timer` and `value` didn't agree on units, just makes things needlessly complicated.

Now, both treat the value (argument to `set_timer` and return value from `value()`) as microseconds. This also fixes issues with the dummy systick for the nrf51822

Tested by merging into one of the nrf51822 branches, result is here: https://github.com/alevy/tock/commit/655af45f72b56fa063524ac78ed6a9fd204932ed