### PR TITLE
Add Accelerometer to LEDs App

### DIFF
--- a/userland/examples/accel-leds/Makefile
+++ b/userland/examples/accel-leds/Makefile
@@ -1,0 +1,21 @@
+# makefile for user application
+
+CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
+TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
+BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
+
+C_SRCS := $(wildcard *.c)
+OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
+
+CPPFLAGS += -DSTACK_SIZE=2048
+
+# include userland master makefile. Contains rules and flags for actually
+# 	building the application
+include $(TOCK_USERLAND_BASE_DIR)/Makefile
+
+.PHONY:
+clean::
+	rm -Rf $(BUILDDIR)
+

--- a/userland/examples/accel-leds/README.md
+++ b/userland/examples/accel-leds/README.md
@@ -1,0 +1,6 @@
+Accelerometer -> LEDs
+=====================
+
+This app makes the accelerometer's readings visual by assigning each
+direction (X, Y, Z) to a color. Whichever direction's magnitude of acceleration
+is greatest gets its color lit.

--- a/userland/examples/accel-leds/main.c
+++ b/userland/examples/accel-leds/main.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <limits.h>
+
+#include <led.h>
+#include <FXOS8700CQ.h>
+
+int main() {
+  printf("[App] Accelerometer -> LEDs\n");
+
+  while (1) {
+    int x, y, z;
+    FXOS8700CQ_read_acceleration_sync(&x, &y, &z);
+
+    // abs()
+    if (x < 0) x *= -1;
+    if (y < 0) y *= -1;
+    if (z < 0) z *= -1;
+
+    // Set LEDs based on acceleration.
+    int largest = INT_MIN;
+    if (x > largest) largest = x;
+    if (y > largest) largest = y;
+    if (z > largest) largest = z;
+
+    if (x == largest) led_on(0); else led_off(0);
+    if (y == largest) led_on(1); else led_off(1);
+    if (z == largest) led_on(2); else led_off(2);
+  }
+
+  return 0;
+}

--- a/userland/libtock/FXOS8700CQ.c
+++ b/userland/libtock/FXOS8700CQ.c
@@ -9,6 +9,8 @@ struct fx0_data {
   bool fired;
 };
 
+static struct fx0_data res = { .fired = false };
+
 // internal callback for faking synchronous reads
 static void FXOS8700CQ_cb(int x, int y, int z, void* ud) {
   struct fx0_data* result = (struct fx0_data*) ud;
@@ -45,4 +47,24 @@ int FXOS8700CQ_subscribe(subscribe_cb callback, void* userdata) {
 
 int FXOS8700CQ_start_accel_reading() {
   return command(11, 0, 0);
+}
+
+int FXOS8700CQ_read_acceleration_sync(int* x, int* y, int* z) {
+    int err;
+    res.fired = false;
+
+    err = FXOS8700CQ_subscribe(FXOS8700CQ_cb, (void*) &res);
+    if (err < 0) return err;
+
+    err = FXOS8700CQ_start_accel_reading();
+    if (err < 0) return err;
+
+    // Wait for the callback.
+    yield_for(&res.fired);
+
+    *x = res.x;
+    *y = res.y;
+    *z = res.z;
+
+    return 0;
 }

--- a/userland/libtock/FXOS8700CQ.h
+++ b/userland/libtock/FXOS8700CQ.h
@@ -15,6 +15,9 @@ int FXOS8700CQ_start_accel_reading();
 // Read square of magnitude of acceleration (blocking)
 double FXOS8700CQ_read_accel_mag();
 
+// Get the magnitude of acceleration in the X,Y,Z directions. Blocking.
+int FXOS8700CQ_read_acceleration_sync(int* x, int* y, int* z);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This is a pretty good test app for the accelerometer because as you hold the board in different orientations, different LEDs come on.

It also adds a `sync` function for getting acceleration data.