### PR TITLE
Make blink app adapt to underlying platform

### DIFF
--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -39,8 +39,11 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for LED<'a, G> {
     fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
         let pins = self.pins.as_ref();
         match command_num {
+            // get number of LEDs
+            0 => pins.len() as isize,
+
             // on
-            0 => {
+            1 => {
                 if data >= pins.len() {
                     -1
                 } else {
@@ -53,7 +56,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for LED<'a, G> {
             }
 
             // off
-            1 => {
+            2 => {
                 if data >= pins.len() {
                     -1
                 } else {
@@ -66,7 +69,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for LED<'a, G> {
             }
 
             // toggle
-            2 => {
+            3 => {
                 if data >= pins.len() {
                     -1
                 } else {

--- a/userland/examples/blink/main.c
+++ b/userland/examples/blink/main.c
@@ -4,8 +4,15 @@
 #include <timer.h>
 
 int main(void) {
-  while (1) {
-    led_toggle(0);
-    delay_ms(500);
+  int num_leds = led_count();
+  for (int count = 0; ; count++) {
+    for (int i = 0; i < num_leds; i++) {
+      if (count & (1 << i)) {
+        led_on(i);
+      } else {
+        led_off(i);
+      }
+    }
+    delay_ms(250);
   }
 }

--- a/userland/libtock/led.c
+++ b/userland/libtock/led.c
@@ -2,13 +2,17 @@
 #include "led.h"
 
 int led_on(int led_num) {
-	return command(DRIVER_NUM_LEDS, 0, led_num);
-}
-
-int led_off(int led_num) {
 	return command(DRIVER_NUM_LEDS, 1, led_num);
 }
 
-int led_toggle(int led_num) {
+int led_off(int led_num) {
 	return command(DRIVER_NUM_LEDS, 2, led_num);
+}
+
+int led_toggle(int led_num) {
+	return command(DRIVER_NUM_LEDS, 3, led_num);
+}
+
+int led_count() {
+	return command(DRIVER_NUM_LEDS, 0, 0);
 }

--- a/userland/libtock/led.h
+++ b/userland/libtock/led.h
@@ -7,3 +7,6 @@
 int led_on(int led_num);
 int led_off(int led_num);
 int led_toggle(int led_num);
+
+// Returns the number of LEDs on the host platform.
+int led_count();


### PR DESCRIPTION
Rather than just blink 1 LED, it now adapts to the number of LEDs on the platform. This is good not only because it looks cooler, but it's a step towards more portable apps.

It does raise a question about what should return this type of information (i.e. "how many LEDs?" or "is there a temperature sensor?"). Each driver somehow? Or something more directly provided by the kernel?