### PR TITLE
Common static_init!

### DIFF
--- a/src/common/src/utils.rs
+++ b/src/common/src/utils.rs
@@ -12,3 +12,35 @@ pub fn init_nones<T, A: FixedSizeArray<Option<T>>>() -> A {
     res
 }
 
+/// Allocates a global array of static size, initially set to zero. When this
+/// macro is hit, it will initialize the array to the value given and return a
+/// `&'static mut` reference to it.
+///
+/// Note that you will have to specify the array-size as an argument, but a
+/// wrong size will result in a compile-time error. This argument will be
+/// removed if `std::mem::size_of<T>` ever becomes a `const` function.
+#[macro_export]
+macro_rules! static_init {
+    ($e:expr, $T:ty, $size:expr) => {
+        // Ideally we could use mem::size_of<$T> here instead of $size, however
+        // that is not currently possible in rust. Instead we write the size as
+        // a constant in the code and use compile-time verification to see that
+        // we got it right
+        {
+            use core::{mem, ptr};
+            // This is our compile-time assertion. The optimizer should be able
+            // to remove it from the generated code.
+            let assert_buf: [u8; $size] = mem::uninitialized();
+            let assert_val: $T = mem::transmute(assert_buf);
+            mem::forget(assert_val);
+
+            // Statically allocate a read-write buffer for the value, write our
+            // initial value into it (without dropping the initial zeros) and
+            // return a reference to it.
+            static mut BUF: [u8; $size] = [0; $size];
+            let mut tmp : &'static mut $T = mem::transmute(&mut BUF);
+            ptr::write(tmp as *mut $T, $e);
+            tmp
+        };
+    }
+}

--- a/src/common/src/utils.rs
+++ b/src/common/src/utils.rs
@@ -19,9 +19,17 @@ pub fn init_nones<T, A: FixedSizeArray<Option<T>>>() -> A {
 /// Note that you will have to specify the array-size as an argument, but a
 /// wrong size will result in a compile-time error. This argument will be
 /// removed if `std::mem::size_of<T>` ever becomes a `const` function.
+///
+/// # Safety
+///
+/// As this macro will write directly to a global area without acquiring a lock
+/// or similar, calling this macro is inherently unsafe. The caller should take
+/// care to never call the code that initializes this buffer twice, as doing so
+/// will overwrite the value from first allocation without running its
+/// destructor.
 #[macro_export]
 macro_rules! static_init {
-    ($e:expr, $T:ty, $size:expr) => {
+    ($T:ty, $e:expr, $size:expr) => {
         // Ideally we could use mem::size_of<$T> here instead of $size, however
         // that is not currently possible in rust. Instead we write the size as
         // a constant in the code and use compile-time verification to see that


### PR DESCRIPTION
Made the `static_init!` macro live in the `common` crate instead of in every platform. Changed its usage slightly and changed the platforms to match.