### PR TITLE
Quantize application timers to 1 millisecond

### DIFF
--- a/capsules/src/timer.rs
+++ b/capsules/src/timer.rs
@@ -122,7 +122,15 @@ impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
                         self.num_armed.set(self.num_armed.get() + 1);
                     }
 
-                    td.t0 = self.alarm.now();
+                    let now = self.alarm.now();
+                    let freq = <A::Frequency>::frequency() / 1000;
+                    let now_mod = now % freq;
+                    let now_adjusted = if now_mod >= freq / 2 {
+                        now - now_mod + 1
+                    } else {
+                        now - now_mod
+                    };
+                    td.t0 = now_adjusted;
                     td.interval = interval;
 
                     // Repeat if cmd_type was 2


### PR DESCRIPTION
When application timers are set to fire very close to one another, it's possible for one of the later one to be passed over until another timer fires because by the time a new timer is set, `timer.now()` has just passed over it.

This resolves this issue by quantizing all application timer start times to the nearest one millisecond (which is closer to the behavior of a raw hardware timer operating at 1kHz anyway). This way application timers will always fire at exactly 1 millisecond interval, so timers that were otherwise close, will now be identical.