### PR TITLE
Add count system call to buttons driver

### DIFF
--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -52,8 +52,10 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
     fn command(&self, command_num: usize, data: usize, appid: AppId) -> isize {
         let pins = self.pins.as_ref();
         match command_num {
+            // return pin count
+            0 => pins.len() as isize,
             // enable interrupts on pin
-            0 => {
+            1 => {
                 if data < pins.len() {
                     self.callback
                         .enter(appid, |cntr, _| {
@@ -68,7 +70,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
 
             // disable interrupts on pin
             // (no affect or reliance on registered callback)
-            1 => {
+            2 => {
                 if data >= pins.len() {
                     -2
                 } else {
@@ -82,7 +84,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
             }
 
             // read input
-            2 => {
+            3 => {
                 if data >= pins.len() {
                     -1
                 } else {

--- a/userland/examples/buttons/main.c
+++ b/userland/examples/buttons/main.c
@@ -22,11 +22,10 @@ static void button_callback(int btn_num,
 int main(void) {
   button_subscribe(button_callback, NULL);
 
-  // Enable interrupts on each button successively until we run into a button
-  // that doesn't exist (negative return value).
-  int j = 0;
-  for (int i = 0; j >= 0; i++) {
-    j = button_enable_interrupt(i);
+  // Enable interrupts on each button.
+  int count = button_count();
+  for (int i = 0; i < count; i++) {
+    button_enable_interrupt(i);
   }
 
   return 0;

--- a/userland/libtock/button.c
+++ b/userland/libtock/button.c
@@ -4,15 +4,19 @@ int button_subscribe(subscribe_cb callback, void *ud) {
   return subscribe(DRIVER_NUM_BUTTON, 0, callback, ud);
 }
 
-int button_enable_interrupt(int pin_num) {
-  return command(DRIVER_NUM_BUTTON, 0, pin_num);  
+int button_count() {
+  return command(DRIVER_NUM_BUTTON, 0, 0);  
 }
 
-int button_disable_interrupt(int pin_num) {
+int button_enable_interrupt(int pin_num) {
   return command(DRIVER_NUM_BUTTON, 1, pin_num);  
 }
 
+int button_disable_interrupt(int pin_num) {
+  return command(DRIVER_NUM_BUTTON, 2, pin_num);  
+}
+
 int button_read(int pin_num) {
-  return command(DRIVER_NUM_BUTTON, 2, pin_num);
+  return command(DRIVER_NUM_BUTTON, 3, pin_num);
 }
 

--- a/userland/libtock/button.h
+++ b/userland/libtock/button.h
@@ -12,6 +12,7 @@ int button_subscribe(subscribe_cb callback, void *ud);
 int button_enable_interrupt(int pin_num);
 int button_disable_interrupt(int pin_num);
 int button_read(int pin_num);
+int button_count();
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Like @bradjc's recent LED driver change, this adds a count system call to the buttons driver so an app can query how many buttons there are on a particular platform.