### PR TITLE
SAM4L: Make base addresses `usize`

### DIFF
--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -64,7 +64,7 @@ pub struct AdcRegisters { // From page 1005 of SAM4L manual
 }
 
 // Page 59 of SAM4L data sheet
-pub const BASE_ADDRESS: usize = 0x40038000;
+const BASE_ADDRESS: usize = 0x40038000;
 
 pub struct Adc {
     registers: *mut AdcRegisters,

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -38,7 +38,7 @@ struct AstRegisters {
     calv: VolatileCell<u32>, // we leave out parameter and version
 }
 
-pub const AST_BASE: isize = 0x400F0800;
+const AST_BASE: usize = 0x400F0800;
 
 pub struct Ast<'a> {
     regs: *mut AstRegisters,

--- a/chips/sam4l/src/bpm.rs
+++ b/chips/sam4l/src/bpm.rs
@@ -17,7 +17,7 @@ struct BpmRegisters {
     io_retention: VolatileCell<u32>,
 }
 
-const BPM_BASE: isize = 0x400F0000;
+const BPM_BASE: usize = 0x400F0000;
 const BPM_UNLOCK_KEY: u32 = 0xAA000000;
 
 static mut bpm: *mut BpmRegisters = BPM_BASE as *mut BpmRegisters;

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -28,10 +28,10 @@ struct DMARegisters {
 }
 
 /// The PDCA's base addresses in memory (Section 7.1 of manual)
-pub const DMA_BASE_ADDR: usize = 0x400A2000;
+const DMA_BASE_ADDR: usize = 0x400A2000;
 
 /// The number of bytes between each memory mapped DMA Channel (Section 16.6.1)
-pub const DMA_CHANNEL_SIZE: usize = 0x40;
+const DMA_CHANNEL_SIZE: usize = 0x40;
 
 /// Shared counter that Keeps track of how many DMA channels are currently
 /// active.

--- a/chips/sam4l/src/nvic.rs
+++ b/chips/sam4l/src/nvic.rs
@@ -103,7 +103,7 @@ impl ::core::default::Default for NvicIdx {
     }
 }
 
-pub const BASE_ADDRESS: usize = 0xe000e100;
+const BASE_ADDRESS: usize = 0xe000e100;
 
 pub unsafe fn enable(signal: NvicIdx) {
     let nvic: &mut Nvic = intrinsics::transmute(BASE_ADDRESS);

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -158,10 +158,10 @@ struct FlashcalwRegisters {
     pvr: VolatileCell<u32>,
 }
 
-const PM_BASE: isize = 0x400E0000;
-const BSCIF_BASE: isize = 0x400F0400;
-const SCIF_BASE: isize = 0x400E0800;
-const FLASHCALW_BASE: isize = 0x400A0000;
+const PM_BASE: usize = 0x400E0000;
+const BSCIF_BASE: usize = 0x400F0400;
+const SCIF_BASE: usize = 0x400E0800;
+const FLASHCALW_BASE: usize = 0x400A0000;
 
 const HSB_MASK_OFFSET: u32 = 0x24;
 const PBA_MASK_OFFSET: u32 = 0x28;

--- a/chips/sam4l/src/scif.rs
+++ b/chips/sam4l/src/scif.rs
@@ -110,7 +110,7 @@ struct Registers {
     gcctrl11: VolatileCell<u32>, // we leave out versions
 }
 
-pub const SCIF_BASE: isize = 0x400E0800;
+const SCIF_BASE: usize = 0x400E0800;
 static mut SCIF: *mut Registers = SCIF_BASE as *mut Registers;
 
 #[repr(usize)]


### PR DESCRIPTION
- No reason a register address could be negative.
- Also no need for them to be public.