### PR TITLE
Fix Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - export PATH=$HOME/.cargo/bin:$PATH
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then \
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       find -path ./extern -prune -o -name '*.rs' -exec rustfmt --write-mode=diff {} +; fi
   - make -C src/platform/storm
   - make -C src/platform/nrf_pca10028

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq gcc-arm-embedded; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; cargo install rustfmt
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; cargo install rustfmt; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap px4/px4; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc-arm-none-eabi; fi
@@ -20,7 +20,7 @@ before_install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; \
-      find -path ./extern -prune -o -name '*.rs' -exec rustfmt --write-mode=diff {} +
+      find -path ./extern -prune -o -name '*.rs' -exec rustfmt --write-mode=diff {} +; fi
   - make -C src/platform/storm
   - make -C src/platform/nrf_pca10028
   - make -C apps/blink TOCK_PLATFORM=storm

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,15 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq gcc-arm-embedded; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; cargo install rustfmt
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap px4/px4; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc-arm-none-eabi; fi
-  - cargo install rustfmt
   - export PATH=$HOME/.cargo/bin:$PATH
 
 script:
-  - find -path ./extern -prune -o -name '*.rs' -exec rustfmt --write-mode=diff {} +
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; \
+      find -path ./extern -prune -o -name '*.rs' -exec rustfmt --write-mode=diff {} +
   - make -C src/platform/storm
   - make -C src/platform/nrf_pca10028
   - make -C apps/blink TOCK_PLATFORM=storm

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq gcc-arm-embedded; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; cargo install rustfmt; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo install rustfmt; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap px4/px4; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc-arm-none-eabi; fi
   - export PATH=$HOME/.cargo/bin:$PATH
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; \
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then \
       find -path ./extern -prune -o -name '*.rs' -exec rustfmt --write-mode=diff {} +; fi
   - make -C src/platform/storm
   - make -C src/platform/nrf_pca10028


### PR DESCRIPTION
#100 ended up breaking the OS X build because `find` on OSX (used for running`rust-fmt`) doesn't have a -path option.

We actually don't care apt running rustfmt on both platforms, so just run it on Linux.