### PR TITLE
Normalize SPI and add virtual_spi.rs

### DIFF
--- a/src/chips/sam4l/src/spi.rs
+++ b/src/chips/sam4l/src/spi.rs
@@ -1,6 +1,6 @@
 
-use core::cell::Cell;
 use common::take_cell::TakeCell;
+use core::cell::Cell;
 
 use core::cmp;
 use dma::DMAChannel;
@@ -21,7 +21,6 @@ use pm;
 ///
 // Driver for the SPI hardware (separate from the USARTS),
 // described in chapter 26 of the datasheet
-
 /// The registers used to interface with the hardware
 #[repr(C, packed)]
 struct SpiRegisters {

--- a/src/chips/sam4l/src/spi.rs
+++ b/src/chips/sam4l/src/spi.rs
@@ -17,10 +17,11 @@ use pm;
 /// Implementation of DMA-based SPI master communication for
 /// the Atmel SAM4L CortexM4 microcontroller.
 /// Authors: Sam Crow <samcrow@uw.edu>
-///          Philip Levis <pal@cs.stanfored.edu>
+///          Philip Levis <pal@cs.stanford.edu>
 ///
-// Driver for the SPI hardware (seperate from the USARTS),
+// Driver for the SPI hardware (separate from the USARTS),
 // described in chapter 26 of the datasheet
+
 /// The registers used to interface with the hardware
 #[repr(C, packed)]
 struct SpiRegisters {
@@ -275,7 +276,7 @@ impl spi::SpiMaster for Spi {
         unsafe { read_volatile(&(*self.regs).rdr) as u8 }
     }
 
-    /// Asynchonous buffer read/write of SPI.
+    /// Asynchronous buffer read/write of SPI.
     /// write_buffer must  be Some; read_buffer may be None;
     /// if read_buffer is Some, then length of read/write is the
     /// minimum of two buffer lengths; returns true if operation

--- a/src/drivers/src/lib.rs
+++ b/src/drivers/src/lib.rs
@@ -16,3 +16,4 @@ pub mod tmp006;
 pub mod spi;
 pub mod virtual_alarm;
 pub mod virtual_i2c;
+pub mod virtual_spi;

--- a/src/drivers/src/spi.rs
+++ b/src/drivers/src/spi.rs
@@ -1,9 +1,9 @@
 use common::take_cell::TakeCell;
 use core::cell::Cell;
 use core::cmp;
-use hil::spi_master::{SpiMaster, SpiCallback};
-use hil::spi_master::ClockPhase;
-use hil::spi_master::ClockPolarity;
+use hil::spi::{SpiMaster, SpiMasterClient};
+use hil::spi::ClockPhase;
+use hil::spi::ClockPolarity;
 use main::{AppId, Driver, Callback, AppSlice, Shared};
 
 
@@ -263,7 +263,7 @@ impl<'a, S: SpiMaster> Driver for Spi<'a, S> {
     }
 }
 
-impl<'a, S: SpiMaster> SpiCallback for Spi<'a, S> {
+impl<'a, S: SpiMaster> SpiMasterClient for Spi<'a, S> {
     fn read_write_done(&self,
                        writebuf: Option<&'static mut [u8]>,
                        readbuf: Option<&'static mut [u8]>,

--- a/src/drivers/src/spi.rs
+++ b/src/drivers/src/spi.rs
@@ -68,7 +68,9 @@ impl<'a, S: SpiMaster> Spi<'a, S> {
             });
         });
 
-        self.spi_master.read_write_bytes(self.kernel_write.take().unwrap(), self.kernel_read.take(), len);
+        self.spi_master.read_write_bytes(self.kernel_write.take().unwrap(),
+                                         self.kernel_read.take(),
+                                         len);
     }
 }
 

--- a/src/drivers/src/virtual_spi.rs
+++ b/src/drivers/src/virtual_spi.rs
@@ -1,0 +1,153 @@
+use common::{List, ListLink, ListNode};
+use common::take_cell::TakeCell;
+use core::cell::Cell;
+use hil;
+
+/// The Mux struct manages multiple SPI clients. Each client may have
+/// at most one outstanding SPI request.
+pub struct MuxSPIMaster<'a> {
+    spi: &'a hil::spi::SpiMaster,
+    devices: List<'a, SPIMasterDevice<'a>>,
+    inflight: TakeCell<&'a SPIMasterDevice<'a>>,
+}
+
+impl<'a> hil::spi::SpiMasterClient for MuxSPIMaster<'a> {
+    fn read_write_done(&self, write_buffer: Option<&'static mut [u8]>, read_buffer: Option<&'static mut [u8]>, len: usize) {
+        self.inflight.take().map(move |device| {
+            device.read_write_done(write_buffer, read_buffer, len);
+        });
+        self.do_next_op();
+    }
+}
+
+impl<'a> MuxSPIMaster<'a> {
+    pub const fn new(spi: &'a hil::spi::SpiMaster) -> MuxSPIMaster<'a> {
+        MuxSPIMaster {
+            spi: spi,
+            devices: List::new(),
+            inflight: TakeCell::empty(),
+        }
+    }
+
+    fn do_next_op(&self) {
+        if self.inflight.is_none() {
+            let mnode = self.devices.iter().find(|node| node.operation.get() != Op::Idle);
+            mnode.map(|node| {
+
+                match node.operation.get() {
+                    Op::Configure(cpol, cpal, rate) => {
+
+                        match node.chip_select {
+                            Some(x) => {
+                                self.spi.set_chip_select(x);
+                            },
+                            None => {}
+                        }
+
+                        // In theory, the SPI interface should support
+                        // using a GPIO in lieu of a hardware CS line.
+                        // This is particularly important for the SAM4L
+                        // if using a USART, but might be relevant
+                        // for other platforms as well.
+                        // TODO: make this do something if given GPIO pin
+                        // match node.chip_select_gpio {
+                        //     Some() => { },
+                        //     None => {}
+                        // }
+
+                        self.spi.set_clock(cpol);
+                        self.spi.set_phase(cpal);
+                        self.spi.set_rate(rate);
+
+
+                    },
+                      //  self.i2c.write(node.addr, buf, len),
+                    Op::ReadWriteBytes(len) => {
+
+
+                        node.txbuffer.take().map(|txbuffer| {
+                            node.rxbuffer.take().map(|rxbuffer| {
+                                self.spi.read_write_bytes(txbuffer, rxbuffer, len);
+                            });
+                        });
+
+                        // Only async operations want to block by setting the devices
+                        // as inflight.
+                        self.inflight.replace(node);
+                    },
+                    Op::Idle => {} // Can't get here...
+                }
+                node.operation.set(Op::Idle);
+            });
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum Op {
+    Idle,
+    Configure(hil::spi::ClockPolarity, hil::spi::ClockPhase, u32),
+    ReadWriteBytes(usize),
+}
+
+pub struct SPIMasterDevice<'a> {
+    mux: &'a MuxSPIMaster<'a>,
+    chip_select: Option<u8>,
+    chip_select_gpio: Option<&'static hil::gpio::GPIOPin>,
+    txbuffer: TakeCell<Option<&'static mut [u8]>>,
+    rxbuffer: TakeCell<Option<&'static mut [u8]>>,
+    operation: Cell<Op>,
+    next: ListLink<'a, SPIMasterDevice<'a>>,
+    client: Cell<Option<&'a hil::spi::SpiMasterClient>>,
+}
+
+impl<'a> SPIMasterDevice<'a> {
+    pub const fn new(mux: &'a MuxSPIMaster<'a>, chip_select: Option<u8>, chip_select_gpio: Option<&'static hil::gpio::GPIOPin>) -> SPIMasterDevice<'a> {
+        SPIMasterDevice {
+            mux: mux,
+            chip_select: chip_select,
+            chip_select_gpio: chip_select_gpio,
+            txbuffer: TakeCell::empty(),
+            rxbuffer: TakeCell::empty(),
+            operation: Cell::new(Op::Idle),
+            next: ListLink::empty(),
+            client: Cell::new(None),
+        }
+    }
+
+    pub fn set_client(&'a self, client: &'a hil::spi::SpiMasterClient) {
+        self.mux.devices.push_head(self);
+        self.client.set(Some(client));
+    }
+}
+
+impl<'a> hil::spi::SpiMasterClient for SPIMasterDevice<'a> {
+    fn read_write_done(&self, write_buffer: Option<&'static mut [u8]>, read_buffer: Option<&'static mut [u8]>, len: usize) {
+        self.client.get().map(move |client| {
+            client.read_write_done(write_buffer, read_buffer, len);
+        });
+    }
+}
+
+impl<'a> ListNode<'a, SPIMasterDevice<'a>> for SPIMasterDevice<'a> {
+    fn next(&'a self) -> &'a ListLink<'a, SPIMasterDevice<'a>> {
+        &self.next
+    }
+}
+
+impl<'a> hil::spi::SPIMasterDevice for SPIMasterDevice<'a> {
+
+    fn configure(&self, cpol: hil::spi::ClockPolarity, cpal: hil::spi::ClockPhase, rate: u32) {
+        self.operation.set(Op::Configure(cpol, cpal, rate));
+        self.mux.do_next_op();
+    }
+
+    fn read_write_bytes(&self, write_buffer: Option<&'static mut [u8]>, read_buffer: Option<&'static mut [u8]>, len: usize) -> bool {
+        self.txbuffer.replace(write_buffer);
+        self.rxbuffer.replace(read_buffer);
+        self.operation.set(Op::ReadWriteBytes(len));
+        self.mux.do_next_op();
+
+        true
+    }
+}

--- a/src/hil/src/lib.rs
+++ b/src/hil/src/lib.rs
@@ -10,7 +10,7 @@ pub mod led;
 pub mod alarm;
 pub mod gpio;
 pub mod i2c;
-pub mod spi_master;
+pub mod spi;
 pub mod timer;
 pub mod uart;
 pub mod adc;

--- a/src/hil/src/spi.rs
+++ b/src/hil/src/spi.rs
@@ -10,14 +10,14 @@ pub enum DataOrder {
 }
 
 /// Values for the clock polarity (idle state or CPOL)
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum ClockPolarity {
     IdleLow,
     IdleHigh,
 }
 
 /// Which clock edge values are sampled on
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum ClockPhase {
     SampleLeading,
     SampleTrailing,
@@ -36,9 +36,11 @@ pub trait SpiMasterClient {
 /// Using SpiMaster normally involves three steps:
 ///
 /// 1. Configure the SPI bus for a peripheral
-///   1a. Call set_chip_select to select which peripheral and
-///       turn on SPI
-///   1b. Call set operations as needed to configure bus
+///    1a. Call set_chip_select to select which peripheral and
+///        turn on SPI
+///    1b. Call set operations as needed to configure bus
+///    NOTE: You MUST select the chip select BEFORE configuring
+///           SPI settings.
 /// 2. Invoke read, write, read_write on SpiMaster
 /// 3a. Call clear_chip_select to turn off bus, or
 /// 3b. Call set_chip_select to choose another peripheral,

--- a/src/hil/src/spi.rs
+++ b/src/hil/src/spi.rs
@@ -25,7 +25,7 @@ pub enum ClockPhase {
 
 pub trait SpiMasterClient {
     /// Called when a read/write operation finishes
-    fn read_write_done(&'static self,
+    fn read_write_done(&self,
                        mut write_buffer: Option<&'static mut [u8]>,
                        mut read_buffer: Option<&'static mut [u8]>,
                        len: usize);

--- a/src/hil/src/spi.rs
+++ b/src/hil/src/spi.rs
@@ -112,7 +112,29 @@ pub trait SpiMaster {
     // is any of the read/read_write calls. These functions
     // allow an application to manually control when the
     // CS line is high or low, such that it can issue multi-byte
-    // requests with single byte oprations.
+    // requests with single byte operations.
     fn hold_low(&self);
     fn release_low(&self);
+}
+
+/// SPIMasterDevice provides a chip-specific interface to the SPI Master
+/// hardware. The interface wraps the chip select line so that chip drivers
+/// cannot communicate with different SPI devices.
+pub trait SPIMasterDevice {
+
+    /// Setup the SPI settings and speed of the bus.
+    fn configure(&self, cpol: ClockPolarity, cpal: ClockPhase, rate: u32);
+
+    /// Perform an asynchronous read/write operation, whose
+    /// completion is signaled by invoking SpiMasterClient.read_write_done on
+    /// the provided client. write_buffer must be Some,
+    /// read_buffer may be None. If read_buffer is Some, the
+    /// length of the operation is the minimum of the size of
+    /// the two buffers.
+    fn read_write_bytes(&self,
+                        mut write_buffer: Option<&'static mut [u8]>,
+                        mut read_buffer: Option<&'static mut [u8]>,
+                        len: usize)
+                        -> bool;
+
 }

--- a/src/hil/src/spi.rs
+++ b/src/hil/src/spi.rs
@@ -23,7 +23,7 @@ pub enum ClockPhase {
     SampleTrailing,
 }
 
-pub trait SpiCallback {
+pub trait SpiMasterClient {
     /// Called when a read/write operation finishes
     fn read_write_done(&'static self,
                        mut write_buffer: Option<&'static mut [u8]>,
@@ -68,11 +68,13 @@ pub trait SpiCallback {
 ///   write_byte(0xaa); // Uses SampleTrailing
 ///
 pub trait SpiMaster {
-    fn init(&mut self, client: &'static SpiCallback);
+    fn set_client(&self, client: &'static SpiMasterClient);
+
+    fn init(&self);
     fn is_busy(&self) -> bool;
 
     /// Perform an asynchronous read/write operation, whose
-    /// completion is signaled by invoking SpiCallback on
+    /// completion is signaled by invoking SpiMasterClient on
     /// the initialzied client. write_buffer must be Some,
     /// read_buffer may be None. If read_buffer is Some, the
     /// length of the operation is the minimum of the size of

--- a/src/hil/src/spi.rs
+++ b/src/hil/src/spi.rs
@@ -26,7 +26,7 @@ pub enum ClockPhase {
 pub trait SpiMasterClient {
     /// Called when a read/write operation finishes
     fn read_write_done(&self,
-                       mut write_buffer: Option<&'static mut [u8]>,
+                       mut write_buffer: &'static mut [u8],
                        mut read_buffer: Option<&'static mut [u8]>,
                        len: usize);
 }
@@ -82,7 +82,7 @@ pub trait SpiMaster {
     /// length of the operation is the minimum of the size of
     /// the two buffers.
     fn read_write_bytes(&self,
-                        mut write_buffer: Option<&'static mut [u8]>,
+                        mut write_buffer: &'static mut [u8],
                         mut read_buffer: Option<&'static mut [u8]>,
                         len: usize)
                         -> bool;
@@ -132,7 +132,7 @@ pub trait SPIMasterDevice {
     /// length of the operation is the minimum of the size of
     /// the two buffers.
     fn read_write_bytes(&self,
-                        mut write_buffer: Option<&'static mut [u8]>,
+                        mut write_buffer: &'static mut [u8],
                         mut read_buffer: Option<&'static mut [u8]>,
                         len: usize)
                         -> bool;

--- a/src/hil/src/spi.rs
+++ b/src/hil/src/spi.rs
@@ -121,7 +121,6 @@ pub trait SpiMaster {
 /// hardware. The interface wraps the chip select line so that chip drivers
 /// cannot communicate with different SPI devices.
 pub trait SPIMasterDevice {
-
     /// Setup the SPI settings and speed of the bus.
     fn configure(&self, cpol: ClockPolarity, cpal: ClockPhase, rate: u32);
 
@@ -136,5 +135,4 @@ pub trait SPIMasterDevice {
                         mut read_buffer: Option<&'static mut [u8]>,
                         len: usize)
                         -> bool;
-
 }

--- a/src/platform/storm/src/main.rs
+++ b/src/platform/storm/src/main.rs
@@ -18,7 +18,7 @@ use drivers::timer::TimerDriver;
 use drivers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use drivers::virtual_i2c::{I2CDevice, MuxI2C};
 use hil::Controller;
-use hil::spi_master::SpiMaster;
+use hil::spi::SpiMaster;
 use main::{Chip, MPU, Platform};
 use sam4l::usart;
 
@@ -373,7 +373,8 @@ pub unsafe fn reset_handler() {
         drivers::spi::Spi::new(&mut sam4l::spi::SPI),
         84);
     spi.config_buffers(&mut spi_read_buf, &mut spi_write_buf);
-    sam4l::spi::SPI.init(spi as &hil::spi_master::SpiCallback);
+    sam4l::spi::SPI.set_client(spi);
+    sam4l::spi::SPI.init();
 
     // set GPIO driver controlling remaining GPIO pins
     let gpio_pins = static_init!(

--- a/src/platform/storm/src/spi_dummy.rs
+++ b/src/platform/storm/src/spi_dummy.rs
@@ -15,7 +15,7 @@ pub static mut buf2: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
 
 impl spi::SpiMasterClient for DummyCB {
     #[allow(unused_variables,dead_code)]
-    fn read_write_done(&'static self,
+    fn read_write_done(&self,
                        write: Option<&'static mut [u8]>,
                        read: Option<&'static mut [u8]>,
                        len: usize) {

--- a/src/platform/storm/src/spi_dummy.rs
+++ b/src/platform/storm/src/spi_dummy.rs
@@ -16,16 +16,16 @@ pub static mut buf2: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
 impl spi::SpiMasterClient for DummyCB {
     #[allow(unused_variables,dead_code)]
     fn read_write_done(&self,
-                       write: Option<&'static mut [u8]>,
+                       write: &'static mut [u8],
                        read: Option<&'static mut [u8]>,
                        len: usize) {
         unsafe {
             FLOP = !FLOP;
             let len: usize = buf1.len();
             if FLOP {
-                sam4l::spi::SPI.read_write_bytes(Some(&mut buf1), Some(&mut buf2), len);
+                sam4l::spi::SPI.read_write_bytes(&mut buf1, Some(&mut buf2), len);
             } else {
-                sam4l::spi::SPI.read_write_bytes(Some(&mut buf2), Some(&mut buf1), len);
+                sam4l::spi::SPI.read_write_bytes(&mut buf2, Some(&mut buf1), len);
             }
         }
     }
@@ -54,6 +54,6 @@ pub unsafe fn spi_dummy_test() {
     sam4l::spi::SPI.init();
     sam4l::spi::SPI.enable();
     let len = buf2.len();
-    sam4l::spi::SPI.read_write_bytes(Some(&mut buf2), Some(&mut buf1), len);
+    sam4l::spi::SPI.read_write_bytes(&mut buf2, Some(&mut buf1), len);
 
 }

--- a/src/platform/storm/src/spi_dummy.rs
+++ b/src/platform/storm/src/spi_dummy.rs
@@ -1,7 +1,7 @@
 //! A dummy SPI client to test the SPI implementation
 
 use hil::gpio;
-use hil::spi_master::{self, SpiMaster};
+use hil::spi::{self, SpiMaster};
 use sam4l;
 
 #[allow(unused_variables,dead_code)]
@@ -13,7 +13,7 @@ pub static mut FLOP: bool = false;
 pub static mut buf1: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
 pub static mut buf2: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
 
-impl spi_master::SpiCallback for DummyCB {
+impl spi::SpiMasterClient for DummyCB {
     #[allow(unused_variables,dead_code)]
     fn read_write_done(&'static self,
                        write: Option<&'static mut [u8]>,
@@ -50,7 +50,8 @@ pub unsafe fn spi_dummy_test() {
 
 
     sam4l::spi::SPI.set_active_peripheral(sam4l::spi::Peripheral::Peripheral1);
-    sam4l::spi::SPI.init(&SPICB);
+    sam4l::spi::SPI.set_client(&SPICB);
+    sam4l::spi::SPI.init();
     sam4l::spi::SPI.enable();
     let len = buf2.len();
     sam4l::spi::SPI.read_write_bytes(Some(&mut buf2), Some(&mut buf1), len);


### PR DESCRIPTION
- Try to get SPI to better parallel I2C and other parts of Tock.
- Add layer that incorporates the chip select line (much like I2CDevice).
- Remove the option<> on txbuffer (which is not optional).
- Fix issues with SPI+DMA.