### PR TITLE
Streamline userland apps makefiles

### DIFF
--- a/userland/Makefile
+++ b/userland/Makefile
@@ -1,8 +1,8 @@
 # userland master makefile. Included by application makefiles
 
-TOCK_USERLAND_BASE_DIR ?= $(abspath .)
-TOCK_BASE_DIR ?= $(abspath ../)
-BUILDDIR ?= $(abspath .)
+TOCK_USERLAND_BASE_DIR ?= ..
+TOCK_BASE_DIR ?= $(TOCK_USERLAND_BASE_DIR)/..
+BUILDDIR ?= build/$(TOCK_ARCH)
 TOCK_BOARD ?= storm
 TOCK_ARCH ?= cortex-m4
 LIBTOCK ?= $(TOCK_USERLAND_BASE_DIR)/libtock/build/$(TOCK_ARCH)/libtock.a
@@ -10,10 +10,16 @@ LIBTOCK ?= $(TOCK_USERLAND_BASE_DIR)/libtock/build/$(TOCK_ARCH)/libtock.a
 TOOLCHAIN := arm-none-eabi
 
 # This could be replaced with an installed version of `elf2tbf`
-ELF2TBF ?= cargo run --manifest-path $(TOCK_USERLAND_BASE_DIR)/tools/elf2tbf/Cargo.toml --
+ELF2TBF ?= cargo run --manifest-path $(abspath $(TOCK_USERLAND_BASE_DIR))/tools/elf2tbf/Cargo.toml --
 ifdef PKG_NAME
 ELF2TBF_ARGS = -n $(PKG_NAME)
 endif
+
+# Collect all desired built output.
+OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
+OBJS += $(patsubst %.cc,$(BUILDDIR)/%.o,$(CXX_SRCS))
+
+CPPFLAGS += -DSTACK_SIZE=2048
 
 AS := $(TOOLCHAIN)-as
 ASFLAGS += -mcpu=$(TOCK_ARCH) -mthumb
@@ -79,6 +85,10 @@ $(BUILDDIR)/app.elf: $(OBJS) $(TOCK_USERLAND_BASE_DIR)/newlib/libc.a $(LIBTOCK) 
 $(BUILDDIR)/app.bin: $(BUILDDIR)/app.elf | $(BUILDDIR)
 	$(TRACE_BIN)
 	$(Q)$(ELF2TBF) $(ELF2TBF_ARGS) -o $@ $<
+
+.PHONY:
+clean::
+	rm -Rf $(BUILDDIR)
 
 # for programming individual apps, include platform app makefile
 #	conditionally included in case it doesn't exist for a board

--- a/userland/examples/accel-leds/Makefile
+++ b/userland/examples/accel-leds/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/adc/Makefile
+++ b/userland/examples/adc/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/ble-env-sense/Makefile
+++ b/userland/examples/ble-env-sense/Makefile
@@ -1,24 +1,14 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
-
-CPPFLAGS += -DSTACK_SIZE=2048
 
 # Include the makefile for using BLE serialization.
 include $(TOCK_USERLAND_BASE_DIR)/libnrfserialization/Makefile.app
 
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)

--- a/userland/examples/blink/Makefile
+++ b/userland/examples/blink/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/blink_sync/Makefile
+++ b/userland/examples/blink_sync/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/build_all.sh
+++ b/userland/examples/build_all.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
 
 set -e
+
+echo "Make clean all apps to ensure warnings are printed..."
 for mkfile in `find . -maxdepth 3 -name Makefile`; do
         dir=`dirname $mkfile`
 	if [ $dir == "." ]; then continue; fi
-	pushd $dir
-	make clean
-	popd
+	pushd $dir > /dev/null
+	make clean > /dev/null
+	popd > /dev/null
 done
+echo "done"
 
 for mkfile in `find . -maxdepth 3 -name Makefile`; do
         dir=`dirname $mkfile`
 	if [ $dir == "." ]; then continue; fi
-	pushd $dir
+	pushd $dir > /dev/null
+	echo ""
+	echo "Building $dir"
 	make
-	popd
+	popd > /dev/null
 done

--- a/userland/examples/buttons/Makefile
+++ b/userland/examples/buttons/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/c_hello/Makefile
+++ b/userland/examples/c_hello/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/cxx_hello/Makefile
+++ b/userland/examples/cxx_hello/Makefile
@@ -1,23 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
-C_SRCS   := $(wildcard *.c)
+# C++ files to compile.
 CXX_SRCS := $(wildcard *.cc)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
-OBJS += $(patsubst %.cc,$(BUILDDIR)/%.o,$(CXX_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/rf233/Makefile
+++ b/userland/examples/rf233/Makefile
@@ -1,22 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CFLAGS += -std=c11 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/rot13_client/Makefile
+++ b/userland/examples/rot13_client/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
 
-C_SRCS   := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
-
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/rot13_service/Makefile
+++ b/userland/examples/rot13_service/Makefile
@@ -1,23 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
 
-C_SRCS   := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
-
-CPPFLAGS += -DSTACK_SIZE=2048
-
-PKG_NAME = org.tockos.examples.rot13
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/security_app/Makefile
+++ b/userland/examples/security_app/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/sensors/Makefile
+++ b/userland/examples/sensors/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/spi_buf/Makefile
+++ b/userland/examples/spi_buf/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/spi_byte/Makefile
+++ b/userland/examples/spi_byte/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/tests/FXOS8700CQ/Makefile
+++ b/userland/examples/tests/FXOS8700CQ/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/tests/gpio/Makefile
+++ b/userland/examples/tests/gpio/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/tests/hail/Makefile
+++ b/userland/examples/tests/hail/Makefile
@@ -1,20 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)

--- a/userland/examples/tests/lps25hb/Makefile
+++ b/userland/examples/tests/lps25hb/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/tests/printf_long/Makefile
+++ b/userland/examples/tests/printf_long/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-TOCK_BASE_DIR = $(abspath $(TOCK_USERLAND_BASE_DIR)/..)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/tests/si7021/Makefile
+++ b/userland/examples/tests/si7021/Makefile
@@ -1,20 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)

--- a/userland/examples/tests/tmp006/Makefile
+++ b/userland/examples/tests/tmp006/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/tests/tsl2561/Makefile
+++ b/userland/examples/tests/tsl2561/Makefile
@@ -1,21 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)
-

--- a/userland/examples/tutorials/02_button_print/Makefile
+++ b/userland/examples/tutorials/02_button_print/Makefile
@@ -1,20 +1,11 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
 
-CPPFLAGS += -DSTACK_SIZE=2048
-
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)

--- a/userland/examples/tutorials/03_ble_scan/Makefile
+++ b/userland/examples/tutorials/03_ble_scan/Makefile
@@ -1,24 +1,14 @@
-# makefile for user application
+# Makefile for user application
 
-CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
 
-TOCK_USERLAND_BASE_DIR = $(abspath $(CURRENT_DIR)/../../..)
-TOCK_BASE_DIR = $(abspath $(CURRENT_DIR)/../../../../)
-BUILDDIR ?= $(abspath build/$(TOCK_ARCH))
-
-
+# Which files to compile.
 C_SRCS := $(wildcard *.c)
-OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
-
-CPPFLAGS += -DSTACK_SIZE=2048
 
 # Include the makefile for using BLE serialization.
 include $(TOCK_USERLAND_BASE_DIR)/libnrfserialization/Makefile.app
 
-# include userland master makefile. Contains rules and flags for actually
-# 	building the application
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
 include $(TOCK_USERLAND_BASE_DIR)/Makefile
-
-.PHONY:
-clean::
-	rm -Rf $(BUILDDIR)

--- a/userland/libnrfserialization/Makefile.app
+++ b/userland/libnrfserialization/Makefile.app
@@ -1,5 +1,4 @@
-LIBNRFSER_MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-LIBNRFSER_DIR := $(abspath $(dir $(LIBNRFSER_MKFILE_PATH)))
+LIBNRFSER_DIR := $(TOCK_USERLAND_BASE_DIR)/libnrfserialization
 
 # So it doesn't think it's on the nRF and try to include nRF code.
 CFLAGS += -D__TOCK__

--- a/userland/libtock/Makefile
+++ b/userland/libtock/Makefile
@@ -1,11 +1,10 @@
-LIBTOCK_MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-LIBTOCK_DIR := $(abspath $(dir $(LIBTOCK_MKFILE_PATH)))
+LIBTOCK_DIR := $(TOCK_USERLAND_BASE_DIR)/libtock
 
-ifeq ($(LIBTOCK_DIR),$(CURDIR)/)
+ifeq ($(LIBTOCK_DIR),/libtock)
 $(error Do not run make from the libtock directory)
 endif
 
-LIBTOCK_BUILDDIR ?= $(abspath $(LIBTOCK_DIR)/build/$(TOCK_ARCH))
+LIBTOCK_BUILDDIR ?= $(LIBTOCK_DIR)/build/$(TOCK_ARCH)
 
 TOOLCHAIN ?= arm-none-eabi
 
@@ -40,4 +39,3 @@ $(LIBTOCK_BUILDDIR)/libtock.a: $(LIBTOCK_OBJS) | $(LIBTOCK_BUILDDIR)
 .PHONY: clean
 clean::
 	rm -Rf $(LIBTOCK_BUILDDIR)
-


### PR DESCRIPTION
A lot of the makefile was just being copy and pasted between apps and didn't really need to be.

This also makes it easier to add new apps in different folders as only one line has to change rather than two.