### PR TITLE
SAM4L: Update SPI to volatile cell

### DIFF
--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -1,17 +1,20 @@
 use core::cell::Cell;
-
 use core::cmp;
+use core::mem;
+
 use dma::DMAChannel;
 use dma::DMAClient;
 use dma::DMAPeripheral;
-use helpers::*;
+
 use kernel::common::take_cell::TakeCell;
+use kernel::common::volatile_cell::VolatileCell;
 
 use kernel::hil::spi;
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::SpiMasterClient;
 use pm;
+
 
 /// Implementation of DMA-based SPI master communication for
 /// the Atmel SAM4L CortexM4 microcontroller.
@@ -23,25 +26,25 @@ use pm;
 /// The registers used to interface with the hardware
 #[repr(C, packed)]
 struct SpiRegisters {
-    cr: u32, // 0x0
-    mr: u32, // 0x4
-    rdr: u32, // 0x8
-    tdr: u32, // 0xC
-    sr: u32, // 0x10
-    ier: u32, // 0x14
-    idr: u32, // 0x18
-    imr: u32, // 0x1C
-    reserved0: [u32; 4], // 0x20, 0x24, 0x28, 0x2C
-    csr0: u32, // 0x30
-    csr1: u32, // 0x34
-    csr2: u32, // 0x38
-    csr3: u32, // 0x3C
-    reserved1: [u32; 41], // 0x40 - 0xE0
-    wpcr: u32, // 0xE4
-    wpsr: u32, // 0xE8
-    reserved2: [u32; 3], // 0xEC - 0xF4
-    features: u32, // 0xF8
-    version: u32, // 0xFC
+    cr: VolatileCell<u32>, //       0x0
+    mr: VolatileCell<u32>, //       0x4
+    rdr: VolatileCell<u32>, //      0x8
+    tdr: VolatileCell<u32>, //      0xC
+    sr: VolatileCell<u32>, //       0x10
+    ier: VolatileCell<u32>, //      0x14
+    idr: VolatileCell<u32>, //      0x18
+    imr: VolatileCell<u32>, //      0x1C
+    _reserved0: [u32; 4], //        0x20, 0x24, 0x28, 0x2C
+    csr0: VolatileCell<u32>, //     0x30
+    csr1: VolatileCell<u32>, //     0x34
+    csr2: VolatileCell<u32>, //     0x38
+    csr3: VolatileCell<u32>, //     0x3C
+    _reserved1: [u32; 41], //       0x40 - 0xE0
+    wpcr: VolatileCell<u32>, //     0xE4
+    wpsr: VolatileCell<u32>, //     0xE8
+    _reserved2: [u32; 3], //        0xEC - 0xF4
+    features: VolatileCell<u32>, // 0xF8
+    version: VolatileCell<u32>, //  0xFC
 }
 
 const SPI_BASE: u32 = 0x40008000;
@@ -58,7 +61,7 @@ pub enum Peripheral {
 ///
 /// The SAM4L supports four peripherals.
 pub struct Spi {
-    regs: *mut SpiRegisters,
+    registers: *mut SpiRegisters,
     client: TakeCell<&'static SpiMasterClient>,
     dma_read: TakeCell<&'static mut DMAChannel>,
     dma_write: TakeCell<&'static mut DMAChannel>,
@@ -74,7 +77,7 @@ impl Spi {
     /// Creates a new SPI object, with peripheral 0 selected
     pub const fn new() -> Spi {
         Spi {
-            regs: SPI_BASE as *mut SpiRegisters,
+            registers: SPI_BASE as *mut SpiRegisters,
             client: TakeCell::empty(),
             dma_read: TakeCell::empty(),
             dma_write: TakeCell::empty(),
@@ -84,22 +87,20 @@ impl Spi {
     }
 
     pub fn enable(&self) {
+        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+
         unsafe {
             pm::enable_clock(pm::Clock::PBA(pm::PBAClock::SPI));
         }
-        // self.dma_read.as_ref().map(|read| read.enable());
-        // self.dma_write.as_ref().map(|write| write.enable());
-        unsafe {
-            write_volatile(&mut (*self.regs).cr, 0b1);
-        }
+        regs.cr.set(0b1);
     }
 
     pub fn disable(&self) {
+        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+
         self.dma_read.map(|read| read.disable());
         self.dma_write.map(|write| write.disable());
-        unsafe {
-            write_volatile(&mut (*self.regs).cr, 0b10);
-        }
+        regs.cr.set(0b10);
     }
 
     /// Sets the approximate baud rate for the active peripheral,
@@ -146,24 +147,26 @@ impl Spi {
     }
 
     pub fn set_active_peripheral(&self, peripheral: Peripheral) {
+        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+
         let peripheral_number: u32 = match peripheral {
             Peripheral::Peripheral0 => 0b1110,
             Peripheral::Peripheral1 => 0b1101,
             Peripheral::Peripheral2 => 0b1011,
             Peripheral::Peripheral3 => 0b0111,
         };
-        let mut mr = unsafe { read_volatile(&(*self.regs).mr) };
+        let mut mr = regs.mr.get();
         let pcs_mask: u32 = 0xFFF0FFFF;
         mr &= pcs_mask;
         mr |= peripheral_number << 16;
-        unsafe {
-            write_volatile(&mut (*self.regs).mr, mr);
-        }
+        regs.mr.set(mr);
     }
 
     /// Returns the currently active peripheral
     pub fn get_active_peripheral(&self) -> Peripheral {
-        let mr = unsafe { read_volatile(&(*self.regs).mr) };
+        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+
+        let mr = regs.mr.get();
         let pcs = (mr >> 16) & 0xF;
         // Split into bits for matching
         match pcs {
@@ -182,21 +185,25 @@ impl Spi {
     /// Returns the value of CSR0, CSR1, CSR2, or CSR3,
     /// whichever corresponds to the active peripheral
     fn read_active_csr(&self) -> u32 {
+        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+
         match self.get_active_peripheral() {
-            Peripheral::Peripheral0 => unsafe { read_volatile(&(*self.regs).csr0) },
-            Peripheral::Peripheral1 => unsafe { read_volatile(&(*self.regs).csr1) },
-            Peripheral::Peripheral2 => unsafe { read_volatile(&(*self.regs).csr2) },
-            Peripheral::Peripheral3 => unsafe { read_volatile(&(*self.regs).csr3) },
+            Peripheral::Peripheral0 => regs.csr0.get(),
+            Peripheral::Peripheral1 => regs.csr1.get(),
+            Peripheral::Peripheral2 => regs.csr2.get(),
+            Peripheral::Peripheral3 => regs.csr3.get(),
         }
     }
     /// Sets the Chip Select Register (CSR) of the active peripheral
     /// (CSR0, CSR1, CSR2, or CSR3).
     fn write_active_csr(&self, value: u32) {
+        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+
         match self.get_active_peripheral() {
-            Peripheral::Peripheral0 => unsafe { write_volatile(&mut (*self.regs).csr0, value) },
-            Peripheral::Peripheral1 => unsafe { write_volatile(&mut (*self.regs).csr1, value) },
-            Peripheral::Peripheral2 => unsafe { write_volatile(&mut (*self.regs).csr2, value) },
-            Peripheral::Peripheral3 => unsafe { write_volatile(&mut (*self.regs).csr3, value) },
+            Peripheral::Peripheral0 => regs.csr0.set(value),
+            Peripheral::Peripheral1 => regs.csr1.set(value),
+            Peripheral::Peripheral2 => regs.csr2.set(value),
+            Peripheral::Peripheral3 => regs.csr3.set(value),
         };
     }
 
@@ -223,14 +230,16 @@ impl spi::SpiMaster for Spi {
     /// By default, initialize SPI to operate at 40KHz, clock is
     /// idle on low, and sample on the leading edge.
     fn init(&self) {
+        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+
         self.enable_clock();
 
-        unsafe { write_volatile(&mut (*self.regs).cr, 1 << 24) };
+        regs.cr.set(1 << 24);
 
-        let mut mode = unsafe { read_volatile(&(*self.regs).mr) };
+        let mut mode = regs.mr.get();
         mode |= 1; // Enable master mode
         mode |= 1 << 4; // Disable mode fault detection (open drain outputs not supported)
-        unsafe { write_volatile(&mut (*self.regs).mr, mode) };
+        regs.mr.set(mode);
     }
 
     fn is_busy(&self) -> bool {
@@ -240,14 +249,16 @@ impl spi::SpiMaster for Spi {
     /// Write a byte to the SPI and discard the read; if an
     /// asynchronous operation is outstanding, do nothing.
     fn write_byte(&self, out_byte: u8) {
+        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+
         if self.transfer_in_progress.get() {
             //           return;
         }
         let tdr = out_byte as u32;
         // Wait for data to leave TDR and enter serializer, so TDR is free
         // for this next byte
-        while (unsafe { read_volatile(&(*self.regs).sr) } & 1 << 1) == 0 {}
-        unsafe { write_volatile(&mut (*self.regs).tdr, tdr) };
+        while (regs.sr.get() & (1 << 1)) == 0 {}
+        regs.tdr.set(tdr);
     }
 
     /// Write 0 to the SPI and return the read; if an
@@ -259,14 +270,16 @@ impl spi::SpiMaster for Spi {
     /// Write a byte to the SPI and return the read; if an
     /// asynchronous operation is outstanding, do nothing.
     fn read_write_byte(&self, val: u8) -> u8 {
+        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+
         if self.transfer_in_progress.get() {
             //          return 0;
         }
         self.write_byte(val);
         // Wait for receive data register full
-        while (unsafe { read_volatile(&(*self.regs).sr) } & 1) != 1 {}
+        while (regs.sr.get() & 1) != 1 {}
         // Return read value
-        unsafe { read_volatile(&(*self.regs).rdr) as u8 }
+        regs.rdr.get() as u8
     }
 
     /// Asynchronous buffer read/write of SPI.


### PR DESCRIPTION
Also rename "regs" to "registers" to be inline with I2C.