### PR TITLE
be consistent with how we format headers

### DIFF
--- a/userland/libtock/adc.h
+++ b/userland/libtock/adc.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 
 #include "tock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define DRIVER_NUM_ADC 7
 

--- a/userland/libtock/button.h
+++ b/userland/libtock/button.h
@@ -2,11 +2,11 @@
 
 #include <tock.h>
 
-#define DRIVER_NUM_BUTTON 9
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define DRIVER_NUM_BUTTON 9
 
 int button_subscribe(subscribe_cb callback, void *ud);
 int button_enable_interrupt(int pin_num);

--- a/userland/libtock/console.h
+++ b/userland/libtock/console.h
@@ -1,5 +1,4 @@
-#ifndef CONSOLE_H
-#define CONSOLE_H
+#pragma once
 
 #include "tock.h"
 
@@ -14,5 +13,3 @@ void putnstr_async(const char* str, size_t len, subscribe_cb cb, void* userdata)
 #ifdef __cplusplus
 }
 #endif
-
-#endif // CONSOLE_H

--- a/userland/libtock/firestorm.h
+++ b/userland/libtock/firestorm.h
@@ -1,5 +1,4 @@
-#ifndef _FIRESTORM_H
-#define _FIRESTORM_H
+#pragma once
 
 #include "tock.h"
 
@@ -17,5 +16,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif // _FIRESTORM_H

--- a/userland/libtock/gpio.h
+++ b/userland/libtock/gpio.h
@@ -1,13 +1,12 @@
-#ifndef _GPIO_H
-#define _GPIO_H
+#pragma once
 
 #include <tock.h>
-
-#define GPIO_DRIVER_NUM 1
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define GPIO_DRIVER_NUM 1
 
 // GPIO pin enum is defined externally in platform headers
 typedef uint32_t GPIO_Pin_t;
@@ -39,5 +38,3 @@ int gpio_interrupt_callback(subscribe_cb callback, void* callback_args);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // _GPIO_H

--- a/userland/libtock/i2c_master_slave.h
+++ b/userland/libtock/i2c_master_slave.h
@@ -2,6 +2,10 @@
 
 #include "tock.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DRIVER_NUM_I2CMASTERSLAVE 13
 
 #define TOCK_I2C_CB_SLAVE_READ_REQUEST   2
@@ -23,3 +27,7 @@ int i2c_master_slave_enable_slave_read(uint32_t len);
 
 int i2c_master_slave_write_sync(uint8_t address, uint8_t length);
 int i2c_master_slave_read_sync(uint16_t address, uint16_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/userland/libtock/ipc.h
+++ b/userland/libtock/ipc.h
@@ -4,11 +4,11 @@
 #include <string.h>
 #include <tock.h>
 
-#define IPC_DRIVER_NUM 0xff
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define IPC_DRIVER_NUM 0xff
 
 // Performs service discovery
 //
@@ -60,4 +60,3 @@ int ipc_share(int pid, void* base, int len);
 #ifdef __cplusplus
 }
 #endif
-

--- a/userland/libtock/isl29035.h
+++ b/userland/libtock/isl29035.h
@@ -1,5 +1,4 @@
-#ifndef _ISL29035_H
-#define _ISL29035_H
+#pragma once
 
 #include <tock.h>
 
@@ -17,5 +16,3 @@ int isl29035_read_light_intensity(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // _ISL29035_H

--- a/userland/libtock/led.h
+++ b/userland/libtock/led.h
@@ -2,6 +2,10 @@
 
 #include "tock.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DRIVER_NUM_LEDS 8
 
 int led_on(int led_num);
@@ -10,3 +14,7 @@ int led_toggle(int led_num);
 
 // Returns the number of LEDs on the host platform.
 int led_count(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/userland/libtock/nrf51_serialization.h
+++ b/userland/libtock/nrf51_serialization.h
@@ -1,5 +1,4 @@
-#ifndef _NRF51_SERIALIZATION_H
-#define _NRF51_SERIALIZATION_H
+#pragma once
 
 #include "tock.h"
 
@@ -23,5 +22,3 @@ void nrf51_wakeup (void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // _NRF51_SERIALIZATION_H

--- a/userland/libtock/radio.h
+++ b/userland/libtock/radio.h
@@ -1,5 +1,4 @@
-#ifndef _RADIO_H
-#define _RADIO_H
+#pragma once
 
 #include <tock.h>
 
@@ -30,5 +29,3 @@ int radio_set_channel(unsigned char channel);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // _RADIO_H

--- a/userland/libtock/rng.h
+++ b/userland/libtock/rng.h
@@ -2,6 +2,10 @@
 
 #include "tock.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DRIVER_NUM_RNG 14
 
 /*  rng_async
@@ -50,3 +54,6 @@ int rng_set_buffer(uint8_t* buf, uint32_t len);
  */
 int rng_get_random(int num_bytes);
 
+#ifdef __cplusplus
+}
+#endif

--- a/userland/libtock/sdcard.h
+++ b/userland/libtock/sdcard.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include <stdint.h>
+
 #include "tock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define DRIVER_NUM_SDCARD 15
 
@@ -87,3 +92,6 @@ int sdcard_write_block (uint32_t sector);
 // returns 0 if the block has been written, < 0 if an error occurrs
 int sdcard_write_block_sync (uint32_t sector);
 
+#ifdef __cplusplus
+}
+#endif

--- a/userland/libtock/spi.h
+++ b/userland/libtock/spi.h
@@ -1,5 +1,4 @@
-#ifndef _SPI_H
-#define _SPI_H
+#pragma once
 
 #include <tock.h>
 
@@ -50,5 +49,3 @@ int spi_read_write_sync(const char* write, char* read, size_t len);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // _SPI_H

--- a/userland/libtock/timer.h
+++ b/userland/libtock/timer.h
@@ -1,5 +1,4 @@
-#ifndef _TIMER_H
-#define _TIMER_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,5 +49,3 @@ void delay_ms(uint32_t ms);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // _TIMER_H

--- a/userland/libtock/tmp006.h
+++ b/userland/libtock/tmp006.h
@@ -1,5 +1,4 @@
-#ifndef _TMP006_H
-#define _TMP006_H
+#pragma once
 
 #include <tock.h>
 
@@ -18,5 +17,3 @@ int tmp006_stop_sampling(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // _TMP006_H

--- a/userland/libtock/tock.h
+++ b/userland/libtock/tock.h
@@ -1,5 +1,4 @@
-#ifndef _TOCK_H
-#define _TOCK_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -43,5 +42,3 @@ bool driver_exists(uint32_t driver);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // _TOCK_H


### PR DESCRIPTION
We were close to a consensus on most of this, but now everything
follows the same format:

    `#pragma once` directive
    [newline]
    System headers in <>'s
    [newline]
    Tock headers in ""'s
    [newline]
    C++ guard
    [newline]
    #define's
    [newline]
    function prototypes
    [newline]
    C++ guard

The only real changes / decisions:

 - `#pragma once` instead of include guards. We were about 50/50.
   I think the pragma looks cleaner and is easier, so I went that way.
 - C++ open guard above defines. We were about 75/25 this way already.
   I think this is easier to parse as it groups the things this header
   is defining together instead of putting this random build artifact
   in the middle
 - Add missing C++ guards. Only a few files had forgotten them. I don't
   think any files were #define only, but even if they were, I'd be
   inclined to still include the guards to be consistent across all
   headers and more importantly to reduce the chance that it's forgetten
   if a method is added.