### PR TITLE
Move process image size to LoadInfo header

### DIFF
--- a/src/main/main.rs
+++ b/src/main/main.rs
@@ -15,8 +15,6 @@ pub mod syscall;
 extern {
     /// Beginning of the ROM region containing app images.
     static _sapps : u8;
-    /// End of the ROM region containing app images.
-    static _eapps : u8;
 }
 
 #[no_mangle]
@@ -29,7 +27,7 @@ pub extern fn main() {
 
 
     let processes = unsafe {
-        process::process::load_processes(&_sapps, &_eapps)
+        process::process::load_processes(&_sapps)
     };
 
     loop {

--- a/src/main/main.rs
+++ b/src/main/main.rs
@@ -12,9 +12,11 @@ mod sched;
 
 pub mod syscall;
 
-#[allow(improper_ctypes)]
 extern {
-    static _sapps : usize;
+    /// Beginning of the ROM region containing app images.
+    static _sapps : u8;
+    /// End of the ROM region containing app images.
+    static _eapps : u8;
 }
 
 #[no_mangle]
@@ -27,7 +29,7 @@ pub extern fn main() {
 
 
     let processes = unsafe {
-        process::process::load_processes(&_sapps)
+        process::process::load_processes(&_sapps, &_eapps)
     };
 
     loop {


### PR DESCRIPTION
This removes a lot of hapzard offsetting from the process loader. Also clean up various part of the process loader.