### PR TITLE
Fix issue with missed timers in virtual_alarm.rs

### DIFF
--- a/capsules/src/virtual_alarm.rs
+++ b/capsules/src/virtual_alarm.rs
@@ -136,10 +136,16 @@ impl<'a, Alrm: Alarm> time::Client for MuxAlarm<'a, Alrm> {
 
         let now = self.alarm.now();
 
+        // Capture this before the loop because it can change while checking
+        // each alarm. If a timer fires, it can immediately set a new timer
+        // by calling `VirtualMuxAlarm.set_alarm()` which can change `self.prev`
+        // to the current timer time.
+        let prev = self.prev.get();
+
         // Check whether to fire each alarm. At this level, alarms are one-shot,
         // so a repeating client will set it again in the fired() callback.
         for cur in self.virtual_alarms.iter() {
-            let should_fire = past_from_base(cur.when.get(), now + 100, self.prev.get());
+            let should_fire = past_from_base(cur.when.get(), now + 100, prev);
             if cur.armed.get() && should_fire {
                 cur.armed.set(false);
                 self.enabled.set(self.enabled.get() - 1);


### PR DESCRIPTION
In certain cases where there are multiple virtual timers and events line up just right, certain timers could be missed. To handle wrapping concerns, timers are compared against a "previous" timestamp, however
this "previous" value can change while the virtual timers are being checked. This can cause a valid timer's "when" time to be less than the new previous value and the timer won't fire.

If I'm not mistaken, this issue happens when three things are true:

1. Two virtual timers are set to fire in the same 100 tic window.
2. One of the timers is from timer.rs.
3. The timer.rs timer is earlier in the array of multiplexed timers.

Because timer.rs will reschedule a timer if it fires too early (becauseof the window) it calls `set_timer()` and `self.mux.prev` is updated to a new time.

Checking all timers by the same "previous" value should fix this.

I've tested this with the virtualized accelerometer which is actually working now.