### PR TITLE
Move application stack to bottom of SRAM

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -10,9 +10,14 @@ pub mod debug;
 pub mod driver;
 pub mod ipc;
 pub mod mem;
-pub mod process;
 pub mod returncode;
 pub mod hil;
+
+// Work around https://github.com/rust-lang-nursery/rustfmt/issues/6
+// It's a little sad that we have to skip the whole module, but that's
+// better than the unmaintainable pile 'o strings IMO
+#[cfg_attr(rustfmt, rustfmt_skip)]
+pub mod process;
 
 pub mod support;
 

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -915,7 +915,6 @@ impl<'a> Process<'a> {
                                    (0xFFFFFFFE & (self.yield_pc - flash_text_size as usize));
 
 
-            // You can thank the piece of garbage rustfmt for this.
             let _ = writer.write_fmt(format_args!("\
             App: {}   -   [{:?}]\
             \r\n Events Queued: {}   Syscall Count: {}   ",
@@ -931,105 +930,76 @@ impl<'a> Process<'a> {
             };
 
             let _ = writer.write_fmt(format_args!("\
-            \r\n\
-            \r\n ╔═══════════╤══════════════\
-════════════════════════════╗\
-            \r\n ║  Address  │ Region Name    Used | Allocated (bytes)  ║\
-              \r\n ╚{:#010X}═╪══════════════\
-════════════════════════════╝\
-            \r\n             │ ▼ Grant      {:6} | {:6}{}\
-              \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈\
-┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈\
-            \r\n             │ Unused\
-              \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈\
-┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈\
-            \r\n             │ ▲ Heap       {:6} | {:6}{}    S\
-              \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈\
-┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ R\
-            \r\n             │ ▼ Stack      {:6} | {:6}{}    A\
-              \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈\
-┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ M\
-            \r\n             │ Unused\
-              \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈\
-┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈\
-            \r\n             │ Data         {:6} | {:6}\
-              \r\n  {:#010X} ┴───────────────\
-────────────────────────────\
-            \r\n             .....\
-              \r\n  {:#010X} ┬───────────────\
-────────────────────────────\
-            \r\n             │ Unused\
-              \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈\
-┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ F\
-            \r\n             │ Data         {:6}                       L\
-              \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈\
-┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ A\
-            \r\n             │ Text         {:6}                       S\
-              \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈\
-┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ H\
-            \r\n             │ Header       {:6}\
-              \r\n  {:#010X} ┴───────────────\
-────────────────────────────\
-            \r\n\
-              \r\n  R0 : {:#010X}    R6 : {:#010X}\
-              \r\n  R1 : {:#010X}    R7 : {:#010X}\
-              \r\n  R2 : {:#010X}    R8 : {:#010X}\
-              \r\n  R3 : {:#010X}    R10: {:#010X}\
-              \r\n  R4 : {:#010X}    R11: {:#010X}\
-              \r\n  R5 : {:#010X}    R12: {:#010X}\
-              \r\n  R9 : {:#010X} (Static Base Register)\
-              \r\n  SP : {:#010X} (Process Stack Pointer)\
-              \r\n  LR : {:#010X} [{:#010X} in lst file]\
-              \r\n  PC : {:#010X} [{:#010X} in lst file]\
-              \r\n YPC : {:#010X} [{:#010X} in lst file]\
-            \r\n\r\n",
-                                                  sram_end,
-                                                  sram_grant_size,
-                                                  sram_grant_allocated,
-                                                  sram_grant_error_str,
-                                                  sram_grant_start,
-                                                  sram_heap_end,
-                                                  sram_heap_size,
-                                                  sram_heap_allocated,
-                                                  sram_heap_error_str,
-                                                  sram_heap_start,
-                                                  sram_stack_size,
-                                                  sram_stack_allocated,
-                                                  sram_stack_error_str,
-                                                  sram_stack_start,
-                                                  sram_data_end,
-                                                  sram_data_size,
-                                                  sram_data_allocated,
-                                                  sram_start,
-                                                  flash_end,
-                                                  flash_data_end,
-                                                  flash_data_size,
-                                                  flash_data_start,
-                                                  flash_text_size,
-                                                  flash_text_start,
-                                                  flash_header_size,
-                                                  flash_start,
-                                                  r0,
-                                                  self.stored_regs.r6,
-                                                  r1,
-                                                  self.stored_regs.r7,
-                                                  r2,
-                                                  self.stored_regs.r8,
-                                                  r3,
-                                                  self.stored_regs.r10,
-                                                  self.stored_regs.r4,
-                                                  self.stored_regs.r11,
-                                                  self.stored_regs.r5,
-                                                  r12,
-                                                  self.stored_regs.r9,
-                                                  sp,
-                                                  lr,
-                                                  lr_lst_relative,
-                                                  pc,
-                                                  pc_lst_relative,
-                                                  self.yield_pc,
-                                                  ypc_lst_relative,
-                                                  ));
+\r\n\
+\r\n ╔═══════════╤══════════════════════════════════════════╗\
+\r\n ║  Address  │ Region Name    Used | Allocated (bytes)  ║\
+\r\n ╚{:#010X}═╪══════════════════════════════════════════╝\
+\r\n             │ ▼ Grant      {:6} | {:6}{}\
+  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈\
+\r\n             │ Unused\
+  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈\
+\r\n             │ ▲ Heap       {:6} | {:6}{}    S\
+  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ R\
+\r\n             │ ▼ Stack      {:6} | {:6}{}    A\
+  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ M\
+\r\n             │ Unused\
+  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈\
+\r\n             │ Data         {:6} | {:6}\
+  \r\n  {:#010X} ┴───────────────────────────────────────────\
+\r\n             .....\
+  \r\n  {:#010X} ┬───────────────────────────────────────────\
+\r\n             │ Unused\
+  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ F\
+\r\n             │ Data         {:6}                       L\
+  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ A\
+\r\n             │ Text         {:6}                       S\
+  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ H\
+\r\n             │ Header       {:6}\
+  \r\n  {:#010X} ┴───────────────────────────────────────────\
+\r\n\
+  \r\n  R0 : {:#010X}    R6 : {:#010X}\
+  \r\n  R1 : {:#010X}    R7 : {:#010X}\
+  \r\n  R2 : {:#010X}    R8 : {:#010X}\
+  \r\n  R3 : {:#010X}    R10: {:#010X}\
+  \r\n  R4 : {:#010X}    R11: {:#010X}\
+  \r\n  R5 : {:#010X}    R12: {:#010X}\
+  \r\n  R9 : {:#010X} (Static Base Register)\
+  \r\n  SP : {:#010X} (Process Stack Pointer)\
+  \r\n  LR : {:#010X} [{:#010X} in lst file]\
+  \r\n  PC : {:#010X} [{:#010X} in lst file]\
+  \r\n YPC : {:#010X} [{:#010X} in lst file]\
+\r\n\r\n",
+  sram_end,
+  sram_grant_size, sram_grant_allocated, sram_grant_error_str,
+  sram_grant_start,
+  sram_heap_end,
+  sram_heap_size, sram_heap_allocated, sram_heap_error_str,
+  sram_heap_start,
+  sram_stack_size, sram_stack_allocated, sram_stack_error_str,
+  sram_stack_start,
+  sram_data_end,
+  sram_data_size, sram_data_allocated,
+  sram_start,
+  flash_end,
+  flash_data_end,
+  flash_data_size,
+  flash_data_start,
+  flash_text_size,
+  flash_text_start,
+  flash_header_size,
+  flash_start,
+  r0, self.stored_regs.r6,
+  r1, self.stored_regs.r7,
+  r2, self.stored_regs.r8,
+  r3, self.stored_regs.r10,
+  self.stored_regs.r4, self.stored_regs.r11,
+  self.stored_regs.r5, r12,
+  self.stored_regs.r9,
+  sp,
+  lr, lr_lst_relative,
+  pc, pc_lst_relative,
+  self.yield_pc, ypc_lst_relative,
+  ));
         } else {
             let _ = writer.write_fmt(format_args!("Unknown Load Info\r\n"));
         }

--- a/userland/examples/tests/mpu_stack_growth/Makefile
+++ b/userland/examples/tests/mpu_stack_growth/Makefile
@@ -1,0 +1,14 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/Makefile
+
+# Include the STACK_SIZE so the test can use it
+CFLAGS += -DSTACK_SIZE=$(STACK_SIZE)

--- a/userland/examples/tests/mpu_stack_growth/main.c
+++ b/userland/examples/tests/mpu_stack_growth/main.c
@@ -1,0 +1,77 @@
+/* vim: set sw=2 expandtab tw=80: */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <console.h>
+
+#define GROW_BY 0x100
+
+uint32_t size_is_at_least = 0;
+
+__attribute__((noinline))
+static void write_ptr(uint32_t* p) {
+  printf(" write to %p\n", p);
+  *p = 33;
+}
+
+__attribute__((noinline))
+static void read_ptr(uint32_t* p) {
+  printf("read from %p\n", p);
+  printf("    value %lu\n", *p);
+}
+
+static void grow_stack(void) {
+  register uint32_t* sp asm ("sp");
+
+  uint32_t buffer[GROW_BY];
+  printf("stack: %p - buffer: %p - STACK_SIZE: 0x%x - at_least: 0x%4lx\n",
+      sp, buffer, STACK_SIZE, size_is_at_least);
+
+  write_ptr(buffer);
+  read_ptr(buffer);
+
+  size_is_at_least += GROW_BY;
+
+  if (size_is_at_least > STACK_SIZE) {
+    printf("This should never print\n");
+  }
+
+  grow_stack();
+}
+
+// Try not to move the stack much so main's reading the sp reg is meaningful
+__attribute__((noinline))
+static void start(
+    void* mem_start,
+    void* app_heap_break,
+    void* kernel_memory_break,
+    void* sp) {
+  printf("\n[TEST] MPU Stack Growth\n");
+
+  printf("This test should recursively add stack frames until exceeding\n");
+  printf("the available stack space and triggering a fault\n\n");
+
+  printf("  mem_start:           %p\n", mem_start);
+  printf("  app_heap_break:      %p\n", app_heap_break);
+  printf("  kernel_memory_break: %p\n", kernel_memory_break);
+  printf("  stack pointer (ish): %p\n", sp);
+
+  putchar('\n');
+
+  grow_stack();
+}
+
+// our main isn't normal
+#pragma GCC diagnostic ignored "-Wmain"
+
+int main(
+    void* mem_start,
+    void* app_heap_break,
+    void* kernel_memory_break) {
+  register uint32_t* sp asm ("sp");
+  start(mem_start, app_heap_break, kernel_memory_break, sp);
+  return 0;
+}

--- a/userland/libtock/crt1.c
+++ b/userland/libtock/crt1.c
@@ -6,7 +6,7 @@ extern unsigned int* _got;
 extern unsigned int* _egot;
 extern unsigned int* _bss;
 extern unsigned int* _ebss;
-extern int main(void);
+extern int main(void*, void*, void*);
 
 // Allow _start to go undeclared
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
@@ -14,10 +14,10 @@ extern int main(void);
 __attribute__ ((section(".start"), used))
 __attribute__ ((noreturn))
 void _start(
-    __attribute__((unused))void* mem_start,
-    __attribute__((unused))void* app_heap_break,
-    __attribute__((unused))void* kernel_memory_break) {
-  main();
+    void* mem_start,
+    void* app_heap_break,
+    void* kernel_memory_break) {
+  main(mem_start, app_heap_break, kernel_memory_break);
   while(1) { yield(); }
 }
 

--- a/userland/libtock/crt1.c
+++ b/userland/libtock/crt1.c
@@ -15,7 +15,7 @@ __attribute__ ((section(".start"), used))
 __attribute__ ((noreturn))
 void _start(
     __attribute__((unused))void* mem_start,
-    __attribute__((unused))void* app_memory_break,
+    __attribute__((unused))void* app_heap_break,
     __attribute__((unused))void* kernel_memory_break) {
   main();
   while(1) { yield(); }

--- a/userland/userland_layout.ld
+++ b/userland/userland_layout.ld
@@ -93,6 +93,16 @@ SECTIONS {
         _ebss = .;
     } > SRAM
 
+/*
+ * __NOTE__: The following symbols are used only to pass information
+ * through the elf -> tbf -> Tock kernel.
+ *
+ * The kernel will place the stack at the beginning of the SRAM section so
+ * that stack overflows run off the end of the memory segment and trigger an
+ * MPU violation instead of overwriting data/got/bss information. This means
+ * the actual location of symbols in those sections in memory will be offset
+ * by STACK_SIZE.
+ */
     .stack :
     {
         _stack = .;


### PR DESCRIPTION
~~**Not Ready: Compile tested only**~~

Move application stack to the bottom of SRAM so that a stack overflow triggers an MPU fault rather than overwriting the data/got/bss segments