### PR TITLE
Don't loose app buffer in console when writing from multiple apps

### DIFF
--- a/src/drivers/console.rs
+++ b/src/drivers/console.rs
@@ -138,8 +138,8 @@ impl<'a, U: UART> Client for Console<'a, U> {
         for cntr in self.apps.iter() {
             let started_tx = cntr.enter(|app, _| {
                 if app.pending_write {
-                    app.write_buffer.take().map(|slice| {
-                        app.pending_write = false;
+                    app.pending_write = false;
+                    app.write_buffer.as_ref().map(|slice| {
                         self.buffer.take().map(|buffer| {
                             for (i, c) in slice.as_ref().iter().enumerate() {
                                 if buffer.len() <= i {


### PR DESCRIPTION
A subtle bug in the console driver resulted in losing all future console writes from all but the second app to write concurrently to the console.