### PR TITLE
Random Number Generator HIL & Implementation for SAM4L

### DIFF
--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -10,6 +10,7 @@ use kernel::common::{RingBuffer, Queue};
 use nvic;
 use spi;
 use usart;
+use trng;
 
 pub struct Sam4l {
     pub mpu: cortexm4::mpu::MPU,
@@ -119,6 +120,8 @@ impl Chip for Sam4l {
 
                     HFLASHC => flashcalw::flash_controller.handle_interrupt(),
                     ADCIFE => adc::ADC.handle_interrupt(),
+
+                    TRNG => trng::TRNG.handle_interrupt(),
                     _ => {}
                 }
                 nvic::enable(interrupt);

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -9,8 +9,8 @@ use kernel::Chip;
 use kernel::common::{RingBuffer, Queue};
 use nvic;
 use spi;
-use usart;
 use trng;
+use usart;
 
 pub struct Sam4l {
     pub mpu: cortexm4::mpu::MPU,

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -24,6 +24,7 @@ pub mod scif;
 pub mod adc;
 pub mod flashcalw;
 pub mod wdt;
+pub mod trng;
 
 unsafe extern "C" fn unhandled_interrupt() {
     let mut interrupt_number: u32;
@@ -164,7 +165,7 @@ pub static INTERRUPT_TABLE: [Option<unsafe extern fn()>; 80] = [
     /* DACC */          Option::Some(unhandled_interrupt),
     /* ACIFC */         Option::Some(unhandled_interrupt),
     /* ABDACB */        Option::Some(unhandled_interrupt),
-    /* TRNG */          Option::Some(unhandled_interrupt),
+    /* TRNG */          Option::Some(trng::trng_handler),
     /* PARC */          Option::Some(unhandled_interrupt),
     /* CATB */          Option::Some(unhandled_interrupt),
     None,

--- a/chips/sam4l/src/trng.rs
+++ b/chips/sam4l/src/trng.rs
@@ -1,0 +1,94 @@
+//! TRNG driver for the SAM4L
+
+use core::cell::Cell;
+use kernel::common::volatile_cell::VolatileCell;
+use kernel::hil::rng::{self, Continue};
+use nvic;
+use pm;
+
+#[repr(C)]
+struct Registers {
+    control: VolatileCell<u32>,
+    _reserved0: [u32; 3],
+    interrupt_enable: VolatileCell<u32>,
+    interrupt_disable: VolatileCell<u32>,
+    interrupt_mask: VolatileCell<u32>,
+    interrupt_status: VolatileCell<u32>,
+    _reserved1: [u32; 12],
+    data: VolatileCell<u32>,
+}
+
+const BASE_ADDRESS: *const Registers = 0x40068000 as *const Registers;
+
+pub struct Trng<'a> {
+    regs: *const Registers,
+    client: Cell<Option<&'a rng::Client>>,
+}
+
+pub static mut TRNG: Trng<'static> = Trng::new();
+const KEY: u32 = 0x524e4700;
+
+impl<'a> Trng<'a> {
+    const fn new() -> Trng<'a> {
+        Trng {
+            regs: BASE_ADDRESS,
+            client: Cell::new(None),
+        }
+    }
+
+    pub fn handle_interrupt(&self) {
+        let regs = unsafe { &*self.regs };
+
+        if regs.interrupt_mask.get() == 0 {
+            return;
+        }
+        regs.interrupt_disable.set(1);
+
+        self.client.get().map(|client| {
+            let result = client.randomness_available(&mut TrngIter(self));
+            if let Continue::Done = result {
+                // disable controller
+                regs.control.set(KEY | 0);
+                unsafe {
+                    pm::disable_clock(pm::Clock::PBA(pm::PBAClock::TRNG));
+                }
+            } else {
+                regs.interrupt_enable.set(1);
+            }
+        });
+    }
+
+    pub fn set_client(&self, client: &'a rng::Client) {
+        self.client.set(Some(client));
+    }
+}
+
+struct TrngIter<'a, 'b: 'a>(&'a Trng<'b>);
+
+impl<'a, 'b> Iterator for TrngIter<'a, 'b> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<u32> {
+        let regs = unsafe { &*self.0.regs };
+        if regs.interrupt_status.get() != 0 {
+            Some(regs.data.get())
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> rng::RNG for Trng<'a> {
+    fn get(&self) {
+        let regs = unsafe { &*self.regs };
+        unsafe {
+            pm::enable_clock(pm::Clock::PBA(pm::PBAClock::TRNG));
+            nvic::enable(nvic::NvicIdx::TRNG);
+        }
+
+        regs.control.set(KEY | 1);
+        regs.interrupt_enable.set(1);
+    }
+}
+
+interrupt_handler!(trng_handler, TRNG);

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -4,6 +4,7 @@ pub mod gpio;
 pub mod i2c;
 pub mod spi;
 pub mod uart;
+pub mod rng;
 pub mod adc;
 pub mod watchdog;
 

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -25,7 +25,7 @@
 //!     rng: &'a RNG,
 //!     alarm: &'a A
 //! }
-//! 
+//!
 //! impl<'a, A: Alarm> RngTest<'a, A> {
 //!     pub fn initialize(&self) {
 //!         let interval = 1 * <A::Frequency>::frequency();

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -1,15 +1,98 @@
 //! Interfaces for accessing a random number generator
+//!
+//! A random number generator produces a stream of random numbers, either from
+//! hardware or based on an initial seed. The [RNG](trait.RNG.html) trait
+//! provides a simple, implementation agnostic interface for getting new random
+//! values.
+//!
+//! The interface is designed to work well with random number generators that
+//! may not have values ready immediately. This is important when generating
+//! numbers from a low-bandwidth hardware random number generator or when the
+//! RNG is virtualized among many consumers.
+//!
+//! Random numbers are yielded to the [Client](trait.Client.html) as an
+//! `Iterator` which only terminates when no more numbers are currently
+//! available. Clients can request more randmoness if needed and will be called
+//! again when more is available.
+//!
+//! # Example
+//!
+//! The following example is a simple capsule that prints out a random number
+//! once a second using the `Alarm` and `RNG` traits.
+//!
+//! ```
+//! struct RngTest<'a, A: Alarm + 'a> {
+//!     rng: &'a RNG,
+//!     alarm: &'a A
+//! }
+//! 
+//! impl<'a, A: Alarm> RngTest<'a, A> {
+//!     pub fn initialize(&self) {
+//!         let interval = 1 * <A::Frequency>::frequency();
+//!         let tics = self.alarm.now().wrapping_add(interval);
+//!         self.alarm.set_alarm(tics);
+//!     }
+//! }
+//!
+//! impl<'a, A: Alarm> time::Client for RngTest<'a, A> {
+//!     fn fired(&self) {
+//!         self.rng.get();
+//!     }
+//! }
+//!
+//! impl<'a, A: Alarm> rng::Client for RngTest<'a, A> {
+//!     fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> rng::Continue {
+//!         match randomness.next() {
+//!             Some(random) => {
+//!                 println!("Rand {}", random);
+//!                 let interval = 1 * <A::Frequency>::frequency();
+//!                 let tics = self.alarm.now().wrapping_add(interval);
+//!                 self.alarm.set_alarm(tics);
+//!                 rng::Continue::Done
+//!             },
+//!             None => rng::Continue::More
+//!         }
+//!     }
+//! }
+//! ```
 
+
+/// Denotes whether the [Client](trait.Client.html) wants to be notified when
+/// `More` randomness is available or if they are `Done`
 #[derive(PartialEq, Eq)]
 pub enum Continue {
+    /// More randomness is required.
     More,
+    /// No more randomness required.
     Done,
 }
 
+/// Generic interface for a random number generator
+///
+/// Implementors should assume the client implements the
+/// [Client](trait.Client.html) trait.
 pub trait RNG {
+    /// Initiate the aquisition of new random number generation.
+    ///
+    /// The implementor may ignore this command if the generation proccess is
+    /// already in progress.
     fn get(&self);
 }
 
+/// An [RNG](trait.RNG.html) client
+///
+/// Clients of an [RNG](trait.RNG.html) must implement this trait.
 pub trait Client {
+    /// Called by the (RNG)[trait.RNG.html] when there are one or more random
+    /// numbers available
+    ///
+    /// `randomness` in an `Iterator` of available random numbers. The amount of
+    /// randomness available may increase if `randomness` is not consumed
+    /// quickly so clients should not rely on iterator termination to finish
+    /// consuming randomn numbers.
+    ///
+    /// The client returns either `Continue::More` if the iterator did not have
+    /// enoug random values and the client would like to be called again when
+    /// more is available, or `Continue::Done`.
     fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> Continue;
 }

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -1,0 +1,15 @@
+//! Interfaces for accessing a random number generator
+
+#[derive(PartialEq, Eq)]
+pub enum Continue {
+    More,
+    Done,
+}
+
+pub trait RNG {
+    fn get(&self);
+}
+
+pub trait Client {
+    fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> Continue;
+}


### PR DESCRIPTION
The RNG HIL uses a generator pattern to yield a stream of random numbers to the client as they become available.

The client requests randomness by calling `RNG#get`. When randomness is available, the client's `randomness_available` method is called along with an iterator over a stream of random `u32`s. When done iteraterating, the client can request more through the return value (which is either `More`, or `Done`).

This pattern balances the fact that generating new randomness might take arbitrarily long (e.g. especially in the case of a virtualized RNG) and that randomness might be available in batches, with the observation that often applications will need more than a single `u32` of randomness (e.g. to fill an 128-bit initialization vector).