### PR TITLE
Add Imix board definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       find -path ./extern -prune -o -name '*.rs' -exec rustfmt --write-mode=diff {} +; fi
   - make -C boards/storm
+  - make -C boards/imix
   - make -C boards/nrf51dk
   - pushd userland/examples && ./build_all.sh
 

--- a/boards/imix/Cargo.lock
+++ b/boards/imix/Cargo.lock
@@ -1,0 +1,48 @@
+[root]
+name = "imix"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+ "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sam4l 0.1.0",
+]
+
+[[package]]
+name = "capsules"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+ "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cortexm4"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+ "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel"
+version = "0.1.0"
+dependencies = [
+ "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rust-libcore"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sam4l"
+version = "0.1.0"
+dependencies = [
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+ "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+

--- a/boards/imix/Cargo.toml
+++ b/boards/imix/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "imix"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+
+[profile.dev]
+panic = "abort"
+lto = true
+opt-level = 0
+debug = false
+# Would prefer to have debug symbols, but there is a Rust bug
+#	https://github.com/rust-lang/rust/issues/25270
+#	https://github.com/rust-lang/rust/issues/34434
+#debug = true
+
+[profile.release]
+panic = "abort"
+lto = true
+
+[dependencies]
+rust-libcore = "*"
+cortexm4 = { path = "../../arch/cortex-m4" }
+capsules = { path = "../../capsules" }
+kernel = { path = "../../kernel" }
+sam4l = { path = "../../chips/sam4l" }

--- a/boards/imix/Makefile
+++ b/boards/imix/Makefile
@@ -1,0 +1,50 @@
+# Makefile for building the tock kernel for the Imix platform
+
+SIZE?=arm-none-eabi-size
+OBJCOPY?=arm-none-eabi-objcopy
+OBJDUMP?=arm-none-eabi-objdump
+OBJDUMP_FLAGS+= --disassemble-all --source --disassembler-options=force-thumb -C --section-headers
+
+OPENOCD=openocd
+OPENOCD_CONF=connect.cfg
+
+.PHONY: all
+all: target/sam4l/release/imix
+
+.PHONY: doc
+doc:
+	@cargo doc --release --target=sam4l.json
+
+.PHONY: target/sam4l/release/imis
+target/sam4l/release/imix:
+	@cargo build --release --target=sam4l.json
+	@$(SIZE) $@
+
+.PHONY: target/sam4l/debug/imix
+target/sam4l/debug/imix:
+	@cargo build --target=sam4l.json
+	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > target/sam4l/debug/imix.lst
+	@$(SIZE) $@
+
+target/sam4l/release/imix.hex: target/sam4l/release/imix
+	@$(OBJCOPY) -Oihex $^ $@
+
+target/sam4l/debug/imix.hex: target/sam4l/debug/imix
+	@$(OBJCOPY) -Oihex $^ $@
+
+.PHONY: clean
+clean::
+	@cargo clean
+
+.PHONY: debug
+debug: target/sam4l/debug/imix
+
+# upload kernel with openocd
+.PHONY: flash
+flash: target/sam4l/release/imix
+	$(OPENOCD) -f $(OPENOCD_CONF) -c "init; reset halt; load_image $<; reset; shutdown"
+
+.PHONY: flash-debug
+flash-debug: target/sam4l/debug/imix
+	$(OPENOCD) -f $(OPENOCD_CONF) -c "init; reset halt; load_image $<; reset; shutdown"
+

--- a/boards/imix/Makefile
+++ b/boards/imix/Makefile
@@ -15,7 +15,7 @@ all: target/sam4l/release/imix
 doc:
 	@cargo doc --release --target=sam4l.json
 
-.PHONY: target/sam4l/release/imis
+.PHONY: target/sam4l/release/imix
 target/sam4l/release/imix:
 	@cargo build --release --target=sam4l.json
 	@$(SIZE) $@
@@ -42,7 +42,8 @@ debug: target/sam4l/debug/imix
 # upload kernel with openocd
 .PHONY: flash
 flash: target/sam4l/release/imix
-	$(OPENOCD) -f $(OPENOCD_CONF) -c "init; reset halt; load_image $<; reset; shutdown"
+	#$(OPENOCD) -f $(OPENOCD_CONF) -c "program $< verify reset exit"
+	$(OPENOCD) -f $(OPENOCD_CONF) -c "init; reset halt; flash write_image $< 0x0 elf; reset; shutdown"
 
 .PHONY: flash-debug
 flash-debug: target/sam4l/debug/imix

--- a/boards/imix/Makefile-app
+++ b/boards/imix/Makefile-app
@@ -1,0 +1,14 @@
+# Makefile for loading applications for the Imix platform
+
+APP_FLASH = $(TOCK_USERLAND_BASE_DIR)/tools/flash/imix.sh
+
+# upload programs over uart with stormloader
+.PHONY: program
+program: $(BUILDDIR)/app.bin
+	$(APP_SLOAD) $(BUILDDIR)/app.bin
+
+# upload programs over JTAG
+.PHONY: flash
+flash: $(BUILDDIR)/app.bin
+	$(APP_FLASH) $(BUILDDIR)/app.bin
+

--- a/boards/imix/connect.cfg
+++ b/boards/imix/connect.cfg
@@ -1,0 +1,3 @@
+interface jlink
+transport select swd
+source [find target/at91sam4lXX.cfg]

--- a/boards/imix/debug.gdb
+++ b/boards/imix/debug.gdb
@@ -1,0 +1,6 @@
+
+target remote :3333
+monitor reset
+monitor reset
+load
+monitor reset

--- a/boards/imix/layout.ld
+++ b/boards/imix/layout.ld
@@ -1,0 +1,56 @@
+MEMORY {
+  rom (rx)  : ORIGIN = 0x00000000, LENGTH = 192K
+  prog (rx) : ORIGIN = 0x00030000, LENGTH = 320K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
+}
+__stack_size__ = DEFINED(__stack_size__) ? __stack_size__ : 0x1000;
+SECTIONS {
+  .text : {
+    KEEP(*(.vectors))
+    KEEP(*(.irqs))
+    *(.text .text.*)
+    *(.rodata*)
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > rom
+
+  .apps :
+  {
+    _sapps = .;
+    KEEP(*(.app.*))
+    LONG(0) /* Marks the end of the app list with a sentinel value. */
+  } > prog
+
+  /* .ARM.exidx is sorted, so has to go in its own output section.  */
+  PROVIDE_HIDDEN (__exidx_start = .);
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > rom
+  PROVIDE_HIDDEN (__exidx_end = .);
+
+  _etext = .;
+
+  .data : AT(_etext) {
+    . = ALIGN(4);
+    _srelocate = .;
+    *(.data .data.*)
+    . = ALIGN(4);
+    _erelocate = .;
+  } > ram
+
+  .bss (NOLOAD) : {
+    . = ALIGN(4);
+    _szero = .;
+    *(.bss .bss.*)
+    _ezero = .;
+
+    _sstack = .;
+    . = . + __stack_size__;
+    . = ALIGN(8);
+    _estack = .;
+
+    . = ALIGN(8K);
+    *(.app_memory)
+  } > ram
+
+}

--- a/boards/imix/layout.ld
+++ b/boards/imix/layout.ld
@@ -16,8 +16,6 @@ SECTIONS {
   .apps :
   {
     _sapps = .;
-    KEEP(*(.app.*))
-    LONG(0) /* Marks the end of the app list with a sentinel value. */
   } > prog
 
   /* .ARM.exidx is sorted, so has to go in its own output section.  */

--- a/boards/imix/sam4l.json
+++ b/boards/imix/sam4l.json
@@ -1,0 +1,1 @@
+../../chips/sam4l/sam4l.json

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -1,0 +1,76 @@
+use core::fmt::*;
+use kernel::hil::Controller;
+use kernel::hil::uart::{self, UART};
+use sam4l;
+
+pub struct Writer {
+    initialized: bool,
+}
+
+pub static mut WRITER: Writer = Writer { initialized: false };
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        let uart = unsafe { &mut sam4l::usart::USART3 };
+        if !self.initialized {
+            self.initialized = true;
+            uart.configure(sam4l::usart::USARTParams {
+                baud_rate: 115200,
+                data_bits: 8,
+                parity: uart::Parity::None,
+                mode: uart::Mode::Normal,
+            });
+            uart.enable_tx();
+
+        }
+        for c in s.bytes() {
+            uart.send_byte(c);
+        }
+        Ok(())
+    }
+}
+
+
+#[cfg(not(test))]
+#[lang="panic_fmt"]
+pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
+
+    let writer = &mut WRITER;
+    let _ = writer.write_fmt(format_args!("Kernel panic at {}:{}:\r\n\t\"", file, line));
+    let _ = write(writer, args);
+    let _ = writer.write_str("\"\r\n");
+
+    let led = &sam4l::gpio::PC[10];
+    led.enable_output();
+    loop {
+        for _ in 0..1000000 {
+            led.clear();
+        }
+        for _ in 0..100000 {
+            led.set();
+        }
+        for _ in 0..1000000 {
+            led.clear();
+        }
+        for _ in 0..500000 {
+            led.set();
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! print {
+        ($($arg:tt)*) => (
+            {
+                use core::fmt::write;
+                let writer = unsafe { &mut $crate::io::WRITER };
+                let _ = write(writer, format_args!($($arg)*));
+            }
+        );
+}
+
+#[macro_export]
+macro_rules! println {
+        ($fmt:expr) => (print!(concat!($fmt, "\n")));
+            ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+}

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -2,14 +2,281 @@
 #![no_main]
 #![feature(const_fn,lang_items)]
 
+extern crate capsules;
+#[macro_use(static_init)]
 extern crate kernel;
 extern crate sam4l;
 
+use kernel::hil::Controller;
+
 mod io;
+
+struct Imix {
+    console: &'static capsules::console::Console<'static, sam4l::usart::USART>
+}
+
+impl kernel::Platform for Imix {
+    fn with_driver<F, R>(&mut self, driver_num: usize, f: F) -> R
+        where F: FnOnce(Option<&kernel::Driver>) -> R {
+            match driver_num {
+                0 => f(Some(self.console)),
+                _ => f(None)
+            }
+    }
+}
+
+unsafe fn set_pin_primary_functions() {
+    use sam4l::gpio::{PA, PB, PC};
+    use sam4l::gpio::PeripheralFunction::{A, B, C, D, E};
+
+    // Configuring pins for RF233
+    // SPI
+    PC[03].configure(Some(A)); // SPI NPCS0
+    PC[02].configure(Some(A)); // SPI NPCS1
+    PC[00].configure(Some(A)); // SPI NPCS2
+    PC[01].configure(Some(A)); // SPI NPCS3 (RF233)
+    PC[06].configure(Some(A)); // SPI CLK
+    PC[04].configure(Some(A)); // SPI MISO
+    PC[05].configure(Some(A)); // SPI MOSI
+    // GIRQ line of RF233
+    PA[20].enable();
+    PA[20].disable_output();
+    PA[20].disable_interrupt();
+    // PA00 is RCLK
+    // PC14 is RSLP
+    // PC15 is RRST
+    PC[14].enable();
+    PC[14].disable_output();
+    PC[15].enable();
+    PC[15].disable_output();
+
+    // Right column: Firestorm pin name
+    // Left  column: SAM4L peripheral function
+    // LI_INT   --  EIC EXTINT2
+    PA[04].configure(Some(C));
+
+    // EXTINT1  --  EIC EXTINT1
+    PA[06].configure(Some(C));
+
+    // PWM 0    --  GPIO pin
+    PA[08].configure(None);
+
+    // PWM 1    --  GPIO pin
+    PC[16].configure(None);
+
+    // PWM 2    --  GPIO pin
+    PC[17].configure(None);
+
+    // PWM 3    --  GPIO pin
+    PC[18].configure(None);
+
+    // AD5      --  ADCIFE AD1
+    PA[05].configure(Some(A));
+
+    // AD4      --  ADCIFE AD2
+    PA[07].configure(Some(A));
+
+    // AD3      --  ADCIFE AD3
+    PB[02].configure(Some(A));
+
+    // AD2      --  ADCIFE AD4
+    PB[03].configure(Some(A));
+
+    // AD1      --  ADCIFE AD5
+    PB[04].configure(Some(A));
+
+    // AD0      --  ADCIFE AD6
+    PB[05].configure(Some(A));
+
+
+    // BL_SEL   --  USART3 RTS
+    PB[06].configure(Some(A));
+
+    //          --  USART3 CTS
+    PB[07].configure(Some(A));
+
+    //          --  USART3 CLK
+    PB[08].configure(Some(A));
+
+    // PRI_RX   --  USART3 RX
+    PB[09].configure(Some(A));
+
+    // PRI_TX   --  USART3 TX
+    PB[10].configure(Some(A));
+
+    // U1_CTS   --  USART0 CTS
+    PB[11].configure(Some(A));
+
+    // U1_RTS   --  USART0 RTS
+    PB[12].configure(Some(A));
+
+    // U1_CLK   --  USART0 CLK
+    PB[13].configure(Some(A));
+
+    // U1_RX    --  USART0 RX
+    PB[14].configure(Some(A));
+
+    // U1_TX    --  USART0 TX
+    PB[15].configure(Some(A));
+
+    // STORMRTS --  USART2 RTS
+    PC[07].configure(Some(B));
+
+    // STORMCTS --  USART2 CTS
+    PC[08].configure(Some(E));
+
+    // STORMRX  --  USART2 RX
+    PC[11].configure(Some(B));
+
+    // STORMTX  --  USART2 TX
+    PC[12].configure(Some(B));
+
+    // STORMCLK --  USART2 CLK
+    PA[18].configure(Some(A));
+
+    // ESDA     --  TWIMS1 TWD
+    PB[00].configure(Some(A));
+
+    // ESCL     --  TWIMS1 TWCK
+    PB[01].configure(Some(A));
+
+    // SDA      --  TWIM2 TWD
+    PA[21].configure(Some(E));
+
+    // SCL      --  TWIM2 TWCK
+    PA[22].configure(Some(E));
+
+    // EPCLK    --  USBC DM
+    PA[25].configure(Some(A));
+
+    // EPDAT    --  USBC DP
+    PA[26].configure(Some(A));
+
+    // PCLK     --  PARC PCCK
+    PC[21].configure(Some(D));
+    // PCEN1    --  PARC PCEN1
+    PC[22].configure(Some(D));
+    // EPGP     --  PARC PCEN2
+    PC[23].configure(Some(D));
+    // PCD0     --  PARC PCDATA0
+    PC[24].configure(Some(D));
+    // PCD1     --  PARC PCDATA1
+    PC[25].configure(Some(D));
+    // PCD2     --  PARC PCDATA2
+    PC[26].configure(Some(D));
+    // PCD3     --  PARC PCDATA3
+    PC[27].configure(Some(D));
+    // PCD4     --  PARC PCDATA4
+    PC[28].configure(Some(D));
+    // PCD5     --  PARC PCDATA5
+    PC[29].configure(Some(D));
+    // PCD6     --  PARC PCDATA6
+    PC[30].configure(Some(D));
+    // PCD7     --  PARC PCDATA7
+    PC[31].configure(Some(D));
+
+    // P2       -- GPIO Pin
+    PA[16].configure(None);
+    // P3       -- GPIO Pin
+    PA[12].configure(None);
+    // P4       -- GPIO Pin
+    PC[09].configure(None);
+    // P5       -- GPIO Pin
+    PA[10].configure(None);
+    // P6       -- GPIO Pin
+    PA[11].configure(None);
+    // P7       -- GPIO Pin
+    PA[19].configure(None);
+    // P8       -- GPIO Pin
+    PA[13].configure(None);
+
+    // none     -- GPIO Pin
+    PA[14].configure(None);
+
+    // ACC_INT2 -- GPIO Pin
+    PC[20].configure(None);
+    // STORMINT -- GPIO Pin
+    PA[17].configure(None);
+    // TMP_DRDY -- GPIO Pin
+    PA[09].configure(None);
+    // ACC_INT1 -- GPIO Pin
+    PC[13].configure(None);
+    // ENSEN    -- GPIO Pin
+    PC[19].configure(None);
+    // LED0     -- GPIO Pin
+    PC[10].configure(None);
+}
+
 
 #[no_mangle]
 pub unsafe fn reset_handler() {
     sam4l::init();
 
-    panic!("foo");
+    // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
+    sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);
+
+    set_pin_primary_functions();
+
+    let console = static_init!(
+        capsules::console::Console<sam4l::usart::USART>,
+        capsules::console::Console::new(&sam4l::usart::USART3,
+                     &mut capsules::console::WRITE_BUF,
+                     kernel::Container::create()),
+        24);
+    sam4l::usart::USART3.set_client(console);
+
+    sam4l::usart::USART3.configure(sam4l::usart::USARTParams {
+        baud_rate: 115200,
+        data_bits: 8,
+        parity: kernel::hil::uart::Parity::None,
+        mode: kernel::hil::uart::Mode::Normal,
+    });
+
+    console.initialize();
+
+    let mut imix = Imix {
+        console: console
+    };
+
+    let mut chip = sam4l::chip::Sam4l::new();
+    kernel::main(&mut imix, &mut chip, load_processes());
 }
+
+unsafe fn load_processes() -> &'static mut [Option<kernel::process::Process<'static>>] {
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+    }
+
+    const NUM_PROCS: usize = 1;
+
+    #[link_section = ".app_memory"]
+    static mut MEMORIES: [[u8; 8192]; NUM_PROCS] = [[0; 8192]; NUM_PROCS];
+
+    static mut processes: [Option<kernel::process::Process<'static>>; NUM_PROCS] = [None];
+
+    let mut addr = &_sapps as *const u8;
+    for i in 0..NUM_PROCS {
+        // The first member of the LoadInfo header contains the total size of each process image. A
+        // sentinel value of 0 (invalid because it's smaller than the header itself) is used to
+        // mark the end of the list of processes.
+        let total_size = *(addr as *const usize);
+        if total_size == 0 {
+            break;
+        }
+
+        let process = &mut processes[i];
+        let memory = &mut MEMORIES[i];
+        *process = Some(kernel::process::Process::create(addr, total_size, memory));
+        // TODO: panic if loading failed?
+
+        addr = addr.offset(total_size as isize);
+    }
+
+    if *(addr as *const usize) != 0 {
+        panic!("Exceeded maximum NUM_PROCS. {:#x}", *(addr as *const usize));
+    }
+
+    &mut processes
+}
+

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -9,8 +9,8 @@ extern crate sam4l;
 
 use capsules::timer::TimerDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
-use kernel::hil::Controller;
 use kernel::{Chip, MPU};
+use kernel::hil::Controller;
 
 mod io;
 
@@ -22,14 +22,15 @@ struct Imix {
 
 impl kernel::Platform for Imix {
     fn with_driver<F, R>(&mut self, driver_num: usize, f: F) -> R
-        where F: FnOnce(Option<&kernel::Driver>) -> R {
-            match driver_num {
-                0 => f(Some(self.console)),
-                1 => f(Some(self.gpio)),
+        where F: FnOnce(Option<&kernel::Driver>) -> R
+    {
+        match driver_num {
+            0 => f(Some(self.console)),
+            1 => f(Some(self.gpio)),
 
-                3 => f(Some(self.timer)),
-                _ => f(None)
-            }
+            3 => f(Some(self.timer)),
+            _ => f(None),
+        }
     }
 }
 
@@ -226,7 +227,7 @@ pub unsafe fn reset_handler() {
     set_pin_primary_functions();
 
 
-    /*** CONSOLE ***/
+    // # CONSOLE
 
     let console = static_init!(
         capsules::console::Console<sam4l::usart::USART>,
@@ -245,7 +246,7 @@ pub unsafe fn reset_handler() {
 
     console.initialize();
 
-    /*** TIMER ***/
+    // # TIMER
 
     let ast = &sam4l::ast::AST;
 
@@ -265,7 +266,8 @@ pub unsafe fn reset_handler() {
         12);
     virtual_alarm1.set_client(timer);
 
-    /*** GPIO ***/
+    // # GPIO
+
     let gpio_pins = static_init!(
         [&'static sam4l::gpio::GPIOPin; 12],
         [&sam4l::gpio::PC[10], // LED_0
@@ -338,4 +340,3 @@ unsafe fn load_processes() -> &'static mut [Option<kernel::process::Process<'sta
 
     &mut processes
 }
-

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -1,0 +1,15 @@
+#![no_std]
+#![no_main]
+#![feature(const_fn,lang_items)]
+
+extern crate kernel;
+extern crate sam4l;
+
+mod io;
+
+#[no_mangle]
+pub unsafe fn reset_handler() {
+    sam4l::init();
+
+    panic!("foo");
+}

--- a/userland/tools/flash/imix.sh
+++ b/userland/tools/flash/imix.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+APP_BASE_ADDR='0x30000'
+
+TMPCONF=$(mktemp)
+TMPAPP=$(mktemp)
+
+for app in "$@"
+do
+  cat "$app" >> $TMPAPP
+done
+
+wc $TMPAPP
+
+printf "\0\0\0\0" >> $TMPAPP
+
+cat << EOF > $TMPCONF
+interface jlink
+transport select swd
+source [find target/at91sam4lXX.cfg]
+EOF
+
+openocd -f $TMPCONF -c "init; reset halt; flash write_image $TMPAPP $APP_BASE_ADDR bin; reset; shutdown"
+
+rm $TMPCONF
+rm $TMPAPP


### PR DESCRIPTION
Basic board definition including:

  * Console, gpio and timer drivers

  * Process loading (done the same as firestorm)

  * Flashing the kernel with openocd

  * Flashing apps with openocd (multiple apps supported)

@shaneleonard can you take a look at the pin configurations? I copied from Firestorm. What's different (if anything)? What needs to be added (e.g. for power domain control, sampling the RNG, etc)?