### PR TITLE
Start on changes to GPIO HIL interface.

### DIFF
--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -46,7 +46,7 @@ extern crate nrf51;
 use capsules::timer::TimerDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::{Chip, SysTick};
-use kernel::hil::gpio::GPIOPin;
+use kernel::hil::gpio::Pin;
 use nrf51::timer::ALARM1;
 use nrf51::timer::TimerAlarm;
 
@@ -140,7 +140,7 @@ pub unsafe fn reset_handler() {
         ],
         4 * 22);
 
-    nrf51::gpio::PORT[LED1_PIN].enable_output();
+    nrf51::gpio::PORT[LED1_PIN].make_output();
     nrf51::gpio::PORT[LED1_PIN].clear();
 
     let gpio = static_init!(
@@ -218,13 +218,13 @@ pub unsafe extern "C" fn rust_begin_unwind(_args: &Arguments,
                                            _file: &'static str,
                                            _line: usize)
                                            -> ! {
-    use kernel::hil::gpio::GPIOPin;
+    use kernel::hil::gpio::Pin;
 
     let led0 = &nrf51::gpio::PORT[LED1_PIN];
     let led1 = &nrf51::gpio::PORT[LED2_PIN];
 
-    led0.enable_output();
-    led1.enable_output();
+    led0.make_output();
+    led1.make_output();
     loop {
         for _ in 0..100000 {
             led0.set();

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -15,6 +15,7 @@ use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use kernel::{Chip, MPU, Platform};
 use kernel::hil::Controller;
+use kernel::hil::gpio::PinCtl;
 use kernel::hil::spi::SpiMaster;
 use sam4l::usart;
 
@@ -338,6 +339,7 @@ pub unsafe fn reset_handler() {
 
     // Configure the TMP006. Device address 0x40
     let tmp006_i2c = static_init!(I2CDevice, I2CDevice::new(mux_i2c, 0x40), 32);
+    sam4l::gpio::PA[9].set_input_mode(kernel::hil::gpio::InputMode::PullUp);
     let tmp006 = static_init!(
         capsules::tmp006::TMP006<'static>,
         capsules::tmp006::TMP006::new(tmp006_i2c,

--- a/capsules/src/tmp006.rs
+++ b/capsules/src/tmp006.rs
@@ -96,6 +96,7 @@ pub struct TMP006<'a> {
 }
 
 impl<'a> TMP006<'a> {
+    /// The `interrupt_pin` must be pulled-up since the TMP006 is open-drain.
     pub fn new(i2c: &'a i2c::I2CDevice,
                interrupt_pin: &'a Pin,
                buffer: &'static mut [u8])
@@ -144,7 +145,6 @@ impl<'a> TMP006<'a> {
 
     fn enable_interrupts(&self) {
         // setup interrupts from the sensor
-        // TODO(alevy): do we need to make sure it's a pull up?
         self.interrupt_pin.make_input();
         self.interrupt_pin.enable_interrupt(0, InterruptMode::FallingEdge);
     }

--- a/capsules/src/tmp006.rs
+++ b/capsules/src/tmp006.rs
@@ -2,7 +2,7 @@ use core::cell::Cell;
 use kernel::{AppId, Callback, Driver};
 use kernel::common::math::{sqrtf32, get_errno};
 use kernel::common::take_cell::TakeCell;
-use kernel::hil::gpio::{GPIOPin, InputMode, InterruptMode, Client};
+use kernel::hil::gpio::{Pin, InterruptMode, Client};
 use kernel::hil::i2c;
 
 pub static mut BUFFER: [u8; 3] = [0; 3];
@@ -87,7 +87,7 @@ enum ProtocolState {
 
 pub struct TMP006<'a> {
     i2c: &'a i2c::I2CDevice,
-    interrupt_pin: &'a GPIOPin,
+    interrupt_pin: &'a Pin,
     sampling_period: Cell<u8>,
     repeated_mode: Cell<bool>,
     callback: Cell<Option<Callback>>,
@@ -97,7 +97,7 @@ pub struct TMP006<'a> {
 
 impl<'a> TMP006<'a> {
     pub fn new(i2c: &'a i2c::I2CDevice,
-               interrupt_pin: &'a GPIOPin,
+               interrupt_pin: &'a Pin,
                buffer: &'static mut [u8])
                -> TMP006<'a> {
         // setup and return struct
@@ -144,7 +144,8 @@ impl<'a> TMP006<'a> {
 
     fn enable_interrupts(&self) {
         // setup interrupts from the sensor
-        self.interrupt_pin.enable_input(InputMode::PullUp);
+        // TODO(alevy): do we need to make sure it's a pull up?
+        self.interrupt_pin.make_input();
         self.interrupt_pin.enable_interrupt(0, InterruptMode::FallingEdge);
     }
 

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -94,7 +94,7 @@ enum Op {
 pub struct SPIMasterDevice<'a> {
     mux: &'a MuxSPIMaster<'a>,
     chip_select: Option<u8>,
-    chip_select_gpio: Option<&'static hil::gpio::GPIOPin>,
+    chip_select_gpio: Option<&'static hil::gpio::Pin>,
     txbuffer: TakeCell<&'static mut [u8]>,
     rxbuffer: TakeCell<Option<&'static mut [u8]>>,
     operation: Cell<Op>,
@@ -105,7 +105,7 @@ pub struct SPIMasterDevice<'a> {
 impl<'a> SPIMasterDevice<'a> {
     pub const fn new(mux: &'a MuxSPIMaster<'a>,
                      chip_select: Option<u8>,
-                     chip_select_gpio: Option<&'static hil::gpio::GPIOPin>)
+                     chip_select_gpio: Option<&'static hil::gpio::Pin>)
                      -> SPIMasterDevice<'a> {
         SPIMasterDevice {
             mux: mux,

--- a/chips/sam4l/src/gpio.rs
+++ b/chips/sam4l/src/gpio.rs
@@ -459,21 +459,8 @@ impl hil::Controller for GPIOPin {
     }
 }
 
-impl hil::gpio::GPIOPin for GPIOPin {
-    fn disable(&self) {
-        GPIOPin::disable(self);
-    }
-
-    fn enable_output(&self) {
-        self.enable();
-        GPIOPin::enable_output(self);
-        self.disable_schmidtt_trigger();
-    }
-
-    fn enable_input(&self, mode: hil::gpio::InputMode) {
-        self.enable();
-        GPIOPin::disable_output(self);
-        self.enable_schmidtt_trigger();
+impl hil::gpio::PinCtl for GPIOPin {
+    fn set_input_mode(&self, mode: hil::gpio::InputMode) {
         match mode {
             hil::gpio::InputMode::PullUp => {
                 self.disable_pull_down();
@@ -488,6 +475,24 @@ impl hil::gpio::GPIOPin for GPIOPin {
                 self.disable_pull_down();
             }
         }
+    }
+}
+
+impl hil::gpio::Pin for GPIOPin {
+    fn disable(&self) {
+        GPIOPin::disable(self);
+    }
+
+    fn make_output(&self) {
+        self.enable();
+        GPIOPin::enable_output(self);
+        self.disable_schmidtt_trigger();
+    }
+
+    fn make_input(&self) {
+        self.enable();
+        GPIOPin::disable_output(self);
+        self.enable_schmidtt_trigger();
     }
 
     fn read(&self) -> bool {
@@ -508,7 +513,7 @@ impl hil::gpio::GPIOPin for GPIOPin {
 
     fn enable_interrupt(&self, client_data: usize, mode: hil::gpio::InterruptMode) {
         let mode_bits = match mode {
-            hil::gpio::InterruptMode::Change => 0b00,
+            hil::gpio::InterruptMode::EitherEdge => 0b00,
             hil::gpio::InterruptMode::RisingEdge => 0b01,
             hil::gpio::InterruptMode::FallingEdge => 0b10,
         };

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -14,37 +14,42 @@ pub enum InterruptMode {
     EitherEdge,
 }
 
+pub trait PinCtl {
+    /// Configure whether the pin should have a pull-up or pull-down resistor or
+    /// neither.
+    fn set_input_mode(&self, InputMode);
+}
+
 /// Interface for synchronous GPIO pins.
 pub trait Pin {
     /// Configure the GPIO pin as an output pin.
     fn make_output(&self);
-    
-    /// Configure the GPIO pin as an input pin. Also configure
-    /// if it should have a pull-up, pull-down, or neither.
-    fn make_input(&self, mode: InputMode);
-    
+
+    /// Configure the GPIO pin as an input pin.
+    fn make_input(&self);
+
     /// Disable the GPIO pin and put it into its lowest power
     /// mode.
     fn disable(&self);
-    
+
     /// Set the GPIO pin high. It must be an output.
     fn set(&self);
-    
+
     /// Set the GPIO pin low. It must be an output.
     fn clear(&self);
-    
+
     /// Toggle the GPIO pin. It must be an output.
     fn toggle(&self);
-    
+
     /// Get the current state of an input GPIO pin.
     fn read(&self) -> bool;
-    
+
     /// Enable an interrupt on the GPIO pin. It must
     /// be configured as an interrupt. The `identifier`
     /// can be any value and will be returned to you
     /// when the interrupt on this pin fires.
     fn enable_interrupt(&self, identifier: usize, mode: InterruptMode);
-    
+
     /// Disable the interrupt for the GPIO pin.
     fn disable_interrupt(&self);
 }

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -1,27 +1,60 @@
+/// Enum for configuring any pull-up or pull-down
+/// resistors on the GPIO pin.
 pub enum InputMode {
     PullUp,
     PullDown,
     PullNone,
 }
 
+/// Enum for selecting which edge to trigger interrupts
+/// on.
 pub enum InterruptMode {
-    Change,
     RisingEdge,
     FallingEdge,
+    EitherEdge,
 }
 
-pub trait GPIOPin {
-    fn enable_output(&self);
-    fn enable_input(&self, mode: InputMode);
+/// Interface for synchronous GPIO pins.
+pub trait Pin {
+    /// Configure the GPIO pin as an output pin.
+    fn make_output(&self);
+    
+    /// Configure the GPIO pin as an input pin. Also configure
+    /// if it should have a pull-up, pull-down, or neither.
+    fn make_input(&self, mode: InputMode);
+    
+    /// Disable the GPIO pin and put it into its lowest power
+    /// mode.
     fn disable(&self);
+    
+    /// Set the GPIO pin high. It must be an output.
     fn set(&self);
+    
+    /// Set the GPIO pin low. It must be an output.
     fn clear(&self);
+    
+    /// Toggle the GPIO pin. It must be an output.
     fn toggle(&self);
+    
+    /// Get the current state of an input GPIO pin.
     fn read(&self) -> bool;
+    
+    /// Enable an interrupt on the GPIO pin. It must
+    /// be configured as an interrupt. The `identifier`
+    /// can be any value and will be returned to you
+    /// when the interrupt on this pin fires.
     fn enable_interrupt(&self, identifier: usize, mode: InterruptMode);
+    
+    /// Disable the interrupt for the GPIO pin.
     fn disable_interrupt(&self);
 }
 
+/// Interface for users of synchronous GPIO. In order
+/// to receive interrupts, the user must implement
+/// this `Client` interface.
 pub trait Client {
+    /// Called when an interrupt occurs. The `identifier` will
+    /// be the same value that was passed to `enable_interrupt()`
+    /// when the interrupt was configured.
     fn fired(&self, identifier: usize);
 }

--- a/kernel/src/hil/led.rs
+++ b/kernel/src/hil/led.rs
@@ -16,29 +16,29 @@ pub trait Led {
 
 /// For LEDs in which on is when GPIO is high.
 pub struct LedHigh {
-    pub pin: &'static mut gpio::GPIOPin,
+    pub pin: &'static mut gpio::Pin,
 }
 
 /// For LEDs in which on is when GPIO is low.
 pub struct LedLow {
-    pub pin: &'static mut gpio::GPIOPin,
+    pub pin: &'static mut gpio::Pin,
 }
 
 impl LedHigh {
-    pub fn new(p: &'static mut gpio::GPIOPin) -> LedHigh {
+    pub fn new(p: &'static mut gpio::Pin) -> LedHigh {
         LedHigh { pin: p }
     }
 }
 
 impl LedLow {
-    pub fn new(p: &'static mut gpio::GPIOPin) -> LedLow {
+    pub fn new(p: &'static mut gpio::Pin) -> LedLow {
         LedLow { pin: p }
     }
 }
 
 impl Led for LedHigh {
     fn init(&mut self) {
-        self.pin.enable_output();
+        self.pin.make_output();
     }
 
     fn on(&mut self) {
@@ -60,7 +60,7 @@ impl Led for LedHigh {
 
 impl Led for LedLow {
     fn init(&mut self) {
-        self.pin.enable_output();
+        self.pin.make_output();
     }
 
     fn on(&mut self) {


### PR DESCRIPTION
Not much here except for comments. Highlights:

- Changed `enable` to `make` when setting up GPIO pins.
- Changed `GPIOPin` to just `Pin`. This better mirrors `Client` (which is not `GPIOClient`) and should be fine when using namespacing (i.e. `hil::gpio::Pin`).
- Document what `disable` is supposed to do.