### PR TITLE
Correct Imix pin assignments

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -44,39 +44,146 @@ impl kernel::Platform for Imix {
 
 unsafe fn set_pin_primary_functions() {
     use sam4l::gpio::{PA, PB, PC};
-    use sam4l::gpio::PeripheralFunction::{A, B, C, D, E};
+    use sam4l::gpio::PeripheralFunction::{A, B, C, E};
 
-    // Configuring pins for RF233
-    // SPI
-    PC[03].configure(Some(A)); // SPI NPCS0
-    PC[02].configure(Some(A)); // SPI NPCS1
-    PC[00].configure(Some(A)); // SPI NPCS2
-    PC[01].configure(Some(A)); // SPI NPCS3 (RF233)
-    PC[06].configure(Some(A)); // SPI CLK
-    PC[04].configure(Some(A)); // SPI MISO
-    PC[05].configure(Some(A)); // SPI MOSI
-    // GIRQ line of RF233
-    PA[20].enable();
-    PA[20].disable_output();
-    PA[20].disable_interrupt();
-    // PA00 is RCLK
-    // PC14 is RSLP
-    // PC15 is RRST
-    PC[14].enable();
-    PC[14].disable_output();
-    PC[15].enable();
-    PC[15].disable_output();
-
-    // Right column: Firestorm pin name
+    // Right column: Imix pin name
     // Left  column: SAM4L peripheral function
+
     // LI_INT   --  EIC EXTINT2
     PA[04].configure(Some(C));
+
+    // AD0      --  ADCIFE AD1
+    PA[05].configure(Some(A));
 
     // EXTINT1  --  EIC EXTINT1
     PA[06].configure(Some(C));
 
-    // PWM 0    --  GPIO pin
+    // AD1      --  ADCIFE AD2
+    PA[07].configure(Some(A));
+
+    // RF233 IRQ --  GPIO pin
     PA[08].configure(None);
+
+    // RF233 RST --  GPIO pin
+    PA[09].configure(None);
+
+    // RF233 SLP --  GPIO pin
+    PA[10].configure(None);
+
+    // TRNG EN   --  GPIO pin
+    PA[13].configure(None);
+
+    // TRNG_OUT  --  GPIO pin
+    PA[14].configure(None);
+
+    // NRF INT   -- GPIO pin
+    PA[17].configure(None);
+
+    // NRF CLK   -- USART2_CLK
+    PA[18].configure(Some(A));
+
+    // TWI2 SDA  -- TWIM2_SDA
+    PA[21].configure(Some(E));
+
+    // TWI2 SCL  --  TWIM2 TWCK
+    PA[22].configure(Some(E));
+
+    // USB_N     --  USB DM
+    PA[25].configure(Some(A));
+
+    // USB_P     --  USB DP
+    PA[26].configure(Some(A));
+
+    // TWI1_SDA  --  TWIMS1 TWD
+    PB[00].configure(Some(A));
+
+    // TWI1_SCL  --  TWIMS1 TWCK
+    PB[01].configure(Some(A));
+
+    // AD2      --  ADCIFE AD3
+    PB[02].configure(Some(A));
+
+    // AD3      --  ADCIFE AD4
+    PB[03].configure(Some(A));
+
+    // AD4      --  ADCIFE AD5
+    PB[04].configure(Some(A));
+
+    // AD5      --  ADCIFE AD6
+    PB[05].configure(Some(A));
+
+    // RTS3     --  USART3 RTS
+    PB[06].configure(Some(A));
+
+    // NRF RESET --  GPIO
+    PB[07].configure(None);
+
+    // RX3      --  USART3 RX
+    PB[09].configure(Some(A));
+
+    // TX3      --  USART3 TX
+    PB[10].configure(Some(A));
+
+    // CTS0     --  USART0 CTS
+    PB[11].configure(Some(A));
+
+    // RTS0     --  USART0 RTS
+    PB[12].configure(Some(A));
+
+    // CLK0     --  USART0 CLK
+    PB[13].configure(Some(A));
+
+    // RX0      --  USART0 RX
+    PB[14].configure(Some(A));
+
+    // TX0      --  USART0 TX
+    PB[15].configure(Some(A));
+
+
+    // CS2      --  SPI NPCS2
+    PC[00].configure(Some(A));
+
+    // CS3 (RF233) -- SPI NPCS3
+    PC[01].configure(Some(A));
+
+    // CS1      --  SPI NPCS1
+    PC[02].configure(Some(A));
+
+    // CS0      --  SPI NPCS0
+    PC[03].configure(Some(A));
+
+    // MISO     --  SPI MISO
+    PC[04].configure(Some(A));
+
+    // MOSI     --  SPI MOSI
+    PC[05].configure(Some(A));
+
+    // SCK      --  SPI CLK
+    PC[06].configure(Some(A));
+
+    // RTS2 (BLE) -- USART2_RTS
+    PC[07].configure(Some(B));
+
+    // CTS2 (BLE) -- USART2_CTS
+    PC[08].configure(Some(B));
+
+    // NRF GPIO   -- GPIO
+    PC[09].configure(None);
+
+    // USER LED   -- GPIO
+    PC[10].configure(None);
+
+    // RX2 (BLE)  -- USART2_RX
+    PC[11].configure(Some(B));
+
+    // TX2 (BLE)  -- USART2_TX
+    PC[12].configure(Some(B));
+
+    // ACC_INT1   -- GPIO
+    PC[13].configure(None);
+
+    // ACC_INT2   -- GPIO
+    PC[14].configure(None);
 
     // SENSE_PWR --  GPIO pin
     PC[16].configure(None);
@@ -90,139 +197,29 @@ unsafe fn set_pin_primary_functions() {
     // TRNG_PWR  -- GPIO Pin
     PC[19].configure(None);
 
-    // AD5      --  ADCIFE AD1
-    PA[05].configure(Some(A));
+    // USER_BTN  -- GPIO Pin
+    PC[24].configure(None);
 
-    // AD4      --  ADCIFE AD2
-    PA[07].configure(Some(A));
+    // D8        -- GPIO Pin
+    PC[25].configure(None);
 
-    // AD3      --  ADCIFE AD3
-    PB[02].configure(Some(A));
+    // D7        -- GPIO Pin
+    PC[26].configure(None);
 
-    // AD2      --  ADCIFE AD4
-    PB[03].configure(Some(A));
+    // D6        -- GPIO Pin
+    PC[27].configure(None);
 
-    // AD1      --  ADCIFE AD5
-    PB[04].configure(Some(A));
+    // D5        -- GPIO Pin
+    PC[28].configure(None);
 
-    // AD0      --  ADCIFE AD6
-    PB[05].configure(Some(A));
+    // D4        -- GPIO Pin
+    PC[29].configure(None);
 
+    // D3        -- GPIO Pin
+    PC[30].configure(None);
 
-    // BL_SEL   --  USART3 RTS
-    PB[06].configure(Some(A));
-
-    //          --  USART3 CTS
-    PB[07].configure(Some(A));
-
-    //          --  USART3 CLK
-    PB[08].configure(Some(A));
-
-    // PRI_RX   --  USART3 RX
-    PB[09].configure(Some(A));
-
-    // PRI_TX   --  USART3 TX
-    PB[10].configure(Some(A));
-
-    // U1_CTS   --  USART0 CTS
-    PB[11].configure(Some(A));
-
-    // U1_RTS   --  USART0 RTS
-    PB[12].configure(Some(A));
-
-    // U1_CLK   --  USART0 CLK
-    PB[13].configure(Some(A));
-
-    // U1_RX    --  USART0 RX
-    PB[14].configure(Some(A));
-
-    // U1_TX    --  USART0 TX
-    PB[15].configure(Some(A));
-
-    // STORMRTS --  USART2 RTS
-    PC[07].configure(Some(B));
-
-    // STORMCTS --  USART2 CTS
-    PC[08].configure(Some(E));
-
-    // STORMRX  --  USART2 RX
-    PC[11].configure(Some(B));
-
-    // STORMTX  --  USART2 TX
-    PC[12].configure(Some(B));
-
-    // STORMCLK --  USART2 CLK
-    PA[18].configure(Some(A));
-
-    // ESDA     --  TWIMS1 TWD
-    PB[00].configure(Some(A));
-
-    // ESCL     --  TWIMS1 TWCK
-    PB[01].configure(Some(A));
-
-    // SDA      --  TWIM2 TWD
-    PA[21].configure(Some(E));
-
-    // SCL      --  TWIM2 TWCK
-    PA[22].configure(Some(E));
-
-    // EPCLK    --  USBC DM
-    PA[25].configure(Some(A));
-
-    // EPDAT    --  USBC DP
-    PA[26].configure(Some(A));
-
-    // PCLK     --  PARC PCCK
-    PC[21].configure(Some(D));
-    // PCEN1    --  PARC PCEN1
-    PC[22].configure(Some(D));
-    // EPGP     --  PARC PCEN2
-    PC[23].configure(Some(D));
-    // PCD0     --  PARC PCDATA0
-    PC[24].configure(Some(D));
-    // PCD1     --  PARC PCDATA1
-    PC[25].configure(Some(D));
-    // PCD2     --  PARC PCDATA2
-    PC[26].configure(Some(D));
-    // PCD3     --  PARC PCDATA3
-    PC[27].configure(Some(D));
-    // PCD4     --  PARC PCDATA4
-    PC[28].configure(Some(D));
-    // PCD5     --  PARC PCDATA5
-    PC[29].configure(Some(D));
-    // PCD6     --  PARC PCDATA6
-    PC[30].configure(Some(D));
-    // PCD7     --  PARC PCDATA7
-    PC[31].configure(Some(D));
-
-    // P2       -- GPIO Pin
-    PA[16].configure(None);
-    // P3       -- GPIO Pin
-    PA[12].configure(None);
-    // P4       -- GPIO Pin
-    PC[09].configure(None);
-    // P5       -- GPIO Pin
-    PA[10].configure(None);
-    // P6       -- GPIO Pin
-    PA[11].configure(None);
-    // P7       -- GPIO Pin
-    PA[19].configure(None);
-    // P8       -- GPIO Pin
-    PA[13].configure(None);
-
-    // none     -- GPIO Pin
-    PA[14].configure(None);
-
-    // ACC_INT2 -- GPIO Pin
-    PC[20].configure(None);
-    // STORMINT -- GPIO Pin
-    PA[17].configure(None);
-    // TMP_DRDY -- GPIO Pin
-    PA[09].configure(None);
-    // ACC_INT1 -- GPIO Pin
-    PC[13].configure(None);
-    // LED0     -- GPIO Pin
-    PC[10].configure(None);
+    // D2        -- GPIO Pin
+    PC[31].configure(None);
 }
 
 
@@ -292,17 +289,6 @@ pub unsafe fn reset_handler() {
     sam4l::gpio::PC[16].enable_output();
     sam4l::gpio::PC[16].clear();
 
-    // # LEDs
-
-    let led_pins = static_init!(
-        [&'static sam4l::gpio::GPIOPin; 1],
-        [&sam4l::gpio::PC[10]],
-        1 * 4);
-    let led = static_init!(
-        capsules::led::LED<'static, sam4l::gpio::GPIOPin>,
-        capsules::led::LED::new(led_pins, capsules::led::ActivationMode::ActiveHigh),
-        96/8);
-
     // # ADC
 
     // Setup ADC
@@ -316,19 +302,15 @@ pub unsafe fn reset_handler() {
 
     // set GPIO driver controlling remaining GPIO pins
     let gpio_pins = static_init!(
-        [&'static sam4l::gpio::GPIOPin; 11],
-        [&sam4l::gpio::PA[16], // P2
-         &sam4l::gpio::PA[12], // P3
-         &sam4l::gpio::PC[9], // P4
-         &sam4l::gpio::PA[10], // P5
-         &sam4l::gpio::PA[11], // P6
-         &sam4l::gpio::PA[19], // P7
-         &sam4l::gpio::PA[13], // P8
-         &sam4l::gpio::PA[17], /* STORM_INT (nRF51822) */
-         &sam4l::gpio::PC[14], /* RSLP (RF233 sleep line) */
-         &sam4l::gpio::PC[15], /* RRST (RF233 reset line) */
-         &sam4l::gpio::PA[20]], /* RIRQ (RF233 interrupt) */
-        11 * 4
+        [&'static sam4l::gpio::GPIOPin; 7],
+        [&sam4l::gpio::PC[31], // P2
+         &sam4l::gpio::PC[30], // P3
+         &sam4l::gpio::PC[29], // P4
+         &sam4l::gpio::PC[28], // P5
+         &sam4l::gpio::PC[27], // P6
+         &sam4l::gpio::PC[26], // P7
+         &sam4l::gpio::PC[25]], // P8
+        7 * 4
     );
     let gpio = static_init!(
         capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
@@ -337,6 +319,17 @@ pub unsafe fn reset_handler() {
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);
     }
+
+    // # LEDs
+
+    let led_pins = static_init!(
+        [&'static sam4l::gpio::GPIOPin; 1],
+        [&sam4l::gpio::PC[10]],
+        1 * 4);
+    let led = static_init!(
+        capsules::led::LED<'static, sam4l::gpio::GPIOPin>,
+        capsules::led::LED::new(led_pins, capsules::led::ActivationMode::ActiveHigh),
+        96/8);
 
     let mut imix = Imix {
         console: console,


### PR DESCRIPTION
Imix pin assignments differ slightly from the Firestorm pin assignments, so I've corrected them in the board initialization.

@shaneleonard would be good to get a second pair of eyes. The relevant modifications are in `boards/imix/src/main.rs` in the `set_pin_primary_functions` function.