### PR TITLE
Add syscall virtualization to ADC capsule

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -316,8 +316,8 @@ pub unsafe fn reset_handler() {
     // Setup ADC
     let adc = static_init!(
         capsules::adc::ADC<'static, sam4l::adc::Adc>,
-        capsules::adc::ADC::new(&mut sam4l::adc::ADC),
-        224/8);
+        capsules::adc::ADC::new(&mut sam4l::adc::ADC, kernel::Container::create()),
+        96/8);
     sam4l::adc::ADC.set_client(adc);
 
     // Setup RNG

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -303,8 +303,8 @@ pub unsafe fn reset_handler() {
     // Setup ADC
     let adc = static_init!(
         capsules::adc::ADC<'static, sam4l::adc::Adc>,
-        capsules::adc::ADC::new(&mut sam4l::adc::ADC),
-        224/8);
+        capsules::adc::ADC::new(&mut sam4l::adc::ADC, kernel::Container::create()),
+        96/8);
     sam4l::adc::ADC.set_client(adc);
 
     // # GPIO

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -338,8 +338,8 @@ pub unsafe fn reset_handler() {
     // Setup ADC
     let adc = static_init!(
         capsules::adc::ADC<'static, sam4l::adc::Adc>,
-        capsules::adc::ADC::new(&mut sam4l::adc::ADC),
-        224/8);
+        capsules::adc::ADC::new(&mut sam4l::adc::ADC, kernel::Container::create()),
+        96/8);
     sam4l::adc::ADC.set_client(adc);
 
     // RNG

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -4,21 +4,27 @@
 //! ADC channels.
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Driver, ReturnCode};
+use kernel::{AppId, Callback, Container, Driver, ReturnCode};
 use kernel::hil::adc::{Client, AdcSingle};
+
+#[derive(Default)]
+pub struct AppData {
+    channel: Option<u8>,
+    callback: Option<Callback>
+}
 
 pub struct ADC<'a, A: AdcSingle + 'a> {
     adc: &'a A,
-    channel: Cell<u8>,
-    callback: Cell<Option<Callback>>,
+    channel: Cell<Option<u8>>,
+    app: Container<AppData>,
 }
 
 impl<'a, A: AdcSingle + 'a> ADC<'a, A> {
-    pub fn new(adc: &'a A) -> ADC<'a, A> {
+    pub fn new(adc: &'a A, container: Container<AppData>) -> ADC<'a, A> {
         ADC {
             adc: adc,
-            channel: Cell::new(0),
-            callback: Cell::new(None),
+            channel: Cell::new(None),
+            app: container,
         }
     }
 
@@ -26,17 +32,38 @@ impl<'a, A: AdcSingle + 'a> ADC<'a, A> {
         self.adc.initialize()
     }
 
-    fn sample(&self, channel: u8) -> ReturnCode {
-        self.channel.set(channel);
-        self.adc.sample(channel)
+    fn sample(&self, channel: u8, appid: AppId) -> ReturnCode {
+        self.app.enter(appid, |app, _| {
+            app.channel = Some(channel);
+
+            if self.channel.get().is_none() {
+                self.channel.set(Some(channel));
+                self.adc.sample(channel)
+            } else {
+                ReturnCode::SUCCESS
+            }
+        }).unwrap_or(ReturnCode::ENOMEM)
     }
 }
 
 impl<'a, A: AdcSingle + 'a> Client for ADC<'a, A> {
     fn sample_done(&self, sample: u16) {
-        self.callback
-            .get()
-            .map(|mut cb| { cb.schedule(0, self.channel.get() as usize, sample as usize); });
+        self.channel.get().map(|cur_channel| {
+            self.channel.set(None);
+            self.app.each(|app| {
+                if app.channel == Some(cur_channel) {
+                    app.channel = None;
+                    app.callback.map(|mut cb|
+                        cb.schedule(0, cur_channel as usize, sample as usize)
+                    );
+                } else if app.channel.is_some() {
+                    self.channel.set(app.channel);
+                }
+            });
+        });
+        self.channel.get().map(|next_channel| {
+            self.adc.sample(next_channel);
+        });
     }
 }
 
@@ -45,7 +72,9 @@ impl<'a, A: AdcSingle + 'a> Driver for ADC<'a, A> {
         match subscribe_num {
             // subscribe to ADC sample done
             0 => {
-                self.callback.set(Some(callback));
+                self.app.enter(callback.app_id(), |app, _| {
+                    app.callback = Some(callback);
+                }).unwrap_or(());
                 ReturnCode::SUCCESS
             }
 
@@ -54,14 +83,16 @@ impl<'a, A: AdcSingle + 'a> Driver for ADC<'a, A> {
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, appid: AppId) -> ReturnCode {
         match command_num {
             // TODO: This should return the number of valid ADC channels.
             0 /* check if present */ => ReturnCode::SUCCESS,
             // Initialize ADC
             1 => self.initialize(),
             // Sample on channel
-            2 => self.sample(data as u8),
+            2 => {
+                self.sample(data as u8, appid)
+            },
 
             // default
             _ => ReturnCode::ENOSUPPORT,


### PR DESCRIPTION
__WORK IN PROGRESS STILL__

This adds system call virtualization to the ADC driver so multiple applications can use the ADC concurrently. Initial tests seem to imply that it's working, but not totally as expected.

The goal is to provide the same sample to multiple apps if they both subscribed to the same channel. In practice what seems to be happening when programming the example ADC app twice, we get something like:

```bash
App1: [Tock] ADC Test
App2: [Tock] ADC Test
App1: ADC Reading: 2385 mV (raw: 0x0b90)
App1: ADC Reading: 2007 mV (raw: 0x09bb)
App2: ADC Reading: 2007 mV (raw: 0x09bb)
App1: ADC Reading: 1859 mV (raw: 0x0903)
App2: ADC Reading: 1627 mV (raw: 0x07e4)
App1: ADC Reading: 1855 mV (raw: 0x08ff)
App2: ADC Reading: 1692 mV (raw: 0x0834)
App1: ADC Reading: 1765 mV (raw: 0x088f)
App2: ADC Reading: 1683 mV (raw: 0x0829
```

Still investigating what's going on...

/cc @brghena @ppannuto 