### PR TITLE
Changes NRF UART from ptrs to volatile cells

### DIFF
--- a/chips/nrf51/src/uart.rs
+++ b/chips/nrf51/src/uart.rs
@@ -1,40 +1,50 @@
-use chip;
 use core::mem;
-use core::ptr;
+use kernel::common::VolatileCell;
 use kernel::hil::uart;
-use nvic;
 use peripheral_interrupts::NvicIdx;
+use chip;
+use nvic;
 
 #[repr(C, packed)]
-struct Registers {
-    startrx: u32,
-    stoprx: u32,
-    starttx: u32,
-    stoptx: u32,
-    _reserved0: [u32; 62],
-    rxdrdy: u32,
-    _reserved1: [u32; 4],
-    txdrdy: u32,
-    error: u32,
-    _reserved2: [u32; 119],
-    inten: u32,
-    intenset: u32,
-    intenclr: u32,
-    _reserved3: [u32; 93],
-    errorsrc: u32,
-    _reserved4: [u32; 31],
-    enable: u32,
-    _reserved5: u32,
-    pselrts: u32,
-    pseltxd: u32,
-    pselcts: u32,
-    pselrxd: u32,
-    rxd: u32,
-    txd: u32,
-    _reserved6: u32,
-    baudrate: u32,
-    _reserved7: [u32; 71],
-    config: u32,
+pub struct Registers {
+    pub task_startrx: VolatileCell<u32>,
+    pub task_stoprx: VolatileCell<u32>,
+    pub task_starttx: VolatileCell<u32>,
+    pub task_stoptx: VolatileCell<u32>,
+    _reserved1: [u32; 3],
+    pub task_suspend: VolatileCell<u32>,
+    _reserved2: [u32; 56],
+    pub event_cts: VolatileCell<u32>,
+    pub event_ncts: VolatileCell<u32>,
+    pub event_rxdrdy: VolatileCell<u32>,
+    _reserved3: [u32; 4],
+    pub event_txdrdy: VolatileCell<u32>,
+    _reserved4: [u32; 1],
+    pub event_error: VolatileCell<u32>,
+    _reserved5: [u32; 7],
+    pub event_rxto: VolatileCell<u32>,
+    _reserved6: [u32; 46], 
+    pub shorts: VolatileCell<u32>,
+    _reserved7: [u32; 64],
+    pub intenset: VolatileCell<u32>,
+    pub intenclr: VolatileCell<u32>,
+    _reserved8: [u32; 93],
+    pub errorsrc: VolatileCell<u32>,
+    _reserved9: [u32; 31],
+    pub enable: VolatileCell<u32>,
+    _reserved10: [u32; 1],
+    pub pselrts: VolatileCell<u32>,
+    pub pseltxd: VolatileCell<u32>,
+    pub pselcts: VolatileCell<u32>,
+    pub pselrxd: VolatileCell<u32>,
+    pub rxd: VolatileCell<u32>,
+    pub txd: VolatileCell<u32>,
+    _reserved11: [u32; 1],
+    pub baudrate: VolatileCell<u32>,
+    _reserved12: [u32; 17],
+    pub config: VolatileCell<u32>,
+    _reserved13: [u32; 675],
+    pub power: VolatileCell<u32>,
 }
 
 const UART_BASE: u32 = 0x40002000;
@@ -66,22 +76,12 @@ impl UART {
 
     fn configure(&mut self, baud_rate: u32) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        unsafe {
-            ptr::write_volatile(&mut regs.enable, 0b100);
-        }
+        regs.enable.set(0b100); 
         self.set_baud_rate(baud_rate);
-        unsafe {
-            ptr::write_volatile(&mut regs.pselrts, 8);
-        }
-        unsafe {
-            ptr::write_volatile(&mut regs.pseltxd, 9);
-        }
-        unsafe {
-            ptr::write_volatile(&mut regs.pselcts, 10);
-        }
-        unsafe {
-            ptr::write_volatile(&mut regs.pselrxd, 11);
-        }
+        regs.pselrts.set(8); 
+        regs.pseltxd.set(9); 
+        regs.pselcts.set(10); 
+        regs.pselrxd.set(11); 
     }
 
     pub fn set_client<C: uart::Client>(&mut self, client: &'static C) {
@@ -89,93 +89,53 @@ impl UART {
     }
 
     fn set_baud_rate(&self, baud_rate: u32) {
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
+        let regs : &mut Registers = unsafe { mem::transmute(self.regs) };
         match baud_rate {
-            1200 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x0004F000);
-            },
-            2400 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x0009D000);
-            },
-            4800 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x0013B000);
-            },
-            9600 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x00275000);
-            },
-            14400 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x003B0000);
-            },
-            19200 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x004EA000);
-            },
-            28800 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x0075F000);
-            },
-            38400 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x009D5000);
-            },
-            57600 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x00EBF000);
-            },
-            76800 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x013A9000);
-            },
-            115200 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x01D7E000);
-            },
-            230400 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x03AFB000);
-            },
-            250000 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x04000000);
-            },
-            460800 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x075F7000);
-            },
-            1000000 => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x10000000);
-            },
-            _ => unsafe {
-                ptr::write_volatile(&mut regs.baudrate, 0x01D7E000);
-            }, //setting default to 115200
+            1200 =>    regs.baudrate.set(0x0004F000),
+            2400 =>    regs.baudrate.set(0x0009D000),
+            4800 =>    regs.baudrate.set(0x0013B000),
+            9600 =>    regs.baudrate.set(0x00275000),
+            14400 =>   regs.baudrate.set(0x003B0000),
+            19200 =>   regs.baudrate.set(0x004EA000),
+            28800 =>   regs.baudrate.set(0x0075F000),
+            38400 =>   regs.baudrate.set(0x009D5000),
+            57600 =>   regs.baudrate.set(0x00EBF000),
+            76800 =>   regs.baudrate.set(0x013A9000),
+            115200 =>  regs.baudrate.set(0x01D7E000),
+            230400 =>  regs.baudrate.set(0x03AFB000),
+            250000 =>  regs.baudrate.set(0x04000000),
+            460800 =>  regs.baudrate.set(0x075F7000),
+            1000000 => regs.baudrate.set(0x10000000),
+            _ => regs.baudrate.set(0x01D7E000), //setting default to 115200
         }
     }
 
     pub fn enable_rx_interrupts(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        unsafe {
-            ptr::write_volatile(&mut regs.intenset, 1 << 3 as u32);
-        }
+        regs.intenset.set(1 << 3 as u32); 
     }
 
     pub fn enable_tx_interrupts(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        unsafe {
-            ptr::write_volatile(&mut regs.intenset, 1 << 7 as u32);
-        }
+        regs.intenset.set(1 << 7 as u32); 
     }
 
     pub fn disable_rx_interrupts(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        unsafe {
-            ptr::write_volatile(&mut regs.intenclr, 1 << 3 as u32);
-        }
+        regs.intenclr.set(1 << 3 as u32); 
     }
 
     pub fn disable_tx_interrupts(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        unsafe {
-            ptr::write_volatile(&mut regs.intenclr, 1 << 7 as u32);
-        }
+        regs.intenclr.set(1 << 7 as u32); 
     }
 
     pub fn handle_interrupt(&mut self) {
         let regs: &Registers = unsafe { mem::transmute(self.regs) };
-        let rx = unsafe { ptr::read_volatile(&regs.rxdrdy) } != 0;
-        let tx = unsafe { ptr::read_volatile(&regs.txdrdy) } != 0;
+        let rx = regs.event_rxdrdy.get() != 0;
+        let tx = regs.event_txdrdy.get() != 0;
         if rx {
-            let val = unsafe { ptr::read_volatile(&regs.rxd) };
+            let val = regs.rxd.get();
             match self.client {
                 Some(ref client) => client.read_done(val as u8),
                 None => {}
@@ -194,29 +154,21 @@ impl uart::UART for UART {
 
     fn rx_ready(&self) -> bool {
         let regs: &Registers = unsafe { mem::transmute(self.regs) };
-        unsafe { ptr::read_volatile(&regs.rxdrdy) & 0b1 != 0 }
+         regs.event_rxdrdy.get() & 0b1 != 0 
     }
 
     fn tx_ready(&self) -> bool {
         let regs: &Registers = unsafe { mem::transmute(self.regs) };
-        unsafe { ptr::read_volatile(&regs.txdrdy) == 1 }
+        regs.event_txdrdy.get() == 1
     }
 
     fn send_byte(&self, byte: u8) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        unsafe {
-            ptr::write_volatile(&mut regs.starttx, 1 as u32);
-        }
-        unsafe {
-            ptr::write_volatile(&mut regs.txdrdy, 0 as u32);
-        }
-        unsafe {
-            ptr::write_volatile(&mut regs.txd, byte as u32);
-        }
-        while !self.tx_ready() {}
-        unsafe {
-            ptr::write_volatile(&mut regs.stoptx, 1 as u32);
-        }
+        regs.task_starttx.set(1 as u32); 
+        regs.event_txdrdy.set(0 as u32); 
+        regs.txd.set(byte as u32); 
+        while !self.tx_ready() {} 
+        regs.task_stoptx.set(1 as u32); 
     }
 
     fn send_bytes(&self, bytes: &'static mut [u8], len: usize) {
@@ -226,38 +178,30 @@ impl uart::UART for UART {
     }
 
     fn read_byte(&self) -> u8 {
-        while !self.rx_ready() {}
         let regs: &Registers = unsafe { mem::transmute(self.regs) };
-        // ptr::write_volatile(&mut regs.startrx, 1 as u32);
-        unsafe { ptr::read_volatile(&regs.rxd) as u8 }
+        regs.task_startrx.set(1 as u32); 
+        while !self.rx_ready() {}
+        regs.rxd.get() as u8 
     }
 
     fn enable_rx(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        unsafe {
-            ptr::write_volatile(&mut regs.startrx, 1);
-        }
+        regs.task_startrx.set(1); 
     }
 
     fn disable_rx(&mut self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        unsafe {
-            ptr::write_volatile(&mut regs.stoprx, 1);
-        }
+        regs.task_stoprx.set(1); 
     }
 
     fn enable_tx(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        unsafe {
-            ptr::write_volatile(&mut regs.starttx, 1);
-        }
+        regs.task_starttx.set(1); 
     }
 
     fn disable_tx(&mut self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        unsafe {
-            ptr::write_volatile(&mut regs.stoptx, 1);
-        }
+        regs.task_stoptx.set(1); 
     }
 }
 

--- a/chips/nrf51/src/uart.rs
+++ b/chips/nrf51/src/uart.rs
@@ -1,9 +1,10 @@
+
+use chip;
 use core::mem;
 use kernel::common::VolatileCell;
 use kernel::hil::uart;
-use peripheral_interrupts::NvicIdx;
-use chip;
 use nvic;
+use peripheral_interrupts::NvicIdx;
 
 #[repr(C, packed)]
 pub struct Registers {
@@ -23,7 +24,7 @@ pub struct Registers {
     pub event_error: VolatileCell<u32>,
     _reserved5: [u32; 7],
     pub event_rxto: VolatileCell<u32>,
-    _reserved6: [u32; 46], 
+    _reserved6: [u32; 46],
     pub shorts: VolatileCell<u32>,
     _reserved7: [u32; 64],
     pub intenset: VolatileCell<u32>,
@@ -76,12 +77,12 @@ impl UART {
 
     fn configure(&mut self, baud_rate: u32) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        regs.enable.set(0b100); 
+        regs.enable.set(0b100);
         self.set_baud_rate(baud_rate);
-        regs.pselrts.set(8); 
-        regs.pseltxd.set(9); 
-        regs.pselcts.set(10); 
-        regs.pselrxd.set(11); 
+        regs.pselrts.set(8);
+        regs.pseltxd.set(9);
+        regs.pselcts.set(10);
+        regs.pselrxd.set(11);
     }
 
     pub fn set_client<C: uart::Client>(&mut self, client: &'static C) {
@@ -89,22 +90,22 @@ impl UART {
     }
 
     fn set_baud_rate(&self, baud_rate: u32) {
-        let regs : &mut Registers = unsafe { mem::transmute(self.regs) };
+        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
         match baud_rate {
-            1200 =>    regs.baudrate.set(0x0004F000),
-            2400 =>    regs.baudrate.set(0x0009D000),
-            4800 =>    regs.baudrate.set(0x0013B000),
-            9600 =>    regs.baudrate.set(0x00275000),
-            14400 =>   regs.baudrate.set(0x003B0000),
-            19200 =>   regs.baudrate.set(0x004EA000),
-            28800 =>   regs.baudrate.set(0x0075F000),
-            38400 =>   regs.baudrate.set(0x009D5000),
-            57600 =>   regs.baudrate.set(0x00EBF000),
-            76800 =>   regs.baudrate.set(0x013A9000),
-            115200 =>  regs.baudrate.set(0x01D7E000),
-            230400 =>  regs.baudrate.set(0x03AFB000),
-            250000 =>  regs.baudrate.set(0x04000000),
-            460800 =>  regs.baudrate.set(0x075F7000),
+            1200 => regs.baudrate.set(0x0004F000),
+            2400 => regs.baudrate.set(0x0009D000),
+            4800 => regs.baudrate.set(0x0013B000),
+            9600 => regs.baudrate.set(0x00275000),
+            14400 => regs.baudrate.set(0x003B0000),
+            19200 => regs.baudrate.set(0x004EA000),
+            28800 => regs.baudrate.set(0x0075F000),
+            38400 => regs.baudrate.set(0x009D5000),
+            57600 => regs.baudrate.set(0x00EBF000),
+            76800 => regs.baudrate.set(0x013A9000),
+            115200 => regs.baudrate.set(0x01D7E000),
+            230400 => regs.baudrate.set(0x03AFB000),
+            250000 => regs.baudrate.set(0x04000000),
+            460800 => regs.baudrate.set(0x075F7000),
             1000000 => regs.baudrate.set(0x10000000),
             _ => regs.baudrate.set(0x01D7E000), //setting default to 115200
         }
@@ -112,22 +113,22 @@ impl UART {
 
     pub fn enable_rx_interrupts(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        regs.intenset.set(1 << 3 as u32); 
+        regs.intenset.set(1 << 3 as u32);
     }
 
     pub fn enable_tx_interrupts(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        regs.intenset.set(1 << 7 as u32); 
+        regs.intenset.set(1 << 7 as u32);
     }
 
     pub fn disable_rx_interrupts(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        regs.intenclr.set(1 << 3 as u32); 
+        regs.intenclr.set(1 << 3 as u32);
     }
 
     pub fn disable_tx_interrupts(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        regs.intenclr.set(1 << 7 as u32); 
+        regs.intenclr.set(1 << 7 as u32);
     }
 
     pub fn handle_interrupt(&mut self) {
@@ -154,7 +155,7 @@ impl uart::UART for UART {
 
     fn rx_ready(&self) -> bool {
         let regs: &Registers = unsafe { mem::transmute(self.regs) };
-         regs.event_rxdrdy.get() & 0b1 != 0 
+        regs.event_rxdrdy.get() & 0b1 != 0
     }
 
     fn tx_ready(&self) -> bool {
@@ -164,11 +165,11 @@ impl uart::UART for UART {
 
     fn send_byte(&self, byte: u8) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        regs.task_starttx.set(1 as u32); 
-        regs.event_txdrdy.set(0 as u32); 
-        regs.txd.set(byte as u32); 
-        while !self.tx_ready() {} 
-        regs.task_stoptx.set(1 as u32); 
+        regs.task_starttx.set(1 as u32);
+        regs.event_txdrdy.set(0 as u32);
+        regs.txd.set(byte as u32);
+        while !self.tx_ready() {}
+        regs.task_stoptx.set(1 as u32);
     }
 
     fn send_bytes(&self, bytes: &'static mut [u8], len: usize) {
@@ -179,29 +180,29 @@ impl uart::UART for UART {
 
     fn read_byte(&self) -> u8 {
         let regs: &Registers = unsafe { mem::transmute(self.regs) };
-        regs.task_startrx.set(1 as u32); 
+        regs.task_startrx.set(1 as u32);
         while !self.rx_ready() {}
-        regs.rxd.get() as u8 
+        regs.rxd.get() as u8
     }
 
     fn enable_rx(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        regs.task_startrx.set(1); 
+        regs.task_startrx.set(1);
     }
 
     fn disable_rx(&mut self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        regs.task_stoprx.set(1); 
+        regs.task_stoprx.set(1);
     }
 
     fn enable_tx(&self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        regs.task_starttx.set(1); 
+        regs.task_starttx.set(1);
     }
 
     fn disable_tx(&mut self) {
         let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        regs.task_stoptx.set(1); 
+        regs.task_stoptx.set(1);
     }
 }
 

--- a/chips/nrf51/src/uart.rs
+++ b/chips/nrf51/src/uart.rs
@@ -1,9 +1,18 @@
 use core::mem;
-use kernel::common::VolatileCell;
 use kernel::hil::uart;
+use core::cell::Cell;
+use kernel::common::VolatileCell;
 use peripheral_interrupts::NvicIdx;
+use kernel::common::take_cell::TakeCell;
+use kernel::hil::gpio::GPIOPin;
 use chip;
 use nvic;
+use gpio;
+
+// configure pins 
+// print from user space
+// handle interrupt -> better send_bytes  
+    // buffer 
 
 #[repr(C, packed)]
 pub struct Registers {
@@ -52,6 +61,9 @@ const UART_BASE: u32 = 0x40002000;
 pub struct UART {
     regs: *mut Registers,
     client: Option<&'static uart::Client>,
+    buffer: TakeCell<&'static mut [u8]>,
+    index: Cell<usize>,
+    len: Cell<usize>
 }
 
 #[derive(Copy, Clone)]
@@ -71,6 +83,9 @@ impl UART {
         UART {
             regs: UART_BASE as *mut Registers,
             client: None,
+            buffer: TakeCell::empty(),
+            len: Cell::new(0),
+            index: Cell::new(0)
         }
     }
 
@@ -82,6 +97,14 @@ impl UART {
         regs.pseltxd.set(9); 
         regs.pselcts.set(10); 
         regs.pselrxd.set(11); 
+    }
+
+    pub fn enable_nvic(&self) {
+        nvic::enable(NvicIdx::UART0);
+    }
+
+    pub fn disable_nvic(&self) {
+        nvic::disable(NvicIdx::UART0);
     }
 
     pub fn set_client<C: uart::Client>(&mut self, client: &'static C) {
@@ -172,10 +195,23 @@ impl uart::UART for UART {
     }
 
     fn send_bytes(&self, bytes: &'static mut [u8], len: usize) {
-        for i in 0..len {
-            self.send_byte(bytes[i]);
+        let regs : &mut Registers = unsafe { mem::transmute(self.regs) };
+        let mut real_len = 0;
+
+        if len == 0 {
+            return; 
         }
+        if len == self.index.get() {
+            // Done sending the string 
+            // TODO how to indicate done? 
+            self.index.set(0); 
+            return; 
+        }
+        self.send_byte(bytes[self.index.get()]); 
+        let next_index = self.index.get() + 1; 
+        self.index.set(next_index); 
     }
+
 
     fn read_byte(&self) -> u8 {
         let regs: &Registers = unsafe { mem::transmute(self.regs) };


### PR DESCRIPTION
ptr::write_volatile and read_volatile no longer used in uart.rs; each register is now a VolatileCell. 