### PR TITLE
Add `make list`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ flash: boards/$(TOCK_BOARD)/
 fmt format:
 	@./tools/run_cargo_fmt.sh
 
+list list-boards list-platforms:
+	@./tools/list_boards.sh
 
 # rule for making userland example applications
 # 	automatically upload after making

--- a/tools/list_boards.sh
+++ b/tools/list_boards.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+boards=`ls -l boards | egrep '^d' | awk '{print $9}'`
+echo Supported Tock boards: $boards
+echo ""
+echo To build the kernel for a particular board, run:
+echo "    make TOCK_BOARD=<board name>"


### PR DESCRIPTION
`make list` prints out the list of boards in Tock. This should help people understand what they can build Tock for.

I'd like to make this more descriptive, like:

```
Tock Boards:

    storm  - Ardiuno form factor dev board  - https://storm.rocks
    imix  - ...
    ...
```
but for now this will do.