### PR TITLE
Catch and reject null callback

### DIFF
--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -24,11 +24,11 @@ pub struct Callback {
 }
 
 impl Callback {
-    pub unsafe fn new(appid: AppId, appdata: usize, fn_ptr: *mut ()) -> Callback {
+    pub fn new(appid: AppId, appdata: usize, fn_ptr: NonZero<*mut ()>) -> Callback {
         Callback {
             app_id: appid,
             appdata: appdata,
-            fn_ptr: NonZero::new(fn_ptr),
+            fn_ptr: fn_ptr,
         }
     }
 

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -1,7 +1,9 @@
+use core::nonzero::NonZero;
 use platform::{Chip, Platform};
 use platform::systick::SysTick;
 use process;
 use process::{Process, Task};
+use returncode::ReturnCode;
 use syscall;
 
 pub unsafe fn do_process<P: Platform, C: Chip>(platform: &P,
@@ -90,16 +92,22 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &P,
             Some(syscall::SUBSCRIBE) => {
                 let driver_num = process.r0();
                 let subdriver_num = process.r1();
-                let callback_ptr = process.r2() as *mut ();
+                let callback_ptr_raw = process.r2() as *mut ();
                 let appdata = process.r3();
 
-                let callback = ::Callback::new(appid, appdata, callback_ptr);
-                let res = platform.with_driver(driver_num, |driver| {
-                    match driver {
-                        Some(d) => d.subscribe(subdriver_num, callback),
-                        None => -1,
-                    }
-                });
+                let res = if callback_ptr_raw as usize == 0 {
+                    ReturnCode::EINVAL as isize * -1
+                } else {
+                    let callback_ptr = NonZero::new(callback_ptr_raw);
+
+                    let callback = ::Callback::new(appid, appdata, callback_ptr);
+                    platform.with_driver(driver_num, |driver| {
+                        match driver {
+                            Some(d) => d.subscribe(subdriver_num, callback),
+                            None => ReturnCode::ENODEVICE as isize * -1,
+                        }
+                    })
+                };
                 process.set_r0(res);
             }
             Some(syscall::COMMAND) => {


### PR DESCRIPTION
Rust's NonZero "function" is really just a compiler hint that the
value enclosed by it is guarenteed not to be zero. Critically, NonZero
doesn't check this, it trusts that the caller validated this in advance
(which is why it's an unsafe fn). We were violating this assumption.

My first instinct was to just rip out the NonZero, because it wasn't
really buying us much - this is just a pointer that rust is holding
onto. However, removing it caused every App struct that holds a
Callback to grow by 8 bytes, even still if you change the type of
`fn_ptr` to usize instead of a function (pointer), so clearly Rust's
optimizer is doing something magical and it's worth keeping around.