### PR TITLE
derive Debug trait for trivial kernel structures

### DIFF
--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -1,7 +1,7 @@
 use core::nonzero::NonZero;
 use process;
 
-#[derive(Clone,Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct AppId {
     idx: usize,
 }
@@ -16,7 +16,7 @@ impl AppId {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Callback {
     app_id: AppId,
     appdata: usize,

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -22,6 +22,7 @@ pub trait Frequency {
     fn frequency() -> u32;
 }
 
+#[derive(Debug)]
 pub struct Freq1KHz;
 impl Frequency for Freq1KHz {
     fn frequency() -> u32 {

--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     PageBoundary,
     WordBoundary,

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -1,5 +1,6 @@
 /// Enum for configuring any pull-up or pull-down
 /// resistors on the GPIO pin.
+#[derive(Debug)]
 pub enum InputMode {
     PullUp,
     PullDown,
@@ -8,6 +9,7 @@ pub enum InputMode {
 
 /// Enum for selecting which edge to trigger interrupts
 /// on.
+#[derive(Debug)]
 pub enum InterruptMode {
     RisingEdge,
     FallingEdge,

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -32,7 +32,7 @@ impl Display for Error {
 }
 
 /// This specifies what type of transmission just finished from a Master device.
-#[derive(Copy,Clone)]
+#[derive(Copy,Clone,Debug)]
 pub enum SlaveTransmissionType {
     Write,
     Read,

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -59,7 +59,7 @@
 
 /// Denotes whether the [Client](trait.Client.html) wants to be notified when
 /// `More` randomness is available or if they are `Done`
-#[derive(PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Continue {
     /// More randomness is required.
     More,

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -3,21 +3,21 @@
 use core::option::Option;
 
 /// Values for the ordering of bits
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum DataOrder {
     MSBFirst,
     LSBFirst,
 }
 
 /// Values for the clock polarity (idle state or CPOL)
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ClockPolarity {
     IdleLow,
     IdleHigh,
 }
 
 /// Which clock edge values are sampled on
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ClockPhase {
     SampleLeading,
     SampleTrailing,

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -15,6 +15,7 @@ pub trait Frequency {
 }
 
 /// 32KHz `Frequency`
+#[derive(Debug)]
 pub struct Freq32KHz;
 impl Frequency for Freq32KHz {
     fn frequency() -> u32 {
@@ -23,6 +24,7 @@ impl Frequency for Freq32KHz {
 }
 
 /// 16KHz `Frequency`
+#[derive(Debug)]
 pub struct Freq16KHz;
 impl Frequency for Freq16KHz {
     fn frequency() -> u32 {
@@ -31,6 +33,7 @@ impl Frequency for Freq16KHz {
 }
 
 /// 1KHz `Frequency`
+#[derive(Debug)]
 pub struct Freq1KHz;
 impl Frequency for Freq1KHz {
     fn frequency() -> u32 {

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -1,18 +1,18 @@
 /// UART hardware interface
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum StopBits {
     One = 0,
     Two = 2,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum Parity {
     None = 0,
     Odd = 1,
     Even = 2,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct UARTParams {
     pub baud_rate: u32, // baud rate in bit/s
     pub stop_bits: StopBits,

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -5,7 +5,9 @@ use core::ptr::Unique;
 use core::slice;
 use process;
 
+#[derive(Debug)]
 pub struct Private;
+#[derive(Debug)]
 pub struct Shared;
 
 pub struct AppPtr<L, T> {

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,4 +1,5 @@
 
+#[derive(Debug)]
 pub enum AccessPermission {
     //                                 Privileged  Unprivileged
     //                                 Access      Access
@@ -12,6 +13,7 @@ pub enum AccessPermission {
     ReadOnlyAlais = 0b111, //......... R-          R-
 }
 
+#[derive(Debug)]
 pub enum ExecutePermission {
     ExecutionPermitted = 0b0,
     ExecutionNotPermitted = 0b1,

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -56,39 +56,39 @@ pub fn schedule(callback: FunctionCall, appid: AppId) -> bool {
     }
 }
 
-#[derive(Copy,Clone,PartialEq,Eq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     NoSuchApp,
     OutOfMemory,
     AddressOutOfBounds,
 }
 
-#[derive(Copy,Clone,Debug,PartialEq,Eq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum State {
     Running,
     Yielded,
     Fault,
 }
 
-#[derive(Copy,Clone,PartialEq,Eq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FaultResponse {
     Panic,
     Restart,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum IPCType {
     Service,
     Client,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum Task {
     FunctionCall(FunctionCall),
     IPC((AppId, IPCType)),
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct FunctionCall {
     pub r0: usize,
     pub r1: usize,


### PR DESCRIPTION
I keep adding these ad-hoc. From a casual grep of pub.struct and
pub.enum, this should hopefully skip future annoying compile hangups.

From my understanding, debug traits cost nothing to derive, as their
implementations will automatically be dropped if nothing prints them.

It's probably a worthwhile question about what structures should have
Debug defined (should everything?), but that's for another day. For today,
just the trivial ones en masse.