### PR TITLE
Add magnetometer read to FXOS8700CQ

### DIFF
--- a/capsules/src/fxos8700_cq.rs
+++ b/capsules/src/fxos8700_cq.rs
@@ -12,34 +12,145 @@ pub static mut BUF: [u8; 6] = [0; 6];
 
 #[allow(dead_code)]
 enum Registers {
-    SensorStatus = 0x00,
-    OutXMSB = 0x01,
-    OutXLSB = 0x02,
-    OutYMSB = 0x03,
-    OutYLSB = 0x04,
-    OutZMSB = 0x05,
-    OutZLSB = 0x06,
-    XyzDataCfg = 0x0E,
-    WhoAmI = 0x0D,
-    CtrlReg1 = 0x2A,
+    Status = 0x00,
+    OutXMsb = 0x01,
+    OutXLsb = 0x02,
+    OutYMsb = 0x03,
+    OutYLsb = 0x04,
+    OutZMsb = 0x05,
+    OutZLsb = 0x06,
+    FSetup = 0x09,
+    TrigCfg = 0x0a,
+    Sysmod = 0x0b,
+    IntSource = 0x0c,
+    WhoAmI = 0x0d,
+    XyzDataCfg = 0x0e,
+    HpFilterCutoff = 0x0f,
+    PlStatus = 0x10,
+    PlCfg = 0x11,
+    PlCount = 0x12,
+    PlBfZcomp = 0x13,
+    PlThsReg = 0x14,
+    AFfmtCfg = 0x15,
+    AFfmtSrc = 0x16,
+    AFfmtThs = 0x17,
+    AFfmtCount = 0x18,
+    TransientCfg = 0x1d,
+    TransientSrc = 0x1e,
+    TransientThs = 0x1f,
+    TransientCount = 0x20,
+    PulseCfg = 0x21,
+    PulseSrc = 0x22,
+    PulseThsx = 0x23,
+    PulseThsy = 0x24,
+    PulseThsz = 0x25,
+    PulseTmlt = 0x26,
+    PulseLtcy = 0x27,
+    PulseWind = 0x28,
+    AslpCount = 0x29,
+    CtrlReg1 = 0x2a,
+    CtrlReg2 = 0x2b,
+    CtrlReg3 = 0x2c,
+    CtrlReg4 = 0x2d,
+    CtrlReg5 = 0x2e,
+    OffX = 0x2f,
+    OffY = 0x30,
+    OffZ = 0x31,
+    MDrStatus = 0x32,
+    MOutXMsb = 0x33,
+    MOutXLsb = 0x34,
+    MOutYMsb = 0x35,
+    MOutYLsb = 0x36,
+    MOutZMsb = 0x37,
+    MOutZLsb = 0x38,
+    CmpXMsb = 0x39,
+    CmpXLsb = 0x3a,
+    CmpYMsb = 0x3b,
+    CmpYLsb = 0x3c,
+    CmpZMsb = 0x3d,
+    CmpZLsb = 0x3e,
+    MOffXMsb = 0x3f,
+    MOffXLsb = 0x40,
+    MOffYMsb = 0x41,
+    MOffYLsb = 0x42,
+    MOffZMsb = 0x43,
+    MOffZLsb = 0x44,
+    MaxXMsb = 0x45,
+    MaxXLsb = 0x46,
+    MaxYMsb = 0x47,
+    MaxYLsb = 0x48,
+    MaxZMsb = 0x49,
+    MaxZLsb = 0x4a,
+    MinXMsb = 0x4b,
+    MinXLsb = 0x4c,
+    MinYMsb = 0x4d,
+    MinYLsb = 0x4e,
+    MinZMsb = 0x4f,
+    MinZLsb = 0x50,
+    Temp = 0x51,
+    MThsCfg = 0x52,
+    MThsSrc = 0x53,
+    MThsXMsb = 0x54,
+    MThsXLsb = 0x55,
+    MThsYMsb = 0x56,
+    MThsYLsb = 0x57,
+    MThsZMsb = 0x58,
+    MThsZLsb = 0x59,
+    MThsCount = 0x5a,
+    MCtrlReg1 = 0x5b,
+    MCtrlReg2 = 0x5c,
+    MCtrlReg3 = 0x5d,
+    MIntSrc = 0x5e,
+    AVecmCfg = 0x5f,
+    AVecmThsMsb = 0x60,
+    AVecmThsLsb = 0x61,
+    AVecmCnt = 0x62,
+    AVecmInitxMsb = 0x63,
+    AVecmInitxLsb = 0x64,
+    AVecmInityMsb = 0x65,
+    AVecmInityLsb = 0x66,
+    AVecmInitzMsb = 0x67,
+    AVecmInitzLsb = 0x68,
+    MVecmCfg = 0x69,
+    MVecmThsMsb = 0x6a,
+    MVecmThsLsb = 0x6b,
+    MVecmCnt = 0x6c,
+    MVecmInitxMsb = 0x6d,
+    MVecmInitxLsb = 0x6e,
+    MVecmInityMsb = 0x6f,
+    MVecmInityLsb = 0x70,
+    MVecmInitzMsb = 0x71,
+    MVecmInitzLsb = 0x72,
+    AFfmtThsXMsb = 0x73,
+    AFfmtThsXLsb = 0x74,
+    AFfmtThsYMsb = 0x75,
+    AFfmtThsYLsb = 0x76,
+    AFfmtThsZMsb = 0x77,
+    AFfmtThsZLsb = 0x78,
 }
 
 #[derive(Clone,Copy,PartialEq)]
 enum State {
-    /// Sensor does not take acceleration readings
+    /// Sensor is in standby mode
     Disabled,
 
     /// Verifying that sensor is present
-    Enabling,
+    ReadAccelEnabling,
 
     /// Activate sensor to take readings
-    Activating,
+    ReadAccelActivating,
 
     /// Reading accelerometer data
-    ReadingAcceleration,
+    ReadAccelReading,
 
     /// Deactivate sensor
-    Deactivating(i16, i16, i16),
+    ReadAccelDeactivating(i16, i16, i16),
+
+    /// Configuring reading the magnetometer
+    ReadMagStart,
+
+    /// Have the magnetometer values and sending them to application
+    ReadMagValues,
 }
 
 pub struct Fxos8700cq<'a> {
@@ -53,7 +164,7 @@ impl<'a> Fxos8700cq<'a> {
     pub fn new(i2c: &'a I2CDevice, buffer: &'static mut [u8]) -> Fxos8700cq<'a> {
         Fxos8700cq {
             i2c: i2c,
-            state: Cell::new(State::Enabling),
+            state: Cell::new(State::Disabled),
             buffer: TakeCell::new(buffer),
             callback: Cell::new(None),
         }
@@ -64,7 +175,18 @@ impl<'a> Fxos8700cq<'a> {
             self.i2c.enable();
             buf[0] = Registers::WhoAmI as u8;
             self.i2c.write_read(buf, 1, 1);
-            self.state.set(State::Enabling);
+            self.state.set(State::ReadAccelEnabling);
+        });
+    }
+
+    fn start_read_magnetometer(&self) {
+        self.buffer.take().map(|buf| {
+            self.i2c.enable();
+            // Configure the magnetometer.
+            buf[0] = Registers::MCtrlReg1 as u8;
+            buf[1] = 0b00100001; // Enable magnetometer and one-shot read.
+            self.i2c.write(buf, 2);
+            self.state.set(State::ReadMagStart);
         });
     }
 }
@@ -72,21 +194,18 @@ impl<'a> Fxos8700cq<'a> {
 impl<'a> I2CClient for Fxos8700cq<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: Error) {
         match self.state.get() {
-            State::Disabled => {
-                // self.i2c.disable();
-            }
-            State::Enabling => {
+            State::ReadAccelEnabling => {
                 buffer[0] = Registers::CtrlReg1 as u8; // CTRL_REG1
                 buffer[1] = 1; // active
                 self.i2c.write(buffer, 2);
-                self.state.set(State::Activating);
+                self.state.set(State::ReadAccelActivating);
             }
-            State::Activating => {
-                buffer[0] = Registers::OutXMSB as u8;
+            State::ReadAccelActivating => {
+                buffer[0] = Registers::OutXMsb as u8;
                 self.i2c.write_read(buffer, 1, 6); // read 6 accel registers for xyz
-                self.state.set(State::ReadingAcceleration);
+                self.state.set(State::ReadAccelReading);
             }
-            State::ReadingAcceleration => {
+            State::ReadAccelReading => {
                 let x = (((buffer[0] as i16) << 8) | buffer[1] as i16) >> 2;
                 let y = (((buffer[2] as i16) << 8) | buffer[3] as i16) >> 2;
                 let z = (((buffer[4] as i16) << 8) | buffer[5] as i16) >> 2;
@@ -97,14 +216,34 @@ impl<'a> I2CClient for Fxos8700cq<'a> {
 
                 buffer[0] = 0;
                 self.i2c.write(buffer, 2);
-                self.state.set(State::Deactivating(x as i16, y as i16, z as i16));
+                self.state.set(State::ReadAccelDeactivating(x as i16, y as i16, z as i16));
             }
-            State::Deactivating(x, y, z) => {
+            State::ReadAccelDeactivating(x, y, z) => {
                 self.i2c.disable();
                 self.state.set(State::Disabled);
                 self.buffer.replace(buffer);
                 self.callback.get().map(|mut cb| cb.schedule(x as usize, y as usize, z as usize));
             }
+            State::ReadMagStart => {
+                // One shot measurement taken, now read result.
+                buffer[0] = Registers::MOutXMsb as u8;
+                self.state.set(State::ReadMagValues);
+                self.i2c.write_read(buffer, 1, 6);
+            }
+            State::ReadMagValues => {
+                let x = (((buffer[0] as u16) << 8) | buffer[1] as u16) as i16;
+                let y = (((buffer[2] as u16) << 8) | buffer[3] as u16) as i16;
+                let z = (((buffer[4] as u16) << 8) | buffer[5] as u16) as i16;
+
+                // Can immediately return values as the one-shot mode automatically
+                // disables the fxo after taking the measurement.
+                self.i2c.disable();
+                self.state.set(State::Disabled);
+                self.buffer.replace(buffer);
+
+                self.callback.get().map(|mut cb| cb.schedule(x as usize, y as usize, z as usize));
+            }
+            _ => {}
         }
     }
 }
@@ -123,9 +262,16 @@ impl<'a> Driver for Fxos8700cq<'a> {
     fn command(&self, command_num: usize, _arg1: usize, _: AppId) -> isize {
         match command_num {
             0 /* check if present */ => 0,
+
+            // Read acceleration.
             1 => {
-                // read acceleration
                 self.start_read_accel();
+                0
+            }
+
+            // Read the magnetometer.
+            2 => {
+                self.start_read_magnetometer();
                 0
             }
             _ => -1,

--- a/userland/examples/find_north/Makefile
+++ b/userland/examples/find_north/Makefile
@@ -1,0 +1,21 @@
+# makefile for user application
+
+CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
+TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
+BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
+
+C_SRCS := $(wildcard *.c)
+OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
+
+CPPFLAGS += -DSTACK_SIZE=2048
+
+# include userland master makefile. Contains rules and flags for actually
+# 	building the application
+include $(TOCK_USERLAND_BASE_DIR)/Makefile
+
+.PHONY:
+clean::
+	rm -Rf $(BUILDDIR)
+

--- a/userland/examples/find_north/README.md
+++ b/userland/examples/find_north/README.md
@@ -1,0 +1,5 @@
+Find North
+==========
+
+This app uses the magnetometer to turn on an LED when the board
+is pointed north.

--- a/userland/examples/find_north/main.c
+++ b/userland/examples/find_north/main.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <math.h>
+
+#include <led.h>
+#include <FXOS8700CQ.h>
+
+int main() {
+  int x, y, z;
+
+  // Choose the LED to use. We want green (which is usually
+  // second in RGB), but will take anything.
+  int led = 0;
+  int num_leds = led_count();
+  if (num_leds > 1) led = 1;
+
+  while(1) {
+    FXOS8700CQ_read_magenetometer_sync(&x, &y, &z);
+    printf("x: %d, y: %d, z: %d\n", x, y, z);
+
+    // Compute the X-Y angle of the board.
+    double angle = atan2((double) y, (double) x);
+    if (y > 0) {
+      angle = 90 - angle * (180 / M_PI);
+    } else {
+      angle = 270 - angle * (180 / M_PI);
+    }
+
+    // Turn the LED on if the board is pointing in a certain range.
+    if (angle > 50 && angle < 310) {
+      led_off(led);
+    } else {
+      led_on(led);
+    }
+  }
+
+  return 0;
+}

--- a/userland/libtock/FXOS8700CQ.c
+++ b/userland/libtock/FXOS8700CQ.c
@@ -46,6 +46,9 @@ int FXOS8700CQ_subscribe(subscribe_cb callback, void* userdata) {
 int FXOS8700CQ_start_accel_reading() {
   return command(11, 1, 0);
 }
+int FXOS8700CQ_start_magnetometer_reading() {
+  return command(11, 2, 0);
+}
 
 int FXOS8700CQ_read_acceleration_sync(int* x, int* y, int* z) {
     int err;
@@ -55,6 +58,26 @@ int FXOS8700CQ_read_acceleration_sync(int* x, int* y, int* z) {
     if (err < 0) return err;
 
     err = FXOS8700CQ_start_accel_reading();
+    if (err < 0) return err;
+
+    // Wait for the callback.
+    yield_for(&res.fired);
+
+    *x = res.x;
+    *y = res.y;
+    *z = res.z;
+
+    return 0;
+}
+
+int FXOS8700CQ_read_magenetometer_sync(int* x, int* y, int* z) {
+    int err;
+    res.fired = false;
+
+    err = FXOS8700CQ_subscribe(FXOS8700CQ_cb, (void*) &res);
+    if (err < 0) return err;
+
+    err = FXOS8700CQ_start_magnetometer_reading();
     if (err < 0) return err;
 
     // Wait for the callback.

--- a/userland/libtock/FXOS8700CQ.h
+++ b/userland/libtock/FXOS8700CQ.h
@@ -18,6 +18,9 @@ double FXOS8700CQ_read_accel_mag();
 // Get the magnitude of acceleration in the X,Y,Z directions. Blocking.
 int FXOS8700CQ_read_acceleration_sync(int* x, int* y, int* z);
 
+// Get a reading from the magnetometer. Blocking.
+int FXOS8700CQ_read_magenetometer_sync(int* x, int* y, int* z);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Add all FXO registers
- Only added simple one-shot read, much like the current acceleration interface.
- Added a test app. The app is calibrated for Hail. I'm not sure how to tell applications which way the x, y, and z directions are.