### PR TITLE
Give MPU settings meaningful names

### DIFF
--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -67,6 +67,7 @@ pub struct Registers {
     pub region_attributes_and_size: VolatileCell<u32>,
 }
 
+
 const MPU_BASE_ADDRESS: *const Registers = 0xE000ED90 as *const Registers;
 
 /// Constructor field is private to limit who can create a new MPU
@@ -84,10 +85,16 @@ impl kernel::MPU for MPU {
         regs.control.set(0b101);
     }
 
-    fn set_mpu(&self, region_num: u32, start_addr: u32, len: u32, execute: bool, ap: u32) {
+    fn set_mpu(&self,
+               region_num: u32,
+               start_addr: u32,
+               len: u32,
+               execute: kernel::ExecutePermission,
+               access: kernel::AccessPermission) {
         let regs = unsafe { &*self.0 };
         regs.region_base_address.set(region_num | 1 << 4 | start_addr);
-        let xn = if execute { 0 } else { 1 };
+        let xn = execute as u32;
+        let ap = access as u32;
         regs.region_attributes_and_size.set(1 | len << 1 | ap << 24 | xn << 28);
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -22,7 +22,7 @@ pub use callback::{AppId, Callback};
 pub use container::Container;
 pub use driver::Driver;
 pub use mem::{AppSlice, AppPtr, Private, Shared};
-pub use platform::{Chip, MPU, Platform, SysTick};
+pub use platform::{Chip, MPU, AccessPermission, ExecutePermission, Platform, SysTick};
 pub use process::{Process, State};
 
 pub fn main<P: Platform, C: Chip>(platform: &P,

--- a/kernel/src/platform.rs
+++ b/kernel/src/platform.rs
@@ -14,6 +14,25 @@ pub trait Chip {
     fn systick(&self) -> &Self::SysTick;
 }
 
+pub enum AccessPermission {
+    //                                 Privileged  Unprivileged
+    //                                 Access      Access
+    NoAccess = 0b000, //.............. --          --
+    PrivilegedOnly = 0b001, //........ RW          --
+    UnprivilegedReadOnly = 0b010, //.. RW          R-
+    ReadWrite = 0b011, //............. RW          RW
+    Reserved = 0b100, //.............. undef       undef
+    PrivilegedOnlyReadOnly = 0b101, // R-          --
+    ReadOnly = 0b110, //.............. R-          R-
+    ReadOnlyAlais = 0b111, //......... R-          R-
+}
+
+pub enum ExecutePermission {
+    ExecutionPermitted = 0b0,
+    ExecutionNotPermitted = 0b1,
+}
+
+
 pub trait MPU {
     /// Enables MPU, allowing privileged software access to the default memory
     /// map.
@@ -29,14 +48,19 @@ pub trait MPU {
     /// `execute`   : whether to enable code execution from this region
     /// `ap`        : access permissions as defined in Table 4.47 of the user
     ///               guide.
-    fn set_mpu(&self, region_num: u32, start_addr: u32, len: u32, execute: bool, ap: u32);
+    fn set_mpu(&self,
+               region_num: u32,
+               start_addr: u32,
+               len: u32,
+               execute: ExecutePermission,
+               ap: AccessPermission);
 }
 
 /// Noop implementation of MPU trait
 impl MPU for () {
     fn enable_mpu(&self) {}
 
-    fn set_mpu(&self, _: u32, _: u32, _: u32, _: bool, _: u32) {}
+    fn set_mpu(&self, _: u32, _: u32, _: u32, _: ExecutePermission, _: AccessPermission) {}
 }
 
 pub trait SysTick {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -209,19 +209,31 @@ impl<'a> Process<'a> {
         let mgrant_size = grant_size.trailing_zeros() - 1;
 
         // Data segment read/write/execute
-        mpu.set_mpu(0, data_start as u32, data_len, true, 0b011);
+        mpu.set_mpu(0,
+                    data_start as u32,
+                    data_len,
+                    ::platform::ExecutePermission::ExecutionPermitted,
+                    ::platform::AccessPermission::ReadWrite);
         // Text segment read/execute (no write)
-        mpu.set_mpu(1, text_start as u32, text_len, true, 0b111);
+        mpu.set_mpu(1,
+                    text_start as u32,
+                    text_len,
+                    ::platform::ExecutePermission::ExecutionPermitted,
+                    ::platform::AccessPermission::ReadOnly);
 
         // Disallow access to grant region
-        mpu.set_mpu(2, grant_base as u32, mgrant_size, false, 0b001);
+        mpu.set_mpu(2,
+                    grant_base as u32,
+                    mgrant_size,
+                    ::platform::ExecutePermission::ExecutionNotPermitted,
+                    ::platform::AccessPermission::PrivilegedOnly);
 
         for (i, region) in self.mpu_regions.iter().enumerate() {
             mpu.set_mpu((i + 3) as u32,
                         region.get().0 as u32,
                         region.get().1 as u32,
-                        true,
-                        0b011);
+                        ::platform::ExecutePermission::ExecutionPermitted,
+                        ::platform::AccessPermission::ReadWrite);
         }
     }
 


### PR DESCRIPTION
@alevy I don't love this as-is [though I don't hate it either], but I couldn't puzzle out how to do what I wanted in Rust.

I want the two new enums I just added to be "part of" (?) the MPU trait. It would be sense for them to be scoped under MPU, i.e. access via `kernel::MPU::AccessPermission::ReadWrite` instead of via `platform::`, but I couldn't make that work.