### PR TITLE
Update DMA in SPI/USART to be in TakeCell

### DIFF
--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -136,7 +136,7 @@ pub struct DMAChannel {
 }
 
 pub trait DMAClient {
-    fn xfer_done(&mut self, pid: DMAPeripheral);
+    fn xfer_done(&self, pid: DMAPeripheral);
 }
 
 impl DMAChannel {

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -311,7 +311,7 @@ impl I2CDevice {
 }
 
 impl DMAClient for I2CDevice {
-    fn xfer_done(&mut self, _pid: DMAPeripheral) {}
+    fn xfer_done(&self, _pid: DMAPeripheral) {}
 }
 
 impl hil::i2c::I2CController for I2CDevice {

--- a/kernel/src/common/take_cell.rs
+++ b/kernel/src/common/take_cell.rs
@@ -102,6 +102,17 @@ impl<T> TakeCell<T> {
         })
     }
 
+    pub fn map_or<F, R>(&self, default: R, closure: F) -> R
+        where F: FnOnce(&mut T) -> R
+    {
+        let maybe_val = self.take();
+        maybe_val.map_or(default, |mut val| {
+            let res = closure(&mut val);
+            self.replace(val);
+            res
+        })
+    }
+
     pub fn modify_or_replace<F, G>(&self, modify: F, mkval: G)
         where F: FnOnce(&mut T),
               G: FnOnce() -> T


### PR DESCRIPTION
This is dependent on `map_or`.

Gets rid of need for `&mut Self` in `dma.xfer_done`.