### PR TITLE
Syscall: make command number 0 return >=0 if the driver exists.

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -51,13 +51,15 @@ impl<'a, A: AdcSingle + 'a> Driver for ADC<'a, A> {
 
     fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
         match command_num {
+            // TODO: This should return the number of valid ADC channels.
+            0 /* check if present */ => 0,
             // Initialize ADC
-            0 => {
+            1 => {
                 self.initialize();
                 0
             }
             // Sample on channel
-            1 => {
+            2 => {
                 self.sample(data as u8);
                 0
             }

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -134,7 +134,8 @@ impl<'a, U: UART> Driver for Console<'a, U> {
 
     fn command(&self, cmd_num: usize, arg1: usize, _: AppId) -> isize {
         match cmd_num {
-            0 /* putc */ => {
+            0 /* check if present */ => 0,
+            1 /* putc */ => {
                 self.tx_buffer.take().map(|buffer| {
                     buffer[0] = arg1 as u8;
                     self.uart.transmit(buffer, 1);

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -371,14 +371,15 @@ impl<'a> Driver for FM25CLDriver<'a> {
 
     fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
         match command_num {
+            0 /* check if present */ => 0,
             // get status
-            0 => {
+            1 => {
                 self.fm25cl.read_status();
                 0
             }
 
             // read
-            1 => {
+            2 => {
                 let address = (data & 0xFFFF) as u16;
                 let len = (data >> 16) & 0xFFFF;
 
@@ -391,7 +392,7 @@ impl<'a> Driver for FM25CLDriver<'a> {
             }
 
             // write
-            2 => {
+            3 => {
                 let address = (data & 0xFFFF) as u16;
                 let len = ((data >> 16) & 0xFFFF) as usize;
 

--- a/capsules/src/fxos8700_cq.rs
+++ b/capsules/src/fxos8700_cq.rs
@@ -122,7 +122,8 @@ impl<'a> Driver for Fxos8700cq<'a> {
 
     fn command(&self, command_num: usize, _arg1: usize, _: AppId) -> isize {
         match command_num {
-            0 => {
+            0 /* check if present */ => 0,
+            1 => {
                 // read acceleration
                 self.start_read_accel();
                 0

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -92,8 +92,11 @@ impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
     fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
         let pins = self.pins.as_ref();
         match command_num {
+            // number of pins
+            0 => pins.len() as isize,
+
             // enable output
-            0 => {
+            1 => {
                 if data >= pins.len() {
                     -1
                 } else {
@@ -103,7 +106,7 @@ impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
             }
 
             // set pin
-            1 => {
+            2 => {
                 if data >= pins.len() {
                     -1
                 } else {
@@ -113,7 +116,7 @@ impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
             }
 
             // clear pin
-            2 => {
+            3 => {
                 if data >= pins.len() {
                     -1
                 } else {
@@ -123,7 +126,7 @@ impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
             }
 
             // toggle pin
-            3 => {
+            4 => {
                 if data >= pins.len() {
                     -1
                 } else {
@@ -133,7 +136,7 @@ impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
             }
 
             // enable and configure input
-            4 => {
+            5 => {
                 // XXX: this is clunky
                 // data == ((pin_config << 8) | pin)
                 // this allows two values to be passed into a command interface
@@ -148,7 +151,7 @@ impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
             }
 
             // read input
-            5 => {
+            6 => {
                 if data >= pins.len() {
                     -1
                 } else {
@@ -159,7 +162,7 @@ impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
 
             // enable and configure interrupts on pin, also sets pin as input
             // (no affect or reliance on registered callback)
-            6 => {
+            7 => {
                 // TODO(brghena): this is clunky
                 // data == ((irq_config << 16) | (pin_config << 8) | pin)
                 // this allows three values to be passed into a command interface
@@ -179,7 +182,7 @@ impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
 
             // disable interrupts on pin, also disables pin
             // (no affect or reliance on registered callback)
-            7 => {
+            8 => {
                 if data >= pins.len() {
                     -1
                 } else {
@@ -190,7 +193,7 @@ impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
             }
 
             // disable pin
-            8 => {
+            9 => {
                 if data >= pins.len() {
                     -1
                 } else {

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -250,8 +250,9 @@ impl<'a> Driver for I2CMasterSlaveDriver<'a> {
 
     fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
         match command_num {
+            0 /* check if present */ => 0,
             // Do a write to another I2C device
-            0 => {
+            1 => {
                 let address = (data & 0xFFFF) as u8;
                 let len = (data >> 16) & 0xFFFF;
 
@@ -282,7 +283,7 @@ impl<'a> Driver for I2CMasterSlaveDriver<'a> {
             }
 
             // Do a read to another I2C device
-            1 => {
+            2 => {
                 let address = (data & 0xFFFF) as u8;
                 let len = (data >> 16) & 0xFFFF;
 
@@ -311,7 +312,7 @@ impl<'a> Driver for I2CMasterSlaveDriver<'a> {
             }
 
             // Listen for messages to this device as a slave.
-            2 => {
+            3 => {
                 // We can always handle a write since this module has a buffer.
                 // .map will handle if we have already done this.
                 self.slave_buffer1.take().map(|buffer| {
@@ -330,7 +331,7 @@ impl<'a> Driver for I2CMasterSlaveDriver<'a> {
 
             // Prepare for a read from another Master by passing what's
             // in the shared slice to the lower level I2C hardware driver.
-            3 => {
+            4 => {
                 self.app_state.map(|app_state| {
                     app_state.slave_tx_buffer.map(|app_tx| {
                         self.slave_buffer2.take().map(|kernel_tx| {
@@ -353,7 +354,7 @@ impl<'a> Driver for I2CMasterSlaveDriver<'a> {
             }
 
             // Stop listening for messages as an I2C slave
-            4 => {
+            5 => {
                 hil::i2c::I2CSlave::disable(self.i2c);
 
                 // We are no longer listening for I2C messages from a different
@@ -363,7 +364,7 @@ impl<'a> Driver for I2CMasterSlaveDriver<'a> {
             }
 
             // Setup this device's slave address.
-            5 => {
+            6 => {
                 let address = data as u8;
                 hil::i2c::I2CSlave::set_address(self.i2c, address);
                 0

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -73,7 +73,8 @@ impl<'a, A: time::Alarm + 'a> Driver for Isl29035<'a, A> {
 
     fn command(&self, command_num: usize, _arg1: usize, _: AppId) -> isize {
         match command_num {
-            0 => {
+            0 /* check if present */ => 0,
+            1 => {
                 self.start_read_lux();
                 0
             }

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -209,8 +209,9 @@ impl<'a> Driver for LPS25HB<'a> {
 
     fn command(&self, command_num: usize, _: usize, _: AppId) -> isize {
         match command_num {
+            0 /* check if present */ => 0,
             // Take a pressure measurement
-            0 => {
+            1 => {
                 self.take_measurement();
 
                 0

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -151,7 +151,8 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
     fn command(&self, command_type: usize, _: usize, _: AppId) -> isize {
 
         match command_type {
-            0 => {
+            0 /* check if present */ => 0,
+            1 => {
                 // On a TX, send the first byte of the TX buffer.
                 // TODO(bradjc): Need to match this to the correct app!
                 //               Can't just use 0!

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -193,8 +193,9 @@ impl<'a, A: time::Alarm + 'a> Driver for SI7021<'a, A> {
 
     fn command(&self, command_num: usize, _: usize, _: AppId) -> isize {
         match command_num {
+            0 /* check if present */ => 0,
             // Take a pressure measurement
-            0 => {
+            1 => {
                 self.take_measurement();
                 0
             }

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -189,10 +189,11 @@ impl<'a, S: SpiMaster> Driver for Spi<'a, S> {
 
     fn command(&self, cmd_num: usize, arg1: usize, _: AppId) -> isize {
         match cmd_num {
-            0 /* read_write_byte */ => {
+            0 /* check if present */ => 0,
+            1 /* read_write_byte */ => {
                 self.spi_master.read_write_byte(arg1 as u8) as isize
             },
-            1 /* read_write_bytes */ => {
+            2 /* read_write_bytes */ => {
                 if self.busy.get() {
                     return -1;
                 }
@@ -216,47 +217,47 @@ impl<'a, S: SpiMaster> Driver for Spi<'a, S> {
                 });
                 return result;
             }
-            2 /* set chip select */ => {
+            3 /* set chip select */ => {
                 let cs = arg1;
                 self.chip_selects.get(cs).map_or(-1, |cs_line| {
                     self.spi_master.specify_chip_select(*cs_line);
                     0
                 })
             }
-            3 /* get chip select */ => {
+            4 /* get chip select */ => {
                 0
             }
-            4 /* set baud rate */ => {
+            5 /* set baud rate */ => {
                 self.spi_master.set_rate(arg1 as u32) as isize
             }
-            5 /* get baud rate */ => {
+            6 /* get baud rate */ => {
                 self.spi_master.get_rate() as isize
             }
-            6 /* set phase */ => {
+            7 /* set phase */ => {
                 match arg1 {
                     0 => self.spi_master.set_phase(ClockPhase::SampleLeading),
                     _ => self.spi_master.set_phase(ClockPhase::SampleTrailing),
                 };
                 0
             }
-            7 /* get phase */ => {
+            8 /* get phase */ => {
                 self.spi_master.get_phase() as isize
             }
-            8 /* set polarity */ => {
+            9 /* set polarity */ => {
                 match arg1 {
                     0 => self.spi_master.set_clock(ClockPolarity::IdleLow),
                     _ => self.spi_master.set_clock(ClockPolarity::IdleHigh),
                 };
                 0
             }
-            9 /* get polarity */ => {
+            10 /* get polarity */ => {
                 self.spi_master.get_clock() as isize
             }
-            10 /* hold low */ => {
+            11 /* hold low */ => {
                 self.spi_master.hold_low();
                 0
             }
-            11 /* release low */ => {
+            12 /* release low */ => {
                 self.spi_master.release_low();
                 0
             }

--- a/capsules/src/timer.rs
+++ b/capsules/src/timer.rs
@@ -81,11 +81,11 @@ impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
         let (err_code, reset) = self.app_timer
             .enter(caller_id, |td, _alloc| {
                 match cmd_type {
-                3 /* capture time */ => {
-		    let curr_time: u32 = self.alarm.now();
-		    (curr_time as isize, true)
+                4 /* capture time */ => {
+                    let curr_time: u32 = self.alarm.now();
+                    (curr_time as isize, true)
                 },
-                2 /* Stop */ => {
+                3 /* Stop */ => {
                     if td.interval > 0 {
                         td.interval = 0;
                         td.t0 = 0;
@@ -101,8 +101,8 @@ impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
                         (-2, false)
                     }
                 },
-                /* 0 for Oneshot, 1 for Repeat */
-                cmd_type if cmd_type <= 1 => {
+                /* 1 for Oneshot, 2 for Repeat */
+                cmd_type if cmd_type <= 2 && cmd_type > 0 => {
                     if interval == 0 {
                         return (-2, false);
                     }
@@ -115,8 +115,8 @@ impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
                     td.t0 = self.alarm.now();
                     td.interval = interval;
 
-                    // Repeat if cmd_type was 1
-                    td.repeating = cmd_type == 1;
+                    // Repeat if cmd_type was 2
+                    td.repeating = cmd_type == 2;
                     if self.alarm.is_armed() {
                         (0, true)
                     } else {
@@ -124,6 +124,7 @@ impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
                         (0, false)
                     }
                 },
+                0 /* check if present */ => (0, false),
                 _ => (-1, false)
             }
             })

--- a/capsules/src/tmp006.rs
+++ b/capsules/src/tmp006.rs
@@ -295,8 +295,9 @@ impl<'a> Driver for TMP006<'a> {
 
     fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
         match command_num {
+            0 /* check if present */ => 0,
             // set period for sensing
-            0 => {
+            1 => {
                 // bounds check on the period
                 if (data & 0xFFFFFFF8) != 0 {
                     return ERR_BAD_VALUE;
@@ -309,7 +310,7 @@ impl<'a> Driver for TMP006<'a> {
             }
 
             // unsubscribe callback
-            1 => {
+            2 => {
                 // clear callback function
                 self.callback.set(None);
 

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -439,8 +439,9 @@ impl<'a> Driver for TSL2561<'a> {
 
     fn command(&self, command_num: usize, _: usize, _: AppId) -> isize {
         match command_num {
-            // Take a pressure measurement
-            0 => {
+            0 /* check if present */ => 0,
+            // Take a measurement
+            1 => {
                 self.take_measurement();
                 0
             }

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -39,6 +39,27 @@ version uploaded, all without modifying the kernel running on a platform.
 
 ### Command
 
+The `command` syscall instructs the driver to perform a specific action.
+`command` syscsalls take two arguments: the command number and a 32 bit
+argument. The command number tells the driver which command was called from
+userspace, and the argument is driver and command number specific. One example
+of the argument being used is in the `led` driver, where the command to turn
+an LED on uses the argument to select which LED.
+
+Each `command` syscall returns a `int32_t` type. This is commonly used as an
+error code (where a negative value indicates an error), but is also used to
+return synchronous data. For example, in the `gpio` driver, the command for
+reading the value of a pin returns 0 or 1 based on the status of the pin.
+
+One Tock convention with the `command` syscall is that command number 0 will always
+return a value of 0 or greater if the driver is supported by the running kernel.
+This means that any application can call command number 0 on any driver number
+to determine if the driver is present and the related functionality is supported.
+In most cases this command number will return 0, indicating that the driver
+is present. In other cases, however, the return value can have an additional
+meaning such as the number of devices present, as is the case in the `led` driver
+to indicate how many LEDs are present on the board.
+
 ### Subscribe
 
 ### Allow

--- a/doc/Userland.md
+++ b/doc/Userland.md
@@ -47,7 +47,7 @@ from [gpio.c](../userland/libtock/gpio.c):
 
 ```c
 int gpio_set(GPIO_Pin_t pin) {
-  return command(GPIO_DRIVER_NUM, 1, pin);
+  return command(GPIO_DRIVER_NUM, 2, pin);
 }
 ```
 
@@ -91,7 +91,7 @@ return from execution (for example, an application that returns from `main`).
 
 ## Libraries
 Application code does not need to stand alone, libraries are available that can
-be utilized! 
+be utilized!
 
 
 ### Newlib

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -8,7 +8,7 @@
 //! by the scheduler, while three others are passed along to drivers:
 //!
 //!   * `subscribe` lets an application pass a callback to the driver to be
-//!   called later, when an event has occured or data of interest is available.
+//!   called later, when an event has occurred or data of interest is available.
 //!
 //!   * `command` tells the driver to do something immediately.
 //!
@@ -25,10 +25,18 @@
 //! determined by a particular platform, while the _driver minor number_ is
 //! driver-specific.
 //!
+//! One convention in Tock is that _driver minor number_ 0 for the `command`
+//! syscall can always be used to determine if the driver is supported by
+//! the running kernel by checking the return code. If the return value is
+//! greater than or equal to zero then the driver is present. Typically this is
+//! implemented by a null command that only returns 0, but in some cases the
+//! command can also return more information, like the number of supported
+//! devices (useful for things like the number of LEDs).
+//!
 //! # The `yield` System-call
 //!
-//! While drivers to handle the `yield` system call, it's important to understand
-//! it's function and it interacts with `subscribe`.
+//! While drivers do not handle the `yield` system call, it is important to
+//! understand its function and how it interacts with `subscribe`.
 
 /// `Driver`s implement the three driver-specific system calls: `subscribe`,
 /// `command` and `allow`.
@@ -73,6 +81,11 @@ pub trait Driver {
     /// Commands should not execute long running tasks synchronously. However,
     /// commands might "kick-off" asynchronous tasks in coordination with a
     /// `subscribe` call.
+    ///
+    /// All drivers must support the command with `minor_num` 0, and return 0
+    /// or greater if the driver is supported. This command should not have any
+    /// side effects. This convention ensures that applications can query the
+    /// kernel for supported drivers on a given platform.
     #[allow(unused_variables)]
     fn command(&self, minor_num: usize, r2: usize, caller_id: ::AppId) -> isize {
         -1

--- a/userland/examples/sensors/main.c
+++ b/userland/examples/sensors/main.c
@@ -1,44 +1,68 @@
 #include <stdio.h>
 #include <stdbool.h>
 
+#include <tock.h>
 #include <timer.h>
 #include <isl29035.h>
 #include <tmp006.h>
+#include <tsl2561.h>
+#include <lps25hb.h>
+#include <si7021.h>
+#include <FXOS8700CQ.h>
 
-void print_intensity(int intensity) {
-  printf("Intensity: %d\n", intensity);
-}
-
-void intensity_cb(int intensity,
-                  __attribute__ ((unused)) int unused1,
-                  __attribute__ ((unused)) int unused2,
-                  __attribute__ ((unused)) void* ud) {
-  print_intensity(intensity);
-}
-
-void temp_callback(int temp_value,
-                   int err,
-                   __attribute__ ((unused)) int unused,
-                   __attribute__ ((unused)) void* ud) {
-  printf("Current Temp (%d) [0x%X]\n", temp_value, err);
-}
+static bool isl29035 = false;
+static bool tmp006 = false;
+static bool tsl2561 = false;
+static bool lps25hb = false;
+static bool si7021 = false;
+static bool fxos8700cq = false;
 
 void timer_fired(__attribute__ ((unused)) int arg0,
                  __attribute__ ((unused)) int arg1,
                  __attribute__ ((unused)) int arg2,
                  __attribute__ ((unused)) void* ud) {
-  isl29035_start_intensity_reading();
+  int light;
+  int16_t tmp006_temp;
+  int tsl2561_lux;
+  int lps25hb_pressure;
+  int si7021_temp, si7021_humi;
+  int fxos8700cq_x, fxos8700cq_y, fxos8700cq_z;
+
+  if (isl29035)   light = isl29035_read_light_intensity();
+  if (tmp006)     tmp006_read_sync(&tmp006_temp);
+  if (tsl2561)    tsl2561_lux = tsl2561_get_lux_sync();
+  if (lps25hb)    lps25hb_pressure = lps25hb_get_pressure_sync();
+  if (si7021)     si7021_get_temperature_humidity_sync(&si7021_temp, &si7021_humi);
+  if (fxos8700cq) FXOS8700CQ_read_acceleration_sync(&fxos8700cq_x, &fxos8700cq_y, &fxos8700cq_z);
+
+
+  if (isl29035)   printf("ISL29035:   Light Intensity: %d\n", light);
+  if (tmp006)     printf("TMP006:     Temperature:     %d\n", tmp006_temp);
+  if (tsl2561)    printf("TSL2561:    Light:           %d lux\n", tsl2561_lux);
+  if (lps25hb)    printf("LPS25HB:    Pressure:        %d\n", lps25hb_pressure);
+  if (si7021)     printf("SI7021:     Temperature:     %d deg C\n", si7021_temp/100);
+  if (si7021)     printf("SI7021:     Humidity:        %d%%\n", si7021_humi/100);
+  if (fxos8700cq) printf("FXOS8700CQ: X:               %d\n", fxos8700cq_x);
+  if (fxos8700cq) printf("FXOS8700CQ: Y:               %d\n", fxos8700cq_y);
+  if (fxos8700cq) printf("FXOS8700CQ: Z:               %d\n", fxos8700cq_z);
+
+  printf("\n");
 }
 
 int main() {
-  printf("Hello\n");
+  printf("[Sensors] Starting Sensors App.\n");
+  printf("[Sensors] All available sensors on the platform will be sampled.\n");
 
-  isl29035_subscribe(intensity_cb, NULL);
-  // Setup periodic timer
+  isl29035 = driver_exists(DRIVER_NUM_ISL29035);
+  tmp006 = driver_exists(DRIVER_NUM_TMP006);
+  tsl2561 = driver_exists(DRIVER_NUM_TSL2561);
+  lps25hb = driver_exists(DRIVER_NUM_LPS25HB);
+  si7021 = driver_exists(DRIVER_NUM_SI7021);
+  fxos8700cq = driver_exists(DRIVER_NUM_FXO);
+
+  // Setup periodic timer to sample the sensors.
   timer_subscribe(timer_fired, NULL);
   timer_start_repeating(1000);
-
-  //tmp006_start_sampling(0x2, temp_callback, NULL);
 
   return 0;
 }

--- a/userland/libtock/FXOS8700CQ.c
+++ b/userland/libtock/FXOS8700CQ.c
@@ -44,7 +44,7 @@ int FXOS8700CQ_subscribe(subscribe_cb callback, void* userdata) {
 }
 
 int FXOS8700CQ_start_accel_reading() {
-  return command(11, 0, 0);
+  return command(11, 1, 0);
 }
 
 int FXOS8700CQ_read_acceleration_sync(int* x, int* y, int* z) {

--- a/userland/libtock/adc.c
+++ b/userland/libtock/adc.c
@@ -25,11 +25,11 @@ int adc_set_callback(subscribe_cb callback, void* callback_args) {
 }
 
 int adc_initialize() {
-    return command(DRIVER_NUM_ADC, 0, 0);
+    return command(DRIVER_NUM_ADC, 1, 0);
 }
 
 int adc_single_sample(uint8_t channel) {
-    return command(DRIVER_NUM_ADC, 1, channel);
+    return command(DRIVER_NUM_ADC, 2, channel);
 }
 
 int adc_read_single_sample(uint8_t channel) {

--- a/userland/libtock/gpio.c
+++ b/userland/libtock/gpio.c
@@ -1,42 +1,42 @@
 #include "gpio.h"
 
 int gpio_enable_output(GPIO_Pin_t pin) {
-  return command(GPIO_DRIVER_NUM, 0, pin);
-}
-
-int gpio_set(GPIO_Pin_t pin) {
   return command(GPIO_DRIVER_NUM, 1, pin);
 }
 
-int gpio_clear(GPIO_Pin_t pin) {
+int gpio_set(GPIO_Pin_t pin) {
   return command(GPIO_DRIVER_NUM, 2, pin);
 }
 
-int gpio_toggle(GPIO_Pin_t pin) {
+int gpio_clear(GPIO_Pin_t pin) {
   return command(GPIO_DRIVER_NUM, 3, pin);
+}
+
+int gpio_toggle(GPIO_Pin_t pin) {
+  return command(GPIO_DRIVER_NUM, 4, pin);
 }
 
 int gpio_enable_input(GPIO_Pin_t pin, GPIO_InputMode_t pin_config) {
   uint32_t data = ((pin_config & 0xFF) << 8) | (pin & 0xFF);
-  return command(GPIO_DRIVER_NUM, 4, data);
+  return command(GPIO_DRIVER_NUM, 5, data);
 }
 
 int gpio_read(GPIO_Pin_t pin) {
-  return command(GPIO_DRIVER_NUM, 5, pin);
+  return command(GPIO_DRIVER_NUM, 6, pin);
 }
 
 int gpio_enable_interrupt(GPIO_Pin_t pin, GPIO_InputMode_t pin_config,
     GPIO_InterruptMode_t irq_config) {
   uint32_t data = ((irq_config & 0xFF) << 16) | ((pin_config & 0xFF) << 8) | (pin & 0xFF);
-  return command(GPIO_DRIVER_NUM, 6, data);
+  return command(GPIO_DRIVER_NUM, 7, data);
 }
 
 int gpio_disable_interrupt(GPIO_Pin_t pin) {
-  return command(GPIO_DRIVER_NUM, 7, pin);
+  return command(GPIO_DRIVER_NUM, 8, pin);
 }
 
 int gpio_disable(GPIO_Pin_t pin) {
-  return command(GPIO_DRIVER_NUM, 8, pin);
+  return command(GPIO_DRIVER_NUM, 9, pin);
 }
 
 int gpio_interrupt_callback(subscribe_cb callback, void* callback_args) {

--- a/userland/libtock/i2c_master_slave.c
+++ b/userland/libtock/i2c_master_slave.c
@@ -43,20 +43,20 @@ int i2c_master_slave_set_slave_write_buffer(uint8_t* buffer, uint32_t len) {
 
 int i2c_master_slave_write(uint8_t address, uint8_t length) {
   uint32_t a = (((uint32_t) length) << 16) | address;
-  return command(DRIVER_NUM_I2CMASTERSLAVE, 0, a);
+  return command(DRIVER_NUM_I2CMASTERSLAVE, 1, a);
 }
 
 int i2c_master_slave_read(uint16_t address, uint16_t len) {
   uint32_t a = (((uint32_t) len) << 16) | address;
-  return command(DRIVER_NUM_I2CMASTERSLAVE, 1, a);
+  return command(DRIVER_NUM_I2CMASTERSLAVE, 2, a);
 }
 
 int i2c_master_slave_listen() {
-  return command(DRIVER_NUM_I2CMASTERSLAVE, 2, 0);
+  return command(DRIVER_NUM_I2CMASTERSLAVE, 3, 0);
 }
 
 int i2c_master_slave_set_slave_address(uint8_t address) {
-  return command(DRIVER_NUM_I2CMASTERSLAVE, 5, address);
+  return command(DRIVER_NUM_I2CMASTERSLAVE, 6, address);
 }
 
 

--- a/userland/libtock/isl29035.c
+++ b/userland/libtock/isl29035.c
@@ -34,10 +34,10 @@ int isl29035_read_light_intensity() {
 }
 
 int isl29035_subscribe(subscribe_cb callback, void* userdata) {
-  return subscribe(6, 0, callback, userdata);
+  return subscribe(DRIVER_NUM_ISL29035, 0, callback, userdata);
 }
 
 int isl29035_start_intensity_reading() {
-  return command(6, 0, 0);
+  return command(DRIVER_NUM_ISL29035, 1, 0);
 }
 

--- a/userland/libtock/isl29035.h
+++ b/userland/libtock/isl29035.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+#define DRIVER_NUM_ISL29035 6
+
 int isl29035_subscribe(subscribe_cb callback, void* userdata);
 int isl29035_start_intensity_reading();
 

--- a/userland/libtock/lps25hb.c
+++ b/userland/libtock/lps25hb.c
@@ -23,7 +23,7 @@ int lps25hb_set_callback (subscribe_cb callback, void* callback_args) {
 }
 
 int lps25hb_get_pressure () {
-    return command(DRIVER_NUM_LPS25HB, 0, 0);
+    return command(DRIVER_NUM_LPS25HB, 1, 0);
 }
 
 int lps25hb_get_pressure_sync () {

--- a/userland/libtock/nrf51_serialization.c
+++ b/userland/libtock/nrf51_serialization.c
@@ -15,7 +15,7 @@ void nrf51_serialization_write (char* tx, int tx_len) {
   allow(5, 1, tx, tx_len);
 
   // Do the write!!!!!
-  command(5, 0, 0);
+  command(5, 1, 0);
 }
 
 void nrf51_wakeup (void) {

--- a/userland/libtock/si7021.c
+++ b/userland/libtock/si7021.c
@@ -25,7 +25,7 @@ int si7021_set_callback (subscribe_cb callback, void* callback_args) {
 }
 
 int si7021_get_temperature_humidity () {
-    return command(DRIVER_NUM_SI7021, 0, 0);
+    return command(DRIVER_NUM_SI7021, 1, 0);
 }
 
 int si7021_get_temperature_humidity_sync (int* temperature, int* humidity) {

--- a/userland/libtock/spi.c
+++ b/userland/libtock/spi.c
@@ -1,19 +1,19 @@
 #include "spi.h"
 
 int spi_init() {return 0;}
-int spi_set_chip_select(unsigned char cs) {return command(4, 2, cs);}
-int spi_get_chip_select()                 {return command(4, 3, 0);}
-int spi_set_rate(int rate)                {return command(4, 4, rate);}
-int spi_get_rate()                        {return command(4, 5, 0);}
-int spi_set_phase(bool phase)             {return command(4, 6, (unsigned char)phase);}
-int spi_get_phase()                       {return command(4, 7, 0);}
-int spi_set_polarity(bool pol)            {return command(4, 8, (unsigned char)pol);}
-int spi_get_polarity()                    {return command(4, 9, 0);}
-int spi_hold_low()                        {return command(4, 10, 0);}
-int spi_release_low()                     {return command(4, 11, 0);}
+int spi_set_chip_select(unsigned char cs) {return command(4, 3, cs);}
+int spi_get_chip_select()                 {return command(4, 4, 0);}
+int spi_set_rate(int rate)                {return command(4, 5, rate);}
+int spi_get_rate()                        {return command(4, 6, 0);}
+int spi_set_phase(bool phase)             {return command(4, 7, (unsigned char)phase);}
+int spi_get_phase()                       {return command(4, 8, 0);}
+int spi_set_polarity(bool pol)            {return command(4, 9, (unsigned char)pol);}
+int spi_get_polarity()                    {return command(4, 10, 0);}
+int spi_hold_low()                        {return command(4, 11, 0);}
+int spi_release_low()                     {return command(4, 12, 0);}
 
 int spi_write_byte(unsigned char byte) {
-  return command(4, 0, byte);
+  return command(4, 1, byte);
 }
 
 int spi_read_buf(const char* str, size_t len) {
@@ -35,11 +35,11 @@ int spi_write(const char* str,
   if (err < 0 ) {
     return err;
   }
-  err = subscribe(4, 0, cb, cond);
+  err = subscribe(4, 1, cb, cond);
   if (err < 0 ) {
     return err;
   }
-  return command(4, 1, len);
+  return command(4, 2, len);
 }
 
 int spi_read_write(const char* write,

--- a/userland/libtock/timer.c
+++ b/userland/libtock/timer.c
@@ -19,17 +19,17 @@ int timer_subscribe(subscribe_cb cb, void *userdata) {
 }
 
 int timer_oneshot(uint32_t interval_ms) {
-  return command(3, 0, (int)interval_ms);
-}
-
-int timer_start_repeating(uint32_t interval_ms) {
   return command(3, 1, (int)interval_ms);
 }
 
+int timer_start_repeating(uint32_t interval_ms) {
+  return command(3, 2, (int)interval_ms);
+}
+
 int timer_stop() {
-  return command(3, 2, 0);
+  return command(3, 3, 0);
 }
 
 unsigned int timer_read() {
-  return (unsigned int) command(3, 3, 0);
+  return (unsigned int) command(3, 4, 0);
 }

--- a/userland/libtock/tmp006.c
+++ b/userland/libtock/tmp006.c
@@ -22,7 +22,7 @@ int tmp006_read_sync(int16_t* temp_reading) {
     int32_t callback_vals[2] = {0};
 
     // request a single sample
-    uint32_t err_code = subscribe(2, 0, tmp006_cb, callback_vals);
+    uint32_t err_code = subscribe(DRIVER_NUM_TMP006, 0, tmp006_cb, callback_vals);
     if (err_code != ERR_NONE) {
         return err_code;
     }
@@ -43,26 +43,26 @@ int tmp006_read_async(subscribe_cb callback, void* callback_args) {
 
     // subscribe to a single temp value callback
     //  also enables the temperature sensor for the duration of one sample
-    return subscribe(2, 0, callback, callback_args);
+    return subscribe(DRIVER_NUM_TMP006, 0, callback, callback_args);
 }
 
 // enable TMP006, configure periodic sampling with interrupts, callback with value on interrupt
 int tmp006_start_sampling(uint8_t period, subscribe_cb callback, void* callback_args) {
     // set period for periodic temp readings
-    uint32_t err_code = command(2, 0, period);
+    uint32_t err_code = command(DRIVER_NUM_TMP006, 1, period);
     if (err_code != ERR_NONE) {
         return err_code;
     }
 
     // subscribe to periodic temp value callbacks
     //  also enables the temperature sensor
-    return subscribe(2, 1, callback, callback_args);
+    return subscribe(DRIVER_NUM_TMP006, 1, callback, callback_args);
 }
 
 // disable TMP006
 int tmp006_stop_sampling(void) {
     // unsubscribe from periodic temp value callbacks
     //  also disables the temperature sensor
-    return command(2, 1, 0);
+    return command(DRIVER_NUM_TMP006, 2, 0);
 }
 

--- a/userland/libtock/tmp006.h
+++ b/userland/libtock/tmp006.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 
 #define ERR_NONE 0
+#define DRIVER_NUM_TMP006 2
 
 int tmp006_read_sync(int16_t* temp_reading);
 int tmp006_read_async(subscribe_cb callback, void* callback_args);

--- a/userland/libtock/tock.c
+++ b/userland/libtock/tock.c
@@ -1,6 +1,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <stdbool.h>
 #include "tock.h"
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -35,3 +36,7 @@ int __attribute__((naked)) memop(uint32_t op_type, int arg1) {
   asm volatile("svc 4\nbx lr" ::: "memory", "r0");
 }
 
+bool driver_exists(uint32_t driver) {
+  int ret = command(driver, 0, 0);
+  return ret >= 0;
+}

--- a/userland/libtock/tock.h
+++ b/userland/libtock/tock.h
@@ -23,6 +23,8 @@ int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size);
 // 1: sbrk, arg1 is increment to increase/decrease memory break
 int memop(uint32_t op_type, int arg1);
 
+// Checks to see if the given driver number exists on this platform.
+bool driver_exists(uint32_t driver);
 
 #ifdef __cplusplus
 }

--- a/userland/libtock/tsl2561.c
+++ b/userland/libtock/tsl2561.c
@@ -23,7 +23,7 @@ int tsl2561_set_callback (subscribe_cb callback, void* callback_args) {
 }
 
 int tsl2561_get_lux () {
-    return command(DRIVER_NUM_TSL2561, 0, 0);
+    return command(DRIVER_NUM_TSL2561, 1, 0);
 }
 
 int tsl2561_get_lux_sync () {


### PR DESCRIPTION
- Renumber commands so that number 0 can be used to check if a driver exists. This helps applications be portable and adapt to the board they are on.
- Update the sensors app to sample all sensors with a driver in libtock, but use the new command 0 to check to see if that driver exists first. In theory, the sensors app can run on any piece of hardware tock supports. I've only tested Hail.
- Add a paragraph to the documentation explaining the convention.
- Add a function to tock.c that wraps command number 0 and checks the return code.