### PR TITLE
Rename `wait` to `yield`

### DIFF
--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -4,7 +4,7 @@
 //!
 //! # System-call Overview
 //!
-//! Tock supports four system calls. The `wait` system call is handled entirely
+//! Tock supports four system calls. The `yield` system call is handled entirely
 //! by the scheduler, while three others are passed along to drivers:
 //!
 //!   * `subscribe` lets an application pass a callback to the driver to be
@@ -25,9 +25,9 @@
 //! determined by a particular platform, while the _driver minor number_ is
 //! driver-specific.
 //!
-//! # The `wait` System-call
+//! # The `yield` System-call
 //!
-//! While drivers to handle the `wait` system call, it's important to understand
+//! While drivers to handle the `yield` system call, it's important to understand
 //! it's function and it interacts with `subscribe`.
 
 /// `Driver`s implement the three driver-specific system calls: `subscribe`,

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -29,7 +29,7 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &mut P,
                 process.switch_to();
                 systick.enable(false);
             }
-            process::State::Waiting => {
+            process::State::Yielded => {
                 match process.callbacks.dequeue() {
                     None => break,
                     Some(cb) => {
@@ -63,8 +63,8 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &mut P,
                 };
                 process.set_r0(res);
             }
-            Some(syscall::WAIT) => {
-                process.state = process::State::Waiting;
+            Some(syscall::YIELD) => {
+                process.state = process::State::Yielded;
                 process.pop_syscall_stack();
 
                 // There might be already enqueued callbacks

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1,4 +1,4 @@
-pub const WAIT: u8 = 0;
+pub const YIELD: u8 = 0;
 pub const SUBSCRIBE: u8 = 1;
 pub const COMMAND: u8 = 2;
 pub const ALLOW: u8 = 3;

--- a/userland/examples/ble-serialization/serialization.c
+++ b/userland/examples/ble-serialization/serialization.c
@@ -398,7 +398,7 @@ void ser_app_power_system_off_enter () {
 // Essentially sleep this process
 uint32_t sd_app_evt_wait () {
   nrf_serialization_done = false;
-  wait_for(&nrf_serialization_done);
+  yield_for(&nrf_serialization_done);
   return NRF_SUCCESS;
 }
 

--- a/userland/examples/gpio_test/main.c
+++ b/userland/examples/gpio_test/main.c
@@ -26,7 +26,7 @@ void gpio_output() {
 
   while (1) {
     gpio_toggle(LED_0);
-    wait();
+    yield();
   }
 }
 
@@ -51,7 +51,7 @@ void gpio_input() {
       sprintf(buf, "\tValue(%d)\n", pin_val);
       putstr(buf);
     }
-    wait();
+    yield();
   }
 }
 
@@ -72,7 +72,7 @@ void gpio_interrupt() {
   gpio_enable_interrupt(LED_0, PullDown, Change);
 
   while (1) {
-    wait();
+    yield();
     putstr("\tGPIO Interrupt!\n");
   }
 }

--- a/userland/examples/rf233/rf233.c
+++ b/userland/examples/rf233/rf233.c
@@ -529,7 +529,7 @@ int rf233_transmit() {
   RF233_COMMAND(TRXCMD_TX_START);
 
   PRINTF("RF233:: Issued TX_START, wait for completion interrupt.\n");
-  wait_for(&radio_tx);
+  yield_for(&radio_tx);
   PRINTF("RF233: tx ok\n\n");
   
   return RADIO_TX_OK;
@@ -736,7 +736,7 @@ int on(void) {
   PRINTF("RF233: State is %s, transitioning to PLL_ON.\n", state_str(rf233_status()));
   radio_pll = false;
   RF233_COMMAND(TRXCMD_PLL_ON);
-  wait_for(&radio_pll);
+  yield_for(&radio_pll);
   delay_ms(1);
   PRINTF("RF233: State is %s, transitioning to RX_ON.\n", state_str(rf233_status()));
   /* go to RX_ON state */

--- a/userland/examples/tmp006/main.c
+++ b/userland/examples/tmp006/main.c
@@ -54,7 +54,7 @@ void temp_callback(int temp_value, int error_code, int unused, void* callback_ar
 }
 
 // start periodic temperature sampling, then print data, sleeping in between
-//  samples. Note that you MUST wait() or else callbacks will never be serviced
+//  samples. Note that you MUST yield() or else callbacks will never be serviced
 void read_periodic (void) {
   int err;
 
@@ -70,7 +70,7 @@ void read_periodic (void) {
   while (1) {
     // yield for callbacks
     putstr("Sleeping...\n");
-    wait();
+    yield_for();
 
     // print new temp reading
     {

--- a/userland/libtock/crt1.c
+++ b/userland/libtock/crt1.c
@@ -48,6 +48,6 @@ void _start(void* mem_start,
 
   main();
 
-  while(1) { wait(); }
+  while(1) { yield(); }
 }
 

--- a/userland/libtock/firestorm.c
+++ b/userland/libtock/firestorm.c
@@ -49,7 +49,7 @@ void putnstr(const char *str, size_t len) {
     putstr_tail = data;
   }
 
-  wait_for(&data->called);
+  yield_for(&data->called);
 
   free(data->buf);
   free(data);
@@ -93,7 +93,7 @@ void delay_ms(uint32_t ms) {
   bool cond = false;
   timer_subscribe(delay_cb, &cond);
   timer_oneshot(ms);
-  wait_for(&cond);
+  yield_for(&cond);
 }
 int spi_init() {return 0;}
 int spi_set_chip_select(unsigned char cs) {return command(4, 2, cs);}
@@ -153,7 +153,7 @@ int spi_write_sync(const char* write,
 		   size_t  len) {
   bool cond = false;
   spi_write(write, len, spi_cb, &cond);
-  wait_for(&cond);
+  yield_for(&cond);
   return 0;
 }
 
@@ -165,7 +165,7 @@ int spi_read_write_sync(const char* write,
   if (err < 0) {
     return err;
   }
-  wait_for(&cond);
+  yield_for(&cond);
   return 0;
 }
 

--- a/userland/libtock/isl29035.c
+++ b/userland/libtock/isl29035.c
@@ -30,7 +30,7 @@ int isl29035_read_light_intensity() {
     return err;
   }
 
-  wait_for(&result.fired);
+  yield_for(&result.fired);
 
   return result.intensity;
 }

--- a/userland/libtock/tmp006.c
+++ b/userland/libtock/tmp006.c
@@ -31,7 +31,7 @@ int tmp006_read_sync(int16_t* temp_reading) {
 
     // wait for result
     readtemp = false;
-    wait_for(&readtemp);
+    yield_for(&readtemp);
 
     // write value for user
     *temp_reading = (int16_t)callback_vals[0];

--- a/userland/libtock/tock.c
+++ b/userland/libtock/tock.c
@@ -6,13 +6,13 @@
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-void wait_for(bool *cond) {
+void yield_for(bool *cond) {
   while(!*cond) {
-    wait();
+    yield();
   }
 }
 
-void __attribute__((naked)) wait() {
+void __attribute__((naked)) yield() {
   asm volatile("push {lr}\nsvc 0\npop {pc}" ::: "memory", "r0");
 }
 

--- a/userland/libtock/tock.h
+++ b/userland/libtock/tock.h
@@ -11,8 +11,8 @@ extern "C" {
 
 typedef void (subscribe_cb)(int, int, int,void*);
 
-void wait();
-void wait_for(bool*);
+void yield();
+void yield_for(bool*);
 int command(uint32_t driver, uint32_t command, int data);
 int subscribe(uint32_t driver, uint32_t subscribe,
               subscribe_cb cb, void* userdata);


### PR DESCRIPTION
`wait` conflicts with libc's `wait`, which causes a naming conflict. It's also potentially confusing (if you type `man 2 wait` you get something, but it's not Tock's `wait`).

I don't think `yield` is overloaded in the C standard library. Alternatives, though:

  * `sys_wait` (and we would change the other syscalls to `sys_`)

  * `tock_wait`

  * ... ideas?

/cc @brghena 