### PR TITLE
SPI: Support GPIO chip select as well as HW chip select

### DIFF
--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -368,10 +368,11 @@ pub unsafe fn reset_handler() {
     virtual_alarm1.set_client(timer);
 
     // Initialize and enable SPI HAL
+    let chip_selects = static_init!([u8; 3], [0, 1, 2], 3);
     let spi = static_init!(
         capsules::spi::Spi<'static, sam4l::spi::Spi>,
-        capsules::spi::Spi::new(&mut sam4l::spi::SPI),
-        84);
+        capsules::spi::Spi::new(&mut sam4l::spi::SPI, chip_selects),
+        92);
     spi.config_buffers(&mut spi_read_buf, &mut spi_write_buf);
     sam4l::spi::SPI.set_client(spi);
     sam4l::spi::SPI.init();

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -218,12 +218,10 @@ impl<'a, S: SpiMaster> Driver for Spi<'a, S> {
             }
             2 /* set chip select */ => {
                 let cs = arg1;
-                if cs <= self.chip_selects.len() {
-                    self.spi_master.specify_chip_select(self.chip_selects[cs]);
+                self.chip_selects.get(cs).map_or(-1, |cs_line| {
+                    self.spi_master.specify_chip_select(*cs_line);
                     0
-                } else {
-                    -1
-                }
+                })
             }
             3 /* get chip select */ => {
                 0

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -5,13 +5,13 @@ use kernel::hil;
 
 /// The Mux struct manages multiple SPI clients. Each client may have
 /// at most one outstanding SPI request.
-pub struct MuxSPIMaster<'a> {
-    spi: &'a hil::spi::SpiMaster,
-    devices: List<'a, SPIMasterDevice<'a>>,
-    inflight: TakeCell<&'a SPIMasterDevice<'a>>,
+pub struct MuxSPIMaster<'a, SPI: hil::spi::SpiMaster + 'a> {
+    spi: &'a SPI,
+    devices: List<'a, SPIMasterDevice<'a, SPI>>,
+    inflight: TakeCell<&'a SPIMasterDevice<'a, SPI>>,
 }
 
-impl<'a> hil::spi::SpiMasterClient for MuxSPIMaster<'a> {
+impl<'a, SPI: hil::spi::SpiMaster> hil::spi::SpiMasterClient for MuxSPIMaster<'a, SPI> {
     fn read_write_done(&self,
                        write_buffer: &'static mut [u8],
                        read_buffer: Option<&'static mut [u8]>,
@@ -23,8 +23,8 @@ impl<'a> hil::spi::SpiMasterClient for MuxSPIMaster<'a> {
     }
 }
 
-impl<'a> MuxSPIMaster<'a> {
-    pub const fn new(spi: &'a hil::spi::SpiMaster) -> MuxSPIMaster<'a> {
+impl<'a, SPI: hil::spi::SpiMaster> MuxSPIMaster<'a, SPI> {
+    pub const fn new(spi: &'a SPI) -> MuxSPIMaster<'a, SPI> {
         MuxSPIMaster {
             spi: spi,
             devices: List::new(),
@@ -40,29 +40,13 @@ impl<'a> MuxSPIMaster<'a> {
                 match node.operation.get() {
                     Op::Configure(cpol, cpal, rate) => {
 
-                        match node.chip_select {
-                            Some(x) => {
-                                self.spi.set_chip_select(x);
-                            }
-                            None => {}
-                        }
-
-                        // In theory, the SPI interface should support
-                        // using a GPIO in lieu of a hardware CS line.
-                        // This is particularly important for the SAM4L
-                        // if using a USART, but might be relevant
-                        // for other platforms as well.
-                        // TODO: make this do something if given GPIO pin
-                        // match node.chip_select_gpio {
-                        //     Some() => { },
-                        //     None => {}
-                        // }
+                        // The `chip_select` type will be correct based on
+                        // what implemented `SpiMaster`.
+                        self.spi.specify_chip_select(node.chip_select.get());
 
                         self.spi.set_clock(cpol);
                         self.spi.set_phase(cpal);
                         self.spi.set_rate(rate);
-
-
                     }
                     Op::ReadWriteBytes(len) => {
 
@@ -91,26 +75,23 @@ enum Op {
     ReadWriteBytes(usize),
 }
 
-pub struct SPIMasterDevice<'a> {
-    mux: &'a MuxSPIMaster<'a>,
-    chip_select: Option<u8>,
-    chip_select_gpio: Option<&'static hil::gpio::Pin>,
+pub struct SPIMasterDevice<'a, SPI: hil::spi::SpiMaster + 'a> {
+    mux: &'a MuxSPIMaster<'a, SPI>,
+    chip_select: Cell<SPI::ChipSelect>,
     txbuffer: TakeCell<&'static mut [u8]>,
     rxbuffer: TakeCell<Option<&'static mut [u8]>>,
     operation: Cell<Op>,
-    next: ListLink<'a, SPIMasterDevice<'a>>,
+    next: ListLink<'a, SPIMasterDevice<'a, SPI>>,
     client: Cell<Option<&'a hil::spi::SpiMasterClient>>,
 }
 
-impl<'a> SPIMasterDevice<'a> {
-    pub const fn new(mux: &'a MuxSPIMaster<'a>,
-                     chip_select: Option<u8>,
-                     chip_select_gpio: Option<&'static hil::gpio::Pin>)
-                     -> SPIMasterDevice<'a> {
+impl<'a, SPI: hil::spi::SpiMaster> SPIMasterDevice<'a, SPI> {
+    pub const fn new(mux: &'a MuxSPIMaster<'a, SPI>,
+                     chip_select: SPI::ChipSelect)
+                     -> SPIMasterDevice<'a, SPI> {
         SPIMasterDevice {
             mux: mux,
-            chip_select: chip_select,
-            chip_select_gpio: chip_select_gpio,
+            chip_select: Cell::new(chip_select),
             txbuffer: TakeCell::empty(),
             rxbuffer: TakeCell::empty(),
             operation: Cell::new(Op::Idle),
@@ -125,7 +106,7 @@ impl<'a> SPIMasterDevice<'a> {
     }
 }
 
-impl<'a> hil::spi::SpiMasterClient for SPIMasterDevice<'a> {
+impl<'a, SPI: hil::spi::SpiMaster> hil::spi::SpiMasterClient for SPIMasterDevice<'a, SPI> {
     fn read_write_done(&self,
                        write_buffer: &'static mut [u8],
                        read_buffer: Option<&'static mut [u8]>,
@@ -136,13 +117,14 @@ impl<'a> hil::spi::SpiMasterClient for SPIMasterDevice<'a> {
     }
 }
 
-impl<'a> ListNode<'a, SPIMasterDevice<'a>> for SPIMasterDevice<'a> {
-    fn next(&'a self) -> &'a ListLink<'a, SPIMasterDevice<'a>> {
+impl<'a, SPI: hil::spi::SpiMaster> ListNode<'a, SPIMasterDevice<'a, SPI>>
+    for SPIMasterDevice<'a, SPI> {
+    fn next(&'a self) -> &'a ListLink<'a, SPIMasterDevice<'a, SPI>> {
         &self.next
     }
 }
 
-impl<'a> hil::spi::SPIMasterDevice for SPIMasterDevice<'a> {
+impl<'a, SPI: hil::spi::SpiMaster> hil::spi::SPIMasterDevice for SPIMasterDevice<'a, SPI> {
     fn configure(&self, cpol: hil::spi::ClockPolarity, cpal: hil::spi::ClockPhase, rate: u32) {
         self.operation.set(Op::Configure(cpol, cpal, rate));
         self.mux.do_next_op();

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -214,6 +214,8 @@ impl Spi {
 }
 
 impl spi::SpiMaster for Spi {
+    type ChipSelect = u8;
+
     fn set_client(&self, client: &'static SpiMasterClient) {
         self.client.replace(client);
     }
@@ -379,32 +381,15 @@ impl spi::SpiMaster for Spi {
         self.write_active_csr(csr);
     }
 
-    fn set_chip_select(&self, cs: u8) -> bool {
+    fn specify_chip_select(&self, cs: Self::ChipSelect) {
         let peripheral_number = match cs {
             0 => Peripheral::Peripheral0,
             1 => Peripheral::Peripheral1,
             2 => Peripheral::Peripheral2,
             3 => Peripheral::Peripheral3,
-            _ => return false,
+            _ => Peripheral::Peripheral0,
         };
         self.set_active_peripheral(peripheral_number);
-        true
-    }
-
-    fn get_chip_select(&self) -> u8 {
-        let mr = unsafe { read_volatile(&(*self.regs).mr) };
-        let cs = (mr >> 16) & 0xF;
-        match cs {
-            0b0000 => 0,
-            0b0001 => 1,
-            0b0011 => 2,
-            0b0111 => 3,
-            _ => 0,
-        }
-    }
-
-    fn clear_chip_select(&self) {
-        unsafe { write_volatile(&mut (*self.regs).cr, 1 << 24) };
     }
 }
 

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -50,17 +50,17 @@ pub trait SpiMasterClient {
 /// a particular peripheral persists across chip select. For
 /// example, with this set of calls:
 ///
-///   set_chip_select(1);
+///   specify_chip_select(1);
 ///   set_phase(SampleLeading);
-///   set_chip_select(2);
+///   specify_chip_select(2);
 ///   set_phase(SampleTrailing);
-///   set_chip_select(1);
+///   specify_chip_select(1);
 ///   write_byte(0); // Uses SampleLeading
 ///
 /// If additional chip selects are needed, they can be performed
 /// with GPIO and manual re-initialization of settings.
 ///
-///   set_chip_select(0);
+///   specify_chip_select(0);
 ///   set_phase(SampleLeading);
 ///   pin_a.set();
 ///   write_byte(0xaa); // Uses SampleLeading
@@ -70,6 +70,8 @@ pub trait SpiMasterClient {
 ///   write_byte(0xaa); // Uses SampleTrailing
 ///
 pub trait SpiMaster {
+    type ChipSelect: Copy;
+
     fn set_client(&self, client: &'static SpiMasterClient);
 
     fn init(&self);
@@ -77,7 +79,7 @@ pub trait SpiMaster {
 
     /// Perform an asynchronous read/write operation, whose
     /// completion is signaled by invoking SpiMasterClient on
-    /// the initialzied client. write_buffer must be Some,
+    /// the initialized client. write_buffer must be Some,
     /// read_buffer may be None. If read_buffer is Some, the
     /// length of the operation is the minimum of the size of
     /// the two buffers.
@@ -90,11 +92,10 @@ pub trait SpiMaster {
     fn read_byte(&self) -> u8;
     fn read_write_byte(&self, val: u8) -> u8;
 
-    /// Returns whether this chip select is valid and was
-    /// applied, 0 is always valid.
-    fn set_chip_select(&self, cs: u8) -> bool;
-    fn clear_chip_select(&self);
-    fn get_chip_select(&self) -> u8;
+    /// Tell the SPI peripheral what to use as a chip select pin.
+    /// The type of the argument is based on what makes sense for the
+    /// peripheral when this trait is implemented.
+    fn specify_chip_select(&self, cs: Self::ChipSelect);
 
     /// Returns the actual rate set
     fn set_rate(&self, rate: u32) -> u32;


### PR DESCRIPTION
Makes an enum that gets passed to `set_chip_select()` so the drivers can use a GPIO pin or a hardware chip select line. 

I need help with virtual_spi.rs. In order to get types to work, I had to call `take()` on the chip select enum before passing it to the hardware. If I'm not mistaken, that will remove it and will effectively only work once. So if there is more than one SPI device, the CS line will not get properly updated.

I also have to make GPIO CS work with the sam4l spi peripheral.