### PR TITLE
SAM4L: Assign more DMA channels

### DIFF
--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -25,21 +25,30 @@ impl Sam4l {
     pub unsafe fn new() -> Sam4l {
         INTERRUPT_QUEUE = Some(RingBuffer::new(&mut IQ_BUF));
 
-        usart::USART2.set_dma(&mut dma::DMAChannels[0], dma::DMAPeripheral::USART2_TX);
-        dma::DMAChannels[0].client = Some(&mut usart::USART2);
+        usart::USART0.set_dma(&mut dma::DMAChannels[0], dma::DMAPeripheral::USART0_TX);
+        dma::DMAChannels[0].client = Some(&mut usart::USART0);
 
-        usart::USART3.set_dma(&mut dma::DMAChannels[1], dma::DMAPeripheral::USART3_TX);
-        dma::DMAChannels[1].client = Some(&mut usart::USART3);
+        usart::USART1.set_dma(&mut dma::DMAChannels[1], dma::DMAPeripheral::USART1_TX);
+        dma::DMAChannels[1].client = Some(&mut usart::USART1);
 
-        spi::SPI.set_dma(&mut dma::DMAChannels[2], &mut dma::DMAChannels[3]);
-        dma::DMAChannels[2].client = Some(&mut spi::SPI);
-        dma::DMAChannels[3].client = Some(&mut spi::SPI);
+        usart::USART2.set_dma(&mut dma::DMAChannels[2], dma::DMAPeripheral::USART2_TX);
+        dma::DMAChannels[2].client = Some(&mut usart::USART2);
 
-        i2c::I2C2.set_dma(&dma::DMAChannels[4]);
-        dma::DMAChannels[4].client = Some(&mut i2c::I2C2);
+        usart::USART3.set_dma(&mut dma::DMAChannels[3], dma::DMAPeripheral::USART3_TX);
+        dma::DMAChannels[3].client = Some(&mut usart::USART3);
 
-        i2c::I2C1.set_dma(&dma::DMAChannels[5]);
-        dma::DMAChannels[5].client = Some(&mut i2c::I2C1);
+        spi::SPI.set_dma(&mut dma::DMAChannels[4], &mut dma::DMAChannels[5]);
+        dma::DMAChannels[4].client = Some(&mut spi::SPI);
+        dma::DMAChannels[5].client = Some(&mut spi::SPI);
+
+        i2c::I2C0.set_dma(&dma::DMAChannels[6]);
+        dma::DMAChannels[6].client = Some(&mut i2c::I2C0);
+
+        i2c::I2C1.set_dma(&dma::DMAChannels[7]);
+        dma::DMAChannels[7].client = Some(&mut i2c::I2C1);
+
+        i2c::I2C2.set_dma(&dma::DMAChannels[8]);
+        dma::DMAChannels[8].client = Some(&mut i2c::I2C2);
 
         Sam4l {
             mpu: cortexm4::mpu::MPU::new(),
@@ -70,6 +79,16 @@ impl Chip for Sam4l {
                     PDCA3 => dma::DMAChannels[3].handle_interrupt(),
                     PDCA4 => dma::DMAChannels[4].handle_interrupt(),
                     PDCA5 => dma::DMAChannels[5].handle_interrupt(),
+                    PDCA6 => dma::DMAChannels[6].handle_interrupt(),
+                    PDCA7 => dma::DMAChannels[7].handle_interrupt(),
+                    PDCA8 => dma::DMAChannels[8].handle_interrupt(),
+                    PDCA9 => dma::DMAChannels[9].handle_interrupt(),
+                    PDCA10 => dma::DMAChannels[10].handle_interrupt(),
+                    PDCA11 => dma::DMAChannels[11].handle_interrupt(),
+                    PDCA12 => dma::DMAChannels[12].handle_interrupt(),
+                    PDCA13 => dma::DMAChannels[13].handle_interrupt(),
+                    PDCA14 => dma::DMAChannels[14].handle_interrupt(),
+                    PDCA15 => dma::DMAChannels[15].handle_interrupt(),
 
                     GPIO0 => gpio::PA.handle_interrupt(),
                     GPIO1 => gpio::PA.handle_interrupt(),


### PR DESCRIPTION
Add USART0/1 and I2C0 for platforms that use those peripherals.