### PR TITLE
Use opaque pinmux type for configuring nrf51 pins

### DIFF
--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -47,6 +47,7 @@ use capsules::timer::TimerDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::{Chip, SysTick};
 use kernel::hil::uart::UART;
+use nrf51::pinmux::Pinmux;
 use nrf51::rtc::{RTC, Rtc};
 
 // The nRF51 DK LEDs (see back of board)
@@ -171,6 +172,10 @@ pub unsafe fn reset_handler() {
         pin.set_client(gpio);
     }
 
+    nrf51::uart::UART0.configure(Pinmux::new(9),
+                                 Pinmux::new(11),
+                                 Pinmux::new(10),
+                                 Pinmux::new(8));
     let console = static_init!(
         capsules::console::Console<nrf51::uart::UART>,
         capsules::console::Console::new(&nrf51::uart::UART0,

--- a/chips/nrf51/src/lib.rs
+++ b/chips/nrf51/src/lib.rs
@@ -17,4 +17,5 @@ pub mod rtc;
 pub mod timer;
 pub mod clock;
 pub mod uart;
+pub mod pinmux;
 pub use chip::NRF51;

--- a/chips/nrf51/src/pinmux.rs
+++ b/chips/nrf51/src/pinmux.rs
@@ -1,0 +1,34 @@
+//! An abstraction over the NRF51 pin multiplexer
+//!
+//! Controller drivers should use the `Pinmux` type (instead of a `u32`) for
+//! fields that determine which pins are used by the hardware. The board
+//! configuration should create `Pinmux`s and pass them into controller drivers
+//! during initialization.
+
+use kernel::common::VolatileCell;
+
+// Keep track of which pins has a `Pinmux` been created for.
+static mut USED_PINS: VolatileCell<u32> = VolatileCell::new(0);
+
+/// An opaque wrapper around a configurable pin.
+#[derive(Copy, Clone)]
+pub struct Pinmux(u32);
+
+impl Pinmux {
+    /// Creates a new `Pinmux` wrapping the numbered pin.
+    ///
+    /// # Panics
+    ///
+    /// If a `Pinmux` for this pin has already
+    /// been created.
+    ///
+    pub unsafe fn new(pin: u32) -> Pinmux {
+        let used_pins = USED_PINS.get();
+        if used_pins & 1 << pin != 0 {
+            panic!("Pin {} is already in use!", pin);
+        } else {
+            USED_PINS.set(used_pins | 1 << pin);
+            Pinmux(pin)
+        }
+    }
+}


### PR DESCRIPTION
The NRF51 does not have a separate pinmux controller like the SAM4L (where it is integrated into the GPIO controller). Instead, each controller decides which pins to use, and it is possible for two controllers to choose the same pins. Behavior is undefined in this case, but at best, this would leak information between controller drivers.

This change exposes an opaque type, `Pinmux` in the nrf51 crate that simply wraps a `u32` such that only trusted code can construct it.