### PR TITLE
[Security] Store process registers in Process struct

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -32,17 +32,18 @@ EXC_RETURN_PSP:
 #[inline(never)]
 /// r0 is top of user stack, r1 Process GOT
 pub unsafe extern "C" fn switch_to_user(mut user_stack: *const u8,
-                                        process_got: *const u8)
+                                        process_got: *const u8,
+                                        process_regs: &mut [usize; 8])
                                         -> *mut u8 {
     asm!("
     /* Load non-hardware-stacked registers from Process stack */
-    subs $0, #32
-    ldmia $0!, {r4-r7}
+    ldmia $3!, {r4-r7}
     mov r11, r7
     mov r10, r6
     mov r9,  r5
     mov r8,  r4
-    ldmia $0!, {r4-r7}
+    ldmia $3!, {r4-r7}
+    subs $3, 32
 
     /* Load bottom of stack into Process Stack Pointer */
     msr psp, $0
@@ -50,32 +51,33 @@ pub unsafe extern "C" fn switch_to_user(mut user_stack: *const u8,
     /* Set PIC base pointer to the Process GOT */
     mov r9, $2
 
+    mov r0, $3
+
     /* SWITCH */
     svc 0xff /* It doesn't matter which SVC number we use here */
 
-    mrs $0, PSP /* PSP into r0 */
-
     /* Push non-hardware-stacked registers onto Process stack */
     /* r0 points to user stack (see to_kernel) */
-    subs r0, #32 // We actually store r4-r11 below the process stack
-    str r4, [$0, #16]
-    str r5, [$0, #20]
-    str r6, [$0, #24]
-    str r7, [$0, #28]
+    str r4, [r0, #16]
+    str r5, [r0, #20]
+    str r6, [r0, #24]
+    str r7, [r0, #28]
 
     mov  r4, r8
     mov  r5, r9
     mov  r6, r10
     mov  r7, r11
 
-    str r4, [$0, #0]
-    str r5, [$0, #4]
-    str r6, [$0, #8]
-    str r7, [$0, #12]
-    adds $0, #32 // We actually store r4-r11 below the process stack
+    str r4, [r0, #0]
+    str r5, [r0, #4]
+    str r6, [r0, #8]
+    str r7, [r0, #12]
+
+    mrs $0, PSP /* PSP into r0 */
+
     "
     : "=r"(user_stack)
-    : "r"(user_stack), "r"(process_got)
+    : "r"(user_stack), "r"(process_got), "r"(process_regs)
     : "r4","r5","r6","r7","r8","r9","r10","r11");
     user_stack as *mut u8
 }

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -20,11 +20,15 @@ pub unsafe extern "C" fn systick_handler() {
         cmp lr, #0xfffffffd
         bne _systick_handler_no_stacking
 
-        mrs r0, PSP /* PSP into r0 */
+        /* We need the most recent kernel's version of r0, which points */
+        /* to the Process struct's stored registers field. The kernel's r0 */
+        /* lives in the first word of the hardware stacked registers on MSP */
+        mov r0, sp
+        ldr r0, [r0, #0]
 
         /* Push non-hardware-stacked registers onto Process stack */
         /* r0 points to user stack (see to_kernel) */
-        stmdb r0, {r4-r11}
+        stmia r0, {r4-r11}
     _systick_handler_no_stacking:
         ldr r0, =OVERFLOW_FIRED
         mov r1, #1
@@ -54,11 +58,15 @@ pub unsafe extern "C" fn generic_isr() {
     cmp lr, #0xfffffffd
     bne _ggeneric_isr_no_stacking
 
-    mrs r0, PSP /* PSP into r0 */
+    /* We need the most recent kernel's version of r0, which points */
+    /* to the Process struct's stored registers field. The kernel's r0 */
+    /* lives in the first word of the hardware stacked registers on MSP */
+    mov r0, sp
+    ldr r0, [r0, #0]
 
     /* Push non-hardware-stacked registers onto Process stack */
     /* r0 points to user stack (see to_kernel) */
-    stmdb r0, {r4-r11}
+    stmia r0, {r4-r11}
 _ggeneric_isr_no_stacking:
     /* Find the ISR number by looking at the low byte of the IPSR registers */
     mrs r0, IPSR
@@ -128,28 +136,31 @@ pub unsafe extern "C" fn switch_to_user(user_stack: *const u8, process_got: *con
 #[inline(never)]
 /// r0 is top of user stack, r1 Process GOT
 pub unsafe extern "C" fn switch_to_user(mut user_stack: *const u8,
-                                        process_got: *const u8)
+                                        process_got: *const u8,
+                                        process_regs: &mut [usize; 8])
                                         -> *mut u8 {
     asm!("
     /* Load non-hardware-stacked registers from Process stack */
-    sub $0, #32
-    ldmia $0!, {r4-r11}
+    ldmia $3, {r4-r11}
     /* Load bottom of stack into Process Stack Pointer */
     msr psp, $0
 
     /* Set PIC base pointer to the Process GOT */
     mov r9, $2
 
+    /* Ensure that $3 is stored in a callee saved register */
+    mov r0, $3
+
     /* SWITCH */
     svc 0xff /* It doesn't matter which SVC number we use here */
 
-    mrs $0, PSP /* PSP into r0 */
+    /* Push non-hardware-stacked registers into Process struct's */
+    /* regs field */
+    stmia r0, {r4-r11}
 
-    /* Push non-hardware-stacked registers onto Process stack */
-    /* r0 points to user stack (see to_kernel) */
-    stmdb $0, {r4-r11}"
+    mrs $0, PSP /* PSP into r0 */"
     : "=r"(user_stack)
-    : "r"(user_stack), "r"(process_got)
+    : "r"(user_stack), "r"(process_got), "r"(process_regs)
     : "r4","r5","r6","r7","r8","r9","r10","r11");
     user_stack as *mut u8
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -11,7 +11,10 @@ pub static mut SYSCALL_FIRED: usize = 0;
 
 #[allow(improper_ctypes)]
 extern "C" {
-    pub fn switch_to_user(user_stack: *const u8, mem_base: *const u8) -> *mut u8;
+    pub fn switch_to_user(user_stack: *const u8,
+                          mem_base: *const u8,
+                          process_regs: &mut [usize; 8])
+                          -> *mut u8;
 }
 
 pub static mut PROCS: &'static mut [Option<Process<'static>>] = &mut [];
@@ -82,6 +85,8 @@ pub struct Process<'a> {
     /// The offset in `memory` to use for the process stack.
     cur_stack: *const u8,
 
+    stored_regs: [usize; 8],
+
     yield_pc: usize,
     psr: usize,
 
@@ -147,6 +152,7 @@ impl<'a> Process<'a> {
             kernel_memory_break: kernel_memory_break,
             text: slice::from_raw_parts(start_addr, length),
             cur_stack: stack_bottom,
+            stored_regs: [0; 8],
             yield_pc: 0,
             psr: 0x01000000,
             state: State::Yielded,
@@ -261,7 +267,7 @@ impl<'a> Process<'a> {
             breakpoint();
         }
         write_volatile(&mut SYSCALL_FIRED, 0);
-        let psp = switch_to_user(self.cur_stack, self.memory.as_ptr());
+        let psp = switch_to_user(self.cur_stack, self.memory.as_ptr(), &mut self.stored_regs);
         self.cur_stack = psp;
     }
 


### PR DESCRIPTION
_This PR requires pretty detailed review. Putting this up early to start to get feedback_

Previously, we were storing the process registers on the process stack
on an SVC or interrupt. However, that is a huge security hole since
we're trusting the integrity of the PSP register to the process, which
could point it anywhere it wanted.

Instead this stores the registers in a fixed location per process, which
is kept track of using supervisor mode's r0 register (on the kernel
stack while running a process is running)
