### PR TITLE
Changed xfer_done DMA interface

### DIFF
--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -66,7 +66,7 @@ pub enum DMAChannelNum {
 /// *_RX means transfer data from peripheral to memory, *_TX means transfer data
 /// from memory to peripheral.
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum DMAPeripheral {
     USART0_RX = 0,
     USART1_RX = 1,
@@ -135,7 +135,7 @@ pub struct DMAChannel {
 }
 
 pub trait DMAClient {
-    fn xfer_done(&mut self, pid: usize);
+    fn xfer_done(&mut self, pid: DMAPeripheral);
 }
 
 impl DMAChannel {
@@ -191,7 +191,8 @@ impl DMAChannel {
 
     pub fn handle_interrupt(&mut self) {
         let registers: &mut DMARegisters = unsafe { mem::transmute(self.registers) };
-        let channel: usize = read_volatile(&registers.peripheral_select);
+        let channel_num: usize = read_volatile(&registers.peripheral_select);
+        let channel: DMAPeripheral = unsafe { mem::transmute(channel_num as u8) };
 
         self.client.as_mut().map(|client| {
             client.xfer_done(channel);

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -311,7 +311,7 @@ impl I2CDevice {
 }
 
 impl DMAClient for I2CDevice {
-    fn xfer_done(&mut self, _pid: usize) {}
+    fn xfer_done(&mut self, _pid: DMAPeripheral) {}
 }
 
 impl hil::i2c::I2CController for I2CDevice {

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -409,12 +409,12 @@ impl spi::SpiMaster for Spi {
 }
 
 impl DMAClient for Spi {
-    fn xfer_done(&mut self, pid: usize) {
+    fn xfer_done(&mut self, pid: DMAPeripheral) {
         // We ignore the RX interrupt because we are guaranteed to have TX
         // DMA setup, but there's no guarantee RX will exist. In the case
         // both are happening, just using TX is sufficient because SPI
         // is full duplex.
-        if pid == 22 {
+        if pid == DMAPeripheral::SPI_TX {
             // SPI TX
             self.transfer_in_progress.set(false);
 

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -182,7 +182,7 @@ impl USART {
 }
 
 impl DMAClient for USART {
-    fn xfer_done(&mut self, _pid: usize) {
+    fn xfer_done(&mut self, _pid: DMAPeripheral) {
         let buffer = match self.dma.as_mut() {
             Some(dma) => {
                 let buf = dma.abort_xfer();


### PR DESCRIPTION
Change DMA xfer_done interface to return a DMAPeripheral enum to clients rather than a u32.

Making this pull request because it's unclear what the best method for changing a numerical register value into an enum in rust.