### PR TITLE
UART HIL redesign with asynchronous calls

### DIFF
--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -14,17 +14,20 @@ impl Write for Writer {
         let uart = unsafe { &mut sam4l::usart::USART3 };
         if !self.initialized {
             self.initialized = true;
-            uart.configure(sam4l::usart::USARTParams {
+            uart.init(uart::UARTParams {
                 baud_rate: 115200,
-                data_bits: 8,
+                stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
-                mode: uart::Mode::Normal,
+                hw_flow_control: false,
             });
+            uart.reset();
             uart.enable_tx();
 
         }
+        // XXX: I'd like to get this working the "right" way, but I'm not sure how
         for c in s.bytes() {
             uart.send_byte(c);
+            while !uart.tx_ready() {}
         }
         Ok(())
     }

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -1,5 +1,4 @@
 use core::fmt::*;
-use kernel::hil::Controller;
 use kernel::hil::uart::{self, UART};
 use sam4l;
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -240,18 +240,12 @@ pub unsafe fn reset_handler() {
     let console = static_init!(
         capsules::console::Console<sam4l::usart::USART>,
         capsules::console::Console::new(&sam4l::usart::USART3,
+                     115200,
                      &mut capsules::console::WRITE_BUF,
+                     &mut capsules::console::READ_BUF,
                      kernel::Container::create()),
-        24);
+        288/8);
     sam4l::usart::USART3.set_client(console);
-
-    sam4l::usart::USART3.configure(sam4l::usart::USARTParams {
-        baud_rate: 115200,
-        data_bits: 8,
-        parity: kernel::hil::uart::Parity::None,
-        mode: kernel::hil::uart::Mode::Normal,
-    });
-
     console.initialize();
 
     // # TIMER

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -11,6 +11,7 @@ use capsules::timer::TimerDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use kernel::{Chip, MPU};
+use kernel::hil;
 use kernel::hil::Controller;
 
 mod io;
@@ -242,10 +243,9 @@ pub unsafe fn reset_handler() {
         capsules::console::Console::new(&sam4l::usart::USART3,
                      115200,
                      &mut capsules::console::WRITE_BUF,
-                     &mut capsules::console::READ_BUF,
                      kernel::Container::create()),
-        288/8);
-    sam4l::usart::USART3.set_client(console);
+        224/8);
+    hil::uart::UART::set_client(&sam4l::usart::USART3, console);
     console.initialize();
 
     // # TIMER

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -175,22 +175,16 @@ pub unsafe fn reset_handler() {
     let console = static_init!(
         capsules::console::Console<nrf51::uart::UART>,
         capsules::console::Console::new(&nrf51::uart::UART0,
-                                       &mut capsules::console::WRITE_BUF,
-                                       kernel::Container::create()),
-        24);
-    nrf51::uart::UART0.set_client(console);
+                                        115200,
+                                        &mut capsules::console::WRITE_BUF,
+                                        kernel::Container::create()),
+        224/8);
+    UART::set_client(&nrf51::uart::UART0, console);
 
     let alarm = &nrf51::rtc::RTC;
     alarm.start();
     let mux_alarm = static_init!(MuxAlarm<'static, Rtc>, MuxAlarm::new(&RTC), 16);
     alarm.set_client(mux_alarm);
-
-    nrf51::uart::UART0.init(kernel::hil::uart::UARTParams {
-        baud_rate: 115200,
-        data_bits: 8,
-        parity: kernel::hil::uart::Parity::None,
-        mode: kernel::hil::uart::Mode::Normal,
-    });
 
 
     let virtual_alarm1 = static_init!(

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -180,6 +180,7 @@ pub unsafe fn reset_handler() {
                                         kernel::Container::create()),
         224/8);
     UART::set_client(&nrf51::uart::UART0, console);
+    console.initialize();
 
     let alarm = &nrf51::rtc::RTC;
     alarm.start();

--- a/boards/storm/src/io.rs
+++ b/boards/storm/src/io.rs
@@ -14,17 +14,20 @@ impl Write for Writer {
         let uart = unsafe { &mut sam4l::usart::USART3 };
         if !self.initialized {
             self.initialized = true;
-            uart.configure(sam4l::usart::USARTParams {
+            uart.init(uart::UARTParams {
                 baud_rate: 115200,
-                data_bits: 8,
+                stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
-                mode: uart::Mode::Normal,
+                hw_flow_control: false,
             });
+            uart.reset();
             uart.enable_tx();
 
         }
+        // XXX: I'd like to get this working the "right" way, but I'm not sure how
         for c in s.bytes() {
             uart.send_byte(c);
+            while !uart.tx_ready() {}
         }
         Ok(())
     }

--- a/boards/storm/src/io.rs
+++ b/boards/storm/src/io.rs
@@ -1,5 +1,4 @@
 use core::fmt::*;
-use kernel::hil::Controller;
 use kernel::hil::uart::{self, UART};
 use sam4l;
 

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -317,8 +317,9 @@ pub unsafe fn reset_handler() {
         Console<usart::USART>,
         Console::new(&usart::USART3,
                      &mut console::WRITE_BUF,
+                     &mut console::READ_BUF,
                      kernel::Container::create()),
-        24);
+        256/8);
     usart::USART3.set_client(console);
 
     // Create the Nrf51822Serialization driver for passing BLE commands
@@ -326,8 +327,9 @@ pub unsafe fn reset_handler() {
     let nrf_serialization = static_init!(
         Nrf51822Serialization<usart::USART>,
         Nrf51822Serialization::new(&usart::USART2,
-                                   &mut nrf51822_serialization::WRITE_BUF),
-        68);
+                                   &mut nrf51822_serialization::WRITE_BUF,
+                                   &mut nrf51822_serialization::READ_BUF),
+        608/8);
     usart::USART2.set_client(nrf_serialization);
 
     let ast = &sam4l::ast::AST;
@@ -445,21 +447,6 @@ pub unsafe fn reset_handler() {
         },
         288/8);
 
-    usart::USART3.configure(usart::USARTParams {
-        // client: &console,
-        baud_rate: 115200,
-        data_bits: 8,
-        parity: kernel::hil::uart::Parity::None,
-        mode: kernel::hil::uart::Mode::Normal,
-    });
-
-    // Setup USART2 for the nRF51822 connection
-    usart::USART2.configure(usart::USARTParams {
-        baud_rate: 250000,
-        data_bits: 8,
-        parity: kernel::hil::uart::Parity::Even,
-        mode: kernel::hil::uart::Mode::FlowControl,
-    });
     // Configure USART2 Pins for connection to nRF51822
     // NOTE: the SAM RTS pin is not working for some reason. Our hypothesis is
     //  that it is because RX DMA is not set up. For now, just having it always

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -316,10 +316,11 @@ pub unsafe fn reset_handler() {
     let console = static_init!(
         Console<usart::USART>,
         Console::new(&usart::USART3,
+                     115200,
                      &mut console::WRITE_BUF,
                      &mut console::READ_BUF,
                      kernel::Container::create()),
-        256/8);
+        288/8);
     usart::USART3.set_client(console);
 
     // Create the Nrf51822Serialization driver for passing BLE commands

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -14,6 +14,7 @@ use capsules::timer::TimerDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use kernel::{Chip, MPU, Platform};
+use kernel::hil;
 use kernel::hil::Controller;
 use kernel::hil::gpio::PinCtl;
 use kernel::hil::spi::SpiMaster;
@@ -318,10 +319,9 @@ pub unsafe fn reset_handler() {
         Console::new(&usart::USART3,
                      115200,
                      &mut console::WRITE_BUF,
-                     &mut console::READ_BUF,
                      kernel::Container::create()),
-        288/8);
-    usart::USART3.set_client(console);
+        224/8);
+    hil::uart::UART::set_client(&usart::USART3, console);
 
     // Create the Nrf51822Serialization driver for passing BLE commands
     // over UART to the nRF51822 radio.
@@ -331,7 +331,7 @@ pub unsafe fn reset_handler() {
                                    &mut nrf51822_serialization::WRITE_BUF,
                                    &mut nrf51822_serialization::READ_BUF),
         608/8);
-    usart::USART2.set_client(nrf_serialization);
+    hil::uart::UART::set_client(&usart::USART2, nrf_serialization);
 
     let ast = &sam4l::ast::AST;
 

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -1,4 +1,3 @@
-use core::cell::Cell;
 use kernel::{AppId, AppSlice, Container, Callback, Shared, Driver};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::uart::{self, UART, Client};
@@ -26,14 +25,13 @@ impl Default for App {
 }
 
 pub static mut WRITE_BUF: [u8; 64] = [0; 64];
-pub static mut READ_BUF: [u8; 1] = [0];
 
 pub struct Console<'a, U: UART + 'a> {
     uart: &'a U,
     apps: Container<App>,
     in_progress: TakeCell<AppId>,
     tx_buffer: TakeCell<&'static mut [u8]>,
-    baud_rate: Cell<u32>,
+    baud_rate: u32,
 }
 
 impl<'a, U: UART> Console<'a, U> {
@@ -47,13 +45,13 @@ impl<'a, U: UART> Console<'a, U> {
             apps: container,
             in_progress: TakeCell::empty(),
             tx_buffer: TakeCell::new(tx_buffer),
-            baud_rate: Cell::new(baud_rate),
+            baud_rate: baud_rate,
         }
     }
 
     pub fn initialize(&self) {
         self.uart.init(uart::UARTParams {
-            baud_rate: self.baud_rate.get(),
+            baud_rate: self.baud_rate,
             stop_bits: uart::StopBits::One,
             parity: uart::Parity::None,
             hw_flow_control: false,

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -4,7 +4,6 @@ use kernel::common::take_cell::TakeCell;
 use kernel::hil::uart::{self, UART, Client};
 
 pub struct App {
-    read_callback: Option<Callback>,
     write_callback: Option<Callback>,
     read_buffer: Option<AppSlice<Shared, u8>>,
     write_buffer: Option<AppSlice<Shared, u8>>,
@@ -16,7 +15,6 @@ pub struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            read_callback: None,
             write_callback: None,
             read_buffer: None,
             write_buffer: None,
@@ -35,7 +33,6 @@ pub struct Console<'a, U: UART + 'a> {
     apps: Container<App>,
     in_progress: TakeCell<AppId>,
     tx_buffer: TakeCell<&'static mut [u8]>,
-    rx_buffer: TakeCell<&'static mut [u8]>,
     baud_rate: Cell<u32>,
 }
 
@@ -43,7 +40,6 @@ impl<'a, U: UART> Console<'a, U> {
     pub fn new(uart: &'a U,
                baud_rate: u32,
                tx_buffer: &'static mut [u8],
-               rx_buffer: &'static mut [u8],
                container: Container<App>)
                -> Console<'a, U> {
         Console {
@@ -51,7 +47,6 @@ impl<'a, U: UART> Console<'a, U> {
             apps: container,
             in_progress: TakeCell::empty(),
             tx_buffer: TakeCell::new(tx_buffer),
-            rx_buffer: TakeCell::new(rx_buffer),
             baud_rate: Cell::new(baud_rate),
         }
     }
@@ -185,7 +180,10 @@ impl<'a, U: UART> Client for Console<'a, U> {
         }
     }
 
-    fn receive_complete(&self, rx_buffer: &'static mut [u8], _rx_len: usize, _error: uart::Error) {
+    fn receive_complete(&self,
+                        _rx_buffer: &'static mut [u8],
+                        _rx_len: usize,
+                        _error: uart::Error) {
         // this is currently unimplemented for console
     }
 }

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -1,6 +1,6 @@
 use kernel::{AppId, AppSlice, Container, Callback, Shared, Driver};
 use kernel::common::take_cell::TakeCell;
-use kernel::hil::uart::{UART, Client};
+use kernel::hil::uart::{self, UART, Client};
 
 pub struct App {
     read_callback: Option<Callback>,
@@ -27,30 +27,41 @@ impl Default for App {
 }
 
 pub static mut WRITE_BUF: [u8; 64] = [0; 64];
+pub static mut READ_BUF: [u8; 1] = [0];
 
 pub struct Console<'a, U: UART + 'a> {
     uart: &'a U,
     apps: Container<App>,
     in_progress: TakeCell<AppId>,
-    buffer: TakeCell<&'static mut [u8]>,
+    tx_buffer: TakeCell<&'static mut [u8]>,
+    rx_buffer: TakeCell<&'static mut [u8]>,
 }
 
 impl<'a, U: UART> Console<'a, U> {
     pub fn new(uart: &'a U,
-               buffer: &'static mut [u8],
+               tx_buffer: &'static mut [u8],
+               rx_buffer: &'static mut [u8],
                container: Container<App>)
                -> Console<'a, U> {
         Console {
             uart: uart,
             apps: container,
             in_progress: TakeCell::empty(),
-            buffer: TakeCell::new(buffer),
+            tx_buffer: TakeCell::new(tx_buffer),
+            rx_buffer: TakeCell::new(rx_buffer),
         }
     }
 
     pub fn initialize(&self) {
-        self.uart.enable_tx();
-        self.uart.enable_rx();
+        self.uart.init(uart::UARTParams {
+            baud_rate: 115200,
+            stop_bits: uart::StopBits::One,
+            parity: uart::Parity::None,
+            hw_flow_control: false,
+        });
+        self.rx_buffer.take().map(|buffer| {
+            self.uart.receive(buffer, 1);
+        });
     }
 }
 
@@ -94,14 +105,14 @@ impl<'a, U: UART> Driver for Console<'a, U> {
                             app.write_len = slice.len();
                             if self.in_progress.is_none() {
                                 self.in_progress.replace(callback.app_id());
-                                self.buffer.take().map(|buffer| {
+                                self.tx_buffer.take().map(|buffer| {
                                     for (i, c) in slice.as_ref().iter().enumerate() {
                                         if buffer.len() <= i {
                                             break;
                                         }
                                         buffer[i] = *c;
                                     }
-                                    self.uart.send_bytes(buffer, app.write_len);
+                                    self.uart.transmit(buffer, app.write_len);
                                 });
                             } else {
                                 app.pending_write = true;
@@ -119,17 +130,23 @@ impl<'a, U: UART> Driver for Console<'a, U> {
 
     fn command(&self, cmd_num: usize, arg1: usize, _: AppId) -> isize {
         match cmd_num {
-            0 /* putc */ => { self.uart.send_byte(arg1 as u8); 1 },
+            0 /* putc */ => {
+                self.tx_buffer.take().map(|buffer| {
+                    buffer[0] = arg1 as u8;
+                    self.uart.transmit(buffer, 1);
+                });
+                1
+            },
             _ => -1
         }
     }
 }
 
 impl<'a, U: UART> Client for Console<'a, U> {
-    fn write_done(&self, buffer: &'static mut [u8]) {
+    fn transmit_complete(&self, buffer: &'static mut [u8], _error: uart::Error) {
         // Write TX is done, notify appropriate app and start another
         // transaction if pending
-        self.buffer.replace(buffer);
+        self.tx_buffer.replace(buffer);
         self.in_progress.take().map(|appid| {
             self.apps.enter(appid, |app, _| {
                 app.write_callback.map(|mut cb| {
@@ -146,14 +163,14 @@ impl<'a, U: UART> Client for Console<'a, U> {
                     app.write_buffer
                         .as_ref()
                         .map(|slice| {
-                            self.buffer.take().map(|buffer| {
+                            self.tx_buffer.take().map(|buffer| {
                                 for (i, c) in slice.as_ref().iter().enumerate() {
                                     if buffer.len() <= i {
                                         break;
                                     }
                                     buffer[i] = *c;
                                 }
-                                self.uart.send_bytes(buffer, app.write_len);
+                                self.uart.transmit(buffer, app.write_len);
                             });
                             self.in_progress.replace(app.appid());
                             true
@@ -169,7 +186,8 @@ impl<'a, U: UART> Client for Console<'a, U> {
         }
     }
 
-    fn read_done(&self, c: u8) {
+    fn receive_complete(&self, rx_buffer: &'static mut [u8], _rx_len: usize, _error: uart::Error) {
+        let c = rx_buffer[0];
         match c as char {
             '\r' => {}
             '\n' => {
@@ -199,5 +217,6 @@ impl<'a, U: UART> Client for Console<'a, U> {
                 });
             }
         }
+        self.uart.receive(rx_buffer, 1);
     }
 }

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -1,6 +1,7 @@
 use kernel::{AppId, Callback, AppSlice, Driver, Shared};
 use kernel::common::take_cell::TakeCell;
-use kernel::hil::uart::{self, UART, Client};
+use kernel::hil::uart::{self, UARTAdvanced, Client};
+use core::cell::Cell;
 
 ///
 /// Nrf51822Serialization is the kernel-level driver that provides
@@ -18,18 +19,18 @@ struct App {
 // Local buffer for storing data between when the application passes it to
 // use
 pub static mut WRITE_BUF: [u8; 256] = [0; 256];
-pub static mut READ_BUF: [u8; 1] = [0];
+pub static mut READ_BUF: [u8; 600] = [0; 600];
 
 // We need two resources: a UART HW driver and driver state for each
 // application.
-pub struct Nrf51822Serialization<'a, U: UART + 'a> {
+pub struct Nrf51822Serialization<'a, U: UARTAdvanced + 'a> {
     uart: &'a U,
     app: TakeCell<App>,
     tx_buffer: TakeCell<&'static mut [u8]>,
     rx_buffer: TakeCell<&'static mut [u8]>,
 }
 
-impl<'a, U: UART> Nrf51822Serialization<'a, U> {
+impl<'a, U: UARTAdvanced> Nrf51822Serialization<'a, U> {
     pub fn new(uart: &'a U,
                tx_buffer: &'static mut [u8],
                rx_buffer: &'static mut [u8])
@@ -49,13 +50,10 @@ impl<'a, U: UART> Nrf51822Serialization<'a, U> {
             parity: uart::Parity::Even,
             hw_flow_control: true,
         });
-        self.rx_buffer.take().map(|buffer| {
-            self.uart.receive(buffer, 1);
-        });
     }
 }
 
-impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
+impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
     /// Pass application space memory to this driver.
     ///
     /// allow_type: 0 - Provide an RX buffer
@@ -124,6 +122,12 @@ impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
                         app
                     }
                     None => {
+                        // can't start receiving until DMA has been set up
+                        //  we'll start here when subscribe is first called
+                        self.rx_buffer.take().map(|buffer| {
+                            self.uart.receive_automatic(buffer, 250);
+                        });
+
                         App {
                             callback: Some(callback),
                             tx_buffer: None,
@@ -134,6 +138,7 @@ impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
                     }
                 };
                 self.app.replace(resapp);
+
                 0
             }
             _ => -1,
@@ -169,13 +174,23 @@ impl<'a, U: UART> Driver for Nrf51822Serialization<'a, U> {
                 });
                 result.unwrap_or(-1)
             }
+            9001 => {
+                self.app.map(|appst| {
+                    appst.callback.as_mut().map(|mut cb| {
+                        // schedule an event just to wake up from yield
+                        cb.schedule(17, 0, 0);
+                    });
+                });
+
+                0
+            }
             _ => -1,
         }
     }
 }
 
 // Callbacks from the underlying UART driver.
-impl<'a, U: UART> Client for Nrf51822Serialization<'a, U> {
+impl<'a, U: UARTAdvanced> Client for Nrf51822Serialization<'a, U> {
     // Called when the UART TX has finished
     fn transmit_complete(&self, buffer: &'static mut [u8], _error: uart::Error) {
         self.tx_buffer.replace(buffer);
@@ -190,64 +205,38 @@ impl<'a, U: UART> Client for Nrf51822Serialization<'a, U> {
     }
 
     // Called when a byte is received on the UART
-    fn receive_complete(&self, buffer: &'static mut [u8], _rx_len: usize, _error: uart::Error) {
-        let c = buffer[0];
+    fn receive_complete(&self, buffer: &'static mut [u8], rx_len: usize, error: uart::Error) {
+
+        self.rx_buffer.replace(buffer);
+
         self.app.map(|appst| {
-            // The PHY layer of the serialization protocol calls for a 16 byte
-            // length field to start the packet. After we receive the first two
-            // bytes we then know how long to wait for to get the rest of
-            // the packet.
+            appst.rx_buffer = appst.rx_buffer.take().map(|mut rb| {
 
-            // Save a local copy of this so we can use it after we have a borrow
-            let rx_count = appst.rx_recv_so_far;
+                // figure out length to copy
+                let mut max_len = rx_len;
+                if rb.len() < rx_len {
+                    max_len = rb.len();
+                }
 
-            if appst.rx_buffer.is_some() && rx_count < appst.rx_buffer.as_ref().unwrap().len() {
-
-                // This is just some rust magic that only gets a mutable
-                // reference to the RX buffer and adds the byte if the buffer
-                // actually exists.
-                // Yes, we did already check that the buffer exists above,
-                // but I don't know what to do about that....
-                appst.rx_buffer.as_mut().map(|buf| {
-                    // Record the received byte
-                    buf.as_mut()[rx_count] = c;
-
+                // copy over data to app buffer
+                self.rx_buffer.map(|buffer| {
+                    for idx in 0..max_len {
+                        rb.as_mut()[idx] = buffer[idx];
+                    }
                 });
 
-                // Increment our counter since we got another byte.
-                appst.rx_recv_so_far += 1;
+                appst.callback.as_mut().map(|cb| {
+                    // send the whole darn buffer to the serialization layer
+                    cb.schedule(4, rx_len, 0);
+                });
 
-                // Check if this was the second byte. If so, we can now
-                // compute how many total bytes we expect to receive.
-                if appst.rx_recv_so_far == 2 {
-                    appst.rx_recv_total =
-                        appst.rx_buffer.as_ref().unwrap().as_ref()[0] as usize |
-                        ((appst.rx_buffer.as_ref().unwrap().as_ref()[1] as usize) << 8);
-
-                    // After first byte let app know that a packet is inbound!
-                    let rx_recv_total = appst.rx_recv_total;
-                    appst.callback.as_mut().map(|mut cb| {
-                        cb.schedule(2, rx_recv_total, 0);
-                    });
-
-                } else if appst.rx_recv_so_far > 2 {
-                    // Check to see if we have gotten all of the data
-                    // we want.
-                    if appst.rx_recv_so_far == appst.rx_recv_total + 2 {
-                        // we did!
-
-                        // Callback the app with an RX done signal
-                        let rx_recv_so_far = appst.rx_recv_so_far;
-                        appst.callback.as_mut().map(|mut cb| {
-                            cb.schedule(3, rx_recv_so_far, 0);
-                        });
-
-                        // Reset this for the next RX
-                        appst.rx_recv_so_far = 0;
-                    }
-                }
-            }
+                rb
+            });
         });
-        self.uart.receive(buffer, 1);
+
+        // restart the uart receive
+        self.rx_buffer.take().map(|buffer| {
+            self.uart.receive_automatic(buffer, 250);
+        });
     }
 }

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -1,7 +1,6 @@
 use kernel::{AppId, Callback, AppSlice, Driver, Shared};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::uart::{self, UARTAdvanced, Client};
-use core::cell::Cell;
 
 ///
 /// Nrf51822Serialization is the kernel-level driver that provides
@@ -205,7 +204,7 @@ impl<'a, U: UARTAdvanced> Client for Nrf51822Serialization<'a, U> {
     }
 
     // Called when a byte is received on the UART
-    fn receive_complete(&self, buffer: &'static mut [u8], rx_len: usize, error: uart::Error) {
+    fn receive_complete(&self, buffer: &'static mut [u8], rx_len: usize, _error: uart::Error) {
 
         self.rx_buffer.replace(buffer);
 

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -25,30 +25,34 @@ impl Sam4l {
     pub unsafe fn new() -> Sam4l {
         INTERRUPT_QUEUE = Some(RingBuffer::new(&mut IQ_BUF));
 
-        usart::USART0.set_dma(&mut dma::DMAChannels[0], dma::DMAPeripheral::USART0_TX);
+        usart::USART0.set_dma(&mut dma::DMAChannels[0], &mut dma::DMAChannels[1]);
         dma::DMAChannels[0].client = Some(&mut usart::USART0);
+        dma::DMAChannels[1].client = Some(&mut usart::USART0);
 
-        usart::USART1.set_dma(&mut dma::DMAChannels[1], dma::DMAPeripheral::USART1_TX);
-        dma::DMAChannels[1].client = Some(&mut usart::USART1);
+        usart::USART1.set_dma(&mut dma::DMAChannels[2], &mut dma::DMAChannels[3]);
+        dma::DMAChannels[2].client = Some(&mut usart::USART1);
+        dma::DMAChannels[3].client = Some(&mut usart::USART1);
 
-        usart::USART2.set_dma(&mut dma::DMAChannels[2], dma::DMAPeripheral::USART2_TX);
-        dma::DMAChannels[2].client = Some(&mut usart::USART2);
+        usart::USART2.set_dma(&mut dma::DMAChannels[4], &mut dma::DMAChannels[5]);
+        dma::DMAChannels[4].client = Some(&mut usart::USART2);
+        dma::DMAChannels[5].client = Some(&mut usart::USART2);
 
-        usart::USART3.set_dma(&mut dma::DMAChannels[3], dma::DMAPeripheral::USART3_TX);
-        dma::DMAChannels[3].client = Some(&mut usart::USART3);
+        usart::USART3.set_dma(&mut dma::DMAChannels[6], &mut dma::DMAChannels[7]);
+        dma::DMAChannels[6].client = Some(&mut usart::USART3);
+        dma::DMAChannels[7].client = Some(&mut usart::USART3);
 
-        spi::SPI.set_dma(&mut dma::DMAChannels[4], &mut dma::DMAChannels[5]);
-        dma::DMAChannels[4].client = Some(&mut spi::SPI);
-        dma::DMAChannels[5].client = Some(&mut spi::SPI);
+        spi::SPI.set_dma(&mut dma::DMAChannels[8], &mut dma::DMAChannels[9]);
+        dma::DMAChannels[8].client = Some(&mut spi::SPI);
+        dma::DMAChannels[9].client = Some(&mut spi::SPI);
 
-        i2c::I2C0.set_dma(&dma::DMAChannels[6]);
-        dma::DMAChannels[6].client = Some(&mut i2c::I2C0);
+        i2c::I2C0.set_dma(&dma::DMAChannels[10]);
+        dma::DMAChannels[10].client = Some(&mut i2c::I2C0);
 
-        i2c::I2C1.set_dma(&dma::DMAChannels[7]);
-        dma::DMAChannels[7].client = Some(&mut i2c::I2C1);
+        i2c::I2C1.set_dma(&dma::DMAChannels[11]);
+        dma::DMAChannels[11].client = Some(&mut i2c::I2C1);
 
-        i2c::I2C2.set_dma(&dma::DMAChannels[8]);
-        dma::DMAChannels[8].client = Some(&mut i2c::I2C2);
+        i2c::I2C2.set_dma(&dma::DMAChannels[12]);
+        dma::DMAChannels[12].client = Some(&mut i2c::I2C2);
 
         Sam4l {
             mpu: cortexm4::mpu::MPU::new(),

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -59,21 +59,6 @@ pub enum USARTStateTX {
     Transfer_Completing, // DMA finished, but not all bytes sent
 }
 
-pub trait UartAdvanced {
-    /// Receive data until `interbyte_timeout` bit periods have passed since the last byte
-    /// or buffer is full. Does not timeout until at least one byte has been
-    /// received
-    ///
-    /// * `interbyte_timeout` - number of bit periods since last data received
-    fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8);
-
-    /// Receive data until `terminator` data byte has been received or buffer
-    /// is full
-    ///
-    /// * `terminator` - data byte terminating a reception
-    fn receive_until_terminator(&self, rx_buffer: &'static mut [u8], terminator: u8);
-}
-
 pub struct USART {
     registers: *mut USARTRegisters,
     clock: pm::Clock,
@@ -545,7 +530,7 @@ impl hil::uart::UART for USART {
     }
 }
 
-impl UartAdvanced for USART {
+impl hil::uart::UARTAdvanced for USART {
     fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8) {
 
         // quit current reception if any

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -1,131 +1,311 @@
+use core::cell::Cell;
 use core::mem;
-use dma::{DMAChannel, DMAClient, DMAPeripheral};
-use helpers::*;
+use dma;
 use kernel::common::take_cell::TakeCell;
-use kernel::hil::{uart, Controller};
-use kernel::hil::uart::{Parity, Mode};
+use kernel::common::volatile_cell::VolatileCell;
+// other modules
+use kernel::hil;
+// local modules
 use nvic;
-use pm::{self, Clock, PBAClock};
+use pm;
 
+// Register map for SAM4L USART
 #[repr(C, packed)]
-struct Registers {
-    cr: u32,
-    mr: u32,
-    ier: u32,
-    idr: u32,
-    imr: u32,
-    csr: u32,
-    rhr: u32,
-    thr: u32,
-    brgr: u32, // 0x20
-    rtor: u32,
-    ttgr: u32,
-    reserved0: [u32; 5],
-    fidi: u32, // 0x40
-    ner: u32,
-    reserved1: u32,
-    ifr: u32,
-    man: u32,
-    linmr: u32,
-    linir: u32,
-    linbrr: u32,
-    wpmr: u32,
-    wpsr: u32,
-    version: u32,
+struct USARTRegisters {
+    cr: VolatileCell<u32>, // 0x00
+    mr: VolatileCell<u32>,
+    ier: VolatileCell<u32>,
+    idr: VolatileCell<u32>,
+    imr: VolatileCell<u32>,
+    csr: VolatileCell<u32>,
+    rhr: VolatileCell<u32>,
+    thr: VolatileCell<u32>,
+    brgr: VolatileCell<u32>,
+    rtor: VolatileCell<u32>,
+    ttgr: VolatileCell<u32>, // 0x28
+    _reserved0: [VolatileCell<u32>; 5],
+    fidi: VolatileCell<u32>, // 0x40
+    ner: VolatileCell<u32>,
+    _reserved1: VolatileCell<u32>,
+    ifr: VolatileCell<u32>,
+    man: VolatileCell<u32>,
+    linmr: VolatileCell<u32>,
+    linir: VolatileCell<u32>,
+    linbrr: VolatileCell<u32>, // 0x5C
+    _reserved2: [VolatileCell<u32>; 33],
+    wpmr: VolatileCell<u32>, // 0xE4
+    wpsr: VolatileCell<u32>,
+    _reserved3: [VolatileCell<u32>; 4],
+    version: VolatileCell<u32>, // 0xFC
 }
 
-const SIZE: usize = 0x4000;
-const BASE_ADDRESS: usize = 0x40024000;
+const USART_BASE_ADDRS: [*mut USARTRegisters; 4] = [0x40024000 as *mut USARTRegisters,
+                                                    0x40028000 as *mut USARTRegisters,
+                                                    0x4002C000 as *mut USARTRegisters,
+                                                    0x40030000 as *mut USARTRegisters];
 
-#[derive(Copy,Clone)]
-pub enum Location {
-    USART0,
-    USART1,
-    USART2,
-    USART3,
+#[derive(Copy, Clone, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum USARTStateRX {
+    Idle,
+    DMA_Receiving,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum USARTStateTX {
+    Idle,
+    DMA_Transmitting,
+    Transfer_Completing, // DMA finished, but not all bytes sent
 }
 
 pub struct USART {
-    regs: *mut Registers,
-    client: Option<&'static uart::Client>,
-    clock: Clock,
+    registers: *mut USARTRegisters,
+    clock: pm::Clock,
     nvic: nvic::NvicIdx,
-    dma_peripheral: DMAPeripheral,
-    dma: TakeCell<&'static mut DMAChannel>,
+
+    usart_tx_state: Cell<USARTStateTX>,
+    usart_rx_state: Cell<USARTStateRX>,
+
+    rx_dma: TakeCell<&'static dma::DMAChannel>,
+    rx_dma_peripheral: dma::DMAPeripheral,
+    rx_len: Cell<usize>,
+    tx_dma: TakeCell<&'static dma::DMAChannel>,
+    tx_dma_peripheral: dma::DMAPeripheral,
+    tx_len: Cell<usize>,
+
+    client: TakeCell<&'static hil::uart::Client>,
 }
 
-pub struct USARTParams {
-    // pub client: &'static Shared<uart::Client>,
-    pub baud_rate: u32,
-    pub data_bits: u8,
-    pub parity: Parity,
-    pub mode: Mode,
-}
-
-impl Controller for USART {
-    type Config = USARTParams;
-
-    fn configure(&self, params: USARTParams) {
-        //   self.client = Some(params.client.borrow_mut());
-        let chrl = ((params.data_bits - 1) & 0x3) as u32;
-        let mode =
-            (params.mode as u32) /* mode */
-            | 0 << 4 /*USCLKS*/
-            | chrl << 6 /* Character Length */
-            | (params.parity as u32) << 9 /* Parity */
-            | 0 << 12 /* Number of stop bits = 1 */
-            | 1 << 19 /* Oversample at 8 times baud rate */;
-
-        self.enable_clock();
-        self.set_baud_rate(params.baud_rate);
-        self.set_mode(mode);
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.ttgr, 4);
-        self.enable_rx_interrupts();
-    }
-}
-
-pub static mut USART0: USART =
-    USART::new(Location::USART0, PBAClock::USART0, nvic::NvicIdx::USART0);
-pub static mut USART1: USART =
-    USART::new(Location::USART1, PBAClock::USART1, nvic::NvicIdx::USART1);
-pub static mut USART2: USART =
-    USART::new(Location::USART2, PBAClock::USART2, nvic::NvicIdx::USART2);
-pub static mut USART3: USART =
-    USART::new(Location::USART3, PBAClock::USART3, nvic::NvicIdx::USART3);
+// USART hardware peripherals on SAM4L
+pub static mut USART0: USART = USART::new(USART_BASE_ADDRS[0],
+                                          pm::PBAClock::USART0,
+                                          nvic::NvicIdx::USART0,
+                                          dma::DMAPeripheral::USART0_RX,
+                                          dma::DMAPeripheral::USART0_TX);
+pub static mut USART1: USART = USART::new(USART_BASE_ADDRS[1],
+                                          pm::PBAClock::USART1,
+                                          nvic::NvicIdx::USART1,
+                                          dma::DMAPeripheral::USART1_RX,
+                                          dma::DMAPeripheral::USART1_TX);
+pub static mut USART2: USART = USART::new(USART_BASE_ADDRS[2],
+                                          pm::PBAClock::USART2,
+                                          nvic::NvicIdx::USART2,
+                                          dma::DMAPeripheral::USART2_RX,
+                                          dma::DMAPeripheral::USART2_TX);
+pub static mut USART3: USART = USART::new(USART_BASE_ADDRS[3],
+                                          pm::PBAClock::USART3,
+                                          nvic::NvicIdx::USART3,
+                                          dma::DMAPeripheral::USART3_RX,
+                                          dma::DMAPeripheral::USART3_TX);
 
 impl USART {
-    const fn new(location: Location, clock: PBAClock, nvic: nvic::NvicIdx) -> USART {
+    const fn new(base_addr: *mut USARTRegisters,
+                 clock: pm::PBAClock,
+                 nvic: nvic::NvicIdx,
+                 rx_dma_peripheral: dma::DMAPeripheral,
+                 tx_dma_peripheral: dma::DMAPeripheral)
+                 -> USART {
         USART {
-            regs: (BASE_ADDRESS + (location as usize) * SIZE) as *mut Registers,
-            clock: Clock::PBA(clock),
+            registers: base_addr,
+            clock: pm::Clock::PBA(clock),
             nvic: nvic,
-            dma: TakeCell::empty(),
-            dma_peripheral: DMAPeripheral::USART0_RX, // Set to some default.
-            // This is updated when a
-            // real DMA is configured.
-            client: None,
+
+            usart_rx_state: Cell::new(USARTStateRX::Idle),
+            usart_tx_state: Cell::new(USARTStateTX::Idle),
+
+            // these get defined later by `chip.rs`
+            rx_dma: TakeCell::empty(),
+            rx_dma_peripheral: rx_dma_peripheral,
+            rx_len: Cell::new(0),
+            tx_dma: TakeCell::empty(),
+            tx_dma_peripheral: tx_dma_peripheral,
+            tx_len: Cell::new(0),
+
+            // this gets defined later by `main.rs`
+            client: TakeCell::empty(),
         }
     }
 
-    pub fn set_client<C: uart::Client>(&mut self, client: &'static C) {
-        self.client = Some(client);
+    pub fn set_client(&self, client: &'static hil::uart::Client) {
+        self.client.replace(client);
     }
 
-    pub fn set_dma(&mut self, dma: &'static mut DMAChannel, dma_peripheral: DMAPeripheral) {
-        self.dma.replace(dma);
-        self.dma_peripheral = dma_peripheral;
+    pub fn set_dma(&self, rx_dma: &'static dma::DMAChannel, tx_dma: &'static dma::DMAChannel) {
+        self.rx_dma.replace(rx_dma);
+        self.tx_dma.replace(tx_dma);
     }
 
-    fn set_baud_rate(&self, baud_rate: u32) {
-        let cd = 48000000 / (8 * baud_rate);
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.brgr, cd);
+    pub fn enable_rx(&self) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let cr_val = 0x00000000 | (1 << 4); // RXEN
+        regs.cr.set(cr_val);
     }
 
-    fn set_mode(&self, mode: u32) {
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.mr, mode);
+    pub fn enable_tx(&self) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let cr_val = 0x00000000 | (1 << 6); // TXEN
+        regs.cr.set(cr_val);
+    }
+
+    pub fn disable_rx(&self) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let cr_val = 0x00000000 | (1 << 5); // RXDIS
+        regs.cr.set(cr_val);
+
+        self.usart_rx_state.set(USARTStateRX::Idle);
+    }
+
+    pub fn disable_tx(&self) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let cr_val = 0x00000000 | (1 << 7); // TXDIS
+        regs.cr.set(cr_val);
+
+        self.usart_tx_state.set(USARTStateTX::Idle);
+    }
+
+    pub fn abort_rx(&self, error: hil::uart::Error) {
+        if self.usart_rx_state.get() == USARTStateRX::DMA_Receiving {
+            self.disable_rx();
+            self.disable_rx_interrupts();
+
+            // get buffer
+            let mut length = 0;
+            let buffer = self.rx_dma.map_or(None, |rx_dma| {
+                length = self.rx_len.get() - rx_dma.transfer_counter();
+                let buf = rx_dma.abort_xfer();
+                rx_dma.disable();
+                buf
+            });
+
+            // alert client
+            self.client.map(|c| {
+                buffer.map(|buf| {
+                    c.receive_complete(buf, length, error);
+                });
+            });
+            self.rx_len.set(0);
+            self.usart_rx_state.set(USARTStateRX::Idle);
+        }
+    }
+
+    pub fn abort_tx(&self, error: hil::uart::Error) {
+        if self.usart_tx_state.get() == USARTStateTX::DMA_Transmitting {
+            self.disable_tx();
+            self.disable_tx_interrupts();
+
+            // get buffer
+            let mut length = 0;
+            let buffer = self.tx_dma.map_or(None, |tx_dma| {
+                length = self.tx_len.get() - tx_dma.transfer_counter();
+                let buf = tx_dma.abort_xfer();
+                tx_dma.disable();
+                buf
+            });
+
+            // alert client
+            self.client.map(|c| {
+                buffer.map(|buf| {
+                    c.receive_complete(buf, length, error);
+                });
+            });
+            self.tx_len.set(0);
+            self.usart_tx_state.set(USARTStateTX::Idle);
+        }
+    }
+
+    pub fn enable_rx_error_interrupts(&self) {
+        self.enable_nvic();
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let ier_val = 0x00000000 |
+            (1 <<  7) | // PARE
+            (1 <<  6) | // FRAME
+            (1 <<  5);  // OVRE
+        regs.ier.set(ier_val);
+    }
+
+    pub fn disable_rx_interrupts(&self) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let idr_val = 0x00000000 |
+            (1 << 12) | // RXBUFF
+            (1 <<  8) | // TIMEOUT
+            (1 <<  7) | // PARE
+            (1 <<  6) | // FRAME
+            (1 <<  5) | // OVRE
+            (1 << 1);   // RXRDY
+        regs.idr.set(idr_val);
+
+        // XXX: disable nvic if no interrupts are enabled
+    }
+
+    pub fn disable_tx_interrupts(&self) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let idr_val = 0x00000000 |
+            (1 << 9) | // TXEMPTY
+            (1 << 1);  // TXREADY
+        regs.idr.set(idr_val);
+
+        // XXX: disable nvic if no interrupts are enabled
+    }
+
+    pub fn disable_interrupts(&self) {
+        self.disable_nvic();
+        self.disable_rx_interrupts();
+        self.disable_tx_interrupts();
+    }
+
+    pub fn reset(&self) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+
+        // reset status bits, transmitter, and receiver
+        let cr_val = 0x00000000 |
+            (1 << 8) | // RSTSTA
+            (1 << 3) | // RSTTX
+            (1 <<2);   // RSTRX
+        regs.cr.set(cr_val);
+
+        self.abort_rx(hil::uart::Error::ResetError);
+        self.abort_tx(hil::uart::Error::ResetError);
+    }
+
+    pub fn handle_interrupt(&self) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let status = regs.csr.get();
+
+        if status & (1 << 12) != 0 {
+            // DO NOTHING. Why are we here!?
+
+        } else if status & (1 << 8) != 0 {
+            // TIMEOUT
+            self.disable_rx_timeout();
+            self.abort_rx(hil::uart::Error::CommandComplete);
+
+        } else if status & (1 << 7) != 0 {
+            // PARE
+            self.abort_rx(hil::uart::Error::ParityError);
+
+        } else if status & (1 << 6) != 0 {
+            // FRAME
+            self.abort_rx(hil::uart::Error::FramingError);
+
+        } else if status & (1 << 5) != 0 {
+            // OVRE
+            self.abort_rx(hil::uart::Error::OverrunError);
+
+        } else {
+            if status != 0x0 {
+                // XXX: I end up getting interrupt calls with no bits set in the status register
+                //  not sure why. Ignoring them for now
+                panic!("unhandled interrupt. Status: 0x{:x}, IMR: 0x{:x}\n States RX: {} TX: {}",
+                       status,
+                       regs.imr.get(),
+                       self.usart_rx_state.get() as u32,
+                       self.usart_tx_state.get() as u32);
+            }
+        }
+
+        // reset status registers
+        regs.cr.set(1 << 8); // RSTSTA
     }
 
     fn enable_clock(&self) {
@@ -146,124 +326,260 @@ impl USART {
         }
     }
 
-    pub fn enable_rx_interrupts(&self) {
+    fn set_mode(&self, mode: u32) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        regs.mr.set(mode);
+    }
+
+    fn set_baud_rate_divider(&self, clock_divider: u16) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let brgr_val: u32 = 0x00000000 | clock_divider as u32;
+        regs.brgr.set(brgr_val);
+    }
+
+    fn set_tx_timeguard(&self, timeguard: u8) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let ttgr_val: u32 = 0x00000000 | timeguard as u32;
+        regs.ttgr.set(ttgr_val);
+    }
+
+    fn enable_rx_timeout(&self, timeout: u8) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let rtor_val: u32 = 0x00000000 | timeout as u32;
+        regs.rtor.set(rtor_val);
+
+        // enable timeout interrupt
+        regs.ier.set((1 << 8)); // TIMEOUT
         self.enable_nvic();
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.ier, 1 as u32);
+
+        // start timeout
+        regs.cr.set((1 << 11)); // STTTO
     }
 
-    pub fn enable_tx_interrupts(&mut self) {
-        self.enable_nvic();
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.ier, 2 as u32);
+    fn disable_rx_timeout(&self) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        regs.rtor.set(0);
+
+        // enable timeout interrupt
+        regs.idr.set((1 << 8)); // TIMEOUT
     }
 
-    pub fn disable_rx_interrupts(&mut self) {
-        self.disable_nvic();
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.idr, 1 as u32);
+    fn enable_rx_terminator(&self, terminator: u8) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        // XXX: implement me
+        panic!("didn't write terminator stuff yet");
     }
 
-    pub fn handle_interrupt(&mut self) {
-        use kernel::hil::uart::UART;
-        if self.rx_ready() {
-            let regs: &Registers = unsafe { mem::transmute(self.regs) };
-            let c = read_volatile(&regs.rhr) as u8;
-            match self.client {
-                Some(ref client) => client.read_done(c),
-                None => {}
-            }
+    fn disable_rx_terminator(&self) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        // XXX: implement me
+        panic!("didn't write terminator stuff yet");
+    }
+
+    // for use by panic in io.rs
+    pub fn send_byte(&self, byte: u8) {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let thr_val: u32 = 0x00000000 | byte as u32;
+        regs.thr.set(thr_val);
+    }
+
+    // for use by panic in io.rs
+    pub fn tx_ready(&self) -> bool {
+        let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
+        let csr_val: u32 = regs.csr.get();
+        let mut ret_val = false;
+        if (csr_val & (1 << 1)) == (1 << 1) {
+            // tx is ready
+            ret_val = true;
+        }
+        ret_val
+    }
+}
+
+impl dma::DMAClient for USART {
+    fn xfer_done(&self, pid: dma::DMAPeripheral) {
+        // determine if it was an RX or TX transfer
+        if pid == self.rx_dma_peripheral {
+
+            // RX transfer was completed
+
+            // disable RX and RX interrupts
+            self.disable_rx();
+            self.disable_rx_interrupts();
+            self.usart_rx_state.set(USARTStateRX::Idle);
+
+            // get buffer
+            let buffer = self.rx_dma.map_or(None, |rx_dma| {
+                let buf = rx_dma.abort_xfer();
+                rx_dma.disable();
+                buf
+            });
+
+            // alert client
+            self.client.map(|c| {
+                buffer.map(|buf| {
+                    let length = self.rx_len.get();
+                    c.receive_complete(buf, length, hil::uart::Error::CommandComplete);
+                });
+            });
+            self.rx_len.set(0);
+
+        } else if pid == self.tx_dma_peripheral {
+
+            // TX transfer was completed
+
+            // note that the DMA has finished but TX cannot be disabled yet
+            self.usart_tx_state.set(USARTStateTX::Transfer_Completing);
+            // self.enable_tx_complete_interrupt();
+
+            // get buffer
+            let buffer = self.tx_dma.map_or(None, |tx_dma| {
+                let buf = tx_dma.abort_xfer();
+                tx_dma.disable();
+                buf
+            });
+
+            // alert client
+            self.client.map(|c| {
+                buffer.map(|buf| c.transmit_complete(buf, hil::uart::Error::CommandComplete));
+            });
+            self.tx_len.set(0);
         }
     }
-
-    pub fn reset_rx(&mut self) {
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.cr, 1 << 2);
-    }
 }
 
-impl DMAClient for USART {
-    fn xfer_done(&self, _pid: DMAPeripheral) {
-        let buffer = self.dma.map_or(None, |dma| {
-            let buf = dma.abort_xfer();
-            dma.disable();
-            buf
-        });
-        self.client.as_ref().map(move |c| {
-            buffer.map(|buf| c.write_done(buf));
-        });
-    }
-}
-
-impl uart::UART for USART {
-    fn init(&mut self, params: uart::UARTParams) {
-        let chrl = ((params.data_bits - 1) & 0x3) as u32;
-        let mode =
-            (params.mode as u32) /* mode */
-            | 0 << 4 /*USCLKS*/
-            | chrl << 6 /* Character Length */
-            | (params.parity as u32) << 9 /* Parity */
-            | 0 << 12 /* Number of stop bits = 1 */
-            | 1 << 19 /* Oversample at 8 times baud rate */;
-
+/// Implementation of kernel::hil::UART
+impl hil::uart::UART for USART {
+    fn init(&self, params: hil::uart::UARTParams) {
+        // enable USART clock
+        //  must do this before writing any registers
         self.enable_clock();
-        self.set_baud_rate(params.baud_rate);
+
+        // disable interrupts
+        self.disable_interrupts();
+
+        // stop any TX and RX and clear status
+        self.reset();
+
+        // set USART mode register
+        let mut mode = 0x00000000;
+        mode |= 0x1 << 19;  //OVER: oversample at 8 times baud rate
+        mode |= 0x3 << 6;  //CHRL: 8-bit characters
+        mode |= 0x0 << 4;  //USCLKS: select CLK_USART
+
+        match params.stop_bits {
+            hil::uart::StopBits::One => mode |= 0x0 << 12,   //NBSTOP: 1 stop bit
+            hil::uart::StopBits::Two => mode |= 0x2 << 12,   //NBSTOP: 2 stop bits
+        };
+
+        match params.parity {
+            hil::uart::Parity::None => mode |= 0x4 << 9,    //PAR: no parity
+            hil::uart::Parity::Odd => mode |= 0x1 << 9,    //PAR: odd parity
+            hil::uart::Parity::Even => mode |= 0x0 << 9,    //PAR: even parity
+        };
+
+        if params.hw_flow_control {
+            mode |= 0x2 << 0;   //MODE: hardware handshaking
+        } else {
+            mode |= 0x0 << 0;   //MODE: normal
+        }
+
         self.set_mode(mode);
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.ttgr, 4);
+
+        // set baud rate
+        // NOTE: dependent on oversampling rate
+        // XXX: how do you determine the current clock frequency?
+        let clock_divider = 48000000 / (8 * params.baud_rate);
+        self.set_baud_rate_divider(clock_divider as u16);
     }
 
-    fn send_byte(&self, byte: u8) {
-        while !self.tx_ready() {}
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.thr, byte as u32);
-    }
+    fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {
 
-    fn send_bytes(&self, bytes: &'static mut [u8], len: usize) {
-        self.dma.map(move |dma| {
+        // quit current transmission if any
+        self.abort_tx(hil::uart::Error::RepeatCallError);
+
+        // enable TX
+        self.enable_tx();
+        self.usart_tx_state.set(USARTStateTX::DMA_Transmitting);
+
+        // set up dma transfer and start transmission
+        self.tx_dma.map(move |dma| {
             dma.enable();
-            dma.do_xfer(self.dma_peripheral, bytes, len);
+            dma.do_xfer(self.tx_dma_peripheral, tx_data, tx_len);
+            self.tx_len.set(tx_len);
         });
     }
 
-    fn rx_ready(&self) -> bool {
-        let regs: &Registers = unsafe { mem::transmute(self.regs) };
-        read_volatile(&regs.csr) & 0b1 != 0
+    fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize) {
+
+        // quit current reception if any
+        self.abort_rx(hil::uart::Error::RepeatCallError);
+
+        // truncate rx_len if necessary
+        let mut length = rx_len;
+        if rx_len > rx_buffer.len() {
+            length = rx_buffer.len();
+        }
+
+        // enable RX
+        self.enable_rx();
+        self.enable_rx_error_interrupts();
+        self.usart_rx_state.set(USARTStateRX::DMA_Receiving);
+
+        // set up dma transfer and start reception
+        self.rx_dma.map(move |dma| {
+            dma.enable();
+            dma.do_xfer(self.rx_dma_peripheral, rx_buffer, length);
+            self.rx_len.set(rx_len);
+        });
     }
 
-    fn tx_ready(&self) -> bool {
-        let regs: &Registers = unsafe { mem::transmute(self.regs) };
-        read_volatile(&regs.csr) & 0b10 != 0
+    fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8) {
+
+        // quit current reception if any
+        self.abort_rx(hil::uart::Error::RepeatCallError);
+
+        // enable receive timeout
+        self.enable_rx_timeout(interbyte_timeout);
+
+        // enable RX
+        self.enable_rx();
+        self.enable_rx_error_interrupts();
+        self.usart_rx_state.set(USARTStateRX::DMA_Receiving);
+
+        // set up dma transfer and start reception
+        self.rx_dma.map(move |dma| {
+            dma.enable();
+            let length = rx_buffer.len();
+            dma.do_xfer(self.rx_dma_peripheral, rx_buffer, length);
+            self.rx_len.set(length);
+        });
     }
 
+    fn receive_until_terminator(&self, rx_buffer: &'static mut [u8], terminator: u8) {
 
-    fn read_byte(&self) -> u8 {
-        while !self.rx_ready() {}
-        let regs: &Registers = unsafe { mem::transmute(self.regs) };
-        read_volatile(&regs.rhr) as u8
-    }
+        // quit current reception if any
+        self.abort_rx(hil::uart::Error::RepeatCallError);
 
-    fn enable_rx(&self) {
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.cr, 1 << 4);
-    }
+        // enable receive terminator
+        self.enable_rx_terminator(terminator);
 
-    fn disable_rx(&mut self) {
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.cr, 1 << 5);
-    }
+        // enable RX
+        self.enable_rx();
+        self.enable_rx_error_interrupts();
+        self.usart_rx_state.set(USARTStateRX::DMA_Receiving);
 
-    fn enable_tx(&self) {
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.cr, 1 << 6);
-    }
-
-    fn disable_tx(&mut self) {
-        let regs: &mut Registers = unsafe { mem::transmute(self.regs) };
-        write_volatile(&mut regs.cr, 1 << 7);
+        // set up dma transfer and start reception
+        self.rx_dma.map(move |dma| {
+            dma.enable();
+            let length = rx_buffer.len();
+            dma.do_xfer(self.rx_dma_peripheral, rx_buffer, length);
+            self.rx_len.set(length);
+        });
     }
 }
 
+// Register interrupt handlers
 interrupt_handler!(usart0_handler, USART0);
 interrupt_handler!(usart1_handler, USART1);
 interrupt_handler!(usart2_handler, USART2);

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -379,7 +379,6 @@ impl dma::DMAClient for USART {
     fn xfer_done(&self, pid: dma::DMAPeripheral) {
         // determine if it was an RX or TX transfer
         if pid == self.rx_dma_peripheral {
-
             // RX transfer was completed
 
             // disable RX and RX interrupts
@@ -404,12 +403,10 @@ impl dma::DMAClient for USART {
             self.rx_len.set(0);
 
         } else if pid == self.tx_dma_peripheral {
-
             // TX transfer was completed
 
             // note that the DMA has finished but TX cannot be disabled yet
             self.usart_tx_state.set(USARTStateTX::Transfer_Completing);
-            // self.enable_tx_complete_interrupt();
 
             // get buffer
             let buffer = self.tx_dma.map_or(None, |tx_dma| {
@@ -446,25 +443,25 @@ impl hil::uart::UART for USART {
 
         // set USART mode register
         let mut mode = 0x00000000;
-        mode |= 0x1 << 19;  //OVER: oversample at 8 times baud rate
-        mode |= 0x3 << 6;  //CHRL: 8-bit characters
-        mode |= 0x0 << 4;  //USCLKS: select CLK_USART
+        mode |= 0x1 << 19; // OVER: oversample at 8 times baud rate
+        mode |= 0x3 << 6;  // CHRL: 8-bit characters
+        mode |= 0x0 << 4;  // USCLKS: select CLK_USART
 
         match params.stop_bits {
-            hil::uart::StopBits::One => mode |= 0x0 << 12,   //NBSTOP: 1 stop bit
-            hil::uart::StopBits::Two => mode |= 0x2 << 12,   //NBSTOP: 2 stop bits
+            hil::uart::StopBits::One => mode |= 0x0 << 12, // NBSTOP: 1 stop bit
+            hil::uart::StopBits::Two => mode |= 0x2 << 12, // NBSTOP: 2 stop bits
         };
 
         match params.parity {
-            hil::uart::Parity::None => mode |= 0x4 << 9,    //PAR: no parity
-            hil::uart::Parity::Odd => mode |= 0x1 << 9,    //PAR: odd parity
-            hil::uart::Parity::Even => mode |= 0x0 << 9,    //PAR: even parity
+            hil::uart::Parity::None => mode |= 0x4 << 9,   // PAR: no parity
+            hil::uart::Parity::Odd => mode |= 0x1 << 9,    // PAR: odd parity
+            hil::uart::Parity::Even => mode |= 0x0 << 9,   // PAR: even parity
         };
 
         if params.hw_flow_control {
-            mode |= 0x2 << 0;   //MODE: hardware handshaking
+            mode |= 0x2 << 0;  // MODE: hardware handshaking
         } else {
-            mode |= 0x0 << 0;   //MODE: normal
+            mode |= 0x0 << 0;  // MODE: normal
         }
 
         self.set_mode(mode);
@@ -474,7 +471,6 @@ impl hil::uart::UART for USART {
     }
 
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {
-
         // quit current transmission if any
         self.abort_tx(hil::uart::Error::RepeatCallError);
 
@@ -491,7 +487,6 @@ impl hil::uart::UART for USART {
     }
 
     fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize) {
-
         // quit current reception if any
         self.abort_rx(hil::uart::Error::RepeatCallError);
 
@@ -517,7 +512,6 @@ impl hil::uart::UART for USART {
 
 impl hil::uart::UARTAdvanced for USART {
     fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8) {
-
         // quit current reception if any
         self.abort_rx(hil::uart::Error::RepeatCallError);
 
@@ -539,7 +533,6 @@ impl hil::uart::UARTAdvanced for USART {
     }
 
     fn receive_until_terminator(&self, rx_buffer: &'static mut [u8], terminator: u8) {
-
         // quit current reception if any
         self.abort_rx(hil::uart::Error::RepeatCallError);
 

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -43,6 +43,10 @@ pub enum Error {
 }
 
 pub trait UART {
+    /// Set the client for this UART peripheral. The client will be
+    /// called when events finish.
+    fn set_client(&self, client: &'static Client);
+
     /// Initialize UART
     ///
     /// # Panics if UARTParams are invalid for the current chip
@@ -55,7 +59,7 @@ pub trait UART {
     fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize);
 }
 
-pub trait UARTAdvanced : UART {
+pub trait UARTAdvanced: UART {
     /// Receive data until `interbyte_timeout` bit periods have passed since the last byte
     /// or buffer is full. Does not timeout until at least one byte has been
     /// received

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -55,6 +55,20 @@ pub trait UART {
     fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize);
 }
 
+pub trait UARTAdvanced : UART {
+    /// Receive data until `interbyte_timeout` bit periods have passed since the last byte
+    /// or buffer is full. Does not timeout until at least one byte has been
+    /// received
+    ///
+    /// * `interbyte_timeout` - number of bit periods since last data received
+    fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8);
+
+    /// Receive data until `terminator` data byte has been received or buffer
+    /// is full
+    ///
+    /// * `terminator` - data byte terminating a reception
+    fn receive_until_terminator(&self, rx_buffer: &'static mut [u8], terminator: u8);
+}
 
 /// Implement Client to receive callbacks from UART
 pub trait Client {

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -45,30 +45,14 @@ pub enum Error {
 pub trait UART {
     /// Initialize UART
     ///
-    /// # Panics
-    ///
-    /// if UARTParams are invalid for the current chip
+    /// # Panics if UARTParams are invalid for the current chip
     fn init(&self, params: UARTParams);
 
     /// Transmit data
-    // XXX: change this to Amit's EitherBuffer
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize);
 
     /// Receive data until buffer is full
     fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize);
-
-    /// Receive data until `interbyte_timeout` bit periods have passed since the last byte
-    /// or buffer is full. Does not timeout until at least one byte has been
-    /// received
-    ///
-    /// * `interbyte_timeout` - number of bit periods since last data received
-    fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8);
-
-    /// Receive data until `terminator` data byte has been received or buffer
-    /// is full
-    ///
-    /// * `terminator` - data byte terminating a reception
-    fn receive_until_terminator(&self, rx_buffer: &'static mut [u8], terminator: u8);
 }
 
 

--- a/userland/libtock/nrf51_serialization.c
+++ b/userland/libtock/nrf51_serialization.c
@@ -1,20 +1,24 @@
 #include "nrf51_serialization.h"
 
-void nrf51822_serialization_subscribe (subscribe_cb cb) {
+void nrf51_serialization_subscribe (subscribe_cb cb) {
   // get some callback love
   subscribe(5, 0, cb, NULL);
 }
 
-void nrf51822_serialization_setup_rx_buffer (char* rx, int rx_len) {
+void nrf51_serialization_setup_rx_buffer (char* rx, int rx_len) {
   // Pass the RX buffer for the UART module to use.
   allow(5, 0, rx, rx_len);
 }
 
-void nrf51822_serialization_write (char* tx, int tx_len) {
+void nrf51_serialization_write (char* tx, int tx_len) {
   // Pass in the TX buffer.
   allow(5, 1, tx, tx_len);
 
   // Do the write!!!!!
   command(5, 0, 0);
+}
+
+void nrf51_wakeup (void) {
+  command(5, 9001, 0);
 }
 

--- a/userland/libtock/nrf51_serialization.h
+++ b/userland/libtock/nrf51_serialization.h
@@ -17,6 +17,9 @@ void nrf51_serialization_setup_rx_buffer (char* rx, int rx_len);
 // Write a packet to the BLE Serialization connectivity processor.
 void nrf51_serialization_write (char* tx, int tx_len);
 
+// Generate an event to wake the app from a yield
+void nrf51_wakeup (void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
UART updates
- Updates UART HIL to an asynchronous interface
- Updates USART implementation of UART to fit and to generally be better
- Updates Console and nrf-serialization to fit
- Updates `io.rs` with new UART interface

DMA updates
- DMA peripheral stuff will mostly disappear once PR #125 hits (intend to merge this after #125)
- Added all the possible DMA interrupts so no one would ever forget to do so again

`take_cell` updates
- added `map_or` function that had a good use as a common idiom in UART and SPI to reduce possible mistakes. Otherwise, implementation requires a `take()` and then remembering to `replace()` in the same code block

Missing Functionality
- `io.rs` currently requires some backdoor methods into the USART until we can figure out how to send static strings to the UART
- automatically disabling tx peripheral is not performed. Turns out that even once the DMA transfer is "finished", the UART is still sending. Need to use interrupts to figure out when transmission is actually complete in order to disable the peripherals
- assumes 48 MHz operation. We need an interface for peripherals to determine the core clock speed, but for now this code just assumes like the others do
- missing @alevy's idea of EitherBuffer which would make sending buffer slices through the UART simpler
