### PR TITLE
Rename built output folder to "build"

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "build"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 build/*
+build
 *.rlib
 *.sdb
 *.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ script:
       find -path ./extern -prune -o -name '*.rs' -exec rustfmt --write-mode=diff {} +; fi
   - make -C boards/storm
   - make -C boards/nrf51dk
-  - make -C userland/libtock ARCH=cortex-m4
-  - make -C userland/examples/blink ARCH=cortex-m4
+  - make -C userland/libtock TOCK_ARCH=cortex-m4
+  - make -C userland/examples/blink TOCK_ARCH=cortex-m4
 
 notifications:
   webhooks:

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
 # default board and architecture
-BOARD ?= storm
-ARCH ?= cortex-m4
+TOCK_BOARD ?= storm
+TOCK_ARCH ?= cortex-m4
 
 
 # rules for making the kernel
 .PHONY: all
-all: $(BOARD)
+all: $(TOCK_BOARD)
 
-$(BOARD): boards/$(BOARD)/
+$(TOCK_BOARD): boards/$(TOCK_BOARD)/
 	$(MAKE) -C $<
 
-clean: boards/$(BOARD)/
+clean: boards/$(TOCK_BOARD)/
 	$(MAKE) clean -C $<
 
-doc: boards/$(BOARD)/
+doc: boards/$(TOCK_BOARD)/
 	$(MAKE) doc -C $<
 
-program: boards/$(BOARD)/
+program: boards/$(TOCK_BOARD)/
 	$(MAKE) program -C $<
 
-flash: boards/$(BOARD)/
+flash: boards/$(TOCK_BOARD)/
 	$(MAKE) flash -C $<
 
 
 # rule for making userland example applications
 examples/%: userland/examples/%
-	$(MAKE) -C $< ARCH=$(ARCH)
+	$(MAKE) -C $< TOCK_ARCH=$(TOCK_ARCH)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Tock Embedded OS [![Build Status](https://travis-ci.org/helena-project/tock.svg?branch=master)](https://travis-ci.org/helena-project/tock)
+# ![TockOS](http://www.tockos.org/assets/img/logo.png "TockOS Logo")
 
-![TockOS](http://www.tockos.org/assets/img/logo.png "TockOS Logo")
-Tock is an operating system designed for running multiple concurrent, mutually
+[![Build Status](https://travis-ci.org/helena-project/tock.svg?branch=master)](https://travis-ci.org/helena-project/tock)
+[![irc](https://img.shields.io/badge/irc-%23tock-lightgrey.svg)](https://kiwiirc.com/client/irc.freenode.net/tock)
+
+Tock is an embedded operating system designed for running multiple concurrent, mutually
 distrustful applications on Cortex-M based embedded platforms. Tock's design
 centers around protection, both from potentially malicious applications and
 from device drivers. Tock uses two mechanisms to protect different components

--- a/boards/nrf51dk/Makefile
+++ b/boards/nrf51dk/Makefile
@@ -1,13 +1,13 @@
 .PHONY: all
-all: target/target/release/nrf_pca10028
+all: build/nrf51/release/nrf_pca10028
 
 .PHONY: doc
 doc:
-	@cargo doc --release --target=../../chips/nrf51/target.json
+	@cargo doc --release --target=../../chips/nrf51/nrf51.json
 
-.PHONY: target/target/release/nrf_pca10028
-target/target/release/nrf_pca10028:
-	@cargo build --release --target=../../chips/nrf51/target.json
+.PHONY: build/nrf51/release/nrf_pca10028
+build/nrf51/release/nrf_pca10028:
+	@cargo build --release --target=../../chips/nrf51/nrf51.json
 
 .PHONY: clean
 clean:

--- a/boards/storm/Makefile
+++ b/boards/storm/Makefile
@@ -13,18 +13,18 @@ JLINK=JLinkExe
 JLINK_OPTIONS=-device ATSAM4LC8C -if swd -speed 1200 -AutoConnect 1
 JLINK_SCRIPTS=jtag/
 
-all: target/target/release/storm
+all: build/sam4l/release/storm
 
 .PHONY: doc
 doc:
-	@cargo doc --release --target=../../chips/sam4l/target.json
+	@cargo doc --release --target=../../chips/sam4l/sam4l.json
 
-.PHONY: target/target/release/storm
-target/target/release/storm:
-	@cargo build --release --target=../../chips/sam4l/target.json
-	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > target/target/release/storm.lst
+.PHONY: build/sam4l/release/storm
+build/sam4l/release/storm:
+	@cargo build --release --target=../../chips/sam4l/sam4l.json
+	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > build/sam4l/release/storm.lst
 
-target/target/release/storm.sdb: target/target/release/storm
+build/sam4l/release/storm.sdb: build/sam4l/release/storm
 	@tput bold ; echo "Packing SDB..." ; tput sgr0
 	@$(SLOAD) pack -m "$(SDB_MAINTAINER)" -v "$(SDB_VERSION)" -n "$(SDB_NAME)" -d $(SDB_DESCRIPTION) -o $@ $<
 
@@ -36,7 +36,7 @@ clean:
 	@cargo clean
 
 .PHONY: program
-program: target/target/release/storm.sdb
+program: build/sam4l/release/storm.sdb
 	$(SLOAD) flash $<
 
 .PHONY: flash

--- a/chips/nrf51/nrf51.json
+++ b/chips/nrf51/nrf51.json
@@ -16,7 +16,7 @@
         "-mcpu=cortex-m0", "-mthumb",
         "-mfloat-abi=soft",
         "-Wl,-gc-sections",
-        "-Ttarget/target/release/build/layout.ld"
+        "-Tbuild/nrf51/release/build/layout.ld"
     ],
     "post-link-args": [
         "-lm", "-lgcc", "-lc"

--- a/chips/sam4l/sam4l.json
+++ b/chips/sam4l/sam4l.json
@@ -16,8 +16,8 @@
         "-mcpu=cortex-m4", "-mthumb",
         "-mfloat-abi=soft",
         "-Wl,-gc-sections",
-        "-Wl,-Map=target/target/release/kernel.Map",
-        "-Ttarget/target/release/build/layout.ld"
+        "-Wl,-Map=build/sam4l/release/kernel.Map",
+        "-Tbuild/sam4l/release/build/layout.ld"
     ],
     "post-link-args": [
         "-lm", "-lgcc", "-lc"

--- a/doc/Compilation.md
+++ b/doc/Compilation.md
@@ -10,7 +10,7 @@ of how platforms program each onto an actual board.
 
 The kernel is divided into five Rust crates (i.e. packages):
 
-  * `main` contains the scheduler, definitions for the the process type and
+  * `main` contains the scheduler, definitions for the process type and
     traits for drivers, platforms and chips.
 
   * An architecture (e.g. _ARM Cortex M4_) crate that implements context
@@ -19,11 +19,11 @@ The kernel is divided into five Rust crates (i.e. packages):
   * A chip-specific (e.g. _Atmel SAM4L_) crate which handles interrupts and
     implements the hardware abstraction layer for a chip's peripherals.
 
-  * One (or more) crates for hardware independnt drivers and virtualization 
+  * One (or more) crates for hardware independent drivers and virtualization 
     layers.
 
   * A platform specific (e.g. _Firestorm_) crate that configures the chip and
-    its peripherals, assigns perpiherals to drivers, sets up virtualization
+    its peripherals, assigns peripherals to drivers, sets up virtualization
     layers and defines a system call interface.
 
 These crates are compiled using [Cargo](http://doc.crates.io), Rust's package
@@ -37,7 +37,7 @@ $ cargo build --release --target=target.json
 
 The `--release` argument tells cargo to invoke the Rust compiler with
 optimizations turned on and without debug symbols. `--target` points cargo to
-the target specification which includes the an LLVM data-layout definition,
+the target specification which includes the LLVM data-layout definition,
 architecture definitions for the compiler, arguments to pass to the linker and
 compilation options such as floating-point support.
 

--- a/doc/Design.md
+++ b/doc/Design.md
@@ -11,7 +11,7 @@ isolation granularity and resource consumption.
 Tock's architecture resolves this trade-off by using a language sandbox to
 isolated components and a cooperative scheduling model for concurrency in the
 kernel. As a result, isolation is (more or less) free in terms of resource
-consumption at the expense of preemtive scheduling (so a malicious component
+consumption at the expense of preemptive scheduling (so a malicious component
 could block the system by, e.g., spinning in an infinite loop).
 
 To first order, all component in Tock, including those in the kernel, are
@@ -94,7 +94,7 @@ explicitly by the hardware Memory Protection Unit (MPU). The MPU limits which
 memory addresses a process can access. Accesses outside of a process’s permitted
 region result in a fault and trap to the kernel.
 
-shows how a process is laid out in memory. Code, stored in flash, is made
+Code, stored in flash, is made
 accessible with a read-only memory protection region. Each process is allocated
 a contiguous region of RAM. One novel aspect of a process is the presence of a
 “grant” region at the top of the address space. This is memory allocated to the

--- a/doc/Firestorm.md
+++ b/doc/Firestorm.md
@@ -1,1 +1,1 @@
-boards/storm/README.md
+../boards/storm/README.md

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -4,7 +4,7 @@
 //!
 //! # System-call Overview
 //!
-//! Tock supports four system calls. The `wait` system call is handled entirely
+//! Tock supports four system calls. The `yield` system call is handled entirely
 //! by the scheduler, while three others are passed along to drivers:
 //!
 //!   * `subscribe` lets an application pass a callback to the driver to be
@@ -25,9 +25,9 @@
 //! determined by a particular platform, while the _driver minor number_ is
 //! driver-specific.
 //!
-//! # The `wait` System-call
+//! # The `yield` System-call
 //!
-//! While drivers to handle the `wait` system call, it's important to understand
+//! While drivers to handle the `yield` system call, it's important to understand
 //! it's function and it interacts with `subscribe`.
 
 /// `Driver`s implement the three driver-specific system calls: `subscribe`,

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -29,7 +29,7 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &mut P,
                 process.switch_to();
                 systick.enable(false);
             }
-            process::State::Waiting => {
+            process::State::Yielded => {
                 match process.callbacks.dequeue() {
                     None => break,
                     Some(cb) => {
@@ -63,8 +63,8 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &mut P,
                 };
                 process.set_r0(res);
             }
-            Some(syscall::WAIT) => {
-                process.state = process::State::Waiting;
+            Some(syscall::YIELD) => {
+                process.state = process::State::Yielded;
                 process.pop_syscall_stack();
 
                 // There might be already enqueued callbacks

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1,4 +1,4 @@
-pub const WAIT: u8 = 0;
+pub const YIELD: u8 = 0;
 pub const SUBSCRIBE: u8 = 1;
 pub const COMMAND: u8 = 2;
 pub const ALLOW: u8 = 3;

--- a/userland/Makefile
+++ b/userland/Makefile
@@ -1,7 +1,7 @@
 TOCK_BASE_DIR ?= .
 BUILDDIR ?= .
-ARCH ?= cortex-m0
-LIBTOCK ?= $(TOCK_BASE_DIR)/libtock/build/$(ARCH)/libtock.a
+TOCK_ARCH ?= cortex-m0
+LIBTOCK ?= $(TOCK_BASE_DIR)/libtock/build/$(TOCK_ARCH)/libtock.a
 
 TOOLCHAIN := arm-none-eabi
 
@@ -9,13 +9,13 @@ TOOLCHAIN := arm-none-eabi
 ELF2TBF ?= cargo run --manifest-path $(TOCK_BASE_DIR)/tools/elf2tbf/Cargo.toml --
 
 AS := $(TOOLCHAIN)-as
-ASFLAGS += -mcpu=$(ARCH) -mthumb
+ASFLAGS += -mcpu=$(TOCK_ARCH) -mthumb
 
 CC := $(TOOLCHAIN)-gcc
 CXX := $(TOOLCHAIN)-g++
 # n.b. make convention is that CPPFLAGS are shared for C and C++ sources
 # [CFLAGS is C only, CXXFLAGS is C++ only]
-CPPFLAGS += -I$(TOCK_BASE_DIR)/libtock -g -mcpu=$(ARCH) -mthumb -mfloat-abi=soft
+CPPFLAGS += -I$(TOCK_BASE_DIR)/libtock -g -mcpu=$(TOCK_ARCH) -mthumb -mfloat-abi=soft
 CPPFLAGS += \
 	    -fdata-sections -ffunction-sections\
 	    -Wall\
@@ -35,7 +35,7 @@ LDFLAGS := -T $(LINKER)
 all:	$(BUILDDIR)/app.bin
 
 $(LIBTOCK):
-	make -C $(TOCK_BASE_DIR)/libtock ARCH=$(ARCH)
+	make -C $(TOCK_BASE_DIR)/libtock TOCK_ARCH=$(TOCK_ARCH)
 
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)

--- a/userland/examples/ble-serialization/Makefile
+++ b/userland/examples/ble-serialization/Makefile
@@ -1,6 +1,6 @@
 TOCK_BASE_DIR = ../..
-LIBTOCK ?= $(TOCK_BASE_DIR)/libtock/build/$(ARCH)/libtock.a
-BUILDDIR ?= build/$(ARCH)
+LIBTOCK ?= $(TOCK_BASE_DIR)/libtock/build/$(TOCK_ARCH)/libtock.a
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 PROJECT_NAME = $(shell basename "$(realpath ./)")
 

--- a/userland/examples/ble-serialization/serialization.c
+++ b/userland/examples/ble-serialization/serialization.c
@@ -398,7 +398,7 @@ void ser_app_power_system_off_enter () {
 // Essentially sleep this process
 uint32_t sd_app_evt_wait () {
   nrf_serialization_done = false;
-  wait_for(&nrf_serialization_done);
+  yield_for(&nrf_serialization_done);
   return NRF_SUCCESS;
 }
 

--- a/userland/examples/blink/Makefile
+++ b/userland/examples/blink/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/blink_sync/Makefile
+++ b/userland/examples/blink_sync/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/c_gpio/Makefile
+++ b/userland/examples/c_gpio/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/c_hello/Makefile
+++ b/userland/examples/c_hello/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/gpio_test/Makefile
+++ b/userland/examples/gpio_test/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/gpio_test/main.c
+++ b/userland/examples/gpio_test/main.c
@@ -26,7 +26,7 @@ void gpio_output() {
 
   while (1) {
     gpio_toggle(LED_0);
-    wait();
+    yield();
   }
 }
 
@@ -51,7 +51,7 @@ void gpio_input() {
       sprintf(buf, "\tValue(%d)\n", pin_val);
       putstr(buf);
     }
-    wait();
+    yield();
   }
 }
 
@@ -72,7 +72,7 @@ void gpio_interrupt() {
   gpio_enable_interrupt(LED_0, PullDown, Change);
 
   while (1) {
-    wait();
+    yield();
     putstr("\tGPIO Interrupt!\n");
   }
 }

--- a/userland/examples/rf233/Makefile
+++ b/userland/examples/rf233/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/rf233/rf233.c
+++ b/userland/examples/rf233/rf233.c
@@ -529,7 +529,7 @@ int rf233_transmit() {
   RF233_COMMAND(TRXCMD_TX_START);
 
   PRINTF("RF233:: Issued TX_START, wait for completion interrupt.\n");
-  wait_for(&radio_tx);
+  yield_for(&radio_tx);
   PRINTF("RF233: tx ok\n\n");
   
   return RADIO_TX_OK;
@@ -736,7 +736,7 @@ int on(void) {
   PRINTF("RF233: State is %s, transitioning to PLL_ON.\n", state_str(rf233_status()));
   radio_pll = false;
   RF233_COMMAND(TRXCMD_PLL_ON);
-  wait_for(&radio_pll);
+  yield_for(&radio_pll);
   delay_ms(1);
   PRINTF("RF233: State is %s, transitioning to RX_ON.\n", state_str(rf233_status()));
   /* go to RX_ON state */

--- a/userland/examples/security_app/Makefile
+++ b/userland/examples/security_app/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/sensors/Makefile
+++ b/userland/examples/sensors/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/spi_buf/Makefile
+++ b/userland/examples/spi_buf/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/spi_byte/Makefile
+++ b/userland/examples/spi_byte/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/tmp006/Makefile
+++ b/userland/examples/tmp006/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 TOCK_BASE_DIR = $(CURRENT_DIR)/../..
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 C_SRCS   := $(wildcard *.c)
 C_SRCS   := $(wildcard *.c)

--- a/userland/examples/tmp006/main.c
+++ b/userland/examples/tmp006/main.c
@@ -54,7 +54,7 @@ void temp_callback(int temp_value, int error_code, int unused, void* callback_ar
 }
 
 // start periodic temperature sampling, then print data, sleeping in between
-//  samples. Note that you MUST wait() or else callbacks will never be serviced
+//  samples. Note that you MUST yield() or else callbacks will never be serviced
 void read_periodic (void) {
   int err;
 
@@ -70,7 +70,7 @@ void read_periodic (void) {
   while (1) {
     // yield for callbacks
     putstr("Sleeping...\n");
-    wait();
+    yield_for();
 
     // print new temp reading
     {

--- a/userland/libtock/Makefile
+++ b/userland/libtock/Makefile
@@ -1,15 +1,15 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CUR_DIR := $(dir $(MKFILE_PATH))
 
-BUILDDIR ?= build/$(ARCH)
+BUILDDIR ?= build/$(TOCK_ARCH)
 
 TOOLCHAIN ?= arm-none-eabi
 
 AS := $(TOOLCHAIN)-as
-ASFLAGS += -mcpu=$(ARCH) -mthumb
+ASFLAGS += -mcpu=$(TOCK_ARCH) -mthumb
 
 CC := $(TOOLCHAIN)-gcc
-CFLAGS += -O3 -Wall -Werror -I$(CUR_DIR) -g -mcpu=$(ARCH) -mthumb
+CFLAGS += -O3 -Wall -Werror -I$(CUR_DIR) -g -mcpu=$(TOCK_ARCH) -mthumb
 CFLAGS += \
 	    -fdata-sections -ffunction-sections\
 	    -Wall\

--- a/userland/libtock/crt1.c
+++ b/userland/libtock/crt1.c
@@ -48,6 +48,6 @@ void _start(void* mem_start,
 
   main();
 
-  while(1) { wait(); }
+  while(1) { yield(); }
 }
 

--- a/userland/libtock/firestorm.c
+++ b/userland/libtock/firestorm.c
@@ -49,7 +49,7 @@ void putnstr(const char *str, size_t len) {
     putstr_tail = data;
   }
 
-  wait_for(&data->called);
+  yield_for(&data->called);
 
   free(data->buf);
   free(data);
@@ -93,7 +93,7 @@ void delay_ms(uint32_t ms) {
   bool cond = false;
   timer_subscribe(delay_cb, &cond);
   timer_oneshot(ms);
-  wait_for(&cond);
+  yield_for(&cond);
 }
 int spi_init() {return 0;}
 int spi_set_chip_select(unsigned char cs) {return command(4, 2, cs);}
@@ -153,7 +153,7 @@ int spi_write_sync(const char* write,
 		   size_t  len) {
   bool cond = false;
   spi_write(write, len, spi_cb, &cond);
-  wait_for(&cond);
+  yield_for(&cond);
   return 0;
 }
 
@@ -165,7 +165,7 @@ int spi_read_write_sync(const char* write,
   if (err < 0) {
     return err;
   }
-  wait_for(&cond);
+  yield_for(&cond);
   return 0;
 }
 

--- a/userland/libtock/isl29035.c
+++ b/userland/libtock/isl29035.c
@@ -30,7 +30,7 @@ int isl29035_read_light_intensity() {
     return err;
   }
 
-  wait_for(&result.fired);
+  yield_for(&result.fired);
 
   return result.intensity;
 }

--- a/userland/libtock/tmp006.c
+++ b/userland/libtock/tmp006.c
@@ -31,7 +31,7 @@ int tmp006_read_sync(int16_t* temp_reading) {
 
     // wait for result
     readtemp = false;
-    wait_for(&readtemp);
+    yield_for(&readtemp);
 
     // write value for user
     *temp_reading = (int16_t)callback_vals[0];

--- a/userland/libtock/tock.c
+++ b/userland/libtock/tock.c
@@ -6,13 +6,13 @@
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-void wait_for(bool *cond) {
+void yield_for(bool *cond) {
   while(!*cond) {
-    wait();
+    yield();
   }
 }
 
-void __attribute__((naked)) wait() {
+void __attribute__((naked)) yield() {
   asm volatile("push {lr}\nsvc 0\npop {pc}" ::: "memory", "r0");
 }
 

--- a/userland/libtock/tock.h
+++ b/userland/libtock/tock.h
@@ -11,8 +11,8 @@ extern "C" {
 
 typedef void (subscribe_cb)(int, int, int,void*);
 
-void wait();
-void wait_for(bool*);
+void yield();
+void yield_for(bool*);
 int command(uint32_t driver, uint32_t command, int data);
 int subscribe(uint32_t driver, uint32_t subscribe,
               subscribe_cb cb, void* userdata);


### PR DESCRIPTION
1. It is pretty straightforward to see how built output ends up in a
folder called "build".
2. "target" is overloaded in embedded systems; I would expect that
folder to contain information about how to load an app onto a specific
target.
3. It's truly awful that cargo only reads config information from hidden
files. I'm not sure I've run across a more user un-friendly thing than
putting key information in a file and then intentionally hiding it.