### PR TITLE
Compile Cortex-M0 apps and more better

### DIFF
--- a/boards/nrf51dk/apps/c_hello
+++ b/boards/nrf51dk/apps/c_hello
@@ -1,0 +1,1 @@
+../../../userland/examples/c_hello

--- a/chips/nrf51/nrf51.json
+++ b/chips/nrf51/nrf51.json
@@ -12,6 +12,7 @@
     "linker": "arm-none-eabi-gcc",
     "linker-is-gnu": true,
     "disable-redzone": true,
+    "features": "+strict-align",
     "pre-link-args": [
         "-mcpu=cortex-m0", "-mthumb",
         "-mfloat-abi=soft",

--- a/userland/Makefile
+++ b/userland/Makefile
@@ -40,9 +40,7 @@ $(BUILDDIR)/%.o: %.c | $(BUILDDIR)
 	$(TRACE_CC)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
-LD := $(TOOLCHAIN)-ld
 LINKER ?= $(TOCK_USERLAND_BASE_DIR)/linker.ld
-LDFLAGS := -T $(LINKER)
 
 SIZE := $(TOOLCHAIN)-size
 
@@ -61,7 +59,7 @@ $(BUILDDIR):
 
 $(BUILDDIR)/app.elf: $(OBJS) $(TOCK_USERLAND_BASE_DIR)/newlib/libc.a $(LIBTOCK) | $(BUILDDIR)
 	$(TRACE_LD)
-	$(Q)$(LD) --gc-sections --emit-relocs --entry=_start $(LDFLAGS) -nostdlib $(OBJS) --start-group $(TOCK_USERLAND_BASE_DIR)/newlib/libc.a $(LIBTOCK) --end-group -o $@
+	$(Q)$(CC) -Wl,--gc-sections -Wl,--emit-relocs --entry=_start $(CFLAGS) $(CPPFLAGS) -T $(LINKER) -nostdlib $(OBJS) -Wl,--start-group $(TOCK_USERLAND_BASE_DIR)/newlib/libc.a $(LIBTOCK) -lm -lgcc -Wl,--end-group -o $@
 
 $(BUILDDIR)/app.bin: $(BUILDDIR)/app.elf | $(BUILDDIR)
 	$(TRACE_BIN)


### PR DESCRIPTION
  * Adds +strict-align to the nrf51 target specification so LLVM doesn't generate byte-aligned load/stores for the kernel

  * Use thumbv6 libc.a for userland so we don't end up with apps that have incorrect instructions for Cortex-M0

  * Fixup userland Makefile to link in arm intrinsics required to replace the instructions above.
