### PR TITLE
Console: Print buffers longer than 64 bytes

### DIFF
--- a/userland/examples/tests/printf_long/Makefile
+++ b/userland/examples/tests/printf_long/Makefile
@@ -1,0 +1,21 @@
+# makefile for user application
+
+CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
+TOCK_BASE_DIR = $(abspath $(TOCK_USERLAND_BASE_DIR)/..)
+BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
+
+C_SRCS := $(wildcard *.c)
+OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
+
+CPPFLAGS += -DSTACK_SIZE=2048
+
+# include userland master makefile. Contains rules and flags for actually
+# 	building the application
+include $(TOCK_USERLAND_BASE_DIR)/Makefile
+
+.PHONY:
+clean::
+	rm -Rf $(BUILDDIR)
+

--- a/userland/examples/tests/printf_long/main.c
+++ b/userland/examples/tests/printf_long/main.c
@@ -1,0 +1,10 @@
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main() {
+  printf("Hi welcome to Tock. This test makes sure that a greater than 64 byte message can be printed.\n");
+  printf("And a short message.\n");
+  return 0;
+}


### PR DESCRIPTION
This adds support for keeping track of how much of an AppSlice the console has printed, and continuing to print after the uart callback.

Should fix #57 