### PR TITLE
Remove dependency on NUM_PROCS in driver

### DIFF
--- a/src/drivers/nrf51822_serialization.rs
+++ b/src/drivers/nrf51822_serialization.rs
@@ -1,5 +1,5 @@
 use common::take_cell::TakeCell;
-use process::{AppId, Callback, AppSlice, Shared, NUM_PROCS};
+use process::{AppId, Callback, AppSlice, Shared};
 use hil::Driver;
 use hil::uart::{UART, Client};
 
@@ -24,7 +24,7 @@ pub static mut WRITE_BUF : [u8; 256] = [0; 256];
 // application.
 pub struct Nrf51822Serialization<'a, U: UART + 'a> {
     uart: &'a U,
-    apps: [TakeCell<App>; NUM_PROCS],
+    app: TakeCell<App>,
     buffer: TakeCell<&'static mut [u8]>
 }
 
@@ -32,7 +32,7 @@ impl<'a, U: UART> Nrf51822Serialization<'a, U> {
     pub fn new(uart: &'a U, buffer: &'static mut [u8]) -> Nrf51822Serialization<'a, U> {
         Nrf51822Serialization {
             uart: uart,
-            apps: [TakeCell::empty(), TakeCell::empty()],
+            app: TakeCell::empty(),
             buffer: TakeCell::new(buffer)
         }
     }
@@ -51,13 +51,12 @@ impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
     /// allow_type: 1 - Provide an TX buffer
     ///
     fn allow(&self,
-             appid: AppId,
+             _appid: AppId,
              allow_type: usize,
              slice: AppSlice<Shared, u8>) -> isize {
-        let app = appid.idx();
         match allow_type {
             0 => {
-                let resapp = match self.apps[app].take() {
+                let resapp = match self.app.take() {
                     Some(mut app) => {
                         app.rx_buffer = Some(slice);
                         app.rx_recv_so_far = 0;
@@ -72,11 +71,11 @@ impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
                         rx_recv_total:  0
                     }
                 };
-                self.apps[app].replace(resapp);
+                self.app.replace(resapp);
                 0
             },
             1 => {
-                let resapp = match self.apps[app].take() {
+                let resapp = match self.app.take() {
                     Some(mut app) => {
                         app.tx_buffer = Some(slice);
                         app
@@ -89,7 +88,7 @@ impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
                         rx_recv_total:  0
                     }
                 };
-                self.apps[app].replace(resapp);
+                self.app.replace(resapp);
                 0
             },
             _ => -1
@@ -105,10 +104,9 @@ impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
     ///
     #[inline(never)]
     fn subscribe(&self, subscribe_type: usize, callback: Callback) -> isize {
-        let app = callback.app_id().idx();
         match subscribe_type {
             0 => {
-                let resapp = match self.apps[app].take() {
+                let resapp = match self.app.take() {
                     Some(mut app) => {
                         app.callback = Some(callback);
                         app
@@ -121,7 +119,7 @@ impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
                         rx_recv_total:  0
                     }
                 };
-                self.apps[app].replace(resapp);
+                self.app.replace(resapp);
                 0
             },
             _ => -1
@@ -139,7 +137,7 @@ impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
                 // On a TX, send the first byte of the TX buffer.
                 // TODO(bradjc): Need to match this to the correct app!
                 //               Can't just use 0!
-                let result = self.apps[0].map(|appst| {
+                let result = self.app.map(|appst| {
 
                     match appst.tx_buffer.take() {
                         Some(slice) => {
@@ -162,13 +160,6 @@ impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
     }
 }
 
-fn each_some<'a, T, I, F>(lst: I, mut f: F)
-        where T: 'a, I: Iterator<Item=&'a TakeCell<T>>, F: FnMut(&mut T) {
-    for item in lst {
-        item.map(|i| f(i));
-    }
-}
-
 // Callbacks from the underlying UART driver.
 impl<'a, U: UART> Client for Nrf51822Serialization<'a, U> {
 
@@ -177,7 +168,7 @@ impl<'a, U: UART> Client for Nrf51822Serialization<'a, U> {
         self.buffer.replace(buffer);
         // TODO(bradjc): Need to match this to the correct app!
         //               Can't just use 0!
-        self.apps[0].map(|appst| {
+        self.app.map(|appst| {
             // Call the callback after TX has finished
             appst.callback.as_mut().map(|mut cb| {
                 cb.schedule(1, 0, 0);
@@ -187,7 +178,7 @@ impl<'a, U: UART> Client for Nrf51822Serialization<'a, U> {
 
     // Called when a byte is received on the UART
     fn read_done(&self, c: u8) {
-        each_some(self.apps.iter(), |appst| {
+        self.app.map(|appst| {
             // The PHY layer of the serialization protocol calls for a 16 byte
             // length field to start the packet. After we receive the first two
             // bytes we then know how long to wait for to get the rest of

--- a/src/drivers/spi.rs
+++ b/src/drivers/spi.rs
@@ -1,6 +1,6 @@
 use common::take_cell::TakeCell;
 use core::cell::Cell;
-use process::{AppId,Callback,AppSlice,Shared,NUM_PROCS};
+use process::{AppId,Callback,AppSlice,Shared};
 use hil::Driver;
 use hil::spi_master::{SpiMaster,SpiCallback};
 use core::cmp;
@@ -28,7 +28,7 @@ struct App {
 pub struct Spi<'a, S: SpiMaster + 'a> {
     spi_master:   &'a mut S,
     busy:         Cell<bool>,
-    apps:         [TakeCell<App>; NUM_PROCS],
+    app:         TakeCell<App>,
     kernel_read:  TakeCell<&'static mut [u8]>,
     kernel_write: TakeCell<&'static mut [u8]>,
     kernel_len:   Cell<usize>
@@ -39,7 +39,7 @@ impl<'a, S: SpiMaster> Spi<'a, S> {
         Spi {
             spi_master: spi_master,
             busy: Cell::new(false),
-            apps: [TakeCell::empty(), TakeCell::empty()],
+            app: TakeCell::empty(),
             kernel_len: Cell::new(0),
             kernel_read : TakeCell::empty(),
             kernel_write : TakeCell::empty()
@@ -77,12 +77,11 @@ impl<'a, S: SpiMaster> Spi<'a, S> {
 }
 
 impl<'a, S: SpiMaster> Driver for Spi<'a, S> {
-    fn allow(&self, appid: AppId,
+    fn allow(&self, _appid: AppId,
              allow_num: usize, slice: AppSlice<Shared, u8>) -> isize {
-        let app = appid.idx();
         match allow_num {
             0 => {
-                let appc = match self.apps[app].take() {
+                let appc = match self.app.take() {
                     None => App {
                         callback: None,
                         app_read: Some(slice),
@@ -95,11 +94,11 @@ impl<'a, S: SpiMaster> Driver for Spi<'a, S> {
                         appc
                     }
                 };
-                self.apps[app].replace(appc);
+                self.app.replace(appc);
                 0
             },
             1 => {
-                let appc = match self.apps[app].take() {
+                let appc = match self.app.take() {
                     None => App {
                         callback: None,
                         app_read: None,
@@ -112,7 +111,7 @@ impl<'a, S: SpiMaster> Driver for Spi<'a, S> {
                         appc
                     }
                 };
-                self.apps[app].replace(appc);
+                self.app.replace(appc);
                 0
             }
             _ => -1
@@ -123,7 +122,7 @@ impl<'a, S: SpiMaster> Driver for Spi<'a, S> {
     fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
         match subscribe_num {
             0 /* read_write */ => {
-                let appc = match self.apps[0].take() {
+                let appc = match self.app.take() {
                     None => App {
                         callback: Some(callback),
                         app_read: None,
@@ -136,7 +135,7 @@ impl<'a, S: SpiMaster> Driver for Spi<'a, S> {
                         appc
                     }
                 };
-                self.apps[0].replace(appc);
+                self.app.replace(appc);
                 0
             },
             _ => -1
@@ -196,7 +195,7 @@ impl<'a, S: SpiMaster> Driver for Spi<'a, S> {
                     return -1;
                 }
                 let mut result = -1;
-                self.apps[0].map(|app| {
+                self.app.map(|app| {
                     let mut mlen = 0;
                     // If write buffer too small, return
                     app.app_write.as_mut().map(|w| {
@@ -271,7 +270,7 @@ impl<'a, S: SpiMaster> SpiCallback for Spi<'a, S> {
                        writebuf: Option<&'static mut [u8]>,
                        readbuf:  Option<&'static mut [u8]>,
                        length: usize) {
-        self.apps[0].map(|app| {
+        self.app.map(|app| {
             if app.app_read.is_some() {
                 let src = readbuf.as_ref().unwrap();
                 let dest = app.app_read.as_mut().unwrap();

--- a/src/platform/storm/lib.rs
+++ b/src/platform/storm/lib.rs
@@ -309,7 +309,7 @@ pub unsafe fn init() -> &'static mut Platform {
             drivers::nrf51822_serialization::Nrf51822Serialization::new(
                 &sam4l::usart::USART2,
                 &mut drivers::nrf51822_serialization::WRITE_BUF
-            ), 124);
+            ), 68);
     sam4l::usart::USART2.set_client(nrf_serialization);
 
     let ast = &sam4l::ast::AST;
@@ -356,7 +356,7 @@ pub unsafe fn init() -> &'static mut Platform {
     // Initialize and enable SPI HAL
     static_init!(spi: drivers::spi::Spi<'static, sam4l::spi::Spi> =
                      drivers::spi::Spi::new(&mut sam4l::spi::SPI),
-                 140);
+                 84);
     spi.config_buffers(&mut spi_read_buf, &mut spi_write_buf);
     sam4l::spi::SPI.init(spi as &hil::spi_master::SpiCallback);
 


### PR DESCRIPTION
In general, drivers should use containers (Grants) to store app specific
state, and not depend on the number of processes allowed by the
platform.

The two specific examples that needed fixing were not virtualized
anyway, so we may as well just store a single app's state and pray for
the best (i.e. that only one app uses them) since two apps using them
was already problematic.