### PR TITLE
Fix MPU region sizes

### DIFF
--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -3,6 +3,8 @@
 #![feature(asm,const_fn,naked_functions)]
 #![no_std]
 
+#[allow(unused_imports)]
+#[macro_use(debug)]
 extern crate kernel;
 
 pub mod mpu;

--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -122,9 +122,13 @@ impl kernel::mpu::MPU for MPU {
                execute: kernel::mpu::ExecutePermission,
                access: kernel::mpu::AccessPermission) {
         let regs = unsafe { &*self.0 };
-        regs.region_base_address.set(region_num | 1 << 4 | start_addr);
+
+        let region_base_address = region_num | 1 << 4 | start_addr;
+        regs.region_base_address.set(region_base_address);
+
         let xn = execute as u32;
         let ap = access as u32;
-        regs.region_attributes_and_size.set(1 | len << 1 | ap << 24 | xn << 28);
+        let region_attributes_and_size = 1 | len << 1 | ap << 24 | xn << 28;
+        regs.region_attributes_and_size.set(region_attributes_and_size);
     }
 }

--- a/userland/examples/tests/mpu_walk_region/Makefile
+++ b/userland/examples/tests/mpu_walk_region/Makefile
@@ -1,0 +1,14 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/Makefile
+
+# Include the STACK_SIZE so the test can use it
+CFLAGS += -DSTACK_SIZE=$(STACK_SIZE)

--- a/userland/examples/tests/mpu_walk_region/main.c
+++ b/userland/examples/tests/mpu_walk_region/main.c
@@ -1,0 +1,82 @@
+/* vim: set sw=2 expandtab tw=80: */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <console.h>
+
+
+static uint32_t read_cpsr(void) {
+  register uint32_t ret asm ("r0");
+  asm volatile(
+      "mrs r0, CONTROL"
+      : "=r"(ret)
+      :
+      :
+      );
+  return ret;
+}
+
+/*
+static void clear_priv(void) {
+  asm volatile(
+      "mov r0, #1\n\tmsr CONTROL, r0"
+      :
+      :
+      : "r0"
+      );
+}
+*/
+
+__attribute__((noinline))
+static void dowork(uint32_t from, uint32_t to, uint32_t incr) {
+  volatile uint8_t* p_from = (uint8_t*) from;
+  volatile uint8_t* p_to = (uint8_t*) to;
+
+  printf("%p -> %p, incr 0x%lx\n", p_from, p_to, incr);
+  printf("       CPSR: %08lx\n", read_cpsr());
+
+  while (p_from < p_to) {
+    printf("%p: ", p_from);
+    fflush(stdout);
+    printf("%08x\n", *p_from);
+    p_from += incr;
+    asm("nop;");
+  }
+}
+
+// Try not to move the stack much so main's reading the sp reg is meaningful
+__attribute__((noinline))
+static void start(
+    void* mem_start,
+    void* app_heap_break,
+    void* kernel_memory_break,
+    void* sp) {
+  printf("\n[TEST] MPU Walk Regions\n");
+  putchar('\n');
+
+  printf("  mem_start:           %p\n", mem_start);
+  printf("  app_heap_break:      %p\n", app_heap_break);
+  printf("  kernel_memory_break: %p\n", kernel_memory_break);
+  printf("  stack pointer (ish): %p\n", sp);
+
+  putchar('\n');
+
+  dowork(0x20004000, (uint32_t)kernel_memory_break & 0xfffffe00, 0x100);
+  dowork(0x20000000, 0x20004000, 0x100);
+}
+
+// our main isn't normal
+#pragma GCC diagnostic ignored "-Wmain"
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+
+int main(
+    void* mem_start,
+    void* app_heap_break,
+    void* kernel_memory_break) {
+  register uint32_t* sp asm ("sp");
+  start(mem_start, app_heap_break, kernel_memory_break, sp);
+  return 0;
+}


### PR DESCRIPTION
Debugging the MPU more revealed a Goldilocks situation: an off-by-one too large
and and off-by-one too small setting up MPU regions. Now we’re just right.
This explains two different issues we’ve been seeing:

  - From #289: Applications could write the region of memory directly below them
  - From @cxbrooks's exploration into very large apps that were seeing odd faults

First, an exploration of how the code was currently running:

Printing the MPU configuration:

    TOCK_DEBUG(313): num 0 start_addr 0x20006000 len 14 base 0x20006010 attr_and_size 0x300001d

In the case the goals is to allow the range 0x20006000-0x20008000

Decomposing the registers:

1. region_base_address is set to 0x20006010

```
    0010 0000 0000 0000 0110 0000 0001 0000
    |                     |          | |...-> region 0
    |                     |          |-----> valid = yes
    bit 31                bit 13
```

The top bits of this register are defined as

    /// [31:N]    | ADDR    | Region base address
    /// [(N-1):5] |         | Reserved

Which means we need N=13

2. attr_and_size is set to 0x300001d

The bottom are of interest here:

    /// 0     | ENABLE | Region enable
    /// 5:1   | SIZE   | Region size is 2^(SIZE+1) (minimum 3)

    0001 1101
      .. ...

    SIZE=01110, N=14

The effect is that the MPU sees a base address of 0x20004000, which
explains why it was allowing accesses lower than it should have.

The bad field is coming from the len parameter, which comes from

    let data_len = (32 - self.memory.len().leading_zeros()) as u32;

in contrast, the MPU documentation specifies that len should be set via

    ///   N = Log2(Region size in bytes)

And log2(0x2000) = 13, not 14. Hence our problem. Off-by-one too large.

Interestingly, the flash segment computed size slightly differently

    let text_len = ((32 - self.text.len().leading_zeros()) - 2) as u32;

This chose a region that was half as large as it should be. However, to
deal with alignment issues, we round up the reported size of applications,
which means that the top half of flash for applications was often unused
space, and this wouldn’t be an issue in practice. That is, until you start
flashing large apps.