### PR TITLE
Sam4l Spi fix

### DIFF
--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -65,13 +65,9 @@ pub struct Spi {
     client: TakeCell<&'static SpiMasterClient>,
     dma_read: TakeCell<&'static mut DMAChannel>,
     dma_write: TakeCell<&'static mut DMAChannel>,
-    // keep track of which interrupts are pending in order
-    // to correctly issue completion event only after both complete.
-    transfer_in_progress: Cell<bool>,
-    // track whether we have just a write or a write/read
-    rw_in_progress: Cell<bool>,
-    // track whether a read or write finished if doing a write/read
-    channel_completed: Cell<bool>,
+    // keep track of which how many DMA transfers are pending to correctly
+    // issue completion event only after both complete.
+    transfers_in_progress: Cell<u8>,
     dma_length: Cell<usize>,
 }
 
@@ -85,9 +81,7 @@ impl Spi {
             client: TakeCell::empty(),
             dma_read: TakeCell::empty(),
             dma_write: TakeCell::empty(),
-            transfer_in_progress: Cell::new(false),
-            rw_in_progress: Cell::new(false),
-            channel_completed: Cell::new(false),
+            transfers_in_progress: Cell::new(0),
             dma_length: Cell::new(0),
         }
     }
@@ -249,7 +243,7 @@ impl spi::SpiMaster for Spi {
     }
 
     fn is_busy(&self) -> bool {
-        self.transfer_in_progress.get()
+        self.transfers_in_progress.get() != 0
     }
 
     /// Write a byte to the SPI and discard the read; if an
@@ -257,9 +251,10 @@ impl spi::SpiMaster for Spi {
     fn write_byte(&self, out_byte: u8) {
         let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
 
-        if self.transfer_in_progress.get() {
+        if self.is_busy() {
             //           return;
         }
+
         let tdr = out_byte as u32;
         // Wait for data to leave TDR and enter serializer, so TDR is free
         // for this next byte
@@ -278,7 +273,7 @@ impl spi::SpiMaster for Spi {
     fn read_write_byte(&self, val: u8) -> u8 {
         let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
 
-        if self.transfer_in_progress.get() {
+        if self.is_busy() {
             //          return 0;
         }
         self.write_byte(val);
@@ -304,12 +299,12 @@ impl spi::SpiMaster for Spi {
         self.enable();
 
         // If busy, don't start.
-        if self.transfer_in_progress.get() {
+        if self.is_busy() {
             return false;
         }
 
-        // Need to mark busy
-        self.transfer_in_progress.set(true);
+        // We will have at least a write transfer in progress
+        self.transfers_in_progress.set(1);
 
         let read_len = match read_buffer {
             Some(ref buf) => buf.len(),
@@ -324,10 +319,6 @@ impl spi::SpiMaster for Spi {
         let count = cmp::min(buflen, len);
         self.dma_length.set(count);
 
-        if read_buffer.is_some() {
-            self.rw_in_progress.set(true);
-        }
-
         // The ordering of these operations matters.
         // For transfers 4 bytes or longer, this will work as expected.
         // For shorter transfers, the first byte will be missing.
@@ -339,6 +330,7 @@ impl spi::SpiMaster for Spi {
         // Only setup the RX channel if we were passed a read_buffer inside
         // of the option. `map()` checks this for us.
         read_buffer.map(|rbuf| {
+            self.transfers_in_progress.set(2);
             self.dma_read.map(move |read| {
                 read.enable();
                 read.do_xfer(DMAPeripheral::SPI_RX, rbuf, count);
@@ -417,27 +409,17 @@ impl spi::SpiMaster for Spi {
 }
 
 impl DMAClient for Spi {
-    fn xfer_done(&self, pid: DMAPeripheral) {
+    fn xfer_done(&self, _pid: DMAPeripheral) {
         // Only callback that the transfer is done if either:
         // 1) The transfer was TX only and TX finished
-        // 2) The transfer was TX and RX, in that case wait for both of them to
-        //    complete. Although they're synchronous in Hardware, in Software
-        //    they aren't, so we don't want to abruptly abort.
+        // 2) The transfer was TX and RX, in that case wait for both of them to complete. Although
+        //    both transactions happen simultaneously over the wire, the DMA may not finish copying
+        //    data over to/from the controller at the same time, so we don't want to abort
+        //    prematurely.
 
-        if self.rw_in_progress.get() {
-            if !self.channel_completed.get() &&
-               (pid == DMAPeripheral::SPI_TX || pid == DMAPeripheral::SPI_RX) {
-                self.channel_completed.set(true);
-                return;
-            }
-        }
+        self.transfers_in_progress.set(self.transfers_in_progress.get() - 1);
 
-        if pid == DMAPeripheral::SPI_TX ||
-           (self.rw_in_progress.get() && self.channel_completed.get()) {
-            self.transfer_in_progress.set(false);
-            self.channel_completed.set(false);
-            self.rw_in_progress.set(false);
-
+        if self.transfers_in_progress.get() == 0 {
             let txbuf = self.dma_write.map_or(None, |dma| {
                 let buf = dma.abort_xfer();
                 dma.disable();


### PR DESCRIPTION
Hey @alevy and @bradjc, 

I'm working on a fix for the SPI for the RF233 in terms of the 'race condition' bug I was getting from aborting the read after the write finish. 

Using a newer codebase ( than the one I originally forked off of ), which is this branch, further modifications to SPI have complicated things. 

I found an off-by-1 bug in the `ChipSelect` that inits the SPI (it forgot to account for Peripheral 3), such that a userland syscall to `specify_chip_select` would fail on peripheral 3. 

Given that I've fixed that in this pull req, I'm a bit lost on why my logic analyzer is saying that the MISO is always 0. Maybe you guys might have a clue... 