### PR TITLE
Kernel debug support

### DIFF
--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -40,7 +40,7 @@ impl Write for Writer {
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
 
     let writer = &mut WRITER;
-    let _ = writer.write_fmt(format_args!("Kernel panic at {}:{}:\r\n\t\"", file, line));
+    let _ = writer.write_fmt(format_args!("\r\n\nKernel panic at {}:{}:\r\n\t\"", file, line));
     let _ = write(writer, args);
     let _ = writer.write_str("\"\r\n");
 

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -38,6 +38,17 @@ impl Write for Writer {
 #[no_mangle]
 #[lang="panic_fmt"]
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
+    // XXX Replace with something like kernel::begin_panic()
+    // XXX Maybe place that call at panic_fmt, as it's called first
+    // XXX Better to cancel the transaction rather than hope we wait long enough
+    // Let any outstanding uart DMA's finish
+    asm!("nop");
+    asm!("nop");
+    for _ in 0..200000 {
+        asm!("nop");
+    }
+    asm!("nop");
+    asm!("nop");
 
     let writer = &mut WRITER;
     let _ = writer.write_fmt(format_args!("\r\n\nKernel panic at {}:{}:\r\n\t\"", file, line));

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -4,7 +4,7 @@
 
 extern crate capsules;
 extern crate cortexm4;
-#[macro_use(static_init)]
+#[macro_use(debug, static_init)]
 extern crate kernel;
 extern crate sam4l;
 
@@ -385,5 +385,6 @@ pub unsafe fn reset_handler() {
     // Uncomment to measure overheads for TakeCell and MapCell:
     // test_take_map_cell::test_take_map_cell();
 
+    debug!("Initialization complete. Entering main loop");
     kernel::main(&hail, &mut chip, load_processes(), &hail.ipc);
 }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -370,6 +370,13 @@ pub unsafe fn reset_handler() {
     sam4l::gpio::PA[17].set();
 
     hail.console.initialize();
+    // Attach the kernel debug interface to this console
+    let kc = static_init!(
+        capsules::console::App,
+        capsules::console::App::default(),
+        480/8);
+    kernel::debug::assign_console_driver(Some(hail.console), kc);
+
     hail.nrf51822.initialize();
 
     let mut chip = sam4l::chip::Sam4l::new();

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -196,7 +196,7 @@ pub unsafe fn reset_handler() {
         Nrf51822Serialization::new(&usart::USART3,
                                    &mut nrf51822_serialization::WRITE_BUF,
                                    &mut nrf51822_serialization::READ_BUF),
-        544/8);
+        608/8);
     hil::uart::UART::set_client(&usart::USART3, nrf_serialization);
 
     let ast = &sam4l::ast::AST;
@@ -224,7 +224,7 @@ pub unsafe fn reset_handler() {
         capsules::si7021::SI7021::new(si7021_i2c,
             si7021_virtual_alarm,
             &mut capsules::si7021::BUFFER),
-        288/8);
+        352/8);
     si7021_i2c.set_client(si7021);
     si7021_virtual_alarm.set_client(si7021);
 
@@ -238,7 +238,7 @@ pub unsafe fn reset_handler() {
         capsules::isl29035::Isl29035<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
         capsules::isl29035::Isl29035::new(isl29035_i2c, isl29035_virtual_alarm,
                                           &mut capsules::isl29035::BUF),
-        320/8);
+        384/8);
     isl29035_i2c.set_client(isl29035);
     isl29035_virtual_alarm.set_client(isl29035);
 
@@ -258,7 +258,7 @@ pub unsafe fn reset_handler() {
     let fxos8700 = static_init!(
         capsules::fxos8700_cq::Fxos8700cq<'static>,
         capsules::fxos8700_cq::Fxos8700cq::new(fxos8700_i2c, &mut capsules::fxos8700_cq::BUF),
-        288/8);
+        352/8);
     fxos8700_i2c.set_client(fxos8700);
 
     // Initialize and enable SPI HAL
@@ -283,7 +283,7 @@ pub unsafe fn reset_handler() {
     let spi_syscalls = static_init!(
         capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
         capsules::spi::Spi::new(syscall_spi_device),
-        608/8);
+        672/8);
 
     spi_syscalls.config_buffers(&mut SPI_READ_BUF, &mut SPI_WRITE_BUF);
     syscall_spi_device.set_client(spi_syscalls);
@@ -317,7 +317,7 @@ pub unsafe fn reset_handler() {
     let adc = static_init!(
         capsules::adc::ADC<'static, sam4l::adc::Adc>,
         capsules::adc::ADC::new(&mut sam4l::adc::ADC),
-        160/8);
+        224/8);
     sam4l::adc::ADC.set_client(adc);
 
     // Setup RNG
@@ -340,7 +340,7 @@ pub unsafe fn reset_handler() {
     let gpio = static_init!(
         capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
         capsules::gpio::GPIO::new(gpio_pins),
-        20);
+        224/8);
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);
     }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(const_fn,lang_items)]
+#![feature(asm,const_fn,lang_items)]
 
 extern crate capsules;
 extern crate cortexm4;

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -40,7 +40,7 @@ impl Write for Writer {
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
 
     let writer = &mut WRITER;
-    let _ = writer.write_fmt(format_args!("Kernel panic at {}:{}:\r\n\t\"", file, line));
+    let _ = writer.write_fmt(format_args!("\r\n\nKernel panic at {}:{}:\r\n\t\"", file, line));
     let _ = write(writer, args);
     let _ = writer.write_str("\"\r\n");
 

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -38,6 +38,17 @@ impl Write for Writer {
 #[no_mangle]
 #[lang="panic_fmt"]
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
+    // XXX Replace with something like kernel::begin_panic()
+    // XXX Maybe place that call at panic_fmt, as it's called first
+    // XXX Better to cancel the transaction rather than hope we wait long enough
+    // Let any outstanding uart DMA's finish
+    asm!("nop");
+    asm!("nop");
+    for _ in 0..200000 {
+        asm!("nop");
+    }
+    asm!("nop");
+    asm!("nop");
 
     let writer = &mut WRITER;
     let _ = writer.write_fmt(format_args!("\r\n\nKernel panic at {}:{}:\r\n\t\"", file, line));

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(asm,const_fn,lang_items)]
 
 extern crate capsules;
-#[macro_use(static_init)]
+#[macro_use(debug, static_init)]
 extern crate kernel;
 extern crate sam4l;
 
@@ -178,6 +178,13 @@ pub unsafe fn reset_handler() {
         224/8);
     hil::uart::UART::set_client(&sam4l::usart::USART3, console);
     console.initialize();
+
+    // Attach the kernel debug interface to this console
+    let kc = static_init!(
+        capsules::console::App,
+        capsules::console::App::default(),
+        480/8);
+    kernel::debug::assign_console_driver(Some(console), kc);
 
     // # TIMER
 
@@ -384,6 +391,8 @@ pub unsafe fn reset_handler() {
     rf233.set_pan(0xABCD);
     rf233.set_address(0x1008);
     rf233.start();
+
+    debug!("Initialization complete. Entering main loop");
     kernel::main(&imix, &mut chip, load_processes(), &imix.ipc);
 }
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -216,7 +216,7 @@ pub unsafe fn reset_handler() {
             isl29035_i2c,
             isl29035_virtual_alarm,
             &mut capsules::isl29035::BUF),
-        320/8);
+        384/8);
     isl29035_i2c.set_client(isl29035);
     isl29035_virtual_alarm.set_client(isl29035);
 
@@ -240,7 +240,7 @@ pub unsafe fn reset_handler() {
     let spi_syscalls = static_init!(
         capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
         capsules::spi::Spi::new(syscall_spi_device),
-        608/8);
+        672/8);
 
     // System call capsule requires static buffers so it can
     // copy from application slices to DMA
@@ -259,7 +259,7 @@ pub unsafe fn reset_handler() {
     let si7021 = static_init!(
         capsules::si7021::SI7021<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
         capsules::si7021::SI7021::new(si7021_i2c, si7021_alarm, &mut capsules::si7021::BUFFER),
-        36);
+        352/8);
     si7021_i2c.set_client(si7021);
     si7021_alarm.set_client(si7021);
 
@@ -284,7 +284,7 @@ pub unsafe fn reset_handler() {
     let fx0 = static_init!(
         capsules::fxos8700_cq::Fxos8700cq<'static>,
         capsules::fxos8700_cq::Fxos8700cq::new(fx0_i2c, &mut capsules::fxos8700_cq::BUF),
-        288/8);
+        352/8);
     fx0_i2c.set_client(fx0);
 
     // Clear sensors enable pin to enable sensor rail
@@ -297,7 +297,7 @@ pub unsafe fn reset_handler() {
     let adc = static_init!(
         capsules::adc::ADC<'static, sam4l::adc::Adc>,
         capsules::adc::ADC::new(&mut sam4l::adc::ADC),
-        160/8);
+        224/8);
     sam4l::adc::ADC.set_client(adc);
 
     // # GPIO
@@ -318,8 +318,7 @@ pub unsafe fn reset_handler() {
     let gpio = static_init!(
         capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
         capsules::gpio::GPIO::new(gpio_pins),
-        20);
-
+        224/8);
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);
     }
@@ -357,7 +356,7 @@ pub unsafe fn reset_handler() {
                                      RF233<'static,
                                            VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>>,
         capsules::radio::RadioDriver::new(rf233),
-        544/8);
+        672/8);
     radio_capsule.config_buffer(&mut RADIO_BUF);
     rf233.set_transmit_client(radio_capsule);
     rf233.set_receive_client(radio_capsule, &mut RF233_RX_BUF);

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(const_fn,lang_items)]
+#![feature(asm,const_fn,lang_items)]
 
 extern crate capsules;
 #[macro_use(static_init)]

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -183,7 +183,7 @@ pub unsafe fn reset_handler() {
     let gpio = static_init!(
         capsules::gpio::GPIO<'static, nrf51::gpio::GPIOPin>,
         capsules::gpio::GPIO::new(gpio_pins),
-        20);
+        224/8);
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);
     }

--- a/boards/storm/src/io.rs
+++ b/boards/storm/src/io.rs
@@ -40,7 +40,7 @@ impl Write for Writer {
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
 
     let writer = &mut WRITER;
-    let _ = writer.write_fmt(format_args!("Kernel panic at {}:{}:\r\n\t\"", file, line));
+    let _ = writer.write_fmt(format_args!("\r\n\nKernel panic at {}:{}:\r\n\t\"", file, line));
     let _ = write(writer, args);
     let _ = writer.write_str("\"\r\n");
 

--- a/boards/storm/src/io.rs
+++ b/boards/storm/src/io.rs
@@ -38,6 +38,17 @@ impl Write for Writer {
 #[no_mangle]
 #[lang="panic_fmt"]
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
+    // XXX Replace with something like kernel::begin_panic()
+    // XXX Maybe place that call at panic_fmt, as it's called first
+    // XXX Better to cancel the transaction rather than hope we wait long enough
+    // Let any outstanding uart DMA's finish
+    asm!("nop");
+    asm!("nop");
+    for _ in 0..200000 {
+        asm!("nop");
+    }
+    asm!("nop");
+    asm!("nop");
 
     let writer = &mut WRITER;
     let _ = writer.write_fmt(format_args!("\r\n\nKernel panic at {}:{}:\r\n\t\"", file, line));

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -4,7 +4,7 @@
 
 extern crate capsules;
 extern crate cortexm4;
-#[macro_use(static_init)]
+#[macro_use(debug, static_init)]
 extern crate kernel;
 extern crate sam4l;
 
@@ -428,9 +428,17 @@ pub unsafe fn reset_handler() {
     firestorm.console.initialize();
     firestorm.nrf51822.initialize();
 
+    // Attach the kernel debug interface to this console
+    let kc = static_init!(
+        capsules::console::App,
+        capsules::console::App::default(),
+        480/8);
+    kernel::debug::assign_console_driver(Some(firestorm.console), kc);
+
     let mut chip = sam4l::chip::Sam4l::new();
     chip.mpu().enable_mpu();
 
 
+    debug!("Initialization complete. Entering main loop");
     kernel::main(&firestorm, &mut chip, load_processes(), &firestorm.ipc);
 }

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -246,7 +246,7 @@ pub unsafe fn reset_handler() {
         Nrf51822Serialization::new(&usart::USART2,
                                    &mut nrf51822_serialization::WRITE_BUF,
                                    &mut nrf51822_serialization::READ_BUF),
-        544/8);
+        608/8);
     hil::uart::UART::set_client(&usart::USART2, nrf_serialization);
 
     let ast = &sam4l::ast::AST;
@@ -268,7 +268,7 @@ pub unsafe fn reset_handler() {
         capsules::tmp006::TMP006::new(tmp006_i2c,
                                      &sam4l::gpio::PA[9],
                                      &mut capsules::tmp006::BUFFER),
-        52);
+        480/8);
     tmp006_i2c.set_client(tmp006);
     sam4l::gpio::PA[9].set_client(tmp006);
 
@@ -284,7 +284,7 @@ pub unsafe fn reset_handler() {
             isl29035_i2c,
             isl29035_virtual_alarm,
             &mut capsules::isl29035::BUF),
-        320/8);
+        384/8);
     isl29035_i2c.set_client(isl29035);
     isl29035_virtual_alarm.set_client(isl29035);
 
@@ -320,7 +320,7 @@ pub unsafe fn reset_handler() {
     let spi_syscalls = static_init!(
         capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
         capsules::spi::Spi::new(syscall_spi_device),
-        608/8);
+        672/8);
 
     spi_syscalls.config_buffers(&mut SPI_READ_BUF, &mut SPI_WRITE_BUF);
     syscall_spi_device.set_client(spi_syscalls);
@@ -339,7 +339,7 @@ pub unsafe fn reset_handler() {
     let adc = static_init!(
         capsules::adc::ADC<'static, sam4l::adc::Adc>,
         capsules::adc::ADC::new(&mut sam4l::adc::ADC),
-        160/8);
+        224/8);
     sam4l::adc::ADC.set_client(adc);
 
     // RNG
@@ -370,7 +370,7 @@ pub unsafe fn reset_handler() {
     let gpio = static_init!(
         capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
         capsules::gpio::GPIO::new(gpio_pins),
-        20);
+        224/8);
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);
     }

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(const_fn,lang_items)]
+#![feature(asm,const_fn,lang_items)]
 
 extern crate capsules;
 extern crate cortexm4;

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(const_fn)]
 #![no_std]
 
+#[macro_use(debug)]
 extern crate kernel;
 
 pub mod button;

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(const_fn)]
 #![no_std]
 
-#[macro_use(debug)]
 extern crate kernel;
 
 pub mod button;

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -40,9 +40,9 @@ pub enum RustOrRawFnPtr {
 
 #[derive(Clone, Copy, Debug)]
 pub struct Callback {
-    pub app_id: AppId,
-    pub appdata: usize,
-    pub fn_ptr: RustOrRawFnPtr,
+    app_id: AppId,
+    appdata: usize,
+    fn_ptr: RustOrRawFnPtr,
 }
 
 impl Callback {
@@ -51,6 +51,14 @@ impl Callback {
             app_id: appid,
             appdata: appdata,
             fn_ptr: RustOrRawFnPtr::Raw { ptr: fn_ptr },
+        }
+    }
+
+    pub const fn kernel_new(appid: AppId, fn_ptr: fn(usize, usize, usize, usize)) -> Callback {
+        Callback {
+            app_id: appid,
+            appdata: 0,
+            fn_ptr: RustOrRawFnPtr::Rust { func: fn_ptr },
         }
     }
 

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -6,9 +6,25 @@ pub struct AppId {
     idx: usize,
 }
 
+/// The kernel can masquerade as an app. IDs >= this value are the kernel.
+/// These IDs are used to identify which kernel container is being accessed.
+const KERNEL_APPID_BOUNDARY: usize = 100;
+
 impl AppId {
     pub fn new(idx: usize) -> AppId {
         AppId { idx: idx }
+    }
+
+    pub const fn kernel_new(idx: usize) -> AppId {
+        AppId { idx: idx }
+    }
+
+    pub const fn is_kernel(appid: AppId) -> bool {
+        appid.idx >= KERNEL_APPID_BOUNDARY
+    }
+
+    pub const fn is_kernel_idx(appid: usize) -> bool {
+        appid >= KERNEL_APPID_BOUNDARY
     }
 
     pub fn idx(&self) -> usize {
@@ -18,9 +34,9 @@ impl AppId {
 
 #[derive(Clone, Copy, Debug)]
 pub struct Callback {
-    app_id: AppId,
-    appdata: usize,
-    fn_ptr: NonZero<*mut ()>,
+    pub app_id: AppId,
+    pub appdata: usize,
+    pub fn_ptr: NonZero<*mut ()>,
 }
 
 impl Callback {
@@ -33,14 +49,18 @@ impl Callback {
     }
 
     pub fn schedule(&mut self, r0: usize, r1: usize, r2: usize) -> bool {
-        process::schedule(process::FunctionCall {
-                              r0: r0,
-                              r1: r1,
-                              r2: r2,
-                              r3: self.appdata,
-                              pc: *self.fn_ptr as usize,
-                          },
-                          self.app_id)
+        if AppId::is_kernel(self.app_id) {
+            unimplemented!();
+        } else {
+            process::schedule(process::FunctionCall {
+                                  r0: r0,
+                                  r1: r1,
+                                  r2: r2,
+                                  r3: self.appdata,
+                                  pc: *self.fn_ptr as usize,
+                              },
+                              self.app_id)
+        }
     }
 
     pub fn app_id(&self) -> AppId {

--- a/kernel/src/container.rs
+++ b/kernel/src/container.rs
@@ -1,5 +1,3 @@
-
-
 use callback::AppId;
 use core::marker::PhantomData;
 use core::mem::size_of;

--- a/kernel/src/container.rs
+++ b/kernel/src/container.rs
@@ -1,8 +1,11 @@
+
+
 use callback::AppId;
 use core::marker::PhantomData;
 use core::mem::size_of;
 use core::ops::{Deref, DerefMut};
 use core::ptr::{read_volatile, write_volatile, Unique};
+use debug;
 use process::{self, Error};
 
 pub static mut CONTAINER_COUNTER: usize = 0;
@@ -18,13 +21,20 @@ pub struct AppliedContainer<T> {
     _phantom: PhantomData<T>,
 }
 
+pub unsafe fn kernel_container_for<T>(app_id: usize) -> *mut T {
+    match app_id {
+        debug::APPID_IDX => debug::get_container(),
+        _ => panic!("lookup for invalid kernel container {}", app_id),
+    }
+}
+
 impl<T> AppliedContainer<T> {
     pub fn enter<F, R>(self, fun: F) -> R
         where F: FnOnce(&mut Owned<T>, &mut Allocator) -> R,
               R: Copy
     {
         let mut allocator = Allocator {
-            app: unsafe { process::PROCS[self.appid].as_mut().unwrap() },
+            app: unsafe { Some(process::PROCS[self.appid].as_mut().unwrap()) },
             app_id: self.appid,
         };
         let mut root = unsafe { Owned::new(self.container, self.appid) };
@@ -33,7 +43,7 @@ impl<T> AppliedContainer<T> {
 }
 
 pub struct Allocator<'a> {
-    app: &'a mut process::Process<'a>,
+    app: Option<&'a mut process::Process<'a>>,
     app_id: usize,
 }
 
@@ -60,10 +70,15 @@ impl<T: ?Sized> Drop for Owned<T> {
         unsafe {
             let app_id = self.app_id;
             let data = self.data.get_mut() as *mut T as *mut u8;
-            match process::PROCS[app_id] {
-                None => {}
-                Some(ref mut app) => {
-                    app.free(data);
+            if AppId::is_kernel_idx(app_id) {
+                /* kernel free is nop */
+;
+            } else {
+                match process::PROCS[app_id] {
+                    None => {}
+                    Some(ref mut app) => {
+                        app.free(data);
+                    }
                 }
             }
         }
@@ -87,11 +102,21 @@ impl<'a> Allocator<'a> {
     pub fn alloc<T>(&mut self, data: T) -> Result<Owned<T>, Error> {
         unsafe {
             let app_id = self.app_id;
-            self.app.alloc(size_of::<T>()).map_or(Err(Error::OutOfMemory), |arr| {
-                let mut owned = Owned::new(arr.as_mut_ptr() as *mut T, app_id);
-                *owned = data;
-                Ok(owned)
-            })
+            match self.app.as_mut() {
+                Some(app) => {
+                    app.alloc(size_of::<T>()).map_or(Err(Error::OutOfMemory), |arr| {
+                        let mut owned = Owned::new(arr.as_mut_ptr() as *mut T, app_id);
+                        *owned = data;
+                        Ok(owned)
+                    })
+                }
+                None => {
+                    if !AppId::is_kernel_idx(app_id) {
+                        panic!("No app for allocator for {}", app_id);
+                    }
+                    panic!("Request to allocate in kernel container");
+                }
+            }
         }
     }
 }
@@ -109,20 +134,29 @@ impl<T: Default> Container<T> {
     pub fn container(&self, appid: AppId) -> Option<AppliedContainer<T>> {
         unsafe {
             let app_id = appid.idx();
-            match process::PROCS[app_id] {
-                Some(ref mut app) => {
-                    let cntr = app.container_for::<T>(self.container_num);
-                    if cntr.is_null() {
-                        None
-                    } else {
-                        Some(AppliedContainer {
-                            appid: app_id,
-                            container: cntr,
-                            _phantom: PhantomData,
-                        })
+            if AppId::is_kernel(appid) {
+                let cntr = kernel_container_for::<T>(app_id);
+                Some(AppliedContainer {
+                    appid: app_id,
+                    container: cntr,
+                    _phantom: PhantomData,
+                })
+            } else {
+                match process::PROCS[app_id] {
+                    Some(ref mut app) => {
+                        let cntr = app.container_for::<T>(self.container_num);
+                        if cntr.is_null() {
+                            None
+                        } else {
+                            Some(AppliedContainer {
+                                appid: app_id,
+                                container: cntr,
+                                _phantom: PhantomData,
+                            })
+                        }
                     }
+                    None => None,
                 }
-                None => None,
             }
         }
     }
@@ -133,20 +167,31 @@ impl<T: Default> Container<T> {
     {
         unsafe {
             let app_id = appid.idx();
-            match process::PROCS[app_id] {
-                Some(ref mut app) => {
-                    app.container_for_or_alloc::<T>(self.container_num)
-                        .map_or(Err(Error::OutOfMemory), move |root_ptr| {
-                            let mut root = Owned::new(root_ptr, app_id);
-                            let mut allocator = Allocator {
-                                app: app,
-                                app_id: app_id,
-                            };
-                            let res = fun(&mut root, &mut allocator);
-                            Ok(res)
-                        })
+            if AppId::is_kernel(appid) {
+                let root_ptr = kernel_container_for::<T>(app_id);
+                let mut root = Owned::new(root_ptr, app_id);
+                let mut allocator = Allocator {
+                    app: None,
+                    app_id: app_id,
+                };
+                let res = fun(&mut root, &mut allocator);
+                Ok(res)
+            } else {
+                match process::PROCS[app_id] {
+                    Some(ref mut app) => {
+                        app.container_for_or_alloc::<T>(self.container_num)
+                            .map_or(Err(Error::OutOfMemory), move |root_ptr| {
+                                let mut root = Owned::new(root_ptr, app_id);
+                                let mut allocator = Allocator {
+                                    app: Some(app),
+                                    app_id: app_id,
+                                };
+                                let res = fun(&mut root, &mut allocator);
+                                Ok(res)
+                            })
+                    }
+                    None => Err(Error::NoSuchApp),
                 }
-                None => Err(Error::NoSuchApp),
             }
         }
     }

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -1,8 +1,7 @@
 
 
-use callback::{AppId, Callback};
+use callback::{AppId, Callback, RustOrRawFnPtr};
 use core::fmt::{Arguments, Result, Write, write};
-use core::nonzero::NonZero;
 use core::str;
 use driver::Driver;
 use mem::AppSlice;
@@ -67,7 +66,7 @@ impl DebugWriter {
             }
         }
     }
-    fn callback() {
+    fn callback(bytes_written: usize, _: usize, _: usize, _: usize) {
         unimplemented!();
     }
 }
@@ -77,10 +76,10 @@ impl DebugWriter {
 // inappropriate way?
 unsafe impl Sync for Callback {}
 
-pub static KERNEL_CONSOLE_CALLBACK: Callback = Callback {
+static KERNEL_CONSOLE_CALLBACK: Callback = Callback {
     app_id: AppId::kernel_new(APPID_IDX),
     appdata: 0,
-    fn_ptr: unsafe { NonZero::new(DebugWriter::callback as *mut ()) },
+    fn_ptr: RustOrRawFnPtr::Rust { func: DebugWriter::callback },
 };
 
 impl Write for DebugWriter {

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -1,4 +1,4 @@
-use callback::{AppId, Callback, RustOrRawFnPtr};
+use callback::{AppId, Callback};
 use core::cmp::min;
 use core::fmt::{Arguments, Result, Write, write};
 use core::ptr::{read_volatile, write_volatile};
@@ -154,11 +154,8 @@ impl DebugWriter {
 // inappropriate way?
 unsafe impl Sync for Callback {}
 
-static KERNEL_CONSOLE_CALLBACK: Callback = Callback {
-    app_id: AppId::kernel_new(APPID_IDX),
-    appdata: 0,
-    fn_ptr: RustOrRawFnPtr::Rust { func: DebugWriter::callback },
-};
+static KERNEL_CONSOLE_CALLBACK: Callback = Callback::kernel_new(AppId::kernel_new(APPID_IDX),
+                                                                DebugWriter::callback);
 
 impl Write for DebugWriter {
     fn write_str(&mut self, s: &str) -> Result {

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -256,29 +256,34 @@ impl Write for DebugWriter {
     }
 }
 
-pub unsafe fn begin_debug_fmt(args: Arguments, file_line: &(&'static str, u32)) {
-    let count = read_volatile(&DEBUG_WRITER.count);
-    write_volatile(&mut DEBUG_WRITER.count, count + 1);
+pub fn begin_debug_fmt(args: Arguments, file_line: &(&'static str, u32)) {
+    unsafe {
+        let count = read_volatile(&DEBUG_WRITER.count);
+        write_volatile(&mut DEBUG_WRITER.count, count + 1);
 
-    let writer = &mut DEBUG_WRITER;
-    let (file, line) = *file_line;
-    let _ = writer.write_fmt(format_args!("TOCK_DEBUG({}): {}:{}: ", count, file, line));
-    let _ = write(writer, args);
-    let _ = writer.write_str("\n");
-    writer.publish_str();
+        let writer = &mut DEBUG_WRITER;
+        let (file, line) = *file_line;
+        let _ = writer.write_fmt(format_args!("TOCK_DEBUG({}): {}:{}: ", count, file, line));
+        let _ = write(writer, args);
+        let _ = writer.write_str("\n");
+        writer.publish_str();
+    }
 }
 
-pub unsafe fn begin_debug(msg: &str, file_line: &(&'static str, u32)) {
-    let count = read_volatile(&DEBUG_WRITER.count);
-    write_volatile(&mut DEBUG_WRITER.count, count + 1);
+pub fn begin_debug(msg: &str, file_line: &(&'static str, u32)) {
+    unsafe {
+        let count = read_volatile(&DEBUG_WRITER.count);
+        write_volatile(&mut DEBUG_WRITER.count, count + 1);
 
-    let writer = &mut DEBUG_WRITER;
-    let (file, line) = *file_line;
-    let _ = writer.write_fmt(format_args!("TOCK_DEBUG({}): {}:{}: ", count, file, line));
-    let _ = writer.write_fmt(format_args!("{}\n", msg));
-    writer.publish_str();
+        let writer = &mut DEBUG_WRITER;
+        let (file, line) = *file_line;
+        let _ = writer.write_fmt(format_args!("TOCK_DEBUG({}): {}:{}: ", count, file, line));
+        let _ = writer.write_fmt(format_args!("{}\n", msg));
+        writer.publish_str();
+    }
 }
 
+#[macro_export]
 macro_rules! debug {
     () => ({
         // Allow an empty debug!() to print the location when hit

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -1,0 +1,152 @@
+
+
+use callback::{AppId, Callback};
+use core::fmt::{Arguments, Result, Write, write};
+use core::nonzero::NonZero;
+use core::str;
+use driver::Driver;
+use mem::AppSlice;
+use returncode::ReturnCode;
+
+pub const APPID_IDX: usize = 255;
+
+pub struct DebugWriter {
+    driver: Option<&'static Driver>,
+    pub container: Option<*mut u8>,
+    output_buffer: [u8; 1024],
+    output_head: usize,
+    output_tail: usize,
+}
+
+static mut DEBUG_WRITER: DebugWriter = DebugWriter {
+    driver: None,
+    container: None,
+    output_buffer: [0; 1024],
+    output_head: 0,
+    output_tail: 0,
+};
+
+pub unsafe fn assign_console_driver<T>(driver: Option<&'static Driver>, container: &mut T) {
+    let ptr: *mut u8 = ::core::mem::transmute(container);
+    DEBUG_WRITER.driver = driver;
+    DEBUG_WRITER.container = Some(ptr);
+}
+
+pub unsafe fn get_container<T>() -> *mut T {
+    match DEBUG_WRITER.container {
+        Some(container) => ::core::mem::transmute(container),
+        None => panic!("Request for unallocated kernel container"),
+    }
+}
+
+impl DebugWriter {
+    fn publish_str(&mut self) {
+        unsafe {
+            match self.driver {
+                Some(driver) => {
+                    /*
+                    let s = match str::from_utf8(&DEBUG_WRITER.output_buffer) {
+                        Ok(v) => v,
+                        Err(e) => panic!("Not uf8 {}", e),
+                    };
+                    panic!("s: {}", s);
+                    */
+                    let slice = AppSlice::new(self.output_buffer.as_mut_ptr(),
+                                              self.output_head - self.output_tail,
+                                              AppId::kernel_new(APPID_IDX));
+                    if driver.allow(AppId::kernel_new(APPID_IDX), 1, slice) != ReturnCode::SUCCESS {
+                        panic!("Debug print allow fail");
+                    }
+                    if driver.subscribe(1, KERNEL_CONSOLE_CALLBACK) != ReturnCode::SUCCESS {
+                        panic!("Debug print subscribe fail");
+                    }
+                }
+                None => {
+                    panic!("Platform has not yet configured kernel debug interface");
+                }
+            }
+        }
+    }
+    fn callback() {
+        unimplemented!();
+    }
+}
+
+//XXX http://stackoverflow.com/questions/28116147
+// I think this is benign and needed because NonZero's assuming threading in an
+// inappropriate way?
+unsafe impl Sync for Callback {}
+
+pub static KERNEL_CONSOLE_CALLBACK: Callback = Callback {
+    app_id: AppId::kernel_new(APPID_IDX),
+    appdata: 0,
+    fn_ptr: unsafe { NonZero::new(DebugWriter::callback as *mut ()) },
+};
+
+impl Write for DebugWriter {
+    fn write_str(&mut self, s: &str) -> Result {
+        unsafe {
+            let bytes = s.as_bytes();
+            if (DEBUG_WRITER.output_buffer.len() - DEBUG_WRITER.output_head) < bytes.len() {
+                panic!("Debug buffer full");
+            }
+            let start = DEBUG_WRITER.output_head;
+            let end = DEBUG_WRITER.output_head + bytes.len();
+            for (dst, src) in DEBUG_WRITER.output_buffer[start..end].iter_mut().zip(bytes.iter()) {
+                *dst = *src;
+            }
+            DEBUG_WRITER.output_head += bytes.len();
+            Ok(())
+        }
+    }
+}
+
+pub unsafe fn begin_debug_fmt(args: Arguments, file_line: &(&'static str, u32)) {
+    let writer = &mut DEBUG_WRITER;
+    let (file, line) = *file_line;
+    let _ = writer.write_fmt(format_args!("TOCK_DEBUG: {}:{}: ", file, line));
+    let _ = write(writer, args);
+    let _ = writer.write_str("\r\n");
+    writer.publish_str();
+}
+
+pub unsafe fn begin_debug(msg: &str, file_line: &(&'static str, u32)) {
+    let writer = &mut DEBUG_WRITER;
+    let (file, line) = *file_line;
+    let _ = writer.write_fmt(format_args!("TOCK_DEBUG: {}:{}: ", file, line));
+    let _ = writer.write_fmt(format_args!("{}\r\n", msg));
+    writer.publish_str();
+}
+
+macro_rules! debug {
+    () => ({
+        // Allow an empty debug!() to print the location when hit
+        debug!("")
+    });
+    ($msg:expr) => ({
+        $crate::debug::begin_debug($msg, {
+            // TODO: Maybe make opposite choice of panic!, no `static`, more
+            // runtime code for less static data
+            static _FILE_LINE: (&'static str, u32) = (file!(), line!());
+            &_FILE_LINE
+        })
+    });
+    ($fmt:expr, $($arg:tt)+) => ({
+        $crate::debug::begin_debug_fmt(format_args!($fmt, $($arg)+), {
+            static _FILE_LINE: (&'static str, u32) = (file!(), line!());
+            &_FILE_LINE
+        })
+    });
+}
+
+pub trait Debug {
+    fn write(&self, buf: &'static mut [u8], len: usize);
+}
+
+#[cfg(debug = "true")]
+impl Default for Debug {
+    fn write(&self, buf: &'static mut [u8], len: usize) {
+        panic!("No registered kernel debug printer. Thrown printing {:?}",
+               buf);
+    }
+}

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -1,5 +1,3 @@
-
-
 use callback::{AppId, Callback, RustOrRawFnPtr};
 use core::cmp::min;
 use core::fmt::{Arguments, Result, Write, write};

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -5,6 +5,8 @@ pub mod common;
 
 pub mod callback;
 pub mod container;
+#[macro_use]
+pub mod debug;
 pub mod driver;
 pub mod ipc;
 pub mod mem;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -488,9 +488,12 @@ impl<'a> Process<'a> {
 
                 HAVE_WORK.set(HAVE_WORK.get() + 1);
 
+                debug!("Loaded process: {}", process.package_name);
+
                 return (Some(process), app_flash_size, app_slice_size);
             }
         }
+        debug!("Finished loading processes");
         (None, 0, 0)
     }
 


### PR DESCRIPTION
This adds support to use `debug!` in the kernel to print debugging messages. It requires platforms to wire the kernel to a console during platform init, and `panic!`s the debug message if it is used without it.

The kernel will act as a client app of the console, interfacing through the syscall interface. The debug structure within the kernel keeps a circular buffer that `debug!` writes into, slices of which are passed to the console, allowing debug printing to proceed asynchronously without blocking the kernel.