### PR TITLE
nrf51/gdb-fix

### DIFF
--- a/boards/nrf51dk/jtag/gdbinit_pca10028.jlink
+++ b/boards/nrf51dk/jtag/gdbinit_pca10028.jlink
@@ -5,7 +5,7 @@
 # for commands on localhost at tcp port 2331
 target remote localhost:2331
 monitor speed 30
-file target/nrf51/release/nrf51dk
+file ../target/nrf51/release/nrf51dk
 monitor reset
 #
 # CPU core initialization (to be done by user)


### PR DESCRIPTION
Modified so that the gdbinit script can be executed from boards/nrf51dk/jtag.

Makes it more convenient if you execute jdbserver_pca10028.sh from boards/nrf51dk/jtag as well.
Execute by:
$ cd boards/nrf51dk/jtag
$ ./jdbserver_pca10028.sh
$ arm-none-eabi-gdb -x gdbinit_pca10028.jlink