### PR TITLE
Use ReturnCode throughout kernel

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -42,40 +42,30 @@ impl<'a, A: AdcSingle + 'a> Client for ADC<'a, A> {
 }
 
 impl<'a, A: AdcSingle + 'a> Driver for ADC<'a, A> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             // subscribe to ADC sample done
             0 => {
                 self.callback.set(Some(callback));
-                0
+                ReturnCode::SUCCESS
             }
 
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
+    fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
         match command_num {
             // TODO: This should return the number of valid ADC channels.
-            0 /* check if present */ => 0,
+            0 /* check if present */ => ReturnCode::SUCCESS,
             // Initialize ADC
-            1 => {
-                match self.initialize() {
-                    ReturnCode::SUCCESS => 0,
-                    _ => -1,
-                }
-            }
+            1 => self.initialize(),
             // Sample on channel
-            2 => {
-                match self.sample(data as u8) {
-                    ReturnCode::SUCCESS => 0,
-                    _ => -1,
-                }
-            }
+            2 => self.sample(data as u8),
 
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -5,6 +5,8 @@
 use kernel::{AppId, Container, Callback, Driver};
 use kernel::hil;
 use kernel::hil::gpio::{Client, InterruptMode};
+use kernel::process::Error;
+use kernel::returncode::ReturnCode;
 
 pub type SubscribeMap = u32;
 
@@ -31,7 +33,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Button<'a, G> {
 }
 
 impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             // set callback for pin interrupts (no affect or reliance on individual pins being
             // configured as interrupts)
@@ -39,32 +41,44 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
                 self.callback
                     .enter(callback.app_id(), |cntr, _| {
                         cntr.0 = Some(callback);
-                        0
+                        ReturnCode::SUCCESS
                     })
-                    .unwrap_or(-2)
+                    .unwrap_or_else(|err| {
+                        match err {
+                            Error::OutOfMemory => ReturnCode::ENOMEM,
+                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                            Error::NoSuchApp => ReturnCode::EINVAL,
+                        }
+                    })
             }
 
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, appid: AppId) -> isize {
+    fn command(&self, command_num: usize, data: usize, appid: AppId) -> ReturnCode {
         let pins = self.pins.as_ref();
         match command_num {
             // return pin count
-            0 => pins.len() as isize,
+            0 => ReturnCode::SuccessWithValue { value: pins.len() as usize },
             // enable interrupts on pin
             1 => {
                 if data < pins.len() {
                     self.callback
                         .enter(appid, |cntr, _| {
                             cntr.1 |= 1 << data;
-                            0
+                            ReturnCode::SUCCESS
                         })
-                        .unwrap_or(-3)
+                        .unwrap_or_else(|err| {
+                            match err {
+                                Error::OutOfMemory => ReturnCode::ENOMEM,
+                                Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                                Error::NoSuchApp => ReturnCode::EINVAL,
+                            }
+                        })
                 } else {
-                    -2
+                    ReturnCode::EINVAL /* impossible pin */
                 }
             }
 
@@ -72,29 +86,35 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
             // (no affect or reliance on registered callback)
             2 => {
                 if data >= pins.len() {
-                    -2
+                    ReturnCode::EINVAL /* impossible pin */
                 } else {
                     self.callback
                         .enter(appid, |cntr, _| {
                             cntr.1 &= !(1 << data);
-                            0
+                            ReturnCode::SUCCESS
                         })
-                        .unwrap_or(-3)
+                        .unwrap_or_else(|err| {
+                            match err {
+                                Error::OutOfMemory => ReturnCode::ENOMEM,
+                                Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                                Error::NoSuchApp => ReturnCode::EINVAL,
+                            }
+                        })
                 }
             }
 
             // read input
             3 => {
                 if data >= pins.len() {
-                    -1
+                    ReturnCode::EINVAL /* impossible pin */
                 } else {
                     let pin_state = pins[data].read();
-                    pin_state as isize
+                    ReturnCode::SuccessWithValue { value: pin_state as usize }
                 }
             }
 
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -6,6 +6,8 @@
 use kernel::{AppId, AppSlice, Container, Callback, Shared, Driver};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::uart::{self, UART, Client};
+use kernel::process::Error;
+use kernel::returncode::ReturnCode;
 
 pub struct App {
     write_callback: Option<Callback>,
@@ -67,34 +69,46 @@ impl<'a, U: UART> Console<'a, U> {
 }
 
 impl<'a, U: UART> Driver for Console<'a, U> {
-    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> isize {
+    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
         match allow_num {
             0 => {
                 self.apps
                     .enter(appid, |app, _| {
                         app.read_buffer = Some(slice);
                         app.read_idx = 0;
-                        0
+                        ReturnCode::SUCCESS
                     })
-                    .unwrap_or(-1)
+                    .unwrap_or_else(|err| {
+                        match err {
+                            Error::OutOfMemory => ReturnCode::ENOMEM,
+                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                            Error::NoSuchApp => ReturnCode::EINVAL,
+                        }
+                    })
             }
             1 => {
                 self.apps
                     .enter(appid, |app, _| {
                         app.write_buffer = Some(slice);
-                        0
+                        ReturnCode::SUCCESS
                     })
-                    .unwrap_or(-1)
+                    .unwrap_or_else(|err| {
+                        match err {
+                            Error::OutOfMemory => ReturnCode::ENOMEM,
+                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                            Error::NoSuchApp => ReturnCode::EINVAL,
+                        }
+                    })
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             0 /* read line */ => {
                 // read line is not implemented for console at this time
-                -1
+                ReturnCode::ENOSUPPORT
             },
             1 /* putstr/write_done */ => {
                 self.apps.enter(callback.app_id(), |app, _| {
@@ -127,27 +141,35 @@ impl<'a, U: UART> Driver for Console<'a, U> {
                                 app.pending_write = true;
                                 app.write_buffer = Some(slice);
                             }
-                            0
+                            ReturnCode::SUCCESS
                         },
-                        None => -1
+                        None => ReturnCode::FAIL
+                        // XXX  ^^^^^^^^^^^^^^^^-- When can we fail to take the write_buffer
+                        //                         which return code is best here?
                     }
-                }).unwrap_or(-1)
+                }).unwrap_or_else(|err| {
+                    match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    }
+                })
             },
-            _ => -1
+            _ => ReturnCode::ENOSUPPORT
         }
     }
 
-    fn command(&self, cmd_num: usize, arg1: usize, _: AppId) -> isize {
+    fn command(&self, cmd_num: usize, arg1: usize, _: AppId) -> ReturnCode {
         match cmd_num {
-            0 /* check if present */ => 0,
+            0 /* check if present */ => ReturnCode::SUCCESS,
             1 /* putc */ => {
                 self.tx_buffer.take().map(|buffer| {
                     buffer[0] = arg1 as u8;
                     self.uart.transmit(buffer, 1);
                 });
-                1
+                ReturnCode::SuccessWithValue { value: 1 }
             },
-            _ => -1
+            _ => ReturnCode::ENOSUPPORT
         }
     }
 }

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -6,6 +6,7 @@ use kernel::{AppId, AppSlice, Callback, Driver, Shared};
 
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
+use kernel::returncode::ReturnCode;
 
 
 
@@ -303,7 +304,7 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CLClient for FM25CLDriver<'a, S>
 }
 
 impl<'a, S: hil::spi::SpiMasterDevice + 'a> Driver for FM25CLDriver<'a, S> {
-    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> isize {
+    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
         match allow_num {
             // Pass read buffer in from application
             0 => {
@@ -321,7 +322,7 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> Driver for FM25CLDriver<'a, S> {
                     }
                 };
                 self.app_state.replace(appst);
-                0
+                ReturnCode::SUCCESS
             }
             // Pass write buffer in from application
             1 => {
@@ -339,13 +340,13 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> Driver for FM25CLDriver<'a, S> {
                     }
                 };
                 self.app_state.replace(appst);
-                0
+                ReturnCode::SUCCESS
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             0 => {
                 let appst = match self.app_state.take() {
@@ -362,21 +363,21 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> Driver for FM25CLDriver<'a, S> {
                     }
                 };
                 self.app_state.replace(appst);
-                0
+                ReturnCode::SUCCESS
             }
 
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
+    fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
         match command_num {
-            0 /* check if present */ => 0,
+            0 /* check if present */ => ReturnCode::SUCCESS,
             // get status
             1 => {
                 self.fm25cl.read_status();
-                0
+                ReturnCode::SUCCESS
             }
 
             // read
@@ -389,7 +390,7 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> Driver for FM25CLDriver<'a, S> {
 
                     self.fm25cl.read(address, kernel_read, read_len as u16);
                 });
-                0
+                ReturnCode::SUCCESS
             }
 
             // write
@@ -413,11 +414,11 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> Driver for FM25CLDriver<'a, S> {
                         });
                     });
                 });
-                0
+                ReturnCode::SUCCESS
             }
 
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/capsules/src/fxos8700_cq.rs
+++ b/capsules/src/fxos8700_cq.rs
@@ -7,6 +7,7 @@ use core::cell::Cell;
 use kernel::{AppId, Callback, Driver};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::i2c::{I2CDevice, I2CClient, Error};
+use kernel::returncode::ReturnCode;
 
 pub static mut BUF: [u8; 6] = [0; 6];
 
@@ -249,32 +250,32 @@ impl<'a> I2CClient for Fxos8700cq<'a> {
 }
 
 impl<'a> Driver for Fxos8700cq<'a> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             0 => {
                 self.callback.set(Some(callback));
-                0
+                ReturnCode::SUCCESS
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn command(&self, command_num: usize, _arg1: usize, _: AppId) -> isize {
+    fn command(&self, command_num: usize, _arg1: usize, _: AppId) -> ReturnCode {
         match command_num {
-            0 /* check if present */ => 0,
+            0 /* check if present */ => ReturnCode::SUCCESS,
 
             // Read acceleration.
             1 => {
                 self.start_read_accel();
-                0
+                ReturnCode::SUCCESS
             }
 
             // Read the magnetometer.
             2 => {
                 self.start_read_magnetometer();
-                0
+                ReturnCode::SUCCESS
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -5,6 +5,7 @@ use kernel::{AppId, Callback, Driver};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::i2c::{I2CDevice, I2CClient, Error};
 use kernel::hil::time::{self, Frequency};
+use kernel::returncode::ReturnCode;
 
 pub static mut BUF: [u8; 3] = [0; 3];
 
@@ -61,24 +62,24 @@ impl<'a, A: time::Alarm + 'a> Isl29035<'a, A> {
 }
 
 impl<'a, A: time::Alarm + 'a> Driver for Isl29035<'a, A> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             0 => {
                 self.callback.set(Some(callback));
-                0
+                ReturnCode::SUCCESS
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn command(&self, command_num: usize, _arg1: usize, _: AppId) -> isize {
+    fn command(&self, command_num: usize, _arg1: usize, _: AppId) -> ReturnCode {
         match command_num {
-            0 /* check if present */ => 0,
+            0 /* check if present */ => ReturnCode::SUCCESS,
             1 => {
                 self.start_read_lux();
-                0
+                ReturnCode::SUCCESS
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -5,6 +5,7 @@
 
 use kernel::{AppId, Driver};
 use kernel::hil;
+use kernel::returncode::ReturnCode;
 
 /// Whether the LEDs are active high or active low on this platform.
 pub enum ActivationMode {
@@ -36,50 +37,50 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> LED<'a, G> {
 }
 
 impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for LED<'a, G> {
-    fn command(&self, command_num: usize, data: usize, _: AppId) -> isize {
+    fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
         let pins = self.pins.as_ref();
         match command_num {
             // get number of LEDs
-            0 => pins.len() as isize,
+            0 => ReturnCode::SuccessWithValue { value: pins.len() as usize },
 
             // on
             1 => {
                 if data >= pins.len() {
-                    -1
+                    ReturnCode::EINVAL /* impossible pin */
                 } else {
                     match self.mode {
                         ActivationMode::ActiveHigh => pins[data].set(),
                         ActivationMode::ActiveLow => pins[data].clear(),
                     }
-                    0
+                    ReturnCode::SUCCESS
                 }
             }
 
             // off
             2 => {
                 if data >= pins.len() {
-                    -1
+                    ReturnCode::EINVAL /* impossible pin */
                 } else {
                     match self.mode {
                         ActivationMode::ActiveHigh => pins[data].clear(),
                         ActivationMode::ActiveLow => pins[data].set(),
                     }
-                    0
+                    ReturnCode::SUCCESS
                 }
             }
 
             // toggle
             3 => {
                 if data >= pins.len() {
-                    -1
+                    ReturnCode::EINVAL /* impossible pin */
                 } else {
                     pins[data].toggle();
-                    0
+                    ReturnCode::SUCCESS
                 }
             }
 
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -8,6 +8,7 @@ use kernel::{AppId, Callback, Driver};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
+use kernel::returncode::ReturnCode;
 
 // Buffer to use for I2C messages
 pub static mut BUFFER: [u8; 5] = [0; 5];
@@ -198,30 +199,29 @@ impl<'a> gpio::Client for LPS25HB<'a> {
 }
 
 impl<'a> Driver for LPS25HB<'a> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             // Set a callback
             0 => {
                 // Set callback function
                 self.callback.set(Some(callback));
-                0
+                ReturnCode::SUCCESS
             }
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: AppId) -> isize {
+    fn command(&self, command_num: usize, _: usize, _: AppId) -> ReturnCode {
         match command_num {
-            0 /* check if present */ => 0,
+            0 /* check if present */ => ReturnCode::SUCCESS,
             // Take a pressure measurement
             1 => {
                 self.take_measurement();
-
-                0
+                ReturnCode::SUCCESS
             }
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -7,6 +7,7 @@
 use kernel::{AppId, Callback, AppSlice, Driver, Shared};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::uart::{self, UARTAdvanced, Client};
+use kernel::returncode::ReturnCode;
 
 struct App {
     callback: Option<Callback>,
@@ -55,7 +56,7 @@ impl<'a, U: UARTAdvanced> Nrf51822Serialization<'a, U> {
 
 impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
     /// Pass application space memory to this driver.
-    fn allow(&self, _appid: AppId, allow_type: usize, slice: AppSlice<Shared, u8>) -> isize {
+    fn allow(&self, _appid: AppId, allow_type: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
         match allow_type {
             // Provide an RX buffer.
             0 => {
@@ -77,7 +78,7 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
                     }
                 };
                 self.app.replace(resapp);
-                0
+                ReturnCode::SUCCESS
             }
 
             // Provide a TX buffer.
@@ -98,9 +99,9 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
                     }
                 };
                 self.app.replace(resapp);
-                0
+                ReturnCode::SUCCESS
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
@@ -109,7 +110,7 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
     /// The callback will be called when a TX finishes and when
     /// RX data is available.
     #[inline(never)]
-    fn subscribe(&self, subscribe_type: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_type: usize, callback: Callback) -> ReturnCode {
         match subscribe_type {
             // Add a callback
             0 => {
@@ -136,24 +137,27 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
                 };
                 self.app.replace(resapp);
 
-                0
+                ReturnCode::SUCCESS
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
     /// Issue a command to the Nrf51822Serialization driver.
-    fn command(&self, command_type: usize, _: usize, _: AppId) -> isize {
+    fn command(&self, command_type: usize, _: usize, _: AppId) -> ReturnCode {
 
         match command_type {
-            0 /* check if present */ => 0,
+            0 /* check if present */ => ReturnCode::SUCCESS,
 
             // Send a buffer to the nRF51822 over UART.
             1 => {
                 // On a TX, send the first byte of the TX buffer.
                 // TODO(bradjc): Need to match this to the correct app!
                 //               Can't just use 0!
-                let result = self.app.map(|appst| {
+                //
+                // When could app be NULL? What return code should be here?
+                // XXX ReturnCode -----------,,,,,,,,,,,,,,,,
+                self.app.map_or(ReturnCode::FAIL, |appst| {
 
                     match appst.tx_buffer.take() {
                         Some(slice) => {
@@ -164,12 +168,13 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
                                 }
                                 self.uart.transmit(buffer, write_len);
                             });
-                            0
+                            ReturnCode::SUCCESS
                         }
-                        None => -2,
+                        None => ReturnCode::FAIL, /* XXX: ReturnCode */
+                        // ^When could this happen - when there wasn't an allow
+                        // first? Maybe ERESERVE?
                     }
-                });
-                result.unwrap_or(-1)
+                })
             }
 
             // Ask the kernel to callback the application. This is used to
@@ -185,9 +190,9 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
                     });
                 });
 
-                0
+                ReturnCode::SUCCESS
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -9,6 +9,8 @@
 use core::cell::Cell;
 use kernel::{AppId, AppSlice, Container, Callback, Shared, Driver};
 use kernel::hil::rng;
+use kernel::process::Error;
+use kernel::returncode::ReturnCode;
 
 pub struct App {
     callback: Option<Callback>,
@@ -121,61 +123,80 @@ impl<'a, RNG: rng::RNG> rng::Client for SimpleRng<'a, RNG> {
 }
 
 impl<'a, RNG: rng::RNG> Driver for SimpleRng<'a, RNG> {
-    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> isize {
+    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
         // pass buffer in from application
         match allow_num {
             0 => {
                 self.apps
                     .enter(appid, |app, _| {
                         app.buffer = Some(slice);
-                        0
+                        ReturnCode::SUCCESS
                     })
-                    .unwrap_or(-1)
+                    .unwrap_or_else(|err| {
+                        match err {
+                            Error::OutOfMemory => ReturnCode::ENOMEM,
+                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                            Error::NoSuchApp => ReturnCode::EINVAL,
+                        }
+                    })
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             0 => {
                 self.apps
                     .enter(callback.app_id(), |app, _| {
                         app.callback = Some(callback);
-                        0
+                        ReturnCode::SUCCESS
                     })
-                    .unwrap_or(-1)
+                    .unwrap_or_else(|err| {
+                        match err {
+                            Error::OutOfMemory => ReturnCode::ENOMEM,
+                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                            Error::NoSuchApp => ReturnCode::EINVAL,
+                        }
+                    })
             }
 
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, appid: AppId) -> isize {
+    fn command(&self, command_num: usize, data: usize, appid: AppId) -> ReturnCode {
         match command_num {
-            0 => /* Check if exists */ 0,
+            0 => /* Check if exists */ ReturnCode::SUCCESS,
 
             // Ask for a given number of random bytes.
             1 => {
                 self.apps
                     .enter(appid, |app, _| {
-                        let mut ret = 0;
                         app.remaining = data;
                         app.idx = 0;
 
                         if app.callback.is_some() && app.buffer.is_some() {
-                          if !self.getting_randomness.get() {
-                              self.getting_randomness.set(true);
-                              self.rng.get();
-                          }
+                            if !self.getting_randomness.get() {
+                                self.getting_randomness.set(true);
+                                self.rng.get();
+                            }
+                            ReturnCode::SUCCESS
                         }
-                        else { ret = -1 }
-                        ret
+                        else {
+                            ReturnCode::FAIL /* FIXME */
+                        }
                     })
-                    .unwrap_or(-1)
+                    .unwrap_or_else(|err| {
+                        match err {
+                            Error::OutOfMemory => ReturnCode::ENOMEM,
+                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                            Error::NoSuchApp => ReturnCode::EINVAL,
+                        }
+                    })
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -9,6 +9,7 @@ use kernel::common::take_cell::TakeCell;
 use kernel::hil::i2c;
 use kernel::hil::time;
 use kernel::hil::time::Frequency;
+use kernel::returncode::ReturnCode;
 
 // Buffer to use for I2C messages
 pub static mut BUFFER: [u8; 14] = [0; 14];
@@ -182,29 +183,29 @@ impl<'a, A: time::Alarm + 'a> time::Client for SI7021<'a, A> {
 }
 
 impl<'a, A: time::Alarm + 'a> Driver for SI7021<'a, A> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             // Set a callback
             0 => {
                 // Set callback function
                 self.callback.set(Some(callback));
-                0
+                ReturnCode::SUCCESS
             }
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: AppId) -> isize {
+    fn command(&self, command_num: usize, _: usize, _: AppId) -> ReturnCode {
         match command_num {
-            0 /* check if present */ => 0,
+            0 /* check if present */ => ReturnCode::SUCCESS,
             // Take a pressure measurement
             1 => {
                 self.take_measurement();
-                0
+                ReturnCode::SUCCESS
             }
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
 
     }

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -8,6 +8,7 @@ use kernel::common::take_cell::TakeCell;
 use kernel::hil::spi::{SpiMasterDevice, SpiMasterClient};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
+use kernel::returncode::ReturnCode;
 
 // SPI operations are handled by coping into a kernel buffer for
 // writes and copying out of a kernel buffer for reads.
@@ -76,7 +77,7 @@ impl<'a, S: SpiMasterDevice> Spi<'a, S> {
 }
 
 impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
-    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> isize {
+    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
         match allow_num {
             0 => {
                 let appc = match self.app.take() {
@@ -95,7 +96,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
                     }
                 };
                 self.app.replace(appc);
-                0
+                ReturnCode::SUCCESS
             }
             1 => {
                 let appc = match self.app.take() {
@@ -114,14 +115,14 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
                     }
                 };
                 self.app.replace(appc);
-                0
+                ReturnCode::SUCCESS
             }
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
     #[inline(never)]
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             0 /* read_write */ => {
                 let appc = match self.app.take() {
@@ -138,9 +139,9 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
                     }
                 };
                 self.app.replace(appc);
-                0
+                ReturnCode::SUCCESS
             },
-            _ => -1
+            _ => ReturnCode::ENOSUPPORT
         }
     }
     // 0: read/write a single byte (blocking)
@@ -186,19 +187,17 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     //   - does nothing if lock not held
     //
 
-    fn command(&self, cmd_num: usize, arg1: usize, _: AppId) -> isize {
+    fn command(&self, cmd_num: usize, arg1: usize, _: AppId) -> ReturnCode {
         match cmd_num {
-            0 /* check if present */ => 0,
+            0 /* check if present */ => ReturnCode::SUCCESS,
             // No longer supported, wrap inside a read_write_bytes
-            1 /* read_write_byte */ => -1,
+            1 /* read_write_byte */ => ReturnCode::ENOSUPPORT,
             2 /* read_write_bytes */ => {
                 if self.busy.get() {
-                    return -1;
+                    return ReturnCode::EBUSY;
                 }
-                let mut result = -1;
-                self.app.map(|app| {
+                self.app.map_or(ReturnCode::FAIL /* XXX app is null? */, |app| {
                     let mut mlen = 0;
-                    // If write buffer too small, return
                     app.app_write.as_mut().map(|w| {
                         mlen = w.len();
                     });
@@ -210,46 +209,51 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
                         app.index = 0;
                         self.busy.set(true);
                         self.do_next_read_write(app);
-                        result = 0;
+                        ReturnCode::SUCCESS
+                    } else {
+                        ReturnCode::EINVAL /* write buffer too small */
                     }
-                });
-                return result;
+                })
             }
             3 /* set chip select */ => {
-                -1 // do nothing, for now, until we fix interface
-                   // so virtual instances can use multiple chip selects
+                // do nothing, for now, until we fix interface
+                // so virtual instances can use multiple chip selects
+                ReturnCode::ENOSUPPORT
             }
             4 /* get chip select */ => {
-                0
+                //XXX Was a naked, uncommented zero. I'm assuming that's
+                //    because the only valid chip select for now is 0,
+                //    and wrapping it appropriately -Pat, ReturnCode fixes
+                ReturnCode::SuccessWithValue { value: 0 }
             }
             5 /* set baud rate */ => {
                 self.spi_master.set_rate(arg1 as u32);
-                0
+                ReturnCode::SUCCESS
             }
             6 /* get baud rate */ => {
-                self.spi_master.get_rate() as isize
+                ReturnCode::SuccessWithValue { value: self.spi_master.get_rate() as usize }
             }
             7 /* set phase */ => {
                 match arg1 {
                     0 => self.spi_master.set_phase(ClockPhase::SampleLeading),
                     _ => self.spi_master.set_phase(ClockPhase::SampleTrailing),
                 };
-                0
+                ReturnCode::SUCCESS
             }
             8 /* get phase */ => {
-                self.spi_master.get_phase() as isize
+                ReturnCode::SuccessWithValue { value: self.spi_master.get_phase() as usize }
             }
             9 /* set polarity */ => {
                 match arg1 {
                     0 => self.spi_master.set_polarity(ClockPolarity::IdleLow),
                     _ => self.spi_master.set_polarity(ClockPolarity::IdleHigh),
                 };
-                0
+                ReturnCode::SUCCESS
             }
             10 /* get polarity */ => {
-                self.spi_master.get_polarity() as isize
+                ReturnCode::SuccessWithValue { value: self.spi_master.get_polarity() as usize }
             }
-            _ => -1
+            _ => ReturnCode::ENOSUPPORT
         }
     }
 }

--- a/capsules/src/timer.rs
+++ b/capsules/src/timer.rs
@@ -5,6 +5,8 @@
 use core::cell::Cell;
 use kernel::{AppId, Container, Callback, Driver};
 use kernel::hil::time::{self, Alarm, Frequency};
+use kernel::process::Error;
+use kernel::returncode::ReturnCode;
 
 #[derive(Copy, Clone)]
 pub struct TimerData {
@@ -63,16 +65,22 @@ impl<'a, A: Alarm> TimerDriver<'a, A> {
 }
 
 impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
-    fn subscribe(&self, _: usize, callback: Callback) -> isize {
+    fn subscribe(&self, _: usize, callback: Callback) -> ReturnCode {
         self.app_timer
             .enter(callback.app_id(), |td, _allocator| {
                 td.callback = Some(callback);
-                0
+                ReturnCode::SUCCESS
             })
-            .unwrap_or(-1)
+            .unwrap_or_else(|err| {
+                match err {
+                    Error::OutOfMemory => ReturnCode::ENOMEM,
+                    Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                    Error::NoSuchApp => ReturnCode::EINVAL,
+                }
+            })
     }
 
-    fn command(&self, cmd_type: usize, interval: usize, caller_id: AppId) -> isize {
+    fn command(&self, cmd_type: usize, interval: usize, caller_id: AppId) -> ReturnCode {
         // First, convert from milliseconds to native clock frequency
         let interval = (interval as u32) * <A::Frequency>::frequency() / 1000;
 
@@ -82,12 +90,13 @@ impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
         // anyway, if the underlying alarm is currently disabled and we're
         // enabling the first alarm, or on an error (i.e. no change to the
         // alarms).
-        let (err_code, reset) = self.app_timer
+        let (return_code, reset) = self.app_timer
             .enter(caller_id, |td, _alloc| {
                 match cmd_type {
+                0 /* check if present */ => (ReturnCode::SUCCESS, false),
                 4 /* capture time */ => {
                     let curr_time: u32 = self.alarm.now();
-                    (curr_time as isize, true)
+                    (ReturnCode::SuccessWithValue { value: curr_time as usize }, true)
                 },
                 3 /* Stop */ => {
                     if td.interval > 0 {
@@ -97,18 +106,20 @@ impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
                         self.num_armed.set(num_armed - 1);
                         if num_armed == 1 {
                             self.alarm.disable();
-                            (0, false)
+                            (ReturnCode::SUCCESS, false)
                         } else {
-                            (0, true)
+                            (ReturnCode::SUCCESS, true)
                         }
                     } else {
-                        (-2, false)
+                        // Request to stop when already stopped
+                        (ReturnCode::EINVAL, false)
                     }
                 },
                 /* 1 for Oneshot, 2 for Repeat */
                 cmd_type if cmd_type <= 2 && cmd_type > 0 => {
                     if interval == 0 {
-                        return (-2, false);
+                        // Request for zero-length timer
+                        return (ReturnCode::EINVAL, false);
                     }
 
                     // if previously unarmed, but now will become armed
@@ -122,21 +133,27 @@ impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
                     // Repeat if cmd_type was 2
                     td.repeating = cmd_type == 2;
                     if self.alarm.is_armed() {
-                        (0, true)
+                        (ReturnCode::SUCCESS, true)
                     } else {
                         self.alarm.set_alarm(td.t0.wrapping_add(td.interval));
-                        (0, false)
+                        (ReturnCode::SUCCESS, false)
                     }
                 },
-                0 /* check if present */ => (0, false),
-                _ => (-1, false)
+                _ => (ReturnCode::ENOSUPPORT, false)
             }
             })
-            .unwrap_or((-3, false));
+            .unwrap_or_else(|err| {
+                let e = match err {
+                    Error::OutOfMemory => ReturnCode::ENOMEM,
+                    Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                    Error::NoSuchApp => ReturnCode::EINVAL,
+                };
+                (e, false)
+            });
         if reset {
             self.reset_active_timer();
         }
-        err_code
+        return_code
     }
 }
 

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -8,6 +8,7 @@ use kernel::{AppId, Callback, Driver};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
+use kernel::returncode::ReturnCode;
 
 // Buffer to use for I2C messages
 pub static mut BUFFER: [u8; 4] = [0; 4];
@@ -424,29 +425,29 @@ impl<'a> gpio::Client for TSL2561<'a> {
 }
 
 impl<'a> Driver for TSL2561<'a> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> isize {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             // Set a callback
             0 => {
                 // Set callback function
                 self.callback.set(Some(callback));
-                0
+                ReturnCode::SUCCESS
             }
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: AppId) -> isize {
+    fn command(&self, command_num: usize, _: usize, _: AppId) -> ReturnCode {
         match command_num {
-            0 /* check if present */ => 0,
+            0 /* check if present */ => ReturnCode::SUCCESS,
             // Take a measurement
             1 => {
                 self.take_measurement();
-                0
+                ReturnCode::SUCCESS
             }
             // default
-            _ => -1,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -38,6 +38,8 @@
 //! While drivers do not handle the `yield` system call, it is important to
 //! understand its function and how it interacts with `subscribe`.
 
+use returncode::ReturnCode;
+
 /// `Driver`s implement the three driver-specific system calls: `subscribe`,
 /// `command` and `allow`.
 ///
@@ -68,8 +70,8 @@ pub trait Driver {
     /// the magnitude of the return value of can signify extra information such
     /// as error type.
     #[allow(unused_variables)]
-    fn subscribe(&self, minor_num: usize, callback: ::Callback) -> isize {
-        -1
+    fn subscribe(&self, minor_num: usize, callback: ::Callback) -> ReturnCode {
+        ReturnCode::ENOSUPPORT
     }
 
     /// `command` instructs a driver to perform some action synchronously.
@@ -87,8 +89,8 @@ pub trait Driver {
     /// side effects. This convention ensures that applications can query the
     /// kernel for supported drivers on a given platform.
     #[allow(unused_variables)]
-    fn command(&self, minor_num: usize, r2: usize, caller_id: ::AppId) -> isize {
-        -1
+    fn command(&self, minor_num: usize, r2: usize, caller_id: ::AppId) -> ReturnCode {
+        ReturnCode::ENOSUPPORT
     }
 
     /// `allow` lets an application give the driver access to a buffer in the
@@ -98,7 +100,7 @@ pub trait Driver {
     /// driver should not rely on the contents of the buffer to remain
     /// unchanged.
     #[allow(unused_variables)]
-    fn allow(&self, app: ::AppId, minor_num: usize, slice: ::AppSlice<::Shared, u8>) -> isize {
-        -1
+    fn allow(&self, app: ::AppId, minor_num: usize, slice: ::AppSlice<::Shared, u8>) -> ReturnCode {
+        ReturnCode::ENOSUPPORT
     }
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -9,6 +9,7 @@ use core::intrinsics;
 use core::ptr::{read_volatile, write_volatile};
 
 use platform::mpu;
+use returncode::ReturnCode;
 
 /// Takes a value and rounds it up to be aligned % 8
 macro_rules! align8 {
@@ -627,6 +628,11 @@ impl<'a> Process<'a> {
     pub fn r0(&self) -> usize {
         let pspr = self.cur_stack as *const usize;
         unsafe { read_volatile(pspr) }
+    }
+
+    pub fn set_return_code(&mut self, return_code: ReturnCode) {
+        let r: isize = return_code.into();
+        self.set_r0(r);
     }
 
     pub fn set_r0(&mut self, val: isize) {

--- a/kernel/src/returncode.rs
+++ b/kernel/src/returncode.rs
@@ -5,16 +5,16 @@
 //!  Date: Dec 22, 2016
 
 pub enum ReturnCode {
-    SUCCESS,
-    FAIL, // Generic failure condition
-    EBUSY, // Underlying system is busy; retry
-    EALREADY, // The state requested is already set
-    EOFF, // The component is powered down
-    ERESERVE, // Reservation required before use
-    EINVAL, // An invalid parameter was passed
-    ESIZE, // Parameter passed was too large
-    ECANCEL, // Operation cancelled by a call
-    ENOMEM, // Memory required not available
-    ENOSUPPORT, // Operation or command is unsupported
-    ENODEVICE, // Device does not exist
+    SUCCESS = 0,
+    FAIL = -1, //.......... Generic failure condition
+    EBUSY = -2, //......... Underlying system is busy; retry
+    EALREADY = -3, //...... The state requested is already set
+    EOFF = -4, //.......... The component is powered down
+    ERESERVE = -5, //...... Reservation required before use
+    EINVAL = -6, //........ An invalid parameter was passed
+    ESIZE = -7, //......... Parameter passed was too large
+    ECANCEL = -8, //....... Operation cancelled by a call
+    ENOMEM = -9, //........ Memory required not available
+    ENOSUPPORT = -10, //... Operation or command is unsupported
+    ENODEVICE = -11, //.... Device does not exist
 }

--- a/kernel/src/returncode.rs
+++ b/kernel/src/returncode.rs
@@ -4,17 +4,39 @@
 //!  Author: Philip Levis <pal@cs.stanford.edu>
 //!  Date: Dec 22, 2016
 
+#[derive(Clone, Copy, PartialEq)]
 pub enum ReturnCode {
-    SUCCESS = 0,
-    FAIL = -1, //.......... Generic failure condition
-    EBUSY = -2, //......... Underlying system is busy; retry
-    EALREADY = -3, //...... The state requested is already set
-    EOFF = -4, //.......... The component is powered down
-    ERESERVE = -5, //...... Reservation required before use
-    EINVAL = -6, //........ An invalid parameter was passed
-    ESIZE = -7, //......... Parameter passed was too large
-    ECANCEL = -8, //....... Operation cancelled by a call
-    ENOMEM = -9, //........ Memory required not available
-    ENOSUPPORT = -10, //... Operation or command is unsupported
-    ENODEVICE = -11, //.... Device does not exist
+    SuccessWithValue { value: usize }, // Success value must be positive
+    SUCCESS,
+    FAIL, //.......... Generic failure condition
+    EBUSY, //......... Underlying system is busy; retry
+    EALREADY, //...... The state requested is already set
+    EOFF, //.......... The component is powered down
+    ERESERVE, //...... Reservation required before use
+    EINVAL, //........ An invalid parameter was passed
+    ESIZE, //......... Parameter passed was too large
+    ECANCEL, //....... Operation cancelled by a call
+    ENOMEM, //........ Memory required not available
+    ENOSUPPORT, //.... Operation or command is unsupported
+    ENODEVICE, //..... Device does not exist
+}
+
+impl From<ReturnCode> for isize {
+    fn from(original: ReturnCode) -> isize {
+        match original {
+            ReturnCode::SuccessWithValue { value } => value as isize,
+            ReturnCode::SUCCESS => 0,
+            ReturnCode::FAIL => -1,
+            ReturnCode::EBUSY => -2,
+            ReturnCode::EALREADY => -3,
+            ReturnCode::EOFF => -4,
+            ReturnCode::ERESERVE => -5,
+            ReturnCode::EINVAL => -6,
+            ReturnCode::ESIZE => -7,
+            ReturnCode::ECANCEL => -8,
+            ReturnCode::ENOMEM => -9,
+            ReturnCode::ENOSUPPORT => -10,
+            ReturnCode::ENODEVICE => -11,
+        }
+    }
 }

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -72,15 +72,17 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &P,
                 let res = match brk_type {
                     0 /* BRK */ => {
                         process.brk(r1 as *const u8)
-                            .map(|_| 0).unwrap_or(-1)
+                            .map(|_| ReturnCode::SUCCESS)
+                            .unwrap_or(ReturnCode::ENOMEM)
                     },
                     1 /* SBRK */ => {
                         process.sbrk(r1 as isize)
-                            .map(|addr| addr as isize).unwrap_or(-1)
+                            .map(|addr| ReturnCode::SuccessWithValue { value: addr as usize })
+                            .unwrap_or(ReturnCode::ENOMEM)
                     },
-                    _ => -2
+                    _ => ReturnCode::ENOSUPPORT
                 };
-                process.set_r0(res);
+                process.set_return_code(res);
             }
             Some(syscall::YIELD) => {
                 process.yield_state();
@@ -96,7 +98,7 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &P,
                 let appdata = process.r3();
 
                 let res = if callback_ptr_raw as usize == 0 {
-                    ReturnCode::EINVAL as isize
+                    ReturnCode::EINVAL
                 } else {
                     let callback_ptr = NonZero::new(callback_ptr_raw);
 
@@ -104,20 +106,20 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &P,
                     platform.with_driver(driver_num, |driver| {
                         match driver {
                             Some(d) => d.subscribe(subdriver_num, callback),
-                            None => ReturnCode::ENODEVICE as isize,
+                            None => ReturnCode::ENODEVICE,
                         }
                     })
                 };
-                process.set_r0(res);
+                process.set_return_code(res);
             }
             Some(syscall::COMMAND) => {
                 let res = platform.with_driver(process.r0(), |driver| {
                     match driver {
                         Some(d) => d.command(process.r1(), process.r2(), appid),
-                        None => -1,
+                        None => ReturnCode::ENODEVICE,
                     }
                 });
-                process.set_r0(res);
+                process.set_return_code(res);
             }
             Some(syscall::ALLOW) => {
                 let res = platform.with_driver(process.r0(), |driver| {
@@ -129,13 +131,13 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &P,
                                 let slice = ::AppSlice::new(start_addr as *mut u8, size, appid);
                                 d.allow(appid, process.r1(), slice)
                             } else {
-                                -1
+                                ReturnCode::EINVAL /* memory not allocated to process */
                             }
                         }
-                        None => -1,
+                        None => ReturnCode::ENODEVICE,
                     }
                 });
-                process.set_r0(res);
+                process.set_return_code(res);
             }
             _ => {}
         }

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -96,7 +96,7 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &P,
                 let appdata = process.r3();
 
                 let res = if callback_ptr_raw as usize == 0 {
-                    ReturnCode::EINVAL as isize * -1
+                    ReturnCode::EINVAL as isize
                 } else {
                     let callback_ptr = NonZero::new(callback_ptr_raw);
 
@@ -104,7 +104,7 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &P,
                     platform.with_driver(driver_num, |driver| {
                         match driver {
                             Some(d) => d.subscribe(subdriver_num, callback),
-                            None => ReturnCode::ENODEVICE as isize * -1,
+                            None => ReturnCode::ENODEVICE as isize,
                         }
                     })
                 };


### PR DESCRIPTION
The driver trait now enforces sanctioned return codes throughout the kernel. Drivers can return any positive (non-error) value using `ReturnCode::SuccessWithValue`

I believe that all of the integer return codes were changed into the appropriate return code, but driver authors should double-check