### PR TITLE
Bigger stack size

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -34,7 +34,7 @@ MEMORY
   ram (rwx) : ORIGIN =  RAM_ORIGIN, LENGTH =  RAM_LENGTH
 }
 
-__stack_size__ = DEFINED(__stack_size__) ? __stack_size__ : 0x1000;
+__stack_size__ = DEFINED(__stack_size__) ? __stack_size__ : 0x2000;
 
 SECTIONS
 {


### PR DESCRIPTION
We ran into two different simultaneous issues tonight that resulted from running out of stack space in the kernel. Looking through the LST file, there are only a couple of data objects that live right below the stack, and they are all pretty critically important: `HAVE_WORK`, `SYSTEM_FREQUENCY`, etc.

This is a band-aid for now, but it would be great if we could use the MPU to do kernel stack checking as well for the future.