### PR TITLE
SAM4L ADC: Fix multiple interrupt issue

### DIFF
--- a/userland/libtock/adc.c
+++ b/userland/libtock/adc.c
@@ -35,6 +35,7 @@ int adc_single_sample(uint8_t channel) {
 int adc_read_single_sample(uint8_t channel) {
   int err;
 
+  result.fired = false;
   err = adc_set_callback(adc_cb, (void*) &result);
   if (err < 0) return err;
 


### PR DESCRIPTION
For some reason the ADC interrupt handler is firing twice for every adc
sample. I checked the status register, and the result is 0x51000001,
where the top 3 1s indicated various things are enabled, and the LSB is
one indicating that the conversion is finished. The status register on
the second interrupt is just 0x51000000.

What we really care about is not calling the callback twice, and this
ensures we only call the callback on the correct interrupt.

Also, `result.fired` needs to be cleared in the userland ADC library.