### PR TITLE
Button driver

### DIFF
--- a/boards/nrf51dk/apps/c_gpio
+++ b/boards/nrf51dk/apps/c_gpio
@@ -1,0 +1,1 @@
+../../../userland/examples/c_gpio

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -92,6 +92,7 @@ pub struct Platform {
     timer: &'static TimerDriver<'static, VirtualMuxAlarm<'static, Rtc>>,
     console: &'static capsules::console::Console<'static, nrf51::uart::UART>,
     led: &'static capsules::led::LED<'static, nrf51::gpio::GPIOPin>,
+    button: &'static capsules::button::Button<'static, nrf51::gpio::GPIOPin>,
 }
 
 
@@ -105,6 +106,7 @@ impl kernel::Platform for Platform {
             1 => f(Some(self.gpio)),
             3 => f(Some(self.timer)),
             8 => f(Some(self.led)),
+            9 => f(Some(self.button)),
             _ => f(None),
         }
     }
@@ -128,28 +130,39 @@ pub unsafe fn reset_handler() {
         capsules::led::LED::new(led_pins, capsules::led::ActivationMode::ActiveLow),
         96/8);
 
-    let gpio_pins = static_init!(
-        [&'static nrf51::gpio::GPIOPin; 18],
+    let button_pins = static_init!(
+        [&'static nrf51::gpio::GPIOPin; 4],
         [&nrf51::gpio::PORT[BUTTON1_PIN], // 17
          &nrf51::gpio::PORT[BUTTON2_PIN], // 18
          &nrf51::gpio::PORT[BUTTON3_PIN], // 19
          &nrf51::gpio::PORT[BUTTON4_PIN], // 20
-         &nrf51::gpio::PORT[1],  // Bottom left header on DK board
+        ],
+        4 * 4);
+    let button = static_init!(
+        capsules::button::Button<'static, nrf51::gpio::GPIOPin>,
+        capsules::button::Button::new(button_pins, kernel::Container::create()),
+        96/8);
+    for btn in button_pins.iter() {
+        use kernel::hil::gpio::PinCtl;
+        btn.set_input_mode(kernel::hil::gpio::InputMode::PullUp);
+        btn.set_client(button);
+    }
+
+    let gpio_pins = static_init!(
+        [&'static nrf51::gpio::GPIOPin; 11],
+        [&nrf51::gpio::PORT[1],  // Bottom left header on DK board
          &nrf51::gpio::PORT[2],  //   |
          &nrf51::gpio::PORT[3],  //   V
          &nrf51::gpio::PORT[4],  //
          &nrf51::gpio::PORT[5],  //
          &nrf51::gpio::PORT[6],  // -----
-         &nrf51::gpio::PORT[19], // Mid right header on DK board
-         &nrf51::gpio::PORT[18], //   |
-         &nrf51::gpio::PORT[17], //   V
          &nrf51::gpio::PORT[16], //
          &nrf51::gpio::PORT[15], //
          &nrf51::gpio::PORT[14], //
          &nrf51::gpio::PORT[13], //
          &nrf51::gpio::PORT[12], //
         ],
-        4 * 18);
+        4 * 11);
 
     let gpio = static_init!(
         capsules::gpio::GPIO<'static, nrf51::gpio::GPIOPin>,
@@ -209,8 +222,9 @@ pub unsafe fn reset_handler() {
             timer: timer,
             console: console,
             led: led,
+            button: button,
         },
-        128/8);
+        160/8);
 
     alarm.start();
 

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -1,0 +1,115 @@
+//! Provide capsule driver for controlling buttons on a board.  This allows for much more cross
+//! platform controlling of buttons without having to know which of the GPIO pins exposed across
+//! the syscall interface are buttons.
+
+use kernel::{AppId, Container, Callback, Driver};
+use kernel::hil;
+use kernel::hil::gpio::{Client, InterruptMode};
+
+pub type SubscribeMap = u32;
+
+pub struct Button<'a, G: hil::gpio::Pin + 'a> {
+    pins: &'a [&'a G],
+    callback: Container<(Option<Callback>, SubscribeMap)>,
+}
+
+impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Button<'a, G> {
+    pub fn new(pins: &'a [&'a G],
+               container: Container<(Option<Callback>, SubscribeMap)>)
+               -> Button<'a, G> {
+        // Make all pins output and off
+        for (i, pin) in pins.iter().enumerate() {
+            pin.make_input();
+            pin.enable_interrupt(i, InterruptMode::EitherEdge);
+        }
+
+        Button {
+            pins: pins,
+            callback: container,
+        }
+    }
+}
+
+impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+        match subscribe_num {
+            // set callback for pin interrupts (no affect or reliance on individual pins being
+            // configured as interrupts)
+            0 => {
+                self.callback
+                    .enter(callback.app_id(), |cntr, _| {
+                        cntr.0 = Some(callback);
+                        0
+                    })
+                    .unwrap_or(-2)
+            }
+
+            // default
+            _ => -1,
+        }
+    }
+
+    fn command(&self, command_num: usize, data: usize, appid: AppId) -> isize {
+        let pins = self.pins.as_ref();
+        match command_num {
+            // enable interrupts on pin
+            0 => {
+                if data < pins.len() {
+                    self.callback
+                        .enter(appid, |cntr, _| {
+                            cntr.1 |= 1 << data;
+                            0
+                        })
+                        .unwrap_or(-3)
+                } else {
+                    -2
+                }
+            }
+
+            // disable interrupts on pin
+            // (no affect or reliance on registered callback)
+            1 => {
+                if data >= pins.len() {
+                    -2
+                } else {
+                    self.callback
+                        .enter(appid, |cntr, _| {
+                            cntr.1 &= !(1 << data);
+                            0
+                        })
+                        .unwrap_or(-3)
+                }
+            }
+
+            // read input
+            2 => {
+                if data >= pins.len() {
+                    -1
+                } else {
+                    let pin_state = pins[data].read();
+                    pin_state as isize
+                }
+            }
+
+            // default
+            _ => -1,
+        }
+    }
+}
+
+impl<'a, G: hil::gpio::Pin> Client for Button<'a, G> {
+    fn fired(&self, pin_num: usize) {
+        // read the value of the pin
+        let pins = self.pins.as_ref();
+        let pin_state = pins[pin_num].read();
+
+        // schedule callback with the pin number and value
+        self.callback.each(|cntr| {
+            cntr.0.map(|mut callback| {
+                if cntr.1 & (1 << pin_num) != 0 {
+                    callback.schedule(pin_num, pin_state as usize, 0);
+                }
+            });
+        });
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate kernel;
 
+pub mod button;
 pub mod console;
 pub mod fm25cl;
 pub mod gpio;

--- a/chips/nrf51/src/gpio.rs
+++ b/chips/nrf51/src/gpio.rs
@@ -111,8 +111,8 @@ impl GPIOPin {
 impl hil::gpio::PinCtl for GPIOPin {
     fn set_input_mode(&self, mode: hil::gpio::InputMode) {
         let conf = match mode {
-            hil::gpio::InputMode::PullUp => 0x3,
-            hil::gpio::InputMode::PullDown => 0x1,
+            hil::gpio::InputMode::PullUp => 3,
+            hil::gpio::InputMode::PullDown => 1,
             hil::gpio::InputMode::PullNone => 0,
         };
         let pin_cnf = GPIO().pin_cnf[self.pin as usize];
@@ -129,6 +129,8 @@ impl hil::gpio::Pin for GPIOPin {
     // mynewt/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51_bitfields.h
     fn make_input(&self) {
         GPIO().dirclr.set(1 << self.pin);
+        let pin_cnf = GPIO().pin_cnf[self.pin as usize];
+        pin_cnf.set(0b1100);
     }
 
     // Not clk
@@ -152,15 +154,15 @@ impl hil::gpio::Pin for GPIOPin {
         GPIO().in_.get() & (1 << self.pin) != 0
     }
 
-    fn enable_interrupt(&self, _client_data: usize, _mode: hil::gpio::InterruptMode) {
-        self.client_data.set(_client_data);
+    fn enable_interrupt(&self, client_data: usize, mode: hil::gpio::InterruptMode) {
+        self.client_data.set(client_data);
         let mut mode_bits: u32 = 1; // Event
-        mode_bits |= match _mode {
+        mode_bits |= match mode {
             hil::gpio::InterruptMode::EitherEdge => 3 << 16,
             hil::gpio::InterruptMode::RisingEdge => 1 << 16,
             hil::gpio::InterruptMode::FallingEdge => 2 << 16,
         };
-        let pin = self.pin as u32;
+        let pin = (self.pin & 0b11111) as u32;
         mode_bits |= pin << 8;
         let channel = allocate_channel();
         match channel {

--- a/chips/nrf51/src/gpio.rs
+++ b/chips/nrf51/src/gpio.rs
@@ -115,7 +115,7 @@ impl hil::gpio::PinCtl for GPIOPin {
             hil::gpio::InputMode::PullDown => 1,
             hil::gpio::InputMode::PullNone => 0,
         };
-        let pin_cnf = GPIO().pin_cnf[self.pin as usize];
+        let pin_cnf = &GPIO().pin_cnf[self.pin as usize];
         pin_cnf.set((pin_cnf.get() & !(0b11 << 2)) | (conf << 2));
     }
 }
@@ -129,8 +129,6 @@ impl hil::gpio::Pin for GPIOPin {
     // mynewt/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51_bitfields.h
     fn make_input(&self) {
         GPIO().dirclr.set(1 << self.pin);
-        let pin_cnf = GPIO().pin_cnf[self.pin as usize];
-        pin_cnf.set(0b1100);
     }
 
     // Not clk

--- a/chips/sam4l/src/gpio.rs
+++ b/chips/sam4l/src/gpio.rs
@@ -266,13 +266,13 @@ pub static mut PC: Port = Port {
            GPIOPin::new(PC21, GPIO10),
            GPIOPin::new(PC22, GPIO10),
            GPIOPin::new(PC23, GPIO10),
-           GPIOPin::new(PC24, GPIO10),
+           GPIOPin::new(PC24, GPIO11),
            GPIOPin::new(PC25, GPIO11),
-           GPIOPin::new(PC26, GPIO10),
+           GPIOPin::new(PC26, GPIO11),
            GPIOPin::new(PC27, GPIO11),
-           GPIOPin::new(PC28, GPIO10),
+           GPIOPin::new(PC28, GPIO11),
            GPIOPin::new(PC29, GPIO11),
-           GPIOPin::new(PC30, GPIO10),
+           GPIOPin::new(PC30, GPIO11),
            GPIOPin::new(PC31, GPIO11)],
 };
 pub struct GPIOPin {

--- a/userland/examples/c_gpio/main.c
+++ b/userland/examples/c_gpio/main.c
@@ -9,62 +9,22 @@
  * Then, when you push the button, the other LED should blink.
  */
 
-#include "led.h"
-#include "gpio.h"
+#include <button.h>
+#include <led.h>
 
-/* Delay for for the given microseconds (approximately).
- *
- * For a 16 MHz CPU, 1us == 16 instructions (assuming each instruction takes
- * one cycle). */
-static void busy_delay_us(int duration)
-{
-	// The inner loop instructions are: 14 NOPs + 1 SUBS/ADDS + 1 CMP
-	while (duration-- != 0) {
-		__asm volatile (
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-			"nop\n"
-		);
-	}
-}
-
-/* Delay for for the given milliseconds (approximately).
- *
- * Note that this is not precise as there are 2 extra instructions on the inner
- * loop. Therefore, there is 1us added every 8 iterations. */
-static void busy_delay_ms(int duration) {
-	while (duration-- != 0) {
-		busy_delay_us(1000);
-	}
-}
-
-void interrupt_callback() {
-    led_toggle(1);
+void interrupt_callback(int pin_num, int val) {
+  if (val == 0) {
+    led_toggle(pin_num);
+  }
 }
 
 int main(void) {
-    led_on(1);
-    // Application pin 0 is Button 1
-    gpio_enable_input(0, PullDown);
-    gpio_enable_interrupt(0, PullDown, RisingEdge);
-    gpio_interrupt_callback(interrupt_callback, NULL);
+  button_subscribe(interrupt_callback, 0);
+  int j = 0;
+  for (int i = 0; i < 4 && j >= 0; i++) {
+    j = button_enable_interrupt(i);
+  }
 
-    int i;
-    for (i = 0; i < 10; i++) {
-      led_toggle(0);
-      busy_delay_ms(200);
-    }
-    return 1;
+  return 0;
 }
 

--- a/userland/libtock/button.c
+++ b/userland/libtock/button.c
@@ -1,0 +1,18 @@
+#include "button.h"
+
+int button_subscribe(subscribe_cb callback, void *ud) {
+  return subscribe(DRIVER_NUM_BUTTON, 0, callback, ud);
+}
+
+int button_enable_interrupt(int pin_num) {
+  return command(DRIVER_NUM_BUTTON, 0, pin_num);  
+}
+
+int button_disable_interrupt(int pin_num) {
+  return command(DRIVER_NUM_BUTTON, 1, pin_num);  
+}
+
+int button_read(int pin_num) {
+  return command(DRIVER_NUM_BUTTON, 2, pin_num);
+}
+

--- a/userland/libtock/button.h
+++ b/userland/libtock/button.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <tock.h>
+
+#define DRIVER_NUM_BUTTON 9
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int button_subscribe(subscribe_cb callback, void *ud);
+int button_enable_interrupt(int pin_num);
+int button_disable_interrupt(int pin_num);
+int button_read(int pin_num);
+
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
Adds a button driver, similar to the LED driver, to make applications
using buttons more portable.

 * Fixes a bug in the SAM4L gpio setup.
 * Add button driver to Imix

~~There are some issues with the NRF51dk buttons (the PIN_CNF doesn't seem to be sticking for some reason, and a PullUp is required, otherwise it works), so that's blocking me on porting to the NRF51dk~~