### PR TITLE
userland: check stack size during compile

### DIFF
--- a/userland/libtock/crt1.c
+++ b/userland/libtock/crt1.c
@@ -21,7 +21,10 @@ extern int main();
  */
 
 #ifndef STACK_SIZE
-#define STACK_SIZE 2048
+#error STACK_SIZE not defined.\
+       libtock expects STACK_SIZE to be defined by the compiling environment\
+       and for the compilation to check and warn for oversized stacks, i.e.\
+         $(CC) -DSTACK_SIZE=$(SIZE) -fstack-usage -Wstack-usage=$(SIZE)
 #endif
 
 __attribute__ ((section(".stack")))


### PR DESCRIPTION
This was inspired by wanting this for kernel, but was way easier to
figure out how to do in userland first, and certainly doesn't hurt.

Unfortunately, I don't think we can do this for the kernel yet, from #rustc:
![image](https://cloud.githubusercontent.com/assets/339422/22531222/b18fd88a-e8ad-11e6-8fcd-0dc4ae62dc06.png)
