### PR TITLE
Assign a DMA channel to the second I2C bus

### DIFF
--- a/src/chips/sam4l/src/chip.rs
+++ b/src/chips/sam4l/src/chip.rs
@@ -39,6 +39,9 @@ impl Sam4l {
         i2c::I2C2.set_dma(&dma::DMAChannels[4]);
         dma::DMAChannels[4].client = Some(&mut i2c::I2C2);
 
+        i2c::I2C1.set_dma(&dma::DMAChannels[5]);
+        dma::DMAChannels[5].client = Some(&mut i2c::I2C1);
+
         Sam4l {
             mpu: cortexm4::mpu::MPU::new(),
             systick: cortexm4::systick::SysTick::new(),


### PR DESCRIPTION
Useful for using peripherals on the pinned out I2C bus of Firestorm.