### PR TITLE
Move linker script and target spec to boards

### DIFF
--- a/boards/nrf51dk/Makefile
+++ b/boards/nrf51dk/Makefile
@@ -1,13 +1,13 @@
 .PHONY: all
-all: target/target/release/nrf_pca10028
+all: target/nrf51/release/nrf51dk
 
 .PHONY: doc
 doc:
-	@cargo doc --release --target=../../chips/nrf51/target.json
+	@cargo doc --release --target=nrf51.json
 
-.PHONY: target/target/release/nrf_pca10028
-target/target/release/nrf_pca10028:
-	@cargo build --release --target=../../chips/nrf51/target.json
+.PHONY: target/target/release/nrf51dk
+target/nrf51/release/nrf51dk:
+	@cargo build --release --target=nrf51.json
 
 .PHONY: clean
 clean:

--- a/boards/nrf51dk/layout.ld
+++ b/boards/nrf51dk/layout.ld
@@ -1,0 +1,1 @@
+../../chips/nrf51/layout.ld

--- a/boards/nrf51dk/nrf51.json
+++ b/boards/nrf51dk/nrf51.json
@@ -1,0 +1,1 @@
+../../chips/nrf51/nrf51.json

--- a/boards/storm/Makefile
+++ b/boards/storm/Makefile
@@ -13,22 +13,22 @@ JLINK=JLinkExe
 JLINK_OPTIONS=-device ATSAM4LC8C -if swd -speed 1200 -AutoConnect 1
 JLINK_SCRIPTS=jtag/
 
-all: target/target/release/storm
+all: target/sam4l/release/storm
 
 .PHONY: doc
 doc:
-	@cargo doc --release --target=../../chips/sam4l/target.json
+	@cargo doc --release --target=sam4l.json
 
-.PHONY: target/target/release/storm
-target/target/release/storm:
-	@cargo build --release --target=../../chips/sam4l/target.json
-	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > target/target/release/storm.lst
+.PHONY: target/sam4l/release/storm
+target/sam4l/release/storm:
+	@cargo build --release --target=sam4l.json
+	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > target/sam4l/release/storm.lst
 
-target/target/release/storm.sdb: target/target/release/storm
+target/sam4l/release/storm.sdb: target/sam4l/release/storm
 	@tput bold ; echo "Packing SDB..." ; tput sgr0
 	@$(SLOAD) pack -m "$(SDB_MAINTAINER)" -v "$(SDB_VERSION)" -n "$(SDB_NAME)" -d $(SDB_DESCRIPTION) -o $@ $<
 
-target/target/release/storm.hex: target/target/release/storm
+target/sam4l/release/storm.hex: target/sam4l/release/storm
 	@$(OBJCOPY) -Oihex $^ $@
 
 .PHONY: clean
@@ -36,11 +36,11 @@ clean:
 	@cargo clean
 
 .PHONY: program
-program: target/target/release/storm.sdb
+program: target/sam4l/release/storm.sdb
 	$(SLOAD) flash $<
 
 .PHONY: flash
-flash: target/target/release/storm.hex
+flash: target/sam4l/release/storm.hex
 	$(JLINK) $(JLINK_OPTIONS) $(JLINK_SCRIPTS)flash-kernel.jlink
 
 # special command for the firestorm. Flashes the stormloader bootloader onto

--- a/boards/storm/layout.ld
+++ b/boards/storm/layout.ld
@@ -1,0 +1,1 @@
+../../chips/sam4l/layout.ld

--- a/boards/storm/sam4l.json
+++ b/boards/storm/sam4l.json
@@ -1,0 +1,1 @@
+../../chips/sam4l/sam4l.json

--- a/chips/nrf51/build.rs
+++ b/chips/nrf51/build.rs
@@ -1,7 +1,6 @@
 extern crate gcc;
 
 use std::env;
-use std::fs;
 use std::path::Path;
 
 fn main() {
@@ -11,8 +10,4 @@ fn main() {
         .flag("-mthumb")
         .file("src/crt1.c")
         .compile("libcrt1.a");
-
-    let src = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("layout.ld");
-    let dst = Path::new(&env::var("OUT_DIR").unwrap()).join("../../layout.ld");
-    fs::copy(src, dst).unwrap();
 }

--- a/chips/nrf51/layout.ld
+++ b/chips/nrf51/layout.ld
@@ -1,4 +1,9 @@
 /*
+ * This is an example linker script. Copy this into your Tock board repository
+ * and modify as needed.
+ */
+
+/*
  * This file is part of StormLoader, the Storm Bootloader
  *
  * StormLoader is free software: you can redistribute it and/or modify
@@ -21,7 +26,7 @@
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
-SEARCH_DIR(.) 
+SEARCH_DIR(.)
 
 MEMORY
 {

--- a/chips/nrf51/nrf51.json
+++ b/chips/nrf51/nrf51.json
@@ -16,7 +16,7 @@
         "-mcpu=cortex-m0", "-mthumb",
         "-mfloat-abi=soft",
         "-Wl,-gc-sections",
-        "-Ttarget/target/release/build/layout.ld"
+        "-Tlayout.ld"
     ],
     "post-link-args": [
         "-lm", "-lgcc", "-lc"

--- a/chips/sam4l/Cargo.toml
+++ b/chips/sam4l/Cargo.toml
@@ -3,8 +3,6 @@ name = "sam4l"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 
-build = "build.rs"
-
 [dependencies]
 rust-libcore = "*"
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/sam4l/build.rs
+++ b/chips/sam4l/build.rs
@@ -1,9 +1,0 @@
-use std::env;
-use std::fs;
-use std::path::Path;
-
-fn main() {
-    let src = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("layout.ld");
-    let dst = Path::new(&env::var("OUT_DIR").unwrap()).join("../../layout.ld");
-    fs::copy(src, dst).unwrap();
-}

--- a/chips/sam4l/layout.ld
+++ b/chips/sam4l/layout.ld
@@ -1,4 +1,9 @@
 /*
+ * This is an example linker script. Copy this into your Tock board repository
+ * and modify as needed.
+ */
+
+/*
  * This file is part of StormLoader, the Storm Bootloader
  *
  * StormLoader is free software: you can redistribute it and/or modify

--- a/chips/sam4l/sam4l.json
+++ b/chips/sam4l/sam4l.json
@@ -16,8 +16,7 @@
         "-mcpu=cortex-m4", "-mthumb",
         "-mfloat-abi=soft",
         "-Wl,-gc-sections",
-        "-Wl,-Map=target/target/release/kernel.Map",
-        "-Ttarget/target/release/build/layout.ld"
+        "-Tlayout.ld"
     ],
     "post-link-args": [
         "-lm", "-lgcc", "-lc"


### PR DESCRIPTION
Relocating the linker script and target specs to the boards directory lets boards customize them. For example, a particular board (e.g. the Firestorm) may need to leave room for a bootloader before the vector table.

It also lets us get rid of the hacky dependency on the output directory name in the target specification.