### PR TITLE
export ReturnCode from returncode module

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -4,9 +4,8 @@
 //! ADC channels.
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Driver};
+use kernel::{AppId, Callback, Driver, ReturnCode};
 use kernel::hil::adc::{Client, AdcSingle};
-use kernel::returncode::ReturnCode;
 
 pub struct ADC<'a, A: AdcSingle + 'a> {
     adc: &'a A,

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -2,11 +2,10 @@
 //! platform controlling of buttons without having to know which of the GPIO pins exposed across
 //! the syscall interface are buttons.
 
-use kernel::{AppId, Container, Callback, Driver};
+use kernel::{AppId, Container, Callback, Driver, ReturnCode};
 use kernel::hil;
 use kernel::hil::gpio::{Client, InterruptMode};
 use kernel::process::Error;
-use kernel::returncode::ReturnCode;
 
 pub type SubscribeMap = u32;
 

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -3,11 +3,10 @@
 //! Console provides userspace with the ability to print text via a serial
 //! interface.
 
-use kernel::{AppId, AppSlice, Container, Callback, Shared, Driver};
+use kernel::{AppId, AppSlice, Container, Callback, Shared, Driver, ReturnCode};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::uart::{self, UART, Client};
 use kernel::process::Error;
-use kernel::returncode::ReturnCode;
 
 pub struct App {
     write_callback: Option<Callback>,

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -2,11 +2,10 @@
 
 use core::cell::Cell;
 use core::cmp;
-use kernel::{AppId, AppSlice, Callback, Driver, Shared};
+use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
-use kernel::returncode::ReturnCode;
 
 
 

--- a/capsules/src/fxos8700_cq.rs
+++ b/capsules/src/fxos8700_cq.rs
@@ -4,10 +4,9 @@
 //! To use readings from the sensor in userland, see FXOS8700CQ.h in libtock.
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Driver};
+use kernel::{AppId, Callback, Driver, ReturnCode};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::i2c::{I2CDevice, I2CClient, Error};
-use kernel::returncode::ReturnCode;
 
 pub static mut BUF: [u8; 6] = [0; 6];
 

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -5,9 +5,8 @@
 //! and a callback for interrupts.
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Driver};
+use kernel::{AppId, Callback, Driver, ReturnCode};
 use kernel::hil::gpio::{Pin, PinCtl, InputMode, InterruptMode, Client};
-use kernel::returncode::ReturnCode;
 
 pub struct GPIO<'a, G: Pin + 'a> {
     pins: &'a [&'a G],

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -12,11 +12,10 @@
 
 use core::cell::Cell;
 use core::cmp;
-use kernel::{AppId, AppSlice, Callback, Driver, Shared};
+use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
-use kernel::returncode::ReturnCode;
 
 pub static mut BUFFER1: [u8; 256] = [0; 256];
 pub static mut BUFFER2: [u8; 256] = [0; 256];

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -1,11 +1,10 @@
 //! Driver for the ISL29035 digital light sensor
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Driver};
+use kernel::{AppId, Callback, Driver, ReturnCode};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::i2c::{I2CDevice, I2CClient, Error};
 use kernel::hil::time::{self, Frequency};
-use kernel::returncode::ReturnCode;
 
 pub static mut BUF: [u8; 3] = [0; 3];
 

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -3,9 +3,8 @@
 //! without having to know which of the GPIO pins exposed across
 //! the syscall interface are LEDs.
 
-use kernel::{AppId, Driver};
+use kernel::{AppId, Driver, ReturnCode};
 use kernel::hil;
-use kernel::returncode::ReturnCode;
 
 /// Whether the LEDs are active high or active low on this platform.
 pub enum ActivationMode {

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -3,12 +3,11 @@
 //! http://www.st.com/en/mems-and-sensors/lps25hb.html
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Driver};
+use kernel::{AppId, Callback, Driver, ReturnCode};
 
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::returncode::ReturnCode;
 
 // Buffer to use for I2C messages
 pub static mut BUFFER: [u8; 5] = [0; 5];

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -4,10 +4,9 @@
 //! This capsule handles interfacing with the UART driver, and includes
 //! some nuances that keep the Nordic BLE serialization library happy.
 
-use kernel::{AppId, Callback, AppSlice, Driver, Shared};
+use kernel::{AppId, Callback, AppSlice, Driver, ReturnCode, Shared};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::uart::{self, UARTAdvanced, Client};
-use kernel::returncode::ReturnCode;
 
 struct App {
     callback: Option<Callback>,

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -7,10 +7,9 @@
 
 
 use core::cell::Cell;
-use kernel::{AppId, AppSlice, Container, Callback, Shared, Driver};
+use kernel::{AppId, AppSlice, Container, Callback, Driver, ReturnCode, Shared};
 use kernel::hil::rng;
 use kernel::process::Error;
-use kernel::returncode::ReturnCode;
 
 pub struct App {
     callback: Option<Callback>,

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -3,13 +3,12 @@
 //! https://www.silabs.com/products/sensors/humidity-sensors/Pages/si7013-20-21.aspx
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Driver};
+use kernel::{AppId, Callback, Driver, ReturnCode};
 
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::i2c;
 use kernel::hil::time;
 use kernel::hil::time::Frequency;
-use kernel::returncode::ReturnCode;
 
 // Buffer to use for I2C messages
 pub static mut BUFFER: [u8; 14] = [0; 14];

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -3,12 +3,11 @@
 
 use core::cell::Cell;
 use core::cmp;
-use kernel::{AppId, Driver, Callback, AppSlice, Shared};
+use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::spi::{SpiMasterDevice, SpiMasterClient};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
-use kernel::returncode::ReturnCode;
 
 // SPI operations are handled by coping into a kernel buffer for
 // writes and copying out of a kernel buffer for reads.

--- a/capsules/src/timer.rs
+++ b/capsules/src/timer.rs
@@ -3,10 +3,9 @@
 //! Provides userspace applications with a timer API.
 
 use core::cell::Cell;
-use kernel::{AppId, Container, Callback, Driver};
+use kernel::{AppId, Callback, Container, Driver, ReturnCode};
 use kernel::hil::time::{self, Alarm, Frequency};
 use kernel::process::Error;
-use kernel::returncode::ReturnCode;
 
 #[derive(Copy, Clone)]
 pub struct TimerData {

--- a/capsules/src/tmp006.rs
+++ b/capsules/src/tmp006.rs
@@ -3,12 +3,11 @@
 //! http://www.ti.com/product/TMP006
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Driver};
+use kernel::{AppId, Callback, Driver, ReturnCode};
 use kernel::common::math::{sqrtf32, get_errno};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::gpio::{Pin, InterruptMode, Client};
 use kernel::hil::i2c;
-use kernel::returncode::ReturnCode;
 
 pub static mut BUFFER: [u8; 3] = [0; 3];
 

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -3,12 +3,11 @@
 //! http://www.digikey.com/product-detail/en/ams-taos-usa-inc/TSL2561FN/TSL2561-FNCT-ND/3095298
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Driver};
+use kernel::{AppId, Callback, Driver, ReturnCode};
 
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::returncode::ReturnCode;
 
 // Buffer to use for I2C messages
 pub static mut BUFFER: [u8; 4] = [0; 4];

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -26,6 +26,7 @@ pub use mem::{AppSlice, AppPtr, Private, Shared};
 pub use platform::{Chip, mpu, Platform, systick};
 pub use platform::systick::SysTick;
 pub use process::{Process, State};
+pub use returncode::ReturnCode;
 
 pub fn main<P: Platform, C: Chip>(platform: &P,
                                   chip: &mut C,


### PR DESCRIPTION
@brghena points out that if ReturnCode is a public interface, its
import shouldn't be dependent on the internal module structure of
the kernel crate, and kernel should export it for other crates' use

If this goes through before #261 (likely), I promise to make the
requisite change there for you Phil :)