### PR TITLE
Fix FXO accelerometer driver resolution and units

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -250,7 +250,7 @@ pub unsafe fn reset_handler() {
     let fxos8700 = static_init!(
         capsules::fxos8700_cq::Fxos8700cq<'static>,
         capsules::fxos8700_cq::Fxos8700cq::new(fxos8700_i2c, &mut capsules::fxos8700_cq::BUF),
-        44);
+        288/8);
     fxos8700_i2c.set_client(fxos8700);
 
     // Initialize and enable SPI HAL

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -227,7 +227,7 @@ pub unsafe fn reset_handler() {
     let fx0 = static_init!(
         capsules::fxos8700_cq::Fxos8700cq<'static>,
         capsules::fxos8700_cq::Fxos8700cq::new(fx0_i2c, &mut capsules::fxos8700_cq::BUF),
-        44);
+        288/8);
     fx0_i2c.set_client(fx0);
 
     // Clear sensors enable pin to enable sensor rail


### PR DESCRIPTION
Correctly parses the accelerometer driver's output as signed, 16-bit
0.244mg and converts to 1mg signed 16-bit units.

Fixes #208