### PR TITLE
SD Card driver

### DIFF
--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -12,6 +12,7 @@ pub mod led;
 pub mod nrf51822_serialization;
 pub mod timer;
 pub mod tmp006;
+pub mod sdcard;
 pub mod si7021;
 pub mod spi;
 pub mod virtual_alarm;

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -274,7 +274,7 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
 
         // append dummy bytes to transmission after command bytes
         // Limit to minimum length between write_buffer and recv_len
-        for (byte, _) in write_buffer.iter_mut().skip(8).zip(0..recv_len) {
+        for byte in write_buffer.iter_mut().skip(8).take(recv_len) {
             *byte = 0xFF;
         }
 
@@ -295,7 +295,7 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
         // Limit to minimum length between write_buffer and recv_len.
         // Note: this could be optimized in the future by allowing SPI to read
         //  without a write buffer passed in
-        for (byte, _) in write_buffer.iter_mut().zip(0..recv_len) {
+        for byte in write_buffer.iter_mut().take(recv_len) {
             *byte = 0xFF;
         }
 
@@ -755,8 +755,8 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
                         // copy data to user buffer
                         // Limit to minimum length between buffer, read_buffer,
                         // and 512 (block size)
-                        for ((client_byte, &read_byte), _) in
-                            buffer.iter_mut().zip(read_buffer.iter()).zip(0..512) {
+                        for (client_byte, &read_byte) in
+                            buffer.iter_mut().zip(read_buffer.iter()).take(512) {
                             *client_byte = read_byte;
                         }
 
@@ -807,8 +807,8 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
                     // Limit to minimum length between buffer, read_buffer, and
                     // 512 (block size)
                     let offset = self.client_offset.get();
-                    for ((client_byte, &read_byte), _) in
-                        buffer.iter_mut().skip(offset).zip(read_buffer.iter()).zip(0..512) {
+                    for (client_byte, &read_byte) in
+                        buffer.iter_mut().skip(offset).zip(read_buffer.iter()).take(512) {
                         *client_byte = read_byte;
                     }
 
@@ -867,8 +867,8 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
                             // copy over data from client buffer
                             // Limit to minimum length between write_buffer,
                             // buffer, and 512 (block size)
-                            for ((write_byte, &client_byte), _) in
-                                write_buffer.iter_mut().skip(1).zip(buffer.iter()).zip(0..512) {
+                            for (write_byte, &client_byte) in
+                                write_buffer.iter_mut().skip(1).zip(buffer.iter()).take(512) {
                                 *write_byte = client_byte;
                             }
 
@@ -877,10 +877,10 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
                         });
 
                         // set a known value for remaining bytes
-                        for (write_byte, _) in write_buffer.iter_mut()
+                        for write_byte in write_buffer.iter_mut()
                             .skip(1)
                             .skip(bytes_written)
-                            .zip(0..512) {
+                            .take(512) {
                             *write_byte = 0xFF;
                         }
 
@@ -1362,8 +1362,8 @@ impl<'a, A: hil::time::Alarm + 'a> SDCardClient for SDCardDriver<'a, A> {
                     // copy bytes to user buffer
                     // Limit to minimum length between read_buffer, data, and
                     // len field
-                    for ((read_byte, &data_byte), _) in
-                        read_buffer.iter_mut().zip(data.iter()).zip(0..len) {
+                    for (read_byte, &data_byte) in
+                        read_buffer.iter_mut().zip(data.iter()).take(len) {
                         *read_byte = data_byte;
                     }
                     read_len = cmp::min(read_buffer.len(), cmp::min(data.len(), len));
@@ -1482,8 +1482,8 @@ impl<'a, A: hil::time::Alarm + 'a> Driver for SDCardDriver<'a, A> {
                             // copy over write data from application
                             // Limit to minimum length between kernel_buf,
                             // write_buffer, and 512 (block size)
-                            for ((kernel_byte, &write_byte), _) in
-                                kernel_buf.iter_mut().zip(write_buffer.iter()).zip(0..512) {
+                            for (kernel_byte, &write_byte) in
+                                kernel_buf.iter_mut().zip(write_buffer.iter()).take(512) {
                                 *kernel_byte = write_byte;
                             }
 

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -1,0 +1,449 @@
+//! Provide capsule driver for accessing an SD Card.
+//! This allows initialization and block reads or writes on top of SPI
+
+// Resources for SD Card API
+// elm-chan.org/docs/mmc/mmc_e.html
+// alumni.cs.ucr.edu/~amitra/sdcard/Additional/sdcard_appnote_foust.pdf
+// luckyresistor.me/cat-protector/software/sdcard-2/
+
+use core::cell::Cell;
+
+use kernel::hil;
+use kernel::common::take_cell::TakeCell;
+
+pub static mut TXBUFFER: [u8; 512] = [0; 512];
+pub static mut RXBUFFER: [u8; 512] = [0; 512];
+
+#[allow(dead_code)]
+#[derive(Clone,Copy,Debug,PartialEq)]
+enum SDCmd {
+    CMD0 = 0, // Reset
+    CMD1 = 1, // Generic init
+    CMD8 = 8, // Check voltage range
+    CMD16 = 16, // Set blocksize
+    CMD55 = 55, // Next command will be application specific
+    CMD58 = 58, // Read operation condition register (OCR)
+    ACMD41 = 0x80 + 41, // App-specific Init
+}
+
+#[allow(dead_code)]
+#[derive(Clone,Copy,Debug,PartialEq)]
+enum SDResponse {
+    R1,
+    R2,
+    R3,
+    R7,
+}
+
+#[derive(Clone,Copy,Debug,PartialEq)]
+enum State {
+    Idle,
+
+    SendACmd { acmd: SDCmd, arg: u32 },
+
+    InitReset,
+    InitCheckVersion,
+    InitRepeatHCSInit,
+    InitCheckCapacity,
+    InitAppSpecificInit,
+    InitRepeatAppSpecificInit,
+    InitRepeatGenericInit,
+    InitSetBlocksize,
+}
+
+// SD Card types
+const CT_MMC: u8 = 0x01;
+const CT_SD1: u8 = 0x02;
+const CT_SD2: u8 = 0x04;
+const CT_SDC: u8 = (CT_SD1|CT_SD2);
+const CT_BLOCK: u8 = 0x08;
+
+//XXX: How do we handle errors with this interface?
+pub trait SDCardClient {
+    fn status(&self, status: u8);
+    fn init_done(&self, status: u8);
+    fn read_done(&self, data: &'static mut [u8], len: usize);
+    fn write_done(&self, buffer: &'static mut [u8]);
+}
+
+// SD Card capsule, capable of being built on top of by other kernel capsules
+pub struct SDCard<'a> {
+    spi: &'a hil::spi::SpiMasterDevice,
+    state: Cell<State>,
+    after_state: Cell<State>,
+    is_slow_mode: Cell<bool>,
+    card_type: Cell<u8>,
+    txbuffer: TakeCell<&'static mut [u8]>,
+    rxbuffer: TakeCell<&'static mut [u8]>,
+    client: TakeCell<&'static SDCardClient>,
+}
+
+impl<'a> SDCard<'a> {
+    pub fn new(spi: &'a hil::spi::SpiMasterDevice,
+               txbuffer: &'static mut [u8],
+               rxbuffer: &'static mut [u8])
+               -> SDCard<'a> {
+
+        // initialize buffers
+        for i in 0..txbuffer.len() {
+            txbuffer[i] = 0xFF;
+        }
+        for i in 0..rxbuffer.len() {
+            rxbuffer[i] = 0xFF;
+        }
+
+        // setup and return struct
+        SDCard {
+            spi: spi,
+            state: Cell::new(State::Idle),
+            after_state: Cell::new(State::Idle),
+            is_slow_mode: Cell::new(true),
+            card_type: Cell::new(0x00),
+            txbuffer: TakeCell::new(txbuffer),
+            rxbuffer: TakeCell::new(rxbuffer),
+            client: TakeCell::empty(),
+        }
+    }
+
+    fn set_spi_slow_mode(&self) {
+        // set to CPHA=0, CPOL=0, 400 kHZ
+        self.spi.configure(hil::spi::ClockPolarity::IdleLow,
+                           hil::spi::ClockPhase::SampleLeading,
+                           400000);
+    }
+
+    fn set_spi_fast_mode(&self) {
+        // set to CPHA=0, CPOL=0, 4 MHz
+        self.spi.configure(hil::spi::ClockPolarity::IdleLow,
+                           hil::spi::ClockPhase::SampleLeading,
+                           4000000);
+    }
+
+    fn send_command(&self, cmd: SDCmd, arg: u32,
+                    mut write_buffer: &'static mut [u8],
+                    mut read_buffer: &'static mut [u8]) {
+        if self.is_slow_mode.get() {
+            self.set_spi_slow_mode();
+        } else {
+            self.set_spi_fast_mode();
+        }
+
+        // send dummy bytes to start
+        write_buffer[0] = 0xFF;
+        write_buffer[1] = 0xFF;
+
+        // command
+        if (0x80 & cmd as u8) != 0x00 {
+            // application-specific command
+            write_buffer[2] = 0x40 | (0x7F & cmd as u8);
+        } else {
+            // normal command
+            write_buffer[2] = 0x40 | cmd as u8;
+        }
+
+        // argument, MSB first
+        write_buffer[3] = ((arg >> 24) & 0xFF) as u8;
+        write_buffer[4] = ((arg >> 16) & 0xFF) as u8;
+        write_buffer[5] = ((arg >>  8) & 0xFF) as u8;
+        write_buffer[6] = ((arg >>  0) & 0xFF) as u8;
+
+        // CRC is ignored except for CMD0 and maybe CMD8
+        if cmd == SDCmd::CMD8 {
+            write_buffer[7] = 0x87; // valid crc for CMD8(0x1AA)
+        } else {
+            write_buffer[7] = 0x95; // valid crc for CMD0
+        }
+
+        // always receive 10 bytes
+        let recv_len = 10;
+
+        // append dummy bytes to transmission
+        for i in 0..recv_len {
+            write_buffer[8+i] = 0xFF;
+        }
+
+        //XXX: Hack. Added one to this
+        self.spi.read_write_bytes(write_buffer, Some(read_buffer), 8+recv_len+1);
+    }
+
+    fn get_response(&self, response: SDResponse, read_buffer: &[u8])
+            -> (u8, u8, u32) {
+
+        let mut r1: u8 = 0xFF;
+        let mut r2: u8 = 0xFF;
+        let mut r3: u32 = 0xFFFFFFFF;
+
+        // scan through read buffer for response byte
+        for i in 0..read_buffer.len() {
+            if (read_buffer[i] & 0x80) == 0x00 {
+                r1 = read_buffer[i];
+
+                match response {
+                    SDResponse::R2 => {
+                        if i+1 < read_buffer.len() {
+                            r2 = read_buffer[i+1];
+                        }
+                    }
+                    SDResponse::R3 | SDResponse::R7=> {
+                        if i+4 < read_buffer.len() {
+                            r3 = (read_buffer[i+1] as u32) << 24 |
+                                 (read_buffer[i+2] as u32) << 16 |
+                                 (read_buffer[i+3] as u32) <<  8 |
+                                 (read_buffer[i+4] as u32);
+                        }
+                    }
+                    _ => {}
+                }
+
+                // response found
+                break;
+            }
+        }
+
+        (r1, r2, r3)
+    }
+
+    fn process_state(&self,
+                   mut write_buffer: &'static mut [u8],
+                   mut read_buffer: &'static mut [u8],
+                   _: usize) {
+
+        // CMD0 - reset to idle state
+
+        //XXX: do we actually care about SDv2, SDv1, and MMC?
+        // CMD8 - checks if SDv2
+
+            // ACMD41 - application-specific initialize
+
+            // repeat until not idle
+
+        // else SDv1 or MMC
+
+            // ACMD41 - application-specific initialize
+
+            // CMD1 - generic initialize
+
+            // repeat until not idle
+
+            // CMD16 - set blocksize to 512
+
+        match self.state.get() {
+            State::SendACmd { acmd, arg } => {
+                // send the application-specific command and resume the state
+                //  machine
+                self.state.set(self.after_state.get());
+                self.send_command(acmd, arg, write_buffer, read_buffer);
+            }
+
+            State::InitReset => {
+                // check response
+                let (r1, _, _) = self.get_response(SDResponse::R1, read_buffer);
+
+                // only continue if we are in idle state
+                if r1 == 0x01 {
+                    // next send Check Voltage Range command that is only valid
+                    //  on SDv2 cards. This is used to check which SD card version
+                    //  is installed
+                    self.state.set(State::InitCheckVersion);
+                    self.send_command(SDCmd::CMD8, 0x1AA, write_buffer, read_buffer);
+                } else {
+                    panic!("Error in {:?}. R1: {:#X}", self.state.get(), r1);
+                }
+            }
+
+            State::InitCheckVersion => {
+                // check response
+                let (r1, _, r7) = self.get_response(SDResponse::R7, read_buffer);
+
+                if r1 == 0x01 && r7 == 0x1AA {
+                    // we have an SDv2 card
+                    // send application-specific initialization in high capacity mode (HCS)
+                    self.state.set(State::SendACmd { acmd: SDCmd::ACMD41, arg: 0x40000000 });
+                    self.after_state.set(State::InitRepeatHCSInit);
+                    self.send_command(SDCmd::CMD55, 0x0, write_buffer, read_buffer);
+                } else {
+                    // we have either an SDv1 or MMCv3 card
+                    // send application-specific initialization
+                    self.state.set(State::SendACmd { acmd: SDCmd::ACMD41, arg: 0x0 });
+                    self.after_state.set(State::InitAppSpecificInit);
+                    self.send_command(SDCmd::CMD55, 0x0, write_buffer, read_buffer);
+                }
+            }
+
+            State::InitRepeatHCSInit => {
+                // check response
+                let (r1, _, _) = self.get_response(SDResponse::R1, read_buffer);
+
+                if r1 == 0x00 {
+                    // card initialized
+                    // check card capacity
+                    self.state.set(State::InitCheckCapacity);
+                    self.send_command(SDCmd::CMD58, 0x0, write_buffer, read_buffer);
+                } else if r1 == 0x01 {
+                    //XXX: replace this with a timer set to 10 ms
+                    // try again
+                    // send application-specific initialization in high capcity mode (HCS)
+                    self.state.set(State::SendACmd { acmd: SDCmd::ACMD41, arg: 0x40000000 });
+                    self.after_state.set(State::InitRepeatHCSInit);
+                    self.send_command(SDCmd::CMD55, 0x0, write_buffer, read_buffer);
+                } else {
+                    panic!("Error in {:?}. R1: {:#X}", self.state.get(), r1);
+                }
+            }
+
+            State::InitCheckCapacity => {
+                // check response
+                let (r1, _, r7) = self.get_response(SDResponse::R7, read_buffer);
+
+                if r1 == 0x00 {
+                    if (r7 & 0x40000000) != 0x00 {
+                        self.card_type.set(CT_SD2 | CT_BLOCK);
+                    } else {
+                        self.card_type.set(CT_SD2);
+                    }
+                } else {
+                    panic!("Error in {:?}. R1: {}", self.state.get(), r1);
+                }
+
+                //XXX: Initialization complete! Do callback
+                self.state.set(State::Idle);
+                self.is_slow_mode.set(true);
+                panic!("Initialization complete");
+            }
+
+            State::InitAppSpecificInit => {
+                // check response
+                let (r1, _, _) = self.get_response(SDResponse::R1, read_buffer);
+
+                if r1 <= 0x01 {
+                    // SDv1 card
+                    // send application-specific initialization
+                    self.card_type.set(CT_SD1);
+                    self.state.set(State::SendACmd { acmd: SDCmd::ACMD41, arg: 0x0 });
+                    self.after_state.set(State::InitRepeatAppSpecificInit);
+                    self.send_command(SDCmd::CMD55, 0x0, write_buffer, read_buffer);
+                } else {
+                    // MMCv3 card
+                    // send generic intialization
+                    self.card_type.set(CT_MMC);
+                    self.state.set(State::InitRepeatGenericInit);
+                    self.send_command(SDCmd::CMD1, 0x0,
+                        write_buffer, read_buffer);
+                }
+            }
+
+            State::InitRepeatAppSpecificInit => {
+                // check response
+                let (r1, _, _) = self.get_response(SDResponse::R1, read_buffer);
+
+                if r1 == 0x00 {
+                    // card initialized
+                    // set blocksize to 512
+                    self.state.set(State::InitSetBlocksize);
+                    self.send_command(SDCmd::CMD16, 512, write_buffer, read_buffer);
+                } else if r1 == 0x01 {
+                    //XXX: replace this with a timer set to 10 ms
+                    // try again
+                    // send application-specific initialization
+                    self.state.set(State::SendACmd { acmd: SDCmd::ACMD41, arg: 0x0 });
+                    self.after_state.set(State::InitRepeatAppSpecificInit);
+                    self.send_command(SDCmd::CMD55, 0x0, write_buffer, read_buffer);
+                } else {
+                    panic!("Error in {:?}. R1: {:#X}", self.state.get(), r1);
+                }
+            }
+
+            State::InitRepeatGenericInit => {
+                // check response
+                let (r1, _, _) = self.get_response(SDResponse::R1, read_buffer);
+
+                if r1 == 0x00 {
+                    // card initialized
+                    // set blocksize to 512
+                    self.state.set(State::InitSetBlocksize);
+                    self.send_command(SDCmd::CMD16, 512, write_buffer, read_buffer);
+                } else if r1 == 0x01 {
+                    //XXX: replace this with a timer set to 10 ms
+                    // try again
+                    // send generic intialization
+                    self.state.set(State::InitRepeatGenericInit);
+                    self.send_command(SDCmd::CMD1, 0x0, write_buffer, read_buffer);
+                } else {
+                    panic!("Error in {:?}. R1: {:#X}", self.state.get(), r1);
+                }
+            }
+
+            State::InitSetBlocksize => {
+                // check response
+                let (r1, _, _) = self.get_response(SDResponse::R1, read_buffer);
+
+                if r1 == 0x00 {
+                    //XXX: Initialization complete! Do callback
+                    self.state.set(State::Idle);
+                    self.is_slow_mode.set(false);
+                    panic!("Initialization complete");
+                } else {
+                    panic!("Error in {:?}. R1: {}", self.state.get(), r1);
+                }
+            }
+
+            State::Idle => {}
+        }
+    }
+
+    pub fn set_client<C: SDCardClient>(&self, client: &'static C) {
+        self.client.replace(client);
+    }
+
+    //XXX: do we actually want an interrupt on install/uninstall?
+    pub fn is_installed(&self) -> bool {
+        // set initialized to be false if the card is ever gone
+        true
+    }
+
+    pub fn initialize(&self) {
+        // initially configure SPI to 400 khz
+        self.is_slow_mode.set(true);
+
+        //XXX: need to check if the SD card is installed before continuing
+
+        // reset the SD card in order to start initializing it
+        self.txbuffer.take().map(|txbuffer| {
+            self.rxbuffer.take().map(move |rxbuffer| {
+                self.state.set(State::InitReset);
+                self.send_command(SDCmd::CMD0, 0x0,
+                    txbuffer, rxbuffer);
+            });
+        });
+    }
+
+    pub fn read_block(&self) {
+        // only if initialzed and installed
+    }
+
+    pub fn write_block(&self) {
+        // only if intialized and installed
+    }
+}
+
+impl<'a> hil::spi::SpiMasterClient for SDCard<'a> {
+    fn read_write_done(&self,
+                       mut write_buffer: &'static mut [u8],
+                       read_buffer: Option<&'static mut [u8]>,
+                       len: usize) {
+
+        // unrwap so we don't have to deal with options everywhere
+        read_buffer.map_or_else(|| {
+            panic!("Didn't receive a read_buffer back");
+        }, move |read_buffer| {
+            self.process_state(write_buffer, read_buffer, len);
+        });
+    }
+}
+
+
+// Application driver for SD Card capsule, layers on top of SD Card capsule
+pub struct SDCardDriver<'a> {
+    sdcard: &'a SDCard<'a>,
+}
+

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -134,6 +134,7 @@ functionality that is handled by the kernel. `command`, `subscribe`, and
 | 12            | TSL2561          | Light sensor                               |
 | 13            | I2C Master/Slave | Raw I2C interface                          |
 | 14            | RNG              | Random number generator                    |
+| 15            | SDCard           | Raw block access to an SD card             |
 | 154           | Radio            | 15.4 radio interface                       |
 | 255           | IPC              | Inter-process communication                |
 

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -87,6 +87,10 @@ impl<L, T> AppSlice<L, T> {
     pub fn iter(&self) -> slice::Iter<T> {
         self.as_ref().iter()
     }
+
+    pub fn iter_mut(&mut self) -> slice::IterMut<T> {
+        self.as_mut().iter_mut()
+    }
 }
 
 impl<L, T> AsRef<[T]> for AppSlice<L, T> {

--- a/kernel/src/returncode.rs
+++ b/kernel/src/returncode.rs
@@ -19,6 +19,7 @@ pub enum ReturnCode {
     ENOMEM, //........ Memory required not available
     ENOSUPPORT, //.... Operation or command is unsupported
     ENODEVICE, //..... Device does not exist
+    EUNINSTALLED, //.. Device is not physically installed
 }
 
 impl From<ReturnCode> for isize {
@@ -37,6 +38,7 @@ impl From<ReturnCode> for isize {
             ReturnCode::ENOMEM => -9,
             ReturnCode::ENOSUPPORT => -10,
             ReturnCode::ENODEVICE => -11,
+            ReturnCode::EUNINSTALLED => -12,
         }
     }
 }

--- a/userland/examples/sdcard/Makefile
+++ b/userland/examples/sdcard/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/Makefile

--- a/userland/examples/sdcard/main.c
+++ b/userland/examples/sdcard/main.c
@@ -15,6 +15,18 @@ int main() {
   int err = 0;
   printf("[TOCK] SD Card Test\n");
 
+  // Check if an SD card is installed
+  err = sdcard_is_installed();
+  if (err < 0) {
+    printf("Is installed error: %d\n", err);
+    return -1;
+  }
+  if (err == 0) {
+    printf("No SD card installed\n");
+    return 0;
+  }
+  printf("Found SD card...\n");
+
   // Set up the SD card
   uint32_t block_size = 0;
   uint32_t size_in_kB = 0;

--- a/userland/examples/sdcard/main.c
+++ b/userland/examples/sdcard/main.c
@@ -35,7 +35,8 @@ int main() {
     printf("Init error: %d\n", err);
     return -1;
   }
-  printf("SD Card Initialized!\n\tBlock size: %lu bytes\n\tSize:       %lu kB\n\n",
+  printf("SD Card Initialized!\n");
+  printf("\tBlock size: %lu bytes\n\tSize:       %lu kB\n\n",
       block_size, size_in_kB);
 
   // Give buffers to SD card

--- a/userland/examples/sdcard/main.c
+++ b/userland/examples/sdcard/main.c
@@ -1,0 +1,88 @@
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <tock.h>
+#include <console.h>
+#include <timer.h>
+#include <sdcard.h>
+
+uint8_t read_buf[512] = {0};
+uint8_t write_buf[512] = {0};
+
+int main() {
+  int err = 0;
+  printf("[TOCK] SD Card Test\n");
+
+  // Set up the SD card
+  uint32_t block_size = 0;
+  uint32_t size_in_kB = 0;
+  err = sdcard_initialize_sync(&block_size, &size_in_kB);
+  if (err < 0) {
+    printf("Init error: %d\n", err);
+    return -1;
+  }
+  printf("SD Card Initialized!\n\tBlock size: %lu bytes\n\tSize:       %lu kB\n\n",
+      block_size, size_in_kB);
+
+  // Give buffers to SD card
+  err = sdcard_set_read_buffer(read_buf, 512);
+  if (err < 0) {
+    printf("Allow read error: %d\n", err);
+    return -1;
+  }
+  err = sdcard_set_write_buffer(write_buf, 512);
+  if (err < 0) {
+    printf("Allow write error: %d\n", err);
+    return -1;
+  }
+
+  // read first block of the SD card
+  err = sdcard_read_block_sync(0);
+  if (err < 0) {
+    printf("Read error: %d\n", err);
+    return -1;
+  }
+  printf("Original data:     [%X, %X, %X, %X, ...]\n\n",
+      read_buf[0], read_buf[1], read_buf[2], read_buf[3]);
+
+  for (int i=0; i<10; i++) {
+    // write first block of the SD card
+    write_buf[0] = 0x1A;
+    write_buf[1] = 0xB1;
+    write_buf[2] = 0x10;
+    write_buf[3] = i;
+    err = sdcard_write_block_sync(0);
+    if (err < 0) {
+      printf("Write error: %d\n", err);
+      return -1;
+    }
+    printf("Wrote to SD card:  [%X, %X, %X, %X, ...]\n",
+        write_buf[0], write_buf[1], write_buf[2], write_buf[3]);
+
+    // read first block of the SD card again
+    err = sdcard_read_block_sync(0);
+    if (err < 0) {
+      printf("Read error: %d\n", err);
+      return -1;
+    }
+    printf("Read from SD card: [%X, %X, %X, %X, ...]\n",
+        read_buf[0], read_buf[1], read_buf[2], read_buf[3]);
+
+    // actually check buffers
+    for (int j=0; j<512; j++) {
+      if (read_buf[i] != write_buf[i]) {
+        printf("ERROR: buffers do not match!\n");
+        return -1;
+      }
+    }
+    printf("Buffers match!\n\n");
+    delay_ms(1000);
+  }
+
+  // test complete
+  printf("SD card test complete!\n\n");
+
+  return 0;
+}

--- a/userland/examples/sdcard/main.c
+++ b/userland/examples/sdcard/main.c
@@ -11,7 +11,7 @@
 uint8_t read_buf[512] = {0};
 uint8_t write_buf[512] = {0};
 
-int main() {
+int main (void) {
   int err = 0;
   printf("[TOCK] SD Card Test\n");
 

--- a/userland/libtock/sdcard.c
+++ b/userland/libtock/sdcard.c
@@ -40,24 +40,24 @@ static void sdcard_cb (int callback_type, int arg1, int arg2, void* callback_arg
   switch (callback_type) {
     case 0:
       // card_detection_changed
-      result->error = -4; // EOFF
+      result->error = EUNINSTALLED;
       break;
 
     case 1:
       // init_done
       result->block_size = arg1;
       result->size_in_kB = arg2;
-      result->error = 0;
+      result->error = SUCCESS;
       break;
 
     case 2:
       // read_done
-      result->error = 0;
+      result->error = SUCCESS;
       break;
 
     case 3:
       // write_done
-      result->error = 0;
+      result->error = SUCCESS;
       break;
 
     case 4:
@@ -93,7 +93,7 @@ int sdcard_initialize_sync (uint32_t* block_size, uint32_t* size_in_kB) {
   int err;
   sdcard_data_t result;
   result.fired = false;
-  result.error = 0;
+  result.error = SUCCESS;
 
   err = sdcard_set_callback(sdcard_cb, (void*) &result);
   if (err < 0) return err;
@@ -123,7 +123,7 @@ int sdcard_read_block_sync (uint32_t sector) {
   int err;
   sdcard_data_t result;
   result.fired = false;
-  result.error = 0;
+  result.error = SUCCESS;
 
   err = sdcard_set_callback(sdcard_cb, (void*) &result);
   if (err < 0) return err;
@@ -145,7 +145,7 @@ int sdcard_write_block_sync (uint32_t sector) {
   int err;
   sdcard_data_t result;
   result.fired = false;
-  result.error = 0;
+  result.error = SUCCESS;
 
   err = sdcard_set_callback(sdcard_cb, (void*) &result);
   if (err < 0) return err;

--- a/userland/libtock/sdcard.c
+++ b/userland/libtock/sdcard.c
@@ -105,8 +105,12 @@ int sdcard_initialize_sync (uint32_t* block_size, uint32_t* size_in_kB) {
   yield_for(&result.fired);
 
   // copy args
-  *block_size = result.block_size;
-  *size_in_kB = result.size_in_kB;
+  if (block_size != NULL) {
+    *block_size = result.block_size;
+  }
+  if (size_in_kB != NULL) {
+    *size_in_kB = result.size_in_kB;
+  }
 
   return result.error;
 }

--- a/userland/libtock/sdcard.c
+++ b/userland/libtock/sdcard.c
@@ -1,0 +1,138 @@
+// SD card interface
+
+#include "tock.h"
+#include "sdcard.h"
+
+struct sdcard_data {
+  bool fired;
+  uint32_t block_size;
+  uint32_t size_in_kB;
+  int32_t error;
+};
+
+static struct sdcard_data result = {
+  .fired = false,
+  .block_size = 0,
+  .size_in_kB = 0,
+  .error = 0,
+};
+
+// Internal callback for faking synchronous reads
+static void sdcard_cb (int callback_type, int arg1, int arg2, void* ud) {
+
+  struct sdcard_data* result = (struct sdcard_data*) ud;
+  switch (callback_type) {
+    case 0:
+      // card_detection_changed
+      result->error = -4; // EOFF
+      break;
+
+    case 1:
+      // init_done
+      result->block_size = arg1;
+      result->size_in_kB = arg2;
+      result->error = 0;
+      break;
+
+    case 2:
+      // read_done
+      result->error = 0;
+      break;
+
+    case 3:
+      // write_done
+      result->error = 0;
+      break;
+
+    case 4:
+      // error
+      result->error = arg1;
+      break;
+  }
+
+  result->fired = true;
+}
+
+int sdcard_set_callback (subscribe_cb callback, void* callback_args) {
+  return subscribe(DRIVER_NUM_SDCARD, 0, callback, callback_args);
+}
+
+int sdcard_set_read_buffer (uint8_t* buffer, uint32_t len) {
+  return allow(DRIVER_NUM_SDCARD, 0, (void*) buffer, len);
+}
+
+int sdcard_set_write_buffer (uint8_t* buffer, uint32_t len) {
+  return allow(DRIVER_NUM_SDCARD, 1, (void*) buffer, len);
+}
+
+int sdcard_is_installed (void) {
+  return command(DRIVER_NUM_SDCARD, 1, 0);
+}
+
+int sdcard_initialize (void) {
+  return command(DRIVER_NUM_SDCARD, 2, 0);
+}
+
+int sdcard_read_block (uint32_t sector) {
+  return command(DRIVER_NUM_SDCARD, 3, sector);
+}
+
+int sdcard_write_block (uint32_t sector) {
+  return command(DRIVER_NUM_SDCARD, 4, sector);
+}
+
+int sdcard_initialize_sync (uint32_t* block_size, uint32_t* size_in_kB) {
+  int err;
+  result.fired = false;
+  result.error = 0;
+
+  err = sdcard_set_callback(sdcard_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = sdcard_initialize();
+  if (err < 0) return err;
+
+  // wait for callback
+  yield_for(&result.fired);
+
+  // copy args
+  *block_size = result.block_size;
+  *size_in_kB = result.size_in_kB;
+
+  return result.error;
+}
+
+int sdcard_read_block_sync (uint32_t sector) {
+  int err;
+  result.fired = false;
+  result.error = 0;
+
+  err = sdcard_set_callback(sdcard_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = sdcard_read_block(sector);
+  if (err < 0) return err;
+
+  // wait for callback
+  yield_for(&result.fired);
+
+  return result.error;
+}
+
+int sdcard_write_block_sync (uint32_t sector) {
+  int err;
+  result.fired = false;
+  result.error = 0;
+
+  err = sdcard_set_callback(sdcard_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = sdcard_write_block(sector);
+  if (err < 0) return err;
+
+  // wait for callback
+  yield_for(&result.fired);
+
+  return result.error;
+}
+

--- a/userland/libtock/sdcard.h
+++ b/userland/libtock/sdcard.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#define DRIVER_NUM_SDCARD 15
+
+int sdcard_set_callback (subscribe_cb callback, void* callback_args);
+int sdcard_set_read_buffer (uint8_t* buffer, uint32_t len);
+int sdcard_set_write_buffer (uint8_t* buffer, uint32_t len);
+
+int sdcard_is_installed (void);
+int sdcard_initialize_sync (uint32_t* block_size, uint32_t* size_in_kB);
+int sdcard_read_block_sync (uint32_t sector);
+int sdcard_write_block_sync (uint32_t sector);
+

--- a/userland/libtock/sdcard.h
+++ b/userland/libtock/sdcard.h
@@ -1,13 +1,89 @@
 #pragma once
 
+#include <stdint.h>
+#include "tock.h"
+
 #define DRIVER_NUM_SDCARD 15
 
+// set a callback function for SD card commands
+// Callback is called upon command completion or when an error occurs. See
+// `sdcard_cb` in sdcard.c for callback documentation
+//
+// returns 0 if successful, < 0 if an error occurrs
 int sdcard_set_callback (subscribe_cb callback, void* callback_args);
+
+// set a buffer that data read from the SD card will be placed into
+// this buffer can be reused across multiple read calls
+//
+// returns 0 if successful, < 0 if an error occurrs
 int sdcard_set_read_buffer (uint8_t* buffer, uint32_t len);
+
+// set a buffer containing data to write to the SD card
+// this buffer can be reused across multiple write calls by changing its
+// contents. No need to call this function a second time
+//
+// returns 0 if successful, < 0 if an error occurrs
 int sdcard_set_write_buffer (uint8_t* buffer, uint32_t len);
 
+// check if an SD card is installed
+// Completes synchronously
+//
+// returns 1 if installed, 0 if not installed, < 0 if an error occurrs
 int sdcard_is_installed (void);
+
+// initialize an SD card asynchronously
+// Note that for a newly powered-on SD card, initialization can take over
+// 100 ms to complete. Expects a callback to have already been set. Callback
+// will be called when either initialization is complete or an error occurs
+//
+// returns 0 if started successfully, < 0 if an error occurrs
+int sdcard_initialize (void);
+
+// initialize an SD card synchronously
+// Note that for a newly powered-on SD card, initialization can take over
+// 100 ms to complete
+//
+// block_size - set to the block size of the SD card, if not NULL
+// size_in_kB - set to the size of the SD card in kilobytes, if not NULL
+//
+// returns 0 if SD card is now initialized, < 0 if an error occurrs
 int sdcard_initialize_sync (uint32_t* block_size, uint32_t* size_in_kB);
+
+// read a single block from an SD card asynchronously
+// Expects a read_buffer and a callback to already have been set up. Callback
+// will be called when either the block has been read or an error occurs. When
+// the callback is successful, data will be in the read_buffer
+//
+// sector - sector address of the block to be read
+//
+// returns 0 if started successfully, < 0 if an error occurrs
+int sdcard_read_block (uint32_t sector);
+
+// read a single block from an SD card synchronously
+// Expects a read_buffer to already have been set up. When the command
+// completes successfully, data will be in the read_buffer
+//
+// sector - sector address of the block to be read
+//
+// returns 0 if the block has been read, < 0 if an error occurrs
 int sdcard_read_block_sync (uint32_t sector);
+
+// write a single block to an SD card asynchronously
+// Expects a write_buffer and a callback to already have been set up. Data in
+// the write_buffer will be written to the SD card. Callback will be called
+// when either the block has been written or an error occurs
+//
+// sector - sector address of the block to be written
+//
+// returns 0 if started successfully, < 0 if an error occurrs
+int sdcard_write_block (uint32_t sector);
+
+// write a single block to an SD card synchronously
+// Expects a write_buffer to already have been set up. Data in the write_buffer
+// will be written to the SD card
+//
+// sector - sector address of the block to be written
+//
+// returns 0 if the block has been written, < 0 if an error occurrs
 int sdcard_write_block_sync (uint32_t sector);
 

--- a/userland/libtock/tock.h
+++ b/userland/libtock/tock.h
@@ -38,6 +38,7 @@ bool driver_exists(uint32_t driver);
 #define ENOMEM   -9
 #define ENOSUPPORT -10
 #define ENODEVICE  -11
+#define EUNINSTALLED -12
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Implementation of a raw SD card interface for Tock. This code has been tested on the [Signpost Control Module](https://github.com/lab11/signpost/tree/master/hardware/controller/rev_b), [Storage Master platform](https://github.com/lab11/signpost/tree/master/software/kernel/boards/storage_master) on multiple 8 GB and 4 GB SDHC cards. The code should also be compatible with older, smaller SD cards, but has not been explicitly tested on them (I don't have any).

These commits should probably be squashed when merging.

## Files

`capsules/src/sdcard.rs`:
 * `SDCard` for interacting with SD cards on a block level
 * `SDCardDriver` implements syscalls for the `SDCard` interface

`userland/libtock/sdcard.c` and `userland/libtock/sdcard.h`:
 * Functions for interacting with an SD card including checking if it is installed, initializing it, and reading/writing single blocks

`userland/examples/sdcard/main.c`:
 * Tests the SD card functionality