### PR TITLE
Upgrade LED capsule to allow individualized modes

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -290,15 +290,15 @@ pub unsafe fn reset_handler() {
 
     // LEDs
     let led_pins = static_init!(
-        [&'static sam4l::gpio::GPIOPin; 3],
-        [&sam4l::gpio::PA[13],  // Red
-         &sam4l::gpio::PA[15],  // Green
-         &sam4l::gpio::PA[14]], // Blue
-        3 * 4);
+        [(&'static sam4l::gpio::GPIOPin, capsules::led::ActivationMode); 3],
+        [(&sam4l::gpio::PA[13], capsules::led::ActivationMode::ActiveLow),  // Red
+         (&sam4l::gpio::PA[15], capsules::led::ActivationMode::ActiveLow),  // Green
+         (&sam4l::gpio::PA[14], capsules::led::ActivationMode::ActiveLow)], // Blue
+        192/8);
     let led = static_init!(
         capsules::led::LED<'static, sam4l::gpio::GPIOPin>,
-        capsules::led::LED::new(led_pins, capsules::led::ActivationMode::ActiveLow),
-        96/8);
+        capsules::led::LED::new(led_pins),
+        64/8);
 
     // BUTTONs
     let button_pins = static_init!(

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -332,13 +332,13 @@ pub unsafe fn reset_handler() {
 
     // # LEDs
     let led_pins = static_init!(
-        [&'static sam4l::gpio::GPIOPin; 1],
-        [&sam4l::gpio::PC[10]],
-        1 * 4);
+        [(&'static sam4l::gpio::GPIOPin, capsules::led::ActivationMode); 1],
+        [(&sam4l::gpio::PC[10], capsules::led::ActivationMode::ActiveHigh)],
+        64/8);
     let led = static_init!(
         capsules::led::LED<'static, sam4l::gpio::GPIOPin>,
-        capsules::led::LED::new(led_pins, capsules::led::ActivationMode::ActiveHigh),
-        96/8);
+        capsules::led::LED::new(led_pins),
+        64/8);
 
     // # BUTTONs
 

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -134,17 +134,17 @@ pub unsafe fn reset_handler() {
 
     // LEDs
     let led_pins = static_init!(
-        [&'static nrf51::gpio::GPIOPin; 4],
-        [&nrf51::gpio::PORT[LED1_PIN], // 21
-         &nrf51::gpio::PORT[LED2_PIN], // 22
-         &nrf51::gpio::PORT[LED3_PIN], // 23
-         &nrf51::gpio::PORT[LED4_PIN], // 24
+        [(&'static nrf51::gpio::GPIOPin, capsules::led::ActivationMode); 4],
+        [(&nrf51::gpio::PORT[LED1_PIN], capsules::led::ActivationMode::ActiveLow), // 21
+         (&nrf51::gpio::PORT[LED2_PIN], capsules::led::ActivationMode::ActiveLow), // 22
+         (&nrf51::gpio::PORT[LED3_PIN], capsules::led::ActivationMode::ActiveLow), // 23
+         (&nrf51::gpio::PORT[LED4_PIN], capsules::led::ActivationMode::ActiveLow), // 24
         ],
-        4 * 4);
+        256/8);
     let led = static_init!(
         capsules::led::LED<'static, nrf51::gpio::GPIOPin>,
-        capsules::led::LED::new(led_pins, capsules::led::ActivationMode::ActiveLow),
-        96/8);
+        capsules::led::LED::new(led_pins),
+        64/8);
 
     let button_pins = static_init!(
         [&'static nrf51::gpio::GPIOPin; 4],

--- a/boards/storm/src/main.rs
+++ b/boards/storm/src/main.rs
@@ -327,13 +327,13 @@ pub unsafe fn reset_handler() {
 
     // LEDs
     let led_pins = static_init!(
-        [&'static sam4l::gpio::GPIOPin; 1],
-        [&sam4l::gpio::PC[10]],
-        1 * 4);
+        [(&'static sam4l::gpio::GPIOPin, capsules::led::ActivationMode); 1],
+        [(&sam4l::gpio::PC[10], capsules::led::ActivationMode::ActiveHigh)],
+        64/8);
     let led = static_init!(
         capsules::led::LED<'static, sam4l::gpio::GPIOPin>,
-        capsules::led::LED::new(led_pins, capsules::led::ActivationMode::ActiveHigh),
-        96/8);
+        capsules::led::LED::new(led_pins),
+        64/8);
 
     // Setup ADC
     let adc = static_init!(

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -28,9 +28,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> LED<'a, G> {
             }
         }
 
-        LED {
-            pins_init: pins_init,
-        }
+        LED { pins_init: pins_init }
     }
 }
 

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -7,20 +7,20 @@ use kernel::{AppId, Driver, ReturnCode};
 use kernel::hil;
 
 /// Whether the LEDs are active high or active low on this platform.
+#[derive(Clone,Copy)]
 pub enum ActivationMode {
     ActiveHigh,
     ActiveLow,
 }
 
 pub struct LED<'a, G: hil::gpio::Pin + 'a> {
-    pins: &'a [&'a G],
-    mode: ActivationMode,
+    pins_init: &'a [(&'a G, ActivationMode)],
 }
 
 impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> LED<'a, G> {
-    pub fn new(pins: &'a [&'a G], mode: ActivationMode) -> LED<'a, G> {
+    pub fn new(pins_init: &'a [(&'a G, ActivationMode)]) -> LED<'a, G> {
         // Make all pins output and off
-        for pin in pins.iter() {
+        for &(pin, mode) in pins_init.as_ref().iter() {
             pin.make_output();
             match mode {
                 ActivationMode::ActiveHigh => pin.clear(),
@@ -29,27 +29,27 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> LED<'a, G> {
         }
 
         LED {
-            pins: pins,
-            mode: mode,
+            pins_init: pins_init,
         }
     }
 }
 
 impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for LED<'a, G> {
     fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
-        let pins = self.pins.as_ref();
+        let pins_init = self.pins_init.as_ref();
         match command_num {
             // get number of LEDs
-            0 => ReturnCode::SuccessWithValue { value: pins.len() as usize },
+            0 => ReturnCode::SuccessWithValue { value: pins_init.len() as usize },
 
             // on
             1 => {
-                if data >= pins.len() {
+                if data >= pins_init.len() {
                     ReturnCode::EINVAL /* impossible pin */
                 } else {
-                    match self.mode {
-                        ActivationMode::ActiveHigh => pins[data].set(),
-                        ActivationMode::ActiveLow => pins[data].clear(),
+                    let (pin, mode) = pins_init[data];
+                    match mode {
+                        ActivationMode::ActiveHigh => pin.set(),
+                        ActivationMode::ActiveLow => pin.clear(),
                     }
                     ReturnCode::SUCCESS
                 }
@@ -57,12 +57,13 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for LED<'a, G> {
 
             // off
             2 => {
-                if data >= pins.len() {
+                if data >= pins_init.len() {
                     ReturnCode::EINVAL /* impossible pin */
                 } else {
-                    match self.mode {
-                        ActivationMode::ActiveHigh => pins[data].clear(),
-                        ActivationMode::ActiveLow => pins[data].set(),
+                    let (pin, mode) = pins_init[data];
+                    match mode {
+                        ActivationMode::ActiveHigh => pin.clear(),
+                        ActivationMode::ActiveLow => pin.set(),
                     }
                     ReturnCode::SUCCESS
                 }
@@ -70,10 +71,11 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for LED<'a, G> {
 
             // toggle
             3 => {
-                if data >= pins.len() {
+                if data >= pins_init.len() {
                     ReturnCode::EINVAL /* impossible pin */
                 } else {
-                    pins[data].toggle();
+                    let (pin, _) = pins_init[data];
+                    pin.toggle();
                     ReturnCode::SUCCESS
                 }
             }


### PR DESCRIPTION
This is necessary for boards that have a mixture of ActiveHigh and ActiveLow LEDs such as occurs on the Signpost platform.

In the end this is a pretty simple change. I'm hoping to have this merged today so that we can use it in signpost.