### PR TITLE
Platform, not Firestorm

### DIFF
--- a/src/main/sched.rs
+++ b/src/main/sched.rs
@@ -1,11 +1,11 @@
-use platform::{Firestorm,systick};
+use platform::{Platform,systick};
 use process;
 use process::Process;
 use process::{AppSlice,AppId};
 use common::Queue;
 use syscall;
 
-pub unsafe fn do_process(platform: &mut Firestorm, process: &mut Process,
+pub unsafe fn do_process(platform: &mut Platform, process: &mut Process,
                   appid: AppId) {
     systick::reset();
     systick::set_timer(10000);

--- a/src/platform/nrf_pca10001/lib.rs
+++ b/src/platform/nrf_pca10001/lib.rs
@@ -10,7 +10,7 @@ extern crate support;
 
 pub mod systick;
 
-pub struct Firestorm {
+pub struct Platform {
     gpio: &'static drivers::gpio::GPIO<'static, nrf51822::gpio::GPIOPin>,
 }
 
@@ -21,7 +21,7 @@ impl DummyMPU {
     }
 }
 
-impl Firestorm {
+impl Platform {
     pub unsafe fn service_pending_interrupts(&mut self) {
     }
 
@@ -58,11 +58,11 @@ macro_rules! static_init {
    }
 }
 
-pub unsafe fn init<'a>() -> &'a mut Firestorm {
+pub unsafe fn init<'a>() -> &'a mut Platform {
     use core::mem;
     use nrf51822::gpio::PA;
 
-    static mut FIRESTORM_BUF : [u8; 1024] = [0; 1024];
+    static mut PLATFORM_BUF : [u8; 1024] = [0; 1024];
 
     //XXX: this should be pared down to only give externally usable pins to the
     //  user gpio driver
@@ -106,12 +106,12 @@ pub unsafe fn init<'a>() -> &'a mut Firestorm {
         pin.set_client(gpio);
     }
 
-    let firestorm : &'static mut Firestorm = mem::transmute(&mut FIRESTORM_BUF);
-    *firestorm = Firestorm {
+    let platform : &'static mut Platform = mem::transmute(&mut PLATFORM_BUF);
+    *platform = Platform {
         gpio: gpio,
     };
 
-    firestorm
+    platform
 }
 
 use core::fmt::Arguments;

--- a/src/platform/storm/lib.rs
+++ b/src/platform/storm/lib.rs
@@ -32,7 +32,7 @@ pub mod systick;
 static mut spi_read_buf:  [u8; 64] = [0; 64];
 static mut spi_write_buf: [u8; 64] = [0; 64];
 
-pub struct Firestorm {
+pub struct Platform {
     chip: sam4l::chip::Sam4l,
     console: &'static drivers::console::Console<'static, sam4l::usart::USART>,
     gpio: &'static drivers::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
@@ -44,7 +44,7 @@ pub struct Firestorm {
     nrf51822: &'static drivers::nrf51822_serialization::Nrf51822Serialization<'static, sam4l::usart::USART>,
 }
 
-impl Firestorm {
+impl Platform {
     pub unsafe fn service_pending_interrupts(&mut self) {
         self.chip.service_pending_interrupts()
     }
@@ -268,7 +268,7 @@ unsafe fn set_pin_primary_functions() {
     PC[10].configure(None);
 }
 
-pub unsafe fn init<'a>() -> &'a mut Firestorm {
+pub unsafe fn init<'a>() -> &'a mut Platform {
     use core::mem;
 
     // Workaround for SB.02 hardware bug
@@ -366,7 +366,7 @@ pub unsafe fn init<'a>() -> &'a mut Firestorm {
     &sam4l::gpio::PA[14] // No Connection
     */
 
-    static_init!(firestorm : Firestorm = Firestorm {
+    static_init!(firestorm : Platform = Platform {
         chip: sam4l::chip::Sam4l::new(),
         console: console,
         gpio: gpio,


### PR DESCRIPTION
Changes the platform structure name from Firestorm to Platform.