### PR TITLE
update to nightly-2017-01-25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
 
 # If you change this, you must also change README and Common.mk
 rust:
-  - nightly-2016-07-29
+  - nightly-2017-01-25
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y; fi

--- a/Makefile.common
+++ b/Makefile.common
@@ -26,6 +26,14 @@ Q=@
 VERBOSE =
 endif
 
+# Check that rustc is the right nightly - warn not error if wrong, sometimes useful to test others
+RUSTC_VERSION_STRING := rustc 1.16.0-nightly (83c2d9523 2017-01-24)
+ifneq ($(shell rustc --version),$(RUSTC_VERSION_STRING))
+    $(warning Unexpected rustc version. Expected $(RUSTC_VERSION_STRING) got $(shell rustc --version))
+    $(warning You may experience unexpected compilation warnings or errors)
+    $(warning To fix, run `rustup override set nightly-2017-01-25`)
+endif
+
 .PHONY: all
 all:	target/$(CHIP)/release/$(PLATFORM).bin
 

--- a/arch/cortex-m4/src/scb.rs
+++ b/arch/cortex-m4/src/scb.rs
@@ -29,11 +29,11 @@ struct ScbRegisters {
 
 const SCB_BASE: usize = 0xE000ED00;
 
-static mut scb: *mut ScbRegisters = SCB_BASE as *mut ScbRegisters;
+static mut SCB: *mut ScbRegisters = SCB_BASE as *mut ScbRegisters;
 
 /// Software reset using the ARM System Control Block
 pub unsafe fn reset() {
-    let aircr = (*scb).aircr.get();
+    let aircr = (*SCB).aircr.get();
     let reset = (0x5FA << 16) | (aircr & (0x7 << 8)) | (1 << 2);
-    (*scb).aircr.set(reset);
+    (*SCB).aircr.set(reset);
 }

--- a/boards/hail/Cargo.lock
+++ b/boards/hail/Cargo.lock
@@ -46,3 +46,5 @@ dependencies = [
  "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[metadata]
+"checksum rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ae7a33830cc02d03ae1e50057d0e4e4b1a84be09bfb158bf95e9c3f3373aa453"

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -35,6 +35,7 @@ impl Write for Writer {
 
 
 #[cfg(not(test))]
+#[no_mangle]
 #[lang="panic_fmt"]
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
 

--- a/boards/imix/Cargo.lock
+++ b/boards/imix/Cargo.lock
@@ -46,3 +46,5 @@ dependencies = [
  "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[metadata]
+"checksum rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ae7a33830cc02d03ae1e50057d0e4e4b1a84be09bfb158bf95e9c3f3373aa453"

--- a/boards/imix/Cargo.toml
+++ b/boards/imix/Cargo.toml
@@ -2,6 +2,7 @@
 name = "imix"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+build = "build.rs"
 
 [profile.dev]
 panic = "abort"

--- a/boards/imix/build.rs
+++ b/boards/imix/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+}

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -35,6 +35,7 @@ impl Write for Writer {
 
 
 #[cfg(not(test))]
+#[no_mangle]
 #[lang="panic_fmt"]
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -21,7 +21,7 @@ use kernel::hil::spi::SpiMaster;
 use kernel::mpu::MPU;
 
 #[macro_use]
-mod io;
+pub mod io;
 
 // Unit Tests for drivers.
 #[allow(dead_code)]

--- a/boards/imix/src/spi_dummy.rs
+++ b/boards/imix/src/spi_dummy.rs
@@ -12,8 +12,8 @@ pub struct DummyCB {
 }
 
 pub static mut FLOP: bool = false;
-pub static mut buf1: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
-pub static mut buf2: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
+pub static mut BUF1: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
+pub static mut BUF2: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
 
 impl spi::SpiMasterClient for DummyCB {
     #[allow(unused_variables,dead_code)]
@@ -23,11 +23,11 @@ impl spi::SpiMasterClient for DummyCB {
                        len: usize) {
         unsafe {
             FLOP = !FLOP;
-            let len: usize = buf1.len();
+            let len: usize = BUF1.len();
             if FLOP {
-                sam4l::spi::SPI.read_write_bytes(&mut buf1, Some(&mut buf2), len);
+                sam4l::spi::SPI.read_write_bytes(&mut BUF1, Some(&mut BUF2), len);
             } else {
-                sam4l::spi::SPI.read_write_bytes(&mut buf2, Some(&mut buf1), len);
+                sam4l::spi::SPI.read_write_bytes(&mut BUF2, Some(&mut BUF1), len);
             }
         }
     }
@@ -64,8 +64,8 @@ pub unsafe fn spi_dummy_test() {
     sam4l::spi::SPI.init();
     sam4l::spi::SPI.enable();
     sam4l::spi::SPI.set_baud_rate(1000000);
-    let len = buf2.len();
-    if sam4l::spi::SPI.read_write_bytes(&mut buf2, Some(&mut buf1), len) == false {
+    let len = BUF2.len();
+    if sam4l::spi::SPI.read_write_bytes(&mut BUF2, Some(&mut BUF1), len) == false {
         loop {
             sam4l::spi::SPI.write_byte(0xA5);
         }

--- a/boards/nrf51dk/Cargo.lock
+++ b/boards/nrf51dk/Cargo.lock
@@ -52,3 +52,6 @@ name = "rust-libcore"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[metadata]
+"checksum gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "91ecd03771effb0c968fd6950b37e89476a578aaf1c70297d8e92b6516ec3312"
+"checksum rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ae7a33830cc02d03ae1e50057d0e4e4b1a84be09bfb158bf95e9c3f3373aa453"

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -79,7 +79,7 @@ unsafe fn load_process() -> &'static mut [Option<kernel::process::Process<'stati
     #[link_section = ".app_memory"]
     static mut APP_MEMORY: [u8; 8192] = [0; 8192];
 
-    static mut processes: [Option<kernel::process::Process<'static>>; NUM_PROCS] = [None];
+    static mut PROCESSES: [Option<kernel::process::Process<'static>>; NUM_PROCS] = [None];
 
     let mut apps_in_flash_ptr = &_sapps as *const u8;
     let mut app_memory_ptr = APP_MEMORY.as_mut_ptr();
@@ -95,13 +95,13 @@ unsafe fn load_process() -> &'static mut [Option<kernel::process::Process<'stati
             break;
         }
 
-        processes[i] = process;
+        PROCESSES[i] = process;
         apps_in_flash_ptr = apps_in_flash_ptr.offset(flash_offset as isize);
         app_memory_ptr = app_memory_ptr.offset(memory_offset as isize);
         app_memory_size -= memory_offset;
     }
 
-    &mut processes
+    &mut PROCESSES
 }
 
 pub struct Platform {

--- a/boards/storm/Cargo.lock
+++ b/boards/storm/Cargo.lock
@@ -46,3 +46,5 @@ dependencies = [
  "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[metadata]
+"checksum rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ae7a33830cc02d03ae1e50057d0e4e4b1a84be09bfb158bf95e9c3f3373aa453"

--- a/boards/storm/src/io.rs
+++ b/boards/storm/src/io.rs
@@ -35,6 +35,7 @@ impl Write for Writer {
 
 
 #[cfg(not(test))]
+#[no_mangle]
 #[lang="panic_fmt"]
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
 

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -39,8 +39,8 @@ pub mod io;
 //
 
 
-static mut spi_read_buf: [u8; 64] = [0; 64];
-static mut spi_write_buf: [u8; 64] = [0; 64];
+static mut SPI_READ_BUF: [u8; 64] = [0; 64];
+static mut SPI_WRITE_BUF: [u8; 64] = [0; 64];
 
 unsafe fn load_processes() -> &'static mut [Option<kernel::process::Process<'static>>] {
     extern "C" {
@@ -56,7 +56,7 @@ unsafe fn load_processes() -> &'static mut [Option<kernel::process::Process<'sta
     #[link_section = ".app_memory"]
     static mut APP_MEMORY: [u8; 16384] = [0; 16384];
 
-    static mut processes: [Option<kernel::process::Process<'static>>; NUM_PROCS] = [None, None];
+    static mut PROCESSES: [Option<kernel::process::Process<'static>>; NUM_PROCS] = [None, None];
 
     let mut apps_in_flash_ptr = &_sapps as *const u8;
     let mut app_memory_ptr = APP_MEMORY.as_mut_ptr();
@@ -72,13 +72,13 @@ unsafe fn load_processes() -> &'static mut [Option<kernel::process::Process<'sta
             break;
         }
 
-        processes[i] = process;
+        PROCESSES[i] = process;
         apps_in_flash_ptr = apps_in_flash_ptr.offset(flash_offset as isize);
         app_memory_ptr = app_memory_ptr.offset(memory_offset as isize);
         app_memory_size -= memory_offset;
     }
 
-    &mut processes
+    &mut PROCESSES
 }
 
 struct Firestorm {
@@ -246,7 +246,7 @@ pub unsafe fn reset_handler() {
         Nrf51822Serialization::new(&usart::USART2,
                                    &mut nrf51822_serialization::WRITE_BUF,
                                    &mut nrf51822_serialization::READ_BUF),
-        608/8);
+        544/8);
     hil::uart::UART::set_client(&usart::USART2, nrf_serialization);
 
     let ast = &sam4l::ast::AST;
@@ -320,9 +320,9 @@ pub unsafe fn reset_handler() {
     let spi_syscalls = static_init!(
         capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
         capsules::spi::Spi::new(syscall_spi_device),
-        672/8);
+        608/8);
 
-    spi_syscalls.config_buffers(&mut spi_read_buf, &mut spi_write_buf);
+    spi_syscalls.config_buffers(&mut SPI_READ_BUF, &mut SPI_WRITE_BUF);
     syscall_spi_device.set_client(spi_syscalls);
 
     // LEDs

--- a/chips/sam4l/src/bpm.rs
+++ b/chips/sam4l/src/bpm.rs
@@ -20,7 +20,7 @@ struct BpmRegisters {
 const BPM_BASE: usize = 0x400F0000;
 const BPM_UNLOCK_KEY: u32 = 0xAA000000;
 
-static mut bpm: *mut BpmRegisters = BPM_BASE as *mut BpmRegisters;
+static mut BPM: *mut BpmRegisters = BPM_BASE as *mut BpmRegisters;
 
 pub enum CK32Source {
     OSC32K = 0,
@@ -29,11 +29,11 @@ pub enum CK32Source {
 
 #[inline(never)]
 pub unsafe fn set_ck32source(source: CK32Source) {
-    let control = (*bpm).control.get();
+    let control = (*BPM).control.get();
     unlock_register(0x1c); // Control
-    (*bpm).control.set(control | (source as u32) << 16);
+    (*BPM).control.set(control | (source as u32) << 16);
 }
 
 unsafe fn unlock_register(register_offset: u32) {
-    (*bpm).unlock.set(BPM_UNLOCK_KEY | register_offset);
+    (*BPM).unlock.set(BPM_UNLOCK_KEY | register_offset);
 }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -26,34 +26,34 @@ impl Sam4l {
     pub unsafe fn new() -> Sam4l {
         INTERRUPT_QUEUE = Some(RingBuffer::new(&mut IQ_BUF));
 
-        usart::USART0.set_dma(&mut dma::DMAChannels[0], &mut dma::DMAChannels[1]);
-        dma::DMAChannels[0].client = Some(&mut usart::USART0);
-        dma::DMAChannels[1].client = Some(&mut usart::USART0);
+        usart::USART0.set_dma(&mut dma::DMA_CHANNELS[0], &mut dma::DMA_CHANNELS[1]);
+        dma::DMA_CHANNELS[0].client = Some(&mut usart::USART0);
+        dma::DMA_CHANNELS[1].client = Some(&mut usart::USART0);
 
-        usart::USART1.set_dma(&mut dma::DMAChannels[2], &mut dma::DMAChannels[3]);
-        dma::DMAChannels[2].client = Some(&mut usart::USART1);
-        dma::DMAChannels[3].client = Some(&mut usart::USART1);
+        usart::USART1.set_dma(&mut dma::DMA_CHANNELS[2], &mut dma::DMA_CHANNELS[3]);
+        dma::DMA_CHANNELS[2].client = Some(&mut usart::USART1);
+        dma::DMA_CHANNELS[3].client = Some(&mut usart::USART1);
 
-        usart::USART2.set_dma(&mut dma::DMAChannels[4], &mut dma::DMAChannels[5]);
-        dma::DMAChannels[4].client = Some(&mut usart::USART2);
-        dma::DMAChannels[5].client = Some(&mut usart::USART2);
+        usart::USART2.set_dma(&mut dma::DMA_CHANNELS[4], &mut dma::DMA_CHANNELS[5]);
+        dma::DMA_CHANNELS[4].client = Some(&mut usart::USART2);
+        dma::DMA_CHANNELS[5].client = Some(&mut usart::USART2);
 
-        usart::USART3.set_dma(&mut dma::DMAChannels[6], &mut dma::DMAChannels[7]);
-        dma::DMAChannels[6].client = Some(&mut usart::USART3);
-        dma::DMAChannels[7].client = Some(&mut usart::USART3);
+        usart::USART3.set_dma(&mut dma::DMA_CHANNELS[6], &mut dma::DMA_CHANNELS[7]);
+        dma::DMA_CHANNELS[6].client = Some(&mut usart::USART3);
+        dma::DMA_CHANNELS[7].client = Some(&mut usart::USART3);
 
-        spi::SPI.set_dma(&mut dma::DMAChannels[8], &mut dma::DMAChannels[9]);
-        dma::DMAChannels[8].client = Some(&mut spi::SPI);
-        dma::DMAChannels[9].client = Some(&mut spi::SPI);
+        spi::SPI.set_dma(&mut dma::DMA_CHANNELS[8], &mut dma::DMA_CHANNELS[9]);
+        dma::DMA_CHANNELS[8].client = Some(&mut spi::SPI);
+        dma::DMA_CHANNELS[9].client = Some(&mut spi::SPI);
 
-        i2c::I2C0.set_dma(&dma::DMAChannels[10]);
-        dma::DMAChannels[10].client = Some(&mut i2c::I2C0);
+        i2c::I2C0.set_dma(&dma::DMA_CHANNELS[10]);
+        dma::DMA_CHANNELS[10].client = Some(&mut i2c::I2C0);
 
-        i2c::I2C1.set_dma(&dma::DMAChannels[11]);
-        dma::DMAChannels[11].client = Some(&mut i2c::I2C1);
+        i2c::I2C1.set_dma(&dma::DMA_CHANNELS[11]);
+        dma::DMA_CHANNELS[11].client = Some(&mut i2c::I2C1);
 
-        i2c::I2C2.set_dma(&dma::DMAChannels[12]);
-        dma::DMAChannels[12].client = Some(&mut i2c::I2C2);
+        i2c::I2C2.set_dma(&dma::DMA_CHANNELS[12]);
+        dma::DMA_CHANNELS[12].client = Some(&mut i2c::I2C2);
 
         Sam4l {
             mpu: cortexm4::mpu::MPU::new(),
@@ -80,22 +80,22 @@ impl Chip for Sam4l {
                     USART2 => usart::USART2.handle_interrupt(),
                     USART3 => usart::USART3.handle_interrupt(),
 
-                    PDCA0 => dma::DMAChannels[0].handle_interrupt(),
-                    PDCA1 => dma::DMAChannels[1].handle_interrupt(),
-                    PDCA2 => dma::DMAChannels[2].handle_interrupt(),
-                    PDCA3 => dma::DMAChannels[3].handle_interrupt(),
-                    PDCA4 => dma::DMAChannels[4].handle_interrupt(),
-                    PDCA5 => dma::DMAChannels[5].handle_interrupt(),
-                    PDCA6 => dma::DMAChannels[6].handle_interrupt(),
-                    PDCA7 => dma::DMAChannels[7].handle_interrupt(),
-                    PDCA8 => dma::DMAChannels[8].handle_interrupt(),
-                    PDCA9 => dma::DMAChannels[9].handle_interrupt(),
-                    PDCA10 => dma::DMAChannels[10].handle_interrupt(),
-                    PDCA11 => dma::DMAChannels[11].handle_interrupt(),
-                    PDCA12 => dma::DMAChannels[12].handle_interrupt(),
-                    PDCA13 => dma::DMAChannels[13].handle_interrupt(),
-                    PDCA14 => dma::DMAChannels[14].handle_interrupt(),
-                    PDCA15 => dma::DMAChannels[15].handle_interrupt(),
+                    PDCA0 => dma::DMA_CHANNELS[0].handle_interrupt(),
+                    PDCA1 => dma::DMA_CHANNELS[1].handle_interrupt(),
+                    PDCA2 => dma::DMA_CHANNELS[2].handle_interrupt(),
+                    PDCA3 => dma::DMA_CHANNELS[3].handle_interrupt(),
+                    PDCA4 => dma::DMA_CHANNELS[4].handle_interrupt(),
+                    PDCA5 => dma::DMA_CHANNELS[5].handle_interrupt(),
+                    PDCA6 => dma::DMA_CHANNELS[6].handle_interrupt(),
+                    PDCA7 => dma::DMA_CHANNELS[7].handle_interrupt(),
+                    PDCA8 => dma::DMA_CHANNELS[8].handle_interrupt(),
+                    PDCA9 => dma::DMA_CHANNELS[9].handle_interrupt(),
+                    PDCA10 => dma::DMA_CHANNELS[10].handle_interrupt(),
+                    PDCA11 => dma::DMA_CHANNELS[11].handle_interrupt(),
+                    PDCA12 => dma::DMA_CHANNELS[12].handle_interrupt(),
+                    PDCA13 => dma::DMA_CHANNELS[13].handle_interrupt(),
+                    PDCA14 => dma::DMA_CHANNELS[14].handle_interrupt(),
+                    PDCA15 => dma::DMA_CHANNELS[15].handle_interrupt(),
 
                     GPIO0 => gpio::PA.handle_interrupt(),
                     GPIO1 => gpio::PA.handle_interrupt(),
@@ -118,7 +118,7 @@ impl Chip for Sam4l {
                     TWIS0 => i2c::I2C0.handle_slave_interrupt(),
                     TWIS1 => i2c::I2C1.handle_slave_interrupt(),
 
-                    HFLASHC => flashcalw::flash_controller.handle_interrupt(),
+                    HFLASHC => flashcalw::FLASH_CONTROLLER.handle_interrupt(),
                     ADCIFE => adc::ADC.handle_interrupt(),
 
                     TRNG => trng::TRNG.handle_interrupt(),

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -109,7 +109,7 @@ pub enum DMAPeripheral {
     LCDCA_ABMDR_TX = 38,
 }
 
-pub static mut DMAChannels: [DMAChannel; 16] =
+pub static mut DMA_CHANNELS: [DMAChannel; 16] =
     [DMAChannel::new(DMAChannelNum::DMAChannel00, nvic::NvicIdx::PDCA0),
      DMAChannel::new(DMAChannelNum::DMAChannel01, nvic::NvicIdx::PDCA1),
      DMAChannel::new(DMAChannelNum::DMAChannel02, nvic::NvicIdx::PDCA2),
@@ -250,7 +250,7 @@ macro_rules! pdca_handler {
             $nvic,
             {
                 let registers : &mut DMARegisters =
-                    mem::transmute(DMAChannels[$num].registers);
+                    mem::transmute(DMA_CHANNELS[$num].registers);
                 registers.interrupt_disable.set(0xffffffff);
             });
     }

--- a/chips/sam4l/src/flashcalw.rs
+++ b/chips/sam4l/src/flashcalw.rs
@@ -166,7 +166,7 @@ pub struct FLASHCALW {
 }
 
 // static instance for the board. Only one FLASHCALW on chip.
-pub static mut flash_controller: FLASHCALW = FLASHCALW::new(FLASHCALW_BASE_ADDRS,
+pub static mut FLASH_CONTROLLER: FLASHCALW = FLASHCALW::new(FLASHCALW_BASE_ADDRS,
                                                             pm::HSBClock::FLASHCALW,
                                                             pm::HSBClock::FLASHCALWP,
                                                             pm::PBBClock::FLASHCALW);
@@ -873,7 +873,7 @@ pub unsafe extern "C" fn flash_handler() {
 
     //  disable the nvic interrupt line for flash, turn of the perherial interrupt,
     //  and queue a handle interrupt.
-    flash_controller.enable_ready_int(false);
+    FLASH_CONTROLLER.enable_ready_int(false);
     nvic::disable(nvic::NvicIdx::HFLASHC);
     chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic::NvicIdx::HFLASHC);
 }

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -4,7 +4,6 @@
 #![no_std]
 
 extern crate cortexm4;
-#[macro_use]
 extern crate kernel;
 
 #[macro_use]

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -15,7 +15,7 @@ developing Tock.
 
 #### Rust (nightly)
 
-We are using `rustc 1.12.0-nightly (54c0dcfd6 2016-07-28)`. We recommend
+We are using `rustc 1.16.0-nightly (df8debf6d 2017-01-25)`. We recommend
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -31,7 +31,7 @@ Then override the default version of Rust to use for Tock by running the
 following from the top-level Tock directory:
 
 ```bash
-$ rustup override set nightly-2016-07-29
+$ rustup override set nightly-2017-01-25
 ```
 
 #### `arm-none-eabi` toolchain

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -26,8 +26,8 @@ pub enum ClockPhase {
 pub trait SpiMasterClient {
     /// Called when a read/write operation finishes
     fn read_write_done(&self,
-                       mut write_buffer: &'static mut [u8],
-                       mut read_buffer: Option<&'static mut [u8]>,
+                       write_buffer: &'static mut [u8],
+                       read_buffer: Option<&'static mut [u8]>,
                        len: usize);
 }
 /// The `SpiMaster` trait for interacting with SPI slave
@@ -84,8 +84,8 @@ pub trait SpiMaster {
     /// length of the operation is the minimum of the size of
     /// the two buffers.
     fn read_write_bytes(&self,
-                        mut write_buffer: &'static mut [u8],
-                        mut read_buffer: Option<&'static mut [u8]>,
+                        write_buffer: &'static mut [u8],
+                        read_buffer: Option<&'static mut [u8]>,
                         len: usize)
                         -> bool;
     fn write_byte(&self, val: u8);
@@ -132,8 +132,8 @@ pub trait SpiMasterDevice {
     /// length of the operation is the minimum of the size of
     /// the two buffers.
     fn read_write_bytes(&self,
-                        mut write_buffer: &'static mut [u8],
-                        mut read_buffer: Option<&'static mut [u8]>,
+                        write_buffer: &'static mut [u8],
+                        read_buffer: Option<&'static mut [u8]>,
                         len: usize)
                         -> bool;
 

--- a/userland/tools/elf2tbf/Cargo.lock
+++ b/userland/tools/elf2tbf/Cargo.lock
@@ -24,3 +24,7 @@ name = "getopts"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[metadata]
+"checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
+"checksum elf 0.0.6 (git+https://github.com/cole14/rust-elf)" = "<none>"
+"checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -63,7 +63,7 @@ Vagrant.configure("2") do |config|
   # Set up rust development environment
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     wget https://sh.rustup.rs -O rustup.sh && sh rustup.sh -y
-    source ~/.profile && cd /tock && rustup override set nightly-2016-07-29
+    source ~/.profile && cd /tock && rustup override set nightly-2017-01-25
   SHELL
 
   # Copy git configuration


### PR DESCRIPTION
This was pretty smooth and painless, mostly fixing up global variable
names to be all caps b/c that's caught now and a few structures got
smaller (whoo!)

One gotcha, the `#[lang=panic_fmt]` now requires you to also add a
`#[no_mangle]` directive, otherwise the symbol will be dropped and
you'll get an undefined reference to `rust_begin_unwind` (which is
what our `panic_fmt` function gets silently renamed to courtesy of
the magic of `#[lang=panic_fmt]`).
More info at https://github.com/rust-lang/rust/issues/38281

An unresolved mystery, imix currently gives this warning:

    warning: function panic_fmt is marked #[no_mangle], but not exported,
    #[warn(private_no_mangle_fns)] on by default
      --> src/io.rs:40:1
       |
    40 | pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
       | ^

Now, of course, removing no_mangle will result in the undefined
reference as described above, with it this at least compiles, unclear
what's different about imix than the other platforms that don't throw
this warning.

Run-tested on hail. Compile-tested on every other platform.