### PR TITLE
Add LED capsule

### DIFF
--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -1,0 +1,82 @@
+/// Provide capsule driver for controlling LEDs on a board.
+/// This allows for much more cross platform controlling of LEDs
+/// without having to know which of the GPIO pins exposed across
+/// the syscall interface are LEDs.
+
+use kernel::{AppId, Driver};
+use kernel::hil;
+
+/// Whether the LEDs are active high or active low on this platform.
+pub enum ActivationMode {
+    ActiveHigh,
+    ActiveLow,
+}
+
+pub struct LED<'a, G: hil::gpio::Pin + 'a> {
+    pins: &'a [&'a G],
+    mode: ActivationMode,
+}
+
+impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> LED<'a, G> {
+    pub fn new(pins: &'a [&'a G], mode: ActivationMode) -> LED<'a, G> {
+        // Make all pins output and off
+        for pin in pins.iter() {
+            pin.make_output();
+            match mode {
+                ActivationMode::ActiveHigh => pin.clear(),
+                ActivationMode::ActiveLow => pin.set(),
+            }
+        }
+
+        LED {
+            pins: pins,
+            mode: mode,
+        }
+    }
+}
+
+impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for LED<'a, G> {
+    fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
+        let pins = self.pins.as_ref();
+        match command_num {
+            // on
+            0 => {
+                if data >= pins.len() {
+                    -1
+                } else {
+                    match self.mode {
+                        ActivationMode::ActiveHigh => pins[data].set(),
+                        ActivationMode::ActiveLow => pins[data].clear(),
+                    }
+                    0
+                }
+            }
+
+            // off
+            1 => {
+                if data >= pins.len() {
+                    -1
+                } else {
+                    match self.mode {
+                        ActivationMode::ActiveHigh => pins[data].clear(),
+                        ActivationMode::ActiveLow => pins[data].set(),
+                    }
+                    0
+                }
+            }
+
+            // toggle
+            2 => {
+                if data >= pins.len() {
+                    -1
+                } else {
+                    pins[data].toggle();
+                    0
+                }
+            }
+
+            // default
+            _ => -1,
+        }
+    }
+}

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -1,7 +1,7 @@
-/// Provide capsule driver for controlling LEDs on a board.
-/// This allows for much more cross platform controlling of LEDs
-/// without having to know which of the GPIO pins exposed across
-/// the syscall interface are LEDs.
+//! Provide capsule driver for controlling LEDs on a board.
+//! This allows for much more cross platform controlling of LEDs
+//! without having to know which of the GPIO pins exposed across
+//! the syscall interface are LEDs.
 
 use kernel::{AppId, Driver};
 use kernel::hil;

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -6,6 +6,7 @@ extern crate kernel;
 pub mod console;
 pub mod gpio;
 pub mod isl29035;
+pub mod led;
 pub mod nrf51822_serialization;
 pub mod timer;
 pub mod tmp006;

--- a/userland/examples/blink/main.c
+++ b/userland/examples/blink/main.c
@@ -1,15 +1,11 @@
 #include <stdio.h>
 
-#include "firestorm.h"
-#include "gpio.h"
+#include "led.h"
 #include "timer.h"
 
 int main(void) {
-    gpio_enable_output(LED_0);
-
     while(1) {
-      gpio_toggle(LED_0);
+      led_toggle(0);
       delay_ms(500);
     }
 }
-

--- a/userland/examples/blink_sync/main.c
+++ b/userland/examples/blink_sync/main.c
@@ -1,5 +1,4 @@
-#include <firestorm.h>
-#include <gpio.h>
+#include "led.h"
 
 /* Delay for for the given microseconds (approximately).
  *
@@ -39,12 +38,9 @@ static void busy_delay_ms(int duration)
 	}
 }
 
-void main(void) {
-    gpio_enable_output(LED_0);
-
+int main(void) {
     while(1) {
-      gpio_toggle(LED_0);
+      led_toggle(0);
       busy_delay_ms(500);
     }
 }
-

--- a/userland/examples/c_gpio/main.c
+++ b/userland/examples/c_gpio/main.c
@@ -2,20 +2,15 @@
  * This application is for testing GPIO interrupts in the nRF51822 EK.
  * To run this application, hook up a button connected to VDD to GPIO pin 1
  * (the top right pin on the top left header).
- *  
+ *
  * When it boots, you should see one of the two LEDs blink 5 times, then
  * go silent. This is to show that the app has booted correctly.
- *  
- * Then, when you push the button, the other LED should blink.
  *
- * Note that to an application, pin 0 is LED0 (GPIO pin 18), pin 1 is 
- * LED1 (GPIO pin 19), and pin 3 is GPIO pin 0.
+ * Then, when you push the button, the other LED should blink.
  */
 
-#include <firestorm.h>
-#include <gpio.h>
-
-#define LED_1 1
+#include "led.h"
+#include "gpio.h"
 
 /* Delay for for the given microseconds (approximately).
  *
@@ -55,21 +50,19 @@ static void busy_delay_ms(int duration) {
 }
 
 void interrupt_callback() {
-    gpio_toggle(LED_1); 
+    led_toggle(1);
 }
 
 int main(void) {
-    gpio_enable_output(LED_0);
-    gpio_enable_output(LED_1);
-    gpio_set(LED_1);
-    // Application pin 3 is HW GPIO pin 0, see nrf_pc10001/lib.rs
-    gpio_enable_input(3, PullDown);
-    gpio_enable_interrupt(3, PullDown, RisingEdge);
+    led_on(1);
+    // Application pin 0 is Button 1
+    gpio_enable_input(0, PullDown);
+    gpio_enable_interrupt(0, PullDown, RisingEdge);
     gpio_interrupt_callback(interrupt_callback, NULL);
 
     int i;
     for (i = 0; i < 10; i++) {
-      gpio_toggle(LED_0);
+      led_toggle(0);
       busy_delay_ms(200);
     }
     return 1;

--- a/userland/examples/security_app/main.c
+++ b/userland/examples/security_app/main.c
@@ -4,10 +4,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <tock.h>
-#include <console.h>
-#include <firestorm.h>
-#include <gpio.h>
+#include "tock.h"
+#include "console.h"
+#include "gpio.h"
+#include "led.h"
 
 typedef struct {
   uint8_t pir;
@@ -20,7 +20,10 @@ static SensorData_t sensor_data = {
 };
 
 // callback for gpio interrupts
-void gpio_cb (int pin_num, int pin_val, int unused, void* userdata) {
+void gpio_cb (int pin_num,
+              int pin_val,
+              __attribute__ ((unused)) int unused,
+              __attribute__ ((unused)) void* userdata) {
 
   // save sensor data
   if (pin_num == 1) {
@@ -44,9 +47,8 @@ int main() {
 
   // configure pins
   gpio_interrupt_callback(gpio_cb, NULL);
-  gpio_enable_output(LED_0);
-  gpio_enable_interrupt(1, PullNone, Change);
-  gpio_enable_interrupt(2, PullUp, Change);
+  gpio_enable_interrupt(0, PullNone, Change);
+  gpio_enable_interrupt(1, PullUp, Change);
 
   // configure accelerometer
   //TODO
@@ -56,7 +58,7 @@ int main() {
 
   while (1) {
     yield();
-    gpio_toggle(LED_0);
+    led_toggle(0);
 
     {
       char buf[64];

--- a/userland/examples/spi_buf/main.c
+++ b/userland/examples/spi_buf/main.c
@@ -1,16 +1,19 @@
 #include <stdbool.h>
-#include <gpio.h>
-#include <firestorm.h>
-#include <spi.h>
+
+#include "led.h"
+#include "spi.h"
 
 #define BUF_SIZE 200
 char rbuf[BUF_SIZE];
 char wbuf[BUF_SIZE];
 bool toggle = true;
 
-void write_cb(int arg0, int arg2, int arg3, void* userdata) {
-    gpio_toggle(LED_0);
-    if (toggle) { 
+void write_cb(__attribute__ ((unused)) int arg0,
+              __attribute__ ((unused)) int arg2,
+              __attribute__ ((unused)) int arg3,
+              __attribute__ ((unused)) void* userdata) {
+    led_toggle(0);
+    if (toggle) {
         spi_read_write(rbuf, wbuf, BUF_SIZE, write_cb, NULL);
     } else {
         spi_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
@@ -28,23 +31,21 @@ void write_cb(int arg0, int arg2, int arg3, void* userdata) {
 // In both cases, the calls alternate on which of two
 // buffers is used as the write buffer. The first call
 // uses the buffer initialized to 0..199. The
-// 2n calls use the buffer initialized to 0. 
+// 2n calls use the buffer initialized to 0.
 //
 // If you use back-to-back operations, the calls
 // both read and write. Periodic operations only
 // write. Therefore, if you set SPI to loopback
-// and use back-to-back // loopback, then the read buffer 
-// on the first call will read in the data written. As a 
-// result, you can check if reads work properly: all writes 
+// and use back-to-back // loopback, then the read buffer
+// on the first call will read in the data written. As a
+// result, you can check if reads work properly: all writes
 // will be 0..n rather than all 0s.
 
 int main(void) {
-        int i;
-	gpio_enable_output(LED_0);
+  int i;
+  for (i = 0; i < 200; i++) {
+    wbuf[i] = i;
+  }
 
-	for (i = 0; i < 200; i++) {
-		wbuf[i] = i;
-	}
-
-        spi_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
+  spi_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
 }

--- a/userland/examples/spi_byte/main.c
+++ b/userland/examples/spi_byte/main.c
@@ -1,22 +1,19 @@
-#include <firestorm.h>
-#include <gpio.h>
-#include <spi.h>
-#include <timer.h>
+#include "led.h"
+#include "spi.h"
+#include "timer.h"
 
-int main(void)
-{
-        int i;
-	gpio_enable_output(LED_0);
+int main(void) {
+  int i;
+  for (i = 0;; i++) {
+    led_off(0);
 
-	for (i = 0;; i++) {
-		gpio_clear(LED_0);
+    spi_write_byte((unsigned char)i & 0xff);
+    delay_ms(25);
 
-		spi_write_byte((unsigned char)i & 0xff);
-		delay_ms(25);
+    led_on(0);
 
-		gpio_set(LED_0);
+    delay_ms(25);
+  }
 
-		delay_ms(25);
-	}
-        return 0;
+  return 0;
 }

--- a/userland/libtock/led.c
+++ b/userland/libtock/led.c
@@ -1,0 +1,14 @@
+#include "tock.h"
+#include "led.h"
+
+int led_on(int led_num) {
+	return command(DRIVER_NUM_LEDS, 0, led_num);
+}
+
+int led_off(int led_num) {
+	return command(DRIVER_NUM_LEDS, 1, led_num);
+}
+
+int led_toggle(int led_num) {
+	return command(DRIVER_NUM_LEDS, 2, led_num);
+}

--- a/userland/libtock/led.h
+++ b/userland/libtock/led.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "tock.h"
+
+#define DRIVER_NUM_LEDS 8
+
+int led_on(int led_num);
+int led_off(int led_num);
+int led_toggle(int led_num);


### PR DESCRIPTION
Also change pin assignments in boards to separate LED pins from other
GPIO pins. Then update apps to use the new pin mappings, cleaning along
the way. A nice benefit of this approach is that we don't have to have a
header file that maps "LED_0" to the correct gpio pin number. To use the
first LED, just call the `led_*()` functions with the number 0.