### PR TITLE
Update SAM4L ADC and add ADC capsule

### DIFF
--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -84,6 +84,7 @@ struct Firestorm {
     isl29035: &'static capsules::isl29035::Isl29035<'static>,
     spi: &'static capsules::spi::Spi<'static, sam4l::spi::Spi>,
     nrf51822: &'static Nrf51822Serialization<'static, usart::USART>,
+    adc: &'static capsules::adc::ADC<'static, sam4l::adc::Adc>,
 }
 
 impl Platform for Firestorm {
@@ -103,6 +104,7 @@ impl Platform for Firestorm {
             4 => f(Some(self.spi)),
             5 => f(Some(self.nrf51822)),
             6 => f(Some(self.isl29035)),
+            7 => f(Some(self.adc)),
             _ => f(None),
         }
     }
@@ -377,6 +379,13 @@ pub unsafe fn reset_handler() {
     sam4l::spi::SPI.set_client(spi);
     sam4l::spi::SPI.init();
 
+    // Setup ADC
+    let adc = static_init!(
+        capsules::adc::ADC<'static, sam4l::adc::Adc>,
+        capsules::adc::ADC::new(&mut sam4l::adc::ADC),
+        160/8);
+    sam4l::adc::ADC.set_client(adc);
+
     // set GPIO driver controlling remaining GPIO pins
     let gpio_pins = static_init!(
         [&'static sam4l::gpio::GPIOPin; 12],
@@ -419,8 +428,9 @@ pub unsafe fn reset_handler() {
             isl29035: isl29035,
             spi: spi,
             nrf51822: nrf_serialization,
+            adc: adc,
         },
-        28);
+        256/8);
 
     usart::USART3.configure(usart::USARTParams {
         // client: &console,

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -1,0 +1,69 @@
+use core::cell::Cell;
+use kernel::{AppId, Callback, Driver};
+use kernel::hil::adc::{Client, AdcSingle};
+
+pub struct ADC<'a, A: AdcSingle + 'a> {
+    adc: &'a A,
+    channel: Cell<u8>,
+    callback: Cell<Option<Callback>>,
+}
+
+impl<'a, A: AdcSingle + 'a> ADC<'a, A> {
+    pub fn new(adc: &'a A) -> ADC<'a, A> {
+        ADC {
+            adc: adc,
+            channel: Cell::new(0),
+            callback: Cell::new(None),
+        }
+    }
+
+    fn initialize(&self) {
+        self.adc.initialize();
+    }
+
+    fn sample(&self, channel: u8) {
+        self.channel.set(channel);
+        self.adc.sample(channel);
+    }
+}
+
+impl<'a, A: AdcSingle + 'a> Client for ADC<'a, A> {
+    fn sample_done(&self, sample: u16) {
+        self.callback.get().map(|mut cb| {
+            cb.schedule(0, self.channel.get() as usize, sample as usize);
+        });
+    }
+}
+
+impl<'a, A: AdcSingle + 'a> Driver for ADC<'a, A> {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+        match subscribe_num {
+            // subscribe to ADC sample done
+            0 => {
+                self.callback.set(Some(callback));
+                0
+            }
+
+            // default
+            _ => -1,
+        }
+    }
+
+    fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
+        match command_num {
+            // Initialize ADC
+            0 => {
+                self.initialize();
+                0
+            }
+            // Sample on channel
+            1 => {
+                self.sample(data as u8);
+                0
+            }
+
+            // default
+            _ => -1,
+        }
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -13,3 +13,4 @@ pub mod spi;
 pub mod virtual_alarm;
 pub mod virtual_i2c;
 pub mod virtual_spi;
+pub mod adc;

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -5,8 +5,8 @@
 // all samples
 //   - are 12 bits
 //   - use the ground pad as the negative reference
-//   - use a 1V positive reference
-//   - are hardware left justified (16 bits wide, bottom 4 bits empty)
+//   - use a VCC/2 positive reference
+//   - are right justified
 //
 // NOTE: The pin labels/assignments on the Firestorm schematic are
 // incorrect. The mappings should be
@@ -31,155 +31,151 @@
 // Date: August 5, 2015
 //
 
-use core::{intrinsics, ptr};
 use core::cell::Cell;
-use kernel::hil::adc::{Request, AdcInternal};
+use core::mem;
+use kernel::common::volatile_cell::VolatileCell;
+use kernel::hil;
+use kernel::hil::adc::AdcSingle;
 use nvic;
 use pm::{self, Clock, PBAClock};
 use scif;
 
 
 #[repr(C, packed)]
-#[allow(dead_code,missing_copy_implementations)]
-#[cfg_attr(rustfmt, rustfmt_skip)]
-pub struct AdcRegisters { // From page 1005 of SAM4L manual
-    cr:        usize,   // Control               (0x00)
-    cfg:       usize,   // Configuration         (0x04)
-    sr:        usize,   // Status                (0x08)
-    scr:       usize,   // Status clear          (0x0c)
-    pad:       usize,   // padding/reserved
-    seqcfg:    usize,   // Sequencer config      (0x14)
-    cdma:      usize,   // Config DMA            (0x18)
-    tim:       usize,   // Timing config         (0x1c)
-    itimer:    usize,   // Internal timer        (0x20)
-    wcfg:      usize,   // Window config         (0x24)
-    wth:       usize,   // Window threshold      (0x28)
-    lcv:       usize,   // Last converted value  (0x2c)
-    ier:       usize,   // Interrupt enable      (0x30)
-    idr:       usize,   // Interrupt disable     (0x34)
-    imr:       usize,   // Interrupt mask        (0x38)
-    calib:     usize,   // Calibration           (0x3c)
-    version:   usize,   // Version               (0x40)
-    parameter: usize,   // Parameter             (0x44)
+pub struct AdcRegisters {
+    // From page 1005 of SAM4L manual
+    cr: VolatileCell<u32>, // Control               (0x00)
+    cfg: VolatileCell<u32>, // Configuration        (0x04)
+    sr: VolatileCell<u32>, // Status                (0x08)
+    scr: VolatileCell<u32>, // Status clear         (0x0c)
+    pad: VolatileCell<u32>, // padding/reserved
+    seqcfg: VolatileCell<u32>, // Sequencer config  (0x14)
+    cdma: VolatileCell<u32>, // Config DMA          (0x18)
+    tim: VolatileCell<u32>, // Timing config        (0x1c)
+    itimer: VolatileCell<u32>, // Internal timer    (0x20)
+    wcfg: VolatileCell<u32>, // Window config       (0x24)
+    wth: VolatileCell<u32>, // Window threshold     (0x28)
+    lcv: VolatileCell<u32>, // Last converted value (0x2c)
+    ier: VolatileCell<u32>, // Interrupt enable     (0x30)
+    idr: VolatileCell<u32>, // Interrupt disable    (0x34)
+    imr: VolatileCell<u32>, // Interrupt mask       (0x38)
+    calib: VolatileCell<u32>, // Calibration        (0x3c)
+    version: VolatileCell<u32>, // Version          (0x40)
+    parameter: VolatileCell<u32>, // Parameter      (0x44)
 }
 
 // Page 59 of SAM4L data sheet
-const BASE_ADDRESS: usize = 0x40038000;
+const BASE_ADDRESS: *mut AdcRegisters = 0x40038000 as *mut AdcRegisters;
 
 pub struct Adc {
     registers: *mut AdcRegisters,
-    enabled: bool,
+    enabled: Cell<bool>,
     channel: Cell<u8>,
-    request: Cell<Option<&'static Request>>,
+    client: Cell<Option<&'static hil::adc::Client>>,
 }
+
+pub static mut ADC: Adc = Adc::new(BASE_ADDRESS);
 
 impl Adc {
-    pub fn new() -> Adc {
-        let address = BASE_ADDRESS;
+    const fn new(base_address: *mut AdcRegisters) -> Adc {
         Adc {
-            registers: unsafe { intrinsics::transmute(address) },
-            enabled: false,
+            registers: base_address,
+            enabled: Cell::new(false),
             channel: Cell::new(0),
-            request: Cell::new(None),
+            client: Cell::new(None),
         }
     }
+
+    pub fn set_client<C: hil::adc::Client>(&self, client: &'static C) {
+        self.client.set(Some(client));
+    }
+
     pub fn handle_interrupt(&mut self) {
         let val: u16;
-        unsafe {
-            // Clear SEOC interrupt
-            ptr::write_volatile(&mut (*self.registers).scr, 0x0000001);
-            // Disable SEOC interrupt
-            ptr::write_volatile(&mut (*self.registers).idr, 0x00000001);
-            // Read the value from the LCV register.
-            // Note that since samples are left-justified (HWLA mode)
-            // the sample is 16 bits wide
-            val = (ptr::read_volatile(&(*self.registers).lcv) & 0xffff) as u16;
-        }
-        if self.request.get().is_none() {
-            return;
-        }
-        let opt = self.request.get().take();
-        let copt: &'static Request = opt.unwrap();
-        self.request = Cell::new(None);
-        copt.sample_done(val, copt);
+        let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
+        // Clear SEOC interrupt
+        regs.scr.set(0x0000001);
+        // Disable SEOC interrupt
+        regs.idr.set(0x00000001);
+        // Read the value from the LCV register.
+        // The sample is 16 bits wide
+        val = (regs.lcv.get() & 0xffff) as u16;
+        self.client.get().map(|client| {
+            client.sample_done(val);
+        });
     }
 }
 
-impl AdcInternal for Adc {
-    fn initialize(&'static mut self) -> bool {
-        if !self.enabled {
-            self.enabled = true;
+impl AdcSingle for Adc {
+    fn initialize(&self) -> bool {
+        let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
+        if !self.enabled.get() {
+            self.enabled.set(true);
+            // This logic is from 38.6.1 "Initializing the ADCIFE" of
+            // the SAM4L data sheet
+            // 1. Start the clocks
             unsafe {
-                // This logic is from 38.6.1 "Initializing the ADCIFE" of
-                // the SAM4L data sheet
-                // 1. Start the clocks
                 pm::enable_clock(Clock::PBA(PBAClock::ADCIFE));
                 nvic::enable(nvic::NvicIdx::ADCIFE);
                 scif::generic_clock_enable(scif::GenericClock::GCLK10, scif::ClockSource::RCSYS);
-                // 2. Insert a fixed delay
-                for _ in 1..10000 {
-                    let _ = ptr::read_volatile(&(*self.registers).cr);
-                }
-
-                // 3, Enable the ADC
-                let mut cr: usize = ptr::read_volatile(&(*self.registers).cr);
-                cr |= 1 << 8;
-                ptr::write_volatile(&mut (*self.registers).cr, cr);
-
-                // 4. Wait until ADC ready
-                while ptr::read_volatile(&(*self.registers).sr) & (1 << 24) == 0 {}
-                // 5. Turn on bandgap and reference buffer
-                let cr2: usize = (1 << 10) | (1 << 8) | (1 << 4);
-                ptr::write_volatile(&mut (*self.registers).cr, cr2);
-
-                // 6. Configure the ADCIFE
-                // Setting all 0s in the configuration register sets
-                //   - the clock divider to be 4,
-                //   - the source to be the Generic clock,
-                //   - the max speed to be 300 ksps, and
-                //   - the reference voltage to be 1.0V
-                ptr::write_volatile(&mut (*self.registers).cfg, 0x00000030 as usize);
-                while ptr::read_volatile(&(*self.registers).sr) & (0x51000000) != 0x51000000 {}
             }
+            // 2. Insert a fixed delay
+            for _ in 1..10000 {
+                let _ = regs.cr.get();
+            }
+
+            // 3, Enable the ADC
+            let mut cr: u32 = regs.cr.get();
+            cr |= 1 << 8;
+            regs.cr.set(cr);
+
+            // 4. Wait until ADC ready
+            while regs.sr.get() & (1 << 24) == 0 {}
+            // 5. Turn on bandgap and reference buffer
+            let cr2: u32 = (1 << 10) | (1 << 8) | (1 << 4);
+            regs.cr.set(cr2);
+
+            // 6. Configure the ADCIFE
+            // Setting below in the configuration register sets
+            //   - the clock divider to be 4,
+            //   - the source to be the Generic clock,
+            //   - the max speed to be 300 ksps, and
+            //   - the reference voltage to be VCC/2
+            regs.cfg.set(0x00000008);
+            while regs.sr.get() & (0x51000000) != 0x51000000 {}
         }
         return true;
     }
 
-    fn sample(&self, channel: u8, request: &'static Request) -> bool {
-        if !self.enabled || self.request.get().is_some() || channel > 14 {
+    fn sample(&self, channel: u8) -> bool {
+        let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
+        if !self.enabled.get() || channel > 14 {
             return false;
         } else {
-            self.request.set(Some(request));
             self.channel.set(channel);
             // This configuration sets the ADC to use Pad Ground as the
             // negative input, and the ADC channel as the positive. Since
             // this is a single-ended sample, the bipolar bit is set to zero.
             // Trigger select is set to zero because this denotes a software
-            // sample. Gain is 1x (set to 0). Resolution is set to 12 bits
-            // (set to 0). The one trick is that the half word left adjust
-            // (HWLA) is set to 1. This means that both 12-bit and 8-bit
-            // samples are left justified to the lower 16 bits. So they share
-            // the same most significant bit but for 8 bit samples the lower
-            // 8 bits are zero and for 12 bits the lower 4 bits are zero.
+            // sample. Gain is 0.5x (set to 111). Resolution is set to 12 bits
+            // (set to 0).
 
-            let chan_field: usize = (self.channel.get() as usize) << 16;
-            unsafe {
-                let mut cfg: usize = chan_field;
-                cfg |= 0x00700000; // MUXNEG   = 111 (ground pad)
-                cfg |= 0x00008000; // INTERNAL =  10 (int neg, ext pos)
-                cfg |= 0x00000000; // RES      =   0 (12-bit)
-                cfg |= 0x00000000; // TRGSEL   =   0 (software)
-                cfg |= 0x00000000; // GCOMP    =   0 (no gain error corr)
-                cfg |= 0x00000000; // GAIN     =   0 (1x gain)
-                cfg |= 0x00000000; // BIPOLAR  =   0 (not bipolar)
-                cfg |= 0x00000001; // HWLA     =   1 (left justify value)
-                ptr::write_volatile(&mut (*self.registers).seqcfg, cfg);
-                // Enable end of conversion interrupt
-                ptr::write_volatile(&mut (*self.registers).ier, 1);
-                // Initiate conversion
-                ptr::write_volatile(&mut (*self.registers).cr, 8);
-                return true;
-            }
+            let chan_field: u32 = (self.channel.get() as u32) << 16;
+            let mut cfg: u32 = chan_field;
+            cfg |= 0x00700000; // MUXNEG   = 111 (ground pad)
+            cfg |= 0x00008000; // INTERNAL =  10 (int neg, ext pos)
+            cfg |= 0x00000000; // RES      =   0 (12-bit)
+            cfg |= 0x00000000; // TRGSEL   =   0 (software)
+            cfg |= 0x00000000; // GCOMP    =   0 (no gain error corr)
+            cfg |= 0x00000070; // GAIN     = 111 (0.5x gain)
+            cfg |= 0x00000000; // BIPOLAR  =   0 (not bipolar)
+            cfg |= 0x00000000; // HWLA     =   0 (no left justify value)
+            regs.seqcfg.set(cfg);
+            // Enable end of conversion interrupt
+            regs.ier.set(1);
+            // Initiate conversion
+            regs.cr.set(8);
+            return true;
         }
     }
 }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -1,6 +1,6 @@
+use adc;
 use ast;
 use cortexm4;
-// use adc;
 use dma;
 use flashcalw;
 use gpio;
@@ -90,7 +90,7 @@ impl Chip for Sam4l {
                     TWIM3 => i2c::I2C3.handle_interrupt(),
 
                     HFLASHC => flashcalw::flash_controller.handle_interrupt(),
-                    // NvicIdx::ADCIFE   => self.adc.handle_interrupt(),
+                    ADCIFE => adc::ADC.handle_interrupt(),
                     _ => {}
                 }
                 nvic::enable(interrupt);

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -1,14 +1,28 @@
-//! Simplest attempt at an ADC interface.
-//!
-//!  Author: Philip Levis <pal@cs.stanford.edu>
-//!  Date: June 10, 2015
-//!
-
-pub trait Request {
-    fn sample_done(&self, val: u16, request: &'static Request);
+/// Trait for handling callbacks from ADC module.
+pub trait Client {
+    /// Called when a sample is ready.
+    fn sample_done(&self, sample: u16);
 }
 
-pub trait AdcInternal {
-    fn initialize(&'static mut self) -> bool;
-    fn sample(&self, channel: u8, callback: &'static Request) -> bool;
+/// Simple interface for reading a single ADC sample on any channel.
+pub trait AdcSingle {
+    /// Initialize must be called before taking a sample.
+    /// Returns true on success.
+    fn initialize(&self) -> bool;
+
+    /// Request a single ADC sample on a particular channel.
+    /// Returns true on success.
+    fn sample(&self, channel: u8) -> bool;
+    // fn cancel_sample(&self) -> bool;
 }
+
+// pub trait Frequency {
+//    fn frequency() -> u32;
+// }
+//
+// pub trait AdcContinuous {
+//    type Frequency: Frequency;
+//    fn compute_interval(&self, interval:u32) -> u32;
+//    fn sample_continuous(&self, channel: u8, interval:u32);
+//    fn cancel_sampling(&self);
+// }

--- a/userland/examples/adc/Makefile
+++ b/userland/examples/adc/Makefile
@@ -1,0 +1,21 @@
+# makefile for user application
+
+CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
+TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
+BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
+
+C_SRCS   := $(wildcard *.c)
+OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
+
+CPPFLAGS += -DSTACK_SIZE=2048
+
+# include userland master makefile. Contains rules and flags for actually
+# 	building the application
+include $(TOCK_USERLAND_BASE_DIR)/Makefile
+
+.PHONY:
+clean::
+	rm -Rf $(BUILDDIR)
+

--- a/userland/examples/adc/main.c
+++ b/userland/examples/adc/main.c
@@ -1,0 +1,35 @@
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "tock.h"
+#include "console.h"
+#include "timer.h"
+#include "adc.h"
+
+
+int main() {
+  putstr("[Tock] ADC Test\n");
+
+  // Setup the ADC
+  adc_initialize();
+  delay_ms(1000);
+
+  while (1) {
+    char buf[128];
+
+    // Sample channel 1. (On Firestorm, this is labeled "A5".)
+    int reading = adc_read_single_sample(1);
+
+    // 12 bit, reference = VCC/2, gain = 0.5
+    // millivolts = ((reading * 2) / (2^12 - 1)) * (3.3 V / 2) * 1000
+    int millivolts = (reading * 3300) / 4095;
+
+    sprintf(buf, "ADC Reading: %i mV (raw: 0x%04x)\n", millivolts, reading);
+    putstr(buf);
+    delay_ms(1000);
+  }
+
+  return 0;
+}

--- a/userland/libtock/adc.c
+++ b/userland/libtock/adc.c
@@ -1,0 +1,48 @@
+#include <stdint.h>
+
+#include "tock.h"
+#include "adc.h"
+
+struct adc_data {
+  int reading;
+  bool fired;
+};
+
+struct adc_data result = { .fired = false };
+
+// Internal callback for faking synchronous reads
+static void adc_cb(__attribute__ ((unused)) int callback_type,
+                   __attribute__ ((unused)) int channel,
+                   int reading,
+                   void* ud) {
+  struct adc_data* result = (struct adc_data*) ud;
+  result->reading = reading;
+  result->fired = true;
+}
+
+int adc_set_callback(subscribe_cb callback, void* callback_args) {
+    return subscribe(DRIVER_NUM_ADC, 0, callback, callback_args);
+}
+
+int adc_initialize() {
+    return command(DRIVER_NUM_ADC, 0, 0);
+}
+
+int adc_single_sample(uint8_t channel) {
+    return command(DRIVER_NUM_ADC, 1, channel);
+}
+
+int adc_read_single_sample(uint8_t channel) {
+  int err;
+
+  err = adc_set_callback(adc_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = adc_single_sample(channel);
+  if (err < 0) return err;
+
+  // Wait for the ADC callback.
+  yield_for(&result.fired);
+
+  return result.reading;
+}

--- a/userland/libtock/adc.h
+++ b/userland/libtock/adc.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#include "tock.h"
+
+#define DRIVER_NUM_ADC 7
+
+int adc_set_callback(subscribe_cb callback, void* callback_args);
+int adc_initialize();
+int adc_single_sample(uint8_t channel);
+
+// Synchronous function to read a single ADC sample.
+int adc_read_single_sample(uint8_t channel);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
All credit for this goes to @nealjack, I just cleaned up the branch for making a pull request.

Marked blocked to allow for more testing.

Also, the register list uses `#[cfg_attr(rustfmt, rustfmt_skip)]`. Doesn't that defeat the point? Or do we want to align all structs like that? Can we get `rustfmt` to do that?

Also, @nealjack feel free to take ownership of these commits. Git was doing the right thing all the way until I split it into two commits.