### PR TITLE
Homebrew default arm-none-eabi is now 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq gcc-arm-embedded; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap px4/px4; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc-arm-none-eabi-49; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc-arm-none-eabi; fi
 
 script:
   - make -C apps/blink TOCK_PLATFORM=storm


### PR DESCRIPTION
Updates travis configuration to pull proper version of arm-none-eabi on OS X