### PR TITLE
Changed the static_init macro to take a size argument

### DIFF
--- a/src/platform/nrf_pca10001/lib.rs
+++ b/src/platform/nrf_pca10001/lib.rs
@@ -46,70 +46,76 @@ impl Firestorm {
 }
 
 macro_rules! static_init {
-   ($V:ident : $T:ty = $e:expr) => {
-        let $V : &mut $T = {
-            // Waiting out for size_of to be available at compile-time to avoid
-            // hardcoding an abitrary large size...
-            static mut BUF : [u8; 1024] = [0; 1024];
+    ($V:ident : $T:ty = $e:expr, $size:expr) => {
+        // Ideally we could use mem::size_of<$T> here instead of $size, however
+        // that is not currently possible in rust. Instead we write the size as
+        // a constant in the code and use compile-time verification to see that
+        // we got it right
+        let $V : &'static mut $T = {
+            use core::{mem, ptr};
+            // This is our compile-time assertion. The optimizer should be able
+            // to remove it from the generated code.
+            let assert_buf: [u8; $size] = mem::uninitialized();
+            let assert_val: $T = mem::transmute(assert_buf);
+            mem::forget(assert_val);
+
+            // Statically allocate a read-write buffer for the value, write our
+            // initial value into it (without dropping the initial zeros) and
+            // return a reference to it.
+            static mut BUF: [u8; $size] = [0; $size];
             let mut tmp : &mut $T = mem::transmute(&mut BUF);
-            *tmp = $e;
+            ptr::write(tmp as *mut $T, $e);
             tmp
         };
-   }
+    }
 }
 
-pub unsafe fn init<'a>() -> &'a mut Firestorm {
-    use core::mem;
+pub unsafe fn init() -> &'static mut Firestorm {
     use nrf51822::gpio::PA;
-
-    static mut FIRESTORM_BUF : [u8; 1024] = [0; 1024];
 
     //XXX: this should be pared down to only give externally usable pins to the
     //  user gpio driver
-    static_init!(gpio_pins : [&'static nrf51822::gpio::GPIOPin; 32] = [
-            &nrf51822::gpio::PA[ 0],
-            &nrf51822::gpio::PA[ 1],
-            &nrf51822::gpio::PA[ 2],
-            &nrf51822::gpio::PA[ 3],
-            &nrf51822::gpio::PA[ 4],
-            &nrf51822::gpio::PA[ 5],
-            &nrf51822::gpio::PA[ 6],
-            &nrf51822::gpio::PA[ 7],
-            &nrf51822::gpio::PA[ 8],
-            &nrf51822::gpio::PA[ 9],
-            &nrf51822::gpio::PA[10],
-            &nrf51822::gpio::PA[11],
-            &nrf51822::gpio::PA[12],
-            &nrf51822::gpio::PA[13],
-            &nrf51822::gpio::PA[14],
-            &nrf51822::gpio::PA[15],
-            &nrf51822::gpio::PA[16],
-            &nrf51822::gpio::PA[17],
-            &nrf51822::gpio::PA[18],
-            &nrf51822::gpio::PA[19],
-            &nrf51822::gpio::PA[20],
-            &nrf51822::gpio::PA[21],
-            &nrf51822::gpio::PA[22],
-            &nrf51822::gpio::PA[23],
-            &nrf51822::gpio::PA[24],
-            &nrf51822::gpio::PA[25],
-            &nrf51822::gpio::PA[26],
-            &nrf51822::gpio::PA[27],
-            &nrf51822::gpio::PA[28],
-            &nrf51822::gpio::PA[29],
-            &nrf51822::gpio::PA[30],
-            &nrf51822::gpio::PA[31],
-            ]);
-    static_init!(gpio : drivers::gpio::GPIO<'static, nrf51822::gpio::GPIOPin> =
-                 drivers::gpio::GPIO::new(gpio_pins));
+    static_init!(gpio_pins: [&'static nrf51822::gpio::GPIOPin; 32] = [
+        &nrf51822::gpio::PA[0],
+        &nrf51822::gpio::PA[1],
+        &nrf51822::gpio::PA[2],
+        &nrf51822::gpio::PA[3],
+        &nrf51822::gpio::PA[4],
+        &nrf51822::gpio::PA[5],
+        &nrf51822::gpio::PA[6],
+        &nrf51822::gpio::PA[7],
+        &nrf51822::gpio::PA[8],
+        &nrf51822::gpio::PA[9],
+        &nrf51822::gpio::PA[10],
+        &nrf51822::gpio::PA[11],
+        &nrf51822::gpio::PA[12],
+        &nrf51822::gpio::PA[13],
+        &nrf51822::gpio::PA[14],
+        &nrf51822::gpio::PA[15],
+        &nrf51822::gpio::PA[16],
+        &nrf51822::gpio::PA[17],
+        &nrf51822::gpio::PA[18],
+        &nrf51822::gpio::PA[19],
+        &nrf51822::gpio::PA[20],
+        &nrf51822::gpio::PA[21],
+        &nrf51822::gpio::PA[22],
+        &nrf51822::gpio::PA[23],
+        &nrf51822::gpio::PA[24],
+        &nrf51822::gpio::PA[25],
+        &nrf51822::gpio::PA[26],
+        &nrf51822::gpio::PA[27],
+        &nrf51822::gpio::PA[28],
+        &nrf51822::gpio::PA[29],
+        &nrf51822::gpio::PA[30],
+        &nrf51822::gpio::PA[31]
+    ], 4 * 32);
+    static_init!(gpio: drivers::gpio::GPIO<'static, nrf51822::gpio::GPIOPin> =
+                     drivers::gpio::GPIO::new(gpio_pins), 20);
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);
     }
 
-    let firestorm : &'static mut Firestorm = mem::transmute(&mut FIRESTORM_BUF);
-    *firestorm = Firestorm {
-        gpio: gpio,
-    };
+    static_init!(firestorm: Firestorm = Firestorm { gpio: gpio }, 4);
 
     firestorm
 }
@@ -141,4 +147,3 @@ pub unsafe extern fn rust_begin_unwind(_args: &Arguments,
         }
     }
 }
-

--- a/src/platform/storm/lib.rs
+++ b/src/platform/storm/lib.rs
@@ -74,16 +74,28 @@ impl Firestorm {
 }
 
 macro_rules! static_init {
-   ($V:ident : $T:ty = $e:expr) => {
-        let $V : &mut $T = {
-            // Waiting out for size_of to be available at compile-time to avoid
-            // hardcoding an abitrary large size...
-            static mut BUF : [u8; 1024] = [0; 1024];
+    ($V:ident : $T:ty = $e:expr, $size:expr) => {
+        // Ideally we could use mem::size_of<$T> here instead of $size, however
+        // that is not currently possible in rust. Instead we write the size as
+        // a constant in the code and use compile-time verification to see that
+        // we got it right
+        let $V : &'static mut $T = {
+            use core::{mem, ptr};
+            // This is our compile-time assertion. The optimizer should be able
+            // to remove it from the generated code.
+            let assert_buf: [u8; $size] = mem::uninitialized();
+            let assert_val: $T = mem::transmute(assert_buf);
+            mem::forget(assert_val);
+
+            // Statically allocate a read-write buffer for the value, write our
+            // initial value into it (without dropping the initial zeros) and
+            // return a reference to it.
+            static mut BUF: [u8; $size] = [0; $size];
             let mut tmp : &mut $T = mem::transmute(&mut BUF);
-            *tmp = $e;
+            ptr::write(tmp as *mut $T, $e);
             tmp
         };
-   }
+    }
 }
 
 unsafe fn set_pin_primary_functions() {
@@ -268,9 +280,7 @@ unsafe fn set_pin_primary_functions() {
     PC[10].configure(None);
 }
 
-pub unsafe fn init<'a>() -> &'a mut Firestorm {
-    use core::mem;
-
+pub unsafe fn init() -> &'static mut Firestorm {
     // Workaround for SB.02 hardware bug
     // TODO(alevy): Get rid of this when we think SB.02 are out of circulation
     sam4l::gpio::PA[14].enable();
@@ -285,97 +295,114 @@ pub unsafe fn init<'a>() -> &'a mut Firestorm {
 
     set_pin_primary_functions();
 
-    static_init!(console : drivers::console::Console<sam4l::usart::USART> =
-                    drivers::console::Console::new(&sam4l::usart::USART3,
-                                       &mut drivers::console::WRITE_BUF,
-                                       process::Container::create()));
+    static_init!(console: drivers::console::Console<sam4l::usart::USART> =
+                     drivers::console::Console::new(&sam4l::usart::USART3,
+                                                    &mut drivers::console::WRITE_BUF,
+                                                    process::Container::create()),
+                 24);
     sam4l::usart::USART3.set_client(console);
 
     // Create the Nrf51822Serialization driver for passing BLE commands
     // over UART to the nRF51822 radio.
-    static_init!(nrf_serialization : drivers::nrf51822_serialization::Nrf51822Serialization<sam4l::usart::USART> =
-                    drivers::nrf51822_serialization::Nrf51822Serialization::new(&sam4l::usart::USART2,
-                                                                                &mut drivers::nrf51822_serialization::WRITE_BUF));
+    static_init!(
+        nrf_serialization: drivers::nrf51822_serialization::Nrf51822Serialization<sam4l::usart::USART> =
+            drivers::nrf51822_serialization::Nrf51822Serialization::new(
+                &sam4l::usart::USART2,
+                &mut drivers::nrf51822_serialization::WRITE_BUF
+            ), 124);
     sam4l::usart::USART2.set_client(nrf_serialization);
 
     let ast = &sam4l::ast::AST;
 
-    static_init!(mux_alarm : MuxAlarm<'static, sam4l::ast::Ast> =
-                    MuxAlarm::new(&sam4l::ast::AST));
+    static_init!(mux_alarm: MuxAlarm<'static, sam4l::ast::Ast> = MuxAlarm::new(&sam4l::ast::AST),
+                 16);
     ast.configure(mux_alarm);
 
-    static_init!(mux_i2c : MuxI2C<'static> = MuxI2C::new(&sam4l::i2c::I2C2));
+    static_init!(mux_i2c: MuxI2C<'static> = MuxI2C::new(&sam4l::i2c::I2C2),
+                 20);
     sam4l::i2c::I2C2.set_client(mux_i2c);
 
     // Configure the TMP006. Device address 0x40
-    static_init!(tmp006_i2c : drivers::virtual_i2c::I2CDevice =
-                 drivers::virtual_i2c::I2CDevice::new(mux_i2c, 0x40));
-    static_init!(tmp006 : drivers::tmp006::TMP006<'static> =
-                    drivers::tmp006::TMP006::new(tmp006_i2c, &sam4l::gpio::PA[9],
-                                                 &mut drivers::tmp006::BUFFER));
+    static_init!(tmp006_i2c: drivers::virtual_i2c::I2CDevice =
+                     drivers::virtual_i2c::I2CDevice::new(mux_i2c, 0x40),
+                 32);
+    static_init!(tmp006: drivers::tmp006::TMP006<'static> =
+                     drivers::tmp006::TMP006::new(tmp006_i2c,
+                                                  &sam4l::gpio::PA[9],
+                                                  &mut drivers::tmp006::BUFFER),
+                 52);
     tmp006_i2c.set_client(tmp006);
     sam4l::gpio::PA[9].set_client(tmp006);
 
     // Configure the ISL29035, device address 0x44
-    static_init!(isl29035_i2c : drivers::virtual_i2c::I2CDevice =
-                 drivers::virtual_i2c::I2CDevice::new(mux_i2c, 0x44));
-    static_init!(isl29035 : drivers::isl29035::Isl29035<'static> =
-                 drivers::isl29035::Isl29035::new(isl29035_i2c,
-                                                  &mut drivers::isl29035::BUF));
+    static_init!(isl29035_i2c: drivers::virtual_i2c::I2CDevice =
+                     drivers::virtual_i2c::I2CDevice::new(mux_i2c, 0x44),
+                 32);
+    static_init!(isl29035: drivers::isl29035::Isl29035<'static> =
+                     drivers::isl29035::Isl29035::new(isl29035_i2c, &mut drivers::isl29035::BUF),
+                 36);
     isl29035_i2c.set_client(isl29035);
 
-    static_init!(virtual_alarm1 : VirtualMuxAlarm<'static, sam4l::ast::Ast> =
-                    VirtualMuxAlarm::new(mux_alarm));
-    static_init!(timer : drivers::timer::TimerDriver<'static,
-                                VirtualMuxAlarm<'static, sam4l::ast::Ast>> =
-                            drivers::timer::TimerDriver::new(virtual_alarm1,
-                                            process::Container::create()));
+    static_init!(virtual_alarm1: VirtualMuxAlarm<'static, sam4l::ast::Ast> =
+                     VirtualMuxAlarm::new(mux_alarm),
+                 24);
+    static_init!(timer: drivers::timer::TimerDriver<'static,
+                                                    VirtualMuxAlarm<'static, sam4l::ast::Ast>> =
+                     drivers::timer::TimerDriver::new(virtual_alarm1,
+                                                      process::Container::create()),
+                 12);
     virtual_alarm1.set_client(timer);
 
     // Initialize and enable SPI HAL
     static_init!(spi: drivers::spi::Spi<'static, sam4l::spi::Spi> =
-                      drivers::spi::Spi::new(&mut sam4l::spi::SPI));
+                     drivers::spi::Spi::new(&mut sam4l::spi::SPI),
+                 140);
     spi.config_buffers(&mut spi_read_buf, &mut spi_write_buf);
     sam4l::spi::SPI.init(spi as &hil::spi_master::SpiCallback);
 
     // set GPIO driver controlling remaining GPIO pins
-    static_init!(gpio_pins : [&'static sam4l::gpio::GPIOPin; 12] = [
-            &sam4l::gpio::PC[10], // LED_0
-            &sam4l::gpio::PA[16], // P2
-            &sam4l::gpio::PA[12], // P3
-            &sam4l::gpio::PC[ 9], // P4
-            &sam4l::gpio::PA[10], // P5
-            &sam4l::gpio::PA[11], // P6
-            &sam4l::gpio::PA[19], // P7
-            &sam4l::gpio::PA[13], // P8
-            &sam4l::gpio::PA[17], // STORM_INT (nRF51822)
-            &sam4l::gpio::PC[14], // RSLP (RF233 sleep line)
-            &sam4l::gpio::PC[15], // RRST (RF233 reset line)
-            &sam4l::gpio::PA[20], // RIRQ (RF233 interrupt)
-            ]);
-    static_init!(gpio : drivers::gpio::GPIO<'static, sam4l::gpio::GPIOPin> =
-                 drivers::gpio::GPIO::new(gpio_pins));
+    static_init!(gpio_pins: [&'static sam4l::gpio::GPIOPin; 12] =
+                 [
+                     &sam4l::gpio::PC[10], // LED_0
+                     &sam4l::gpio::PA[16], // P2
+                     &sam4l::gpio::PA[12], // P3
+                     &sam4l::gpio::PC[9], // P4
+                     &sam4l::gpio::PA[10], // P5
+                     &sam4l::gpio::PA[11], // P6
+                     &sam4l::gpio::PA[19], // P7
+                     &sam4l::gpio::PA[13], // P8
+                     &sam4l::gpio::PA[17], /* STORM_INT (nRF51822) */
+                     &sam4l::gpio::PC[14], /* RSLP (RF233 sleep line) */
+                     &sam4l::gpio::PC[15], /* RRST (RF233 reset line) */
+                     &sam4l::gpio::PA[20], /* RIRQ (RF233 interrupt) */
+                 ],
+                 12 * 4
+    );
+    static_init!(gpio: drivers::gpio::GPIO<'static, sam4l::gpio::GPIOPin> =
+                     drivers::gpio::GPIO::new(gpio_pins),
+                 20);
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);
     }
 
-    /* Note: The following GPIO pins aren't assigned to anything:
-    &sam4l::gpio::PC[19] // !ENSEN
-    &sam4l::gpio::PC[13] // ACC_INT1
-    &sam4l::gpio::PC[20] // ACC_INT2
-    &sam4l::gpio::PA[14] // No Connection
-    */
+    // Note: The following GPIO pins aren't assigned to anything:
+    // &sam4l::gpio::PC[19] // !ENSEN
+    // &sam4l::gpio::PC[13] // ACC_INT1
+    // &sam4l::gpio::PC[20] // ACC_INT2
+    // &sam4l::gpio::PA[14] // No Connection
+    //
 
-    static_init!(firestorm : Firestorm = Firestorm {
-        chip: sam4l::chip::Sam4l::new(),
-        console: console,
-        gpio: gpio,
-        timer: timer,
-        tmp006: tmp006,
-        isl29035: isl29035,
-        spi: spi,
-        nrf51822: nrf_serialization,
-    });
+    static_init!(firestorm: Firestorm = Firestorm {
+                     chip: sam4l::chip::Sam4l::new(),
+                     console: console,
+                     gpio: gpio,
+                     timer: timer,
+                     tmp006: tmp006,
+                     isl29035: isl29035,
+                     spi: spi,
+                     nrf51822: nrf_serialization,
+                 },
+                 32);
 
     sam4l::usart::USART3.configure(sam4l::usart::USARTParams {
         //client: &console,


### PR DESCRIPTION
- Changed `static_init!()` to take a size argument. This size argument should ideally be inferred, but for now we write it manually and do a compile-time verification that it is correct.
- Changed the type signature from `pub unsafe fn init<'a>() -> &'a mut Firestorm ` to `pub unsafe fn init() -> &'static mut Firestorm`, since the first is just a more convuluted way of writing the second.