### PR TITLE
kernel: Add new ReturnCode values

### DIFF
--- a/kernel/src/returncode.rs
+++ b/kernel/src/returncode.rs
@@ -15,4 +15,6 @@ pub enum ReturnCode {
     ESIZE, // Parameter passed was too large
     ECANCEL, // Operation cancelled by a call
     ENOMEM, // Memory required not available
+    ENOSUPPORT, // Operation or command is unsupported
+    ENODEVICE, // Device does not exist
 }


### PR DESCRIPTION
New:
```
ENOSUPPORT, // Operation or command is unsupported
ENODEVICE, // Device does not exist
```

Thoughts? I was looking for a way for a driver to say it doesn't support particular command. While I was there, it might be nice to signal that a device does not exist on a platform.