### PR TITLE
Add ability to use OSC0 as system clock

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -230,6 +230,8 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
+    sam4l::pm::setup_system_clock(sam4l::pm::SystemClockSource::DfllRc32k, 48000000);
+
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);
 

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -300,6 +300,8 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
+    sam4l::pm::setup_system_clock(sam4l::pm::SystemClockSource::DfllRc32k, 48000000);
+
     // Workaround for SB.02 hardware bug
     // TODO(alevy): Get rid of this when we think SB.02 are out of circulation
     sam4l::gpio::PA[14].enable();

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -198,9 +198,6 @@ pub unsafe fn init() {
         *pdest = 0;
         pdest = pdest.offset(1);
     }
-
-    // Setup the clock to run at 48 MHz
-    pm::configure_48mhz_dfll();
 }
 
 unsafe extern "C" fn hard_fault_handler() {

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -266,7 +266,7 @@ static mut BSCIF: *mut BscifRegisters = BSCIF_BASE as *mut BscifRegisters;
 static mut SCIF: *mut ScifRegisters = SCIF_BASE as *mut ScifRegisters;
 static mut FLASHCALW: *mut FlashcalwRegisters = FLASHCALW_BASE as *mut FlashcalwRegisters;
 
-static mut SYSTEM_FREQUENCY: u32 = 0;
+static mut SYSTEM_FREQUENCY: VolatileCell<u32> = VolatileCell::new(0);
 
 unsafe fn unlock(register_offset: u32) {
     (*PM).unlock.set(0xAA000000 | register_offset);
@@ -424,7 +424,7 @@ unsafe fn configure_external_oscillator() {
 }
 
 pub unsafe fn setup_system_clock(clock_source: SystemClockSource, frequency: u32) {
-    SYSTEM_FREQUENCY = frequency;
+    SYSTEM_FREQUENCY.set(frequency);
 
     match clock_source {
         SystemClockSource::DfllRc32k => {
@@ -438,7 +438,7 @@ pub unsafe fn setup_system_clock(clock_source: SystemClockSource, frequency: u32
 }
 
 pub unsafe fn get_system_frequency() -> u32 {
-    SYSTEM_FREQUENCY
+    SYSTEM_FREQUENCY.get()
 }
 
 macro_rules! mask_clock {

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -158,21 +158,6 @@ struct FlashcalwRegisters {
     pvr: VolatileCell<u32>,
 }
 
-const PM_BASE: usize = 0x400E0000;
-const BSCIF_BASE: usize = 0x400F0400;
-const SCIF_BASE: usize = 0x400E0800;
-const FLASHCALW_BASE: usize = 0x400A0000;
-
-const HSB_MASK_OFFSET: u32 = 0x24;
-const PBA_MASK_OFFSET: u32 = 0x28;
-const PBB_MASK_OFFSET: u32 = 0x2C;
-const PBD_MASK_OFFSET: u32 = 0x34;
-
-static mut PM: *mut PmRegisters = PM_BASE as *mut PmRegisters;
-static mut BSCIF: *mut BscifRegisters = BSCIF_BASE as *mut BscifRegisters;
-static mut SCIF: *mut ScifRegisters = SCIF_BASE as *mut ScifRegisters;
-static mut FLASHCALW: *mut FlashcalwRegisters = FLASHCALW_BASE as *mut FlashcalwRegisters;
-
 pub enum MainClock {
     RCSYS,
     OSC0,
@@ -254,20 +239,46 @@ pub enum PBDClock {
     PICOUART,
 }
 
+/// Which source the system clock should be generated from.
+pub enum SystemClockSource {
+    /// Use the internal digital frequency locked loop (DFLL) sourced from
+    /// the internal RC32K clock. Note this typically requires calibration
+    /// of the RC32K to have a consistent clock.
+    DfllRc32k,
+
+    /// Use an external crystal oscillator as the direct source for the
+    /// system clock.
+    ExternalOscillator,
+}
+
+const PM_BASE: usize = 0x400E0000;
+const BSCIF_BASE: usize = 0x400F0400;
+const SCIF_BASE: usize = 0x400E0800;
+const FLASHCALW_BASE: usize = 0x400A0000;
+
+const HSB_MASK_OFFSET: u32 = 0x24;
+const PBA_MASK_OFFSET: u32 = 0x28;
+const PBB_MASK_OFFSET: u32 = 0x2C;
+const PBD_MASK_OFFSET: u32 = 0x34;
+
+static mut PM: *mut PmRegisters = PM_BASE as *mut PmRegisters;
+static mut BSCIF: *mut BscifRegisters = BSCIF_BASE as *mut BscifRegisters;
+static mut SCIF: *mut ScifRegisters = SCIF_BASE as *mut ScifRegisters;
+static mut FLASHCALW: *mut FlashcalwRegisters = FLASHCALW_BASE as *mut FlashcalwRegisters;
+
+static mut SYSTEM_FREQUENCY: u32 = 0;
+
 unsafe fn unlock(register_offset: u32) {
     (*PM).unlock.set(0xAA000000 | register_offset);
 }
 
-pub unsafe fn select_main_clock(clock: MainClock) {
+unsafe fn select_main_clock(clock: MainClock) {
     unlock(0);
     (*PM).mcctrl.set(clock as u32);
 }
 
-/// Configure the system clock to use the DFLL with the RC32K as the source.
-/// Run at 48 MHz.
-pub unsafe fn configure_48mhz_dfll() {
-    // Enable HCACHE
-    //
+/// Enable HCACHE
+unsafe fn enable_cache() {
     enable_clock(Clock::HSB(HSBClock::FLASHCALWP));
     enable_clock(Clock::PBB(PBBClock::HRAMC1));
     // Enable cache
@@ -275,23 +286,57 @@ pub unsafe fn configure_48mhz_dfll() {
 
     // Wait for the cache controller to be enabled.
     while (*FLASHCALW).sr.get() & (1 << 0) == 0 {}
+}
+
+/// Configure high-speed flash mode. This is taken from the ASF code
+unsafe fn enable_high_speed_flash() {
+    // Since we are running at a fast speed we have to set a clock delay
+    // for flash, as well as enable fast flash mode.
+    let flashcalw_fcr = (*FLASHCALW).fcr.get();
+    (*FLASHCALW).fcr.set(flashcalw_fcr | (1 << 6));
+
+    // Enable high speed mode for flash
+    let flashcalw_fcmd = (*FLASHCALW).fcmd.get();
+    let flashcalw_fcmd_new1 = flashcalw_fcmd & (!(0x3F << 0));
+    let flashcalw_fcmd_new2 = flashcalw_fcmd_new1 | (0xA5 << 24) | (0x10 << 0);
+    (*FLASHCALW).fcmd.set(flashcalw_fcmd_new2);
+
+    // And wait for the flash to be ready
+    while (*FLASHCALW).fsr.get() & (1 << 0) == 0 {}
+}
+
+/// Setup the internal 32kHz RC oscillator.
+unsafe fn enable_rc32k() {
+    let bscif_rc32kcr = (*BSCIF).rc32kcr.get();
+    // Unlock the BSCIF::RC32KCR register
+    (*BSCIF).unlock.set(0xAA000024);
+    // Write the BSCIF::RC32KCR register.
+    // Enable the generic clock source, the temperature compensation, and the
+    // 32k output.
+    (*BSCIF).rc32kcr.set(bscif_rc32kcr | (1 << 2) | (1 << 1) | (1 << 0));
+    // Wait for it to be ready, although it feels like this won't do anything
+    while (*BSCIF).rc32kcr.get() & (1 << 0) == 0 {}
+
+    // Load magic calibration value for the 32KHz RC oscillator
+    //
+    // Unlock the BSCIF::RC32KTUNE register
+    (*BSCIF).unlock.set(0xAA000028);
+    // Write the BSCIF::RC32KTUNE register
+    (*BSCIF).rc32ktune.set(0x001d0015);
+}
+
+/// Configure the system clock to use the DFLL with the RC32K as the source.
+/// Run at 48 MHz.
+unsafe fn configure_48mhz_dfll() {
+    // Enable HCACHE
+    enable_cache();
 
     // Check to see if the DFLL is already setup.
     //
     if (((*SCIF).dfll0conf.get() & 0x03) == 0) || (((*SCIF).pclksr.get() & (1 << 2)) == 0) {
 
         // Enable the GENCLK_SRC_RC32K
-        //
-        // Get the original value
-        let bscif_rc32kcr = (*BSCIF).rc32kcr.get();
-        // Unlock the BSCIF::RC32KCR register
-        (*BSCIF).unlock.set(0xAA000024);
-        // Write the BSCIF::RC32KCR register.
-        // Enable the generic clock source, the temperature compensation, and the
-        // 32k output.
-        (*BSCIF).rc32kcr.set(bscif_rc32kcr | (1 << 1) | (1 << 2) | (1 << 0));
-        // Wait for it to be ready, although it feels like this won't do anything
-        while (*BSCIF).rc32kcr.get() & (1 << 0) == 0 {}
+        enable_rc32k();
 
         // Next init closed loop mode.
         //
@@ -350,31 +395,50 @@ pub unsafe fn configure_48mhz_dfll() {
 
     // Since we are running at a fast speed we have to set a clock delay
     // for flash, as well as enable fast flash mode.
-    //
-    let flashcalw_fcr = (*FLASHCALW).fcr.get();
-    (*FLASHCALW).fcr.set(flashcalw_fcr | (1 << 6));
-
-    // Enable high speed mode for flash
-    let flashcalw_fcmd = (*FLASHCALW).fcmd.get();
-    let flashcalw_fcmd_new1 = flashcalw_fcmd & (!(0x3F << 0));
-    let flashcalw_fcmd_new2 = flashcalw_fcmd_new1 | (0xA5 << 24) | (0x10 << 0);
-    (*FLASHCALW).fcmd.set(flashcalw_fcmd_new2);
-
-    // And wait for the flash to be ready
-    while (*FLASHCALW).fsr.get() & (1 << 0) == 0 {}
-
-    // TODO: run bpm_configure_power_scaling()
+    enable_high_speed_flash();
 
     // Choose the main clock
-    //
     select_main_clock(MainClock::DFLL);
+}
 
-    // Load magic calibration value for the 32KHz RC oscillator
-    //
-    // Unlock the BSCIF::RC32KTUNE register
-    (*BSCIF).unlock.set(0xAA000028);
-    // Write the BSCIF::RC32KTUNE register
-    (*BSCIF).rc32ktune.set(0x001d0015);
+/// Configure the system clock to use the DFLL with the 16 MHz external crystal.
+unsafe fn configure_external_oscillator() {
+    // Use the cache
+    enable_cache();
+
+    // Need the 32k RC oscillator for things like BPM module and AST.
+    enable_rc32k();
+
+    // Enable the OSC0
+    (*SCIF).unlock.set(0xAA000020);
+    // enable, 557 us startup time, gain level 4 (sortof), is crystal.
+    (*SCIF).oscctrl0.set((1 << 16) | (1 << 8) | (4 << 1) | (1 << 0));
+    // Wait for oscillator to be ready
+    while (*SCIF).pclksr.get() & (1 << 0) == 0 {}
+
+    // Go to high speed flash mode
+    enable_high_speed_flash();
+
+    // Set the main clock to be the external oscillator
+    select_main_clock(MainClock::OSC0);
+}
+
+pub unsafe fn setup_system_clock(clock_source: SystemClockSource, frequency: u32) {
+    SYSTEM_FREQUENCY = frequency;
+
+    match clock_source {
+        SystemClockSource::DfllRc32k => {
+            configure_48mhz_dfll();
+        }
+
+        SystemClockSource::ExternalOscillator => {
+            configure_external_oscillator();
+        }
+    }
+}
+
+pub unsafe fn get_system_frequency() -> u32 {
+    SYSTEM_FREQUENCY
 }
 
 macro_rules! mask_clock {

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -106,7 +106,7 @@ impl Spi {
     /// Sets the approximate baud rate for the active peripheral,
     /// and return the actual baud rate set.
     ///
-    /// Since the only supported baud rates are 48 MHz / n where n
+    /// Since the only supported baud rates are (system clock / n) where n
     /// is an integer from 1 to 255, the exact baud rate may not
     /// be available. In that case, the next lower baud rate will
     /// be selected.
@@ -116,7 +116,7 @@ impl Spi {
     pub fn set_baud_rate(&self, rate: u32) -> u32 {
         // Main clock frequency
         let mut real_rate = rate;
-        let clock = 48000000;
+        let clock = unsafe { pm::get_system_frequency() };
 
         if real_rate < 188235 {
             real_rate = 188235;

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -316,17 +316,12 @@ impl USART {
         regs.mr.set(mode);
     }
 
-    // NOTE: dependent on oversampling rate
-    // XXX: how do you determine the current clock frequency?
     fn set_baud_rate(&self, baud_rate: u32) {
-        let cd = 48000000 / (8 * baud_rate);
-        self.set_baud_rate_divider(cd as u16);
-    }
-
-    fn set_baud_rate_divider(&self, clock_divider: u16) {
         let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
-        let brgr_val: u32 = 0x00000000 | clock_divider as u32;
-        regs.brgr.set(brgr_val);
+
+        let system_frequency = unsafe { pm::get_system_frequency() };
+        let cd = system_frequency / (8 * baud_rate);
+        regs.brgr.set(cd);
     }
 
     fn enable_rx_timeout(&self, timeout: u8) {


### PR DESCRIPTION
Because there are now multiple clock options, setting the clock has to be a platform specific option.

I do need help making a function that returns the current system clock frequency (for use in things like usart.rs). The way it's setup right now it needs unsafe. Is there a good way to do this that doesn't need unsafe? Should I go all the way to making `pm` a struct like the other modules?
