### PR TITLE
Build rules to program kernel + app on nrf51dk

### DIFF
--- a/boards/nrf51dk/Makefile
+++ b/boards/nrf51dk/Makefile
@@ -5,6 +5,8 @@ OBJCOPY?=arm-none-eabi-objcopy
 OBJDUMP?=arm-none-eabi-objdump
 OBJDUMP_FLAGS+= --disassemble-all --source --disassembler-options=force-thumb -C --section-headers
 
+TOCK_ARCH=cortex-m0
+
 .PHONY: all
 all: target/nrf51/release/nrf51dk
 
@@ -30,5 +32,39 @@ clean:
 .PHONY: debug
 debug: target/nrf51/debug/nrf51dk
 
-#TODO: Figure out how to program the nRF51dk
+.PHONY: apps/$(APP)/build/$(TOCK_ARCH)/app.bin
+apps/$(APP)/build/$(TOCK_ARCH)/app.bin:
+	@make -C apps/$(APP) TOCK_ARCH=$(TOCK_ARCH)
+
+target/nrf51/release/nrf51dk-$(APP): target/nrf51/release/nrf51dk apps/$(APP)/build/$(TOCK_ARCH)/app.bin
+	@$(OBJCOPY) --update-section .apps=../../userland/examples/$(APP)/build/$(TOCK_ARCH)/app.bin \
+	  --set-section-flags .apps=alloc,code \
+	  target/nrf51/release/nrf51dk $@
+
+target/nrf51/release/nrf51dk.hex: target/nrf51/release/nrf51dk
+	@$(OBJCOPY) -Oihex $^ $@
+
+target/nrf51/release/nrf51dk-$(APP).hex: target/nrf51/release/nrf51dk-$(APP)
+	@$(OBJCOPY) -Oihex $^ $@
+
+JLINK=JLinkExe
+JLINK_OPTIONS+=-device nrf51422 -if swd -speed 1200 -AutoConnect 1
+JLINK_SCRIPTS_DIR=jtag/
+
+# Upload the kernel over JTAG
+.PHONY: program
+program: target/nrf51/release/nrf51dk.hex
+	$(JLINK) $(JLINK_OPTIONS) $(JLINK_SCRIPTS_DIR)/flash-kernel.jlink
+
+# Upload kernel + app over JTAG
+.PHONY: program-full
+program-full: target/nrf51/release/nrf51dk-$(APP).hex
+	@$(eval TEMPFILE := $(shell mktemp -t nrf51dk-$(APP).jlink.XXXXXXXXXX))
+	@echo r > $(TEMPFILE)
+	@echo loadfile $< >> $(TEMPFILE)
+	@echo r >> $(TEMPFILE)
+	@echo g >> $(TEMPFILE)
+	@echo q >> $(TEMPFILE)
+	$(JLINK) $(JLINK_OPTIONS) $(TEMPFILE)
+	@rm $(TEMPFILE)
 

--- a/boards/nrf51dk/apps/blink
+++ b/boards/nrf51dk/apps/blink
@@ -1,0 +1,1 @@
+../../../userland/examples/blink

--- a/boards/nrf51dk/jtag/flash-full.jlink
+++ b/boards/nrf51dk/jtag/flash-full.jlink
@@ -1,0 +1,6 @@
+r
+loadfile target/nrf51/release/nrf51dk-blink.hex
+r
+g
+q
+

--- a/boards/nrf51dk/jtag/flash-kernel.jlink
+++ b/boards/nrf51dk/jtag/flash-kernel.jlink
@@ -1,0 +1,6 @@
+r
+loadfile target/nrf51/release/nrf51dk.hex
+r
+g
+q
+

--- a/chips/nrf51/layout.ld
+++ b/chips/nrf51/layout.ld
@@ -88,22 +88,11 @@ SECTIONS
         KEEP (*(SORT(.dtors.*)))
         KEEP (*crtend.o(.dtors))
 
-        . = ALIGN(4);
-        _sapps = .;
-        KEEP(*(.app.*))
-        _eapps = .;
+        *(.got*)
 
         . = ALIGN(4);
         _efixed = .;            /* End of text section */
     } > rom
-
-    .apps :
-    {
-        . = ALIGN(4);
-        _sapps = .;
-        KEEP (*(.app.*))
-        _eapps = .;
-    } > prog
 
     /* .ARM.exidx is sorted, so has to go in its own output section.  */
     PROVIDE_HIDDEN (__exidx_start = .);
@@ -117,7 +106,7 @@ SECTIONS
     _etext = .;
     _textend = .;
 
-    .relocate : AT (_etext)
+    .relocate :
     {
         . = ALIGN(4);
         _srelocate = .;
@@ -127,6 +116,12 @@ SECTIONS
         . = ALIGN(4);
         _erelocate = .;
     } > ram
+
+    .apps 0x20000 :
+    {
+        _sapps = .;
+        LONG(0)
+    } > prog
 
     /* .bss section which is used for uninitialized data */
     .bss (NOLOAD) :

--- a/chips/nrf51/layout.ld
+++ b/chips/nrf51/layout.ld
@@ -88,11 +88,22 @@ SECTIONS
         KEEP (*(SORT(.dtors.*)))
         KEEP (*crtend.o(.dtors))
 
-        *(.got*)
+        . = ALIGN(4);
+        _sapps = .;
+        KEEP(*(.app.*))
+        _eapps = .;
 
         . = ALIGN(4);
         _efixed = .;            /* End of text section */
     } > rom
+
+    .apps :
+    {
+        . = ALIGN(4);
+        _sapps = .;
+        KEEP (*(.app.*))
+        _eapps = .;
+    } > prog
 
     /* .ARM.exidx is sorted, so has to go in its own output section.  */
     PROVIDE_HIDDEN (__exidx_start = .);
@@ -106,7 +117,7 @@ SECTIONS
     _etext = .;
     _textend = .;
 
-    .relocate :
+    .relocate : AT (_etext)
     {
         . = ALIGN(4);
         _srelocate = .;
@@ -116,12 +127,6 @@ SECTIONS
         . = ALIGN(4);
         _erelocate = .;
     } > ram
-
-    .apps 0x20000 :
-    {
-        _sapps = .;
-        LONG(0)
-    } > prog
 
     /* .bss section which is used for uninitialized data */
     .bss (NOLOAD) :


### PR DESCRIPTION
Allows programming over JLINK of the kernel + one app for the nrf51dk. The app must be located in `boards/nrf51dk/apps/APP_NAME`. As a starter, I've symlinked the blink example app into that folder. Now, from the nrf51dk folder you can run:

```
$ make program-full APP=blink
```
