### PR TITLE
console: consolidate send logic

### DIFF
--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -76,7 +76,7 @@ impl<'a, U: UART> Console<'a, U> {
                 app.write_callback = Some(callback);
                 self.send(app_id, app, slice);
                 ReturnCode::SUCCESS
-            },
+            }
             None => ReturnCode::EBUSY,
         }
     }
@@ -104,7 +104,9 @@ impl<'a, U: UART> Console<'a, U> {
             self.in_progress.replace(app_id);
             self.tx_buffer.take().map(|buffer| {
                 let mut transaction_len = app.write_remaining;
-                for (i, c) in slice.as_ref()[slice.len() - app.write_remaining .. slice.len()].iter().enumerate() {
+                for (i, c) in slice.as_ref()[slice.len() - app.write_remaining..slice.len()]
+                    .iter()
+                    .enumerate() {
                     if buffer.len() <= i {
                         break;
                     }
@@ -207,7 +209,7 @@ impl<'a, U: UART> Client for Console<'a, U> {
             self.apps.enter(appid, |app, _| {
                 match self.send_continue(appid, app) {
                     Ok(more_to_send) => {
-                        if ! more_to_send {
+                        if !more_to_send {
                             // Go ahead and signal the application
                             let written = app.write_len;
                             app.write_len = 0;

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -66,6 +66,68 @@ impl<'a, U: UART> Console<'a, U> {
             hw_flow_control: false,
         });
     }
+
+    /// Internal helper function for setting up a new send transaction
+    fn send_new(&self, app_id: AppId, app: &mut App, callback: Callback) -> ReturnCode {
+        match app.write_buffer.take() {
+            Some(slice) => {
+                app.write_len = slice.len();
+                app.write_remaining = app.write_len;
+                app.write_callback = Some(callback);
+                self.send(app_id, app, slice);
+                ReturnCode::SUCCESS
+            },
+            None => ReturnCode::EBUSY,
+        }
+    }
+
+    /// Internal helper function for continuing a previously set up transaction
+    /// Returns true if this send is still active, or false if it has completed
+    fn send_continue(&self, app_id: AppId, app: &mut App) -> bool {
+        if app.write_remaining > 0 {
+            match app.write_buffer.take() {
+                Some(slice) => {
+                    self.send(app_id, app, slice);
+                }
+                None => panic!("Consistency error. In-progress write had no write_buffer?"),
+            };
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Internal helper function for sending data for an existing transaction.
+    /// Cannot fail. If can't send now, it will schedule for sending later.
+    fn send(&self, app_id: AppId, app: &mut App, slice: AppSlice<Shared, u8>) {
+        if self.in_progress.is_none() {
+            self.in_progress.replace(app_id);
+            self.tx_buffer.take().map(|buffer| {
+                let mut transaction_len = app.write_remaining;
+                for (i, c) in slice.as_ref()[slice.len() - app.write_remaining .. slice.len()].iter().enumerate() {
+                    if buffer.len() <= i {
+                        break;
+                    }
+                    buffer[i] = *c;
+                }
+
+                // Check if everything we wanted to print
+                // fit in the buffer.
+                if app.write_remaining > buffer.len() {
+                    transaction_len = buffer.len();
+                    app.write_remaining -= buffer.len();
+                    app.write_buffer = Some(slice);
+                } else {
+                    app.write_remaining = 0;
+                }
+
+                self.uart.transmit(buffer, transaction_len);
+            });
+        } else {
+            app.pending_write = true;
+            app.write_buffer = Some(slice);
+        }
+    }
 }
 
 impl<'a, U: UART> Driver for Console<'a, U> {
@@ -108,41 +170,7 @@ impl<'a, U: UART> Driver for Console<'a, U> {
             },
             1 /* putstr/write_done */ => {
                 self.apps.enter(callback.app_id(), |app, _| {
-                    match app.write_buffer.take() {
-                        Some(slice) => {
-                            app.write_callback = Some(callback);
-                            app.write_len = slice.len();
-                            app.write_remaining = 0;
-                            if self.in_progress.is_none() {
-                                self.in_progress.replace(callback.app_id());
-                                self.tx_buffer.take().map(|buffer| {
-                                    for (i, c) in slice.as_ref().iter().enumerate() {
-                                        if buffer.len() <= i {
-                                            break;
-                                        }
-                                        buffer[i] = *c;
-                                    }
-
-                                    // Check if everything we wanted to print
-                                    // fit in the buffer.
-                                    if slice.len() > buffer.len() {
-                                        app.write_len = buffer.len();
-                                        app.write_remaining = slice.len() - buffer.len();
-                                        app.write_buffer = Some(slice);
-                                    }
-
-                                    self.uart.transmit(buffer, app.write_len);
-                                });
-                            } else {
-                                app.pending_write = true;
-                                app.write_buffer = Some(slice);
-                            }
-                            ReturnCode::SUCCESS
-                        },
-                        None => ReturnCode::FAIL
-                        // XXX  ^^^^^^^^^^^^^^^^-- When can we fail to take the write_buffer
-                        //                         which return code is best here?
-                    }
+                    self.send_new(callback.app_id(), app, callback)
                 }).unwrap_or_else(|err| {
                     match err {
                         Error::OutOfMemory => ReturnCode::ENOMEM,
@@ -177,44 +205,13 @@ impl<'a, U: UART> Client for Console<'a, U> {
         self.tx_buffer.replace(buffer);
         self.in_progress.take().map(|appid| {
             self.apps.enter(appid, |app, _| {
-                // Check to see if we have more to write that didn't fit in our
-                // buffer.
-                if app.write_remaining > 0 {
-                    match app.write_buffer.take() {
-                        Some(slice) => {
-                            let mut transaction_len = app.write_remaining;
-                            self.in_progress.replace(appid);
-                            self.tx_buffer.take().map(|buffer| {
-                                for (i, c) in slice.as_ref()[slice.len() - app.write_remaining..
-                                              slice.len()]
-                                    .iter()
-                                    .enumerate() {
-                                    if buffer.len() <= i {
-                                        break;
-                                    }
-                                    buffer[i] = *c;
-                                }
+                let finished = ! self.send_continue(appid, app);
 
-                                // Check to see if we need to keep going.
-                                if app.write_remaining > buffer.len() {
-                                    transaction_len = buffer.len();
-                                    app.write_remaining = app.write_remaining - buffer.len();
-                                    app.write_buffer = Some(slice);
-                                } else {
-                                    app.write_remaining = 0;
-                                }
-
-                                self.uart.transmit(buffer, transaction_len);
-                            });
-                            0
-                        }
-                        None => -1,
-                    };
-
-                } else {
+                if finished {
                     // Go ahead and signal the application
-                    app.write_callback.map(|mut cb| { cb.schedule(app.write_len, 0, 0); });
+                    let written = app.write_len;
                     app.write_len = 0;
+                    app.write_callback.map(|mut cb| { cb.schedule(written, 0, 0); });
                 }
             })
         });
@@ -226,32 +223,7 @@ impl<'a, U: UART> Client for Console<'a, U> {
                 let started_tx = cntr.enter(|app, _| {
                     if app.pending_write {
                         app.pending_write = false;
-                        match app.write_buffer.take() {
-                            Some(slice) => {
-                                app.write_remaining = 0;
-                                self.in_progress.replace(app.appid());
-                                self.tx_buffer.take().map(|buffer| {
-                                    for (i, c) in slice.as_ref().iter().enumerate() {
-                                        if buffer.len() <= i {
-                                            break;
-                                        }
-                                        buffer[i] = *c;
-                                    }
-
-                                    // Check if everything we wanted to print
-                                    // fit in the buffer.
-                                    if slice.len() > buffer.len() {
-                                        app.write_len = buffer.len();
-                                        app.write_remaining = slice.len() - buffer.len();
-                                        app.write_buffer = Some(slice);
-                                    }
-
-                                    self.uart.transmit(buffer, app.write_len);
-                                });
-                                true
-                            }
-                            None => false,
-                        }
+                        self.send_continue(app.appid(), app)
                     } else {
                         false
                     }


### PR DESCRIPTION
We were essentially doing the same thing in three places. That meant
that #260 only fixed the problem in 1 of 3 cases. This consolidates
the send logic into a shared helper function and makes more clear
when/how we're setting things up or continuing active transactions.