### PR TITLE
Send multiple bytes by setting txdrdy to 0

### DIFF
--- a/chips/nrf51/src/uart.rs
+++ b/chips/nrf51/src/uart.rs
@@ -208,6 +208,9 @@ impl uart::UART for UART {
             ptr::write_volatile(&mut regs.starttx, 1 as u32);
         }
         unsafe {
+            ptr::write_volatile(&mut regs.txdrdy, 0 as u32);
+        }
+        unsafe {
             ptr::write_volatile(&mut regs.txd, byte as u32);
         }
         while !self.tx_ready() {}


### PR DESCRIPTION
Every time a byte is transmitted, it generates a TXDRDY event by setting this register to 1. This must be manually cleared before another byte can be sent. 

See sections 10.1.3 and 29.4 of the nRF51822 manual. 