### PR TITLE
trd1: fix typos, try to address style issues

### DIFF
--- a/doc/reference/trd1-trds.md
+++ b/doc/reference/trd1-trds.md
@@ -33,8 +33,7 @@ describes and follows both.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in TRD 1
-<a href="#TRD1">[TRD1]</a>.
+document are to be interpreted as described in [TRD1].
 
 Note that the force of these words is modified by the requirement
 level of the document in which they are used. These words hold their
@@ -105,9 +104,8 @@ A TRD MUST begin with a title, and then follow with a header and a
 body. The header states document metadata, for management and status.
 The body contains the content of the proposal.
 
-All TRDs MUST conform to Markdown syntax
-<a href="#markdown">[markdown]</a> to enable translation to HTML and
-LaTeX, and for useful display in web tools.
+All TRDs MUST conform to [Markdown syntax][markdown] to enable
+translation to HTML and LaTeX, and for useful display in web tools.
 
 3.1 TRD Header
 --------------------------------------------------------------------
@@ -259,17 +257,12 @@ from TinyOS Enhancement Proposal 1 (TEP 1).
     email - pal@cs.stanford.edu
 
 
-8. Citations
-====================================================================
-
-<a name="TRD1" />[TRD1]
-  <a href="trd1-trds.md">Tock Reference Document (TRD) Structure and Keywords</a>
-
-<a name="markdown" />[markdown]
-  <a href="https://daringfireball.net/projects/markdown/">Markdown</a>
- 
-
 Appendix A. Example Appendix
 ====================================================================
 
 This is an example appendix. Appendices begin with the letter A.
+
+[TRD1]: trd1-trds.md "Tock Reference Document (TRD) Structure and Keywords"
+
+[markdown]: https://daringfireball.net/projects/markdown/ "Markdown"
+

--- a/doc/reference/trd1-trds.md
+++ b/doc/reference/trd1-trds.md
@@ -1,22 +1,22 @@
 Tock Reference Document (TRD) Structure and Keywords
 ========================================
 
-**TRD:** 1 <br/>
+**TRD:** 1<br/>
 **Working Group:** Kernel<br/>
 **Type:** Best Common Practice<br/>
-**Status:** Draft <br/>
-**Author:** Philip Levis <br/>
+**Status:** Draft<br/>
+**Authors:** Philip Levis<br/>
 **Draft-Created:** Jan 30, 2017<br/>
-**Draft-Modified:** Jan 30, 2017<br/>
-**Draft-Version:** 1<br/>
+**Draft-Modified:** Mar 9, 2017<br/>
+**Draft-Version:** 2<br/>
 **Draft-Discuss:** tock-dev@googlegroups.com<br/>
 
 Abstract
 -------------------------------
 
-This document describes the structure of all Tock Reference Documents
-(TRDs) follow, and defines the meaning of several key words in those
-documents.
+This document describes the structure followed by all Tock Reference
+Documents (TRDs), and defines the meaning of several key words in
+those documents.
 
 1. Introduction
 ====================================================================
@@ -33,7 +33,8 @@ describes and follows both.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in TRD 1[TRD].
+document are to be interpreted as described in TRD 1
+<a href="#TRD1">[TRD1]</a>.
 
 Note that the force of these words is modified by the requirement
 level of the document in which they are used. These words hold their
@@ -80,8 +81,8 @@ implementer feels that it enhances the system while another
 implementer may omit the same item.  An implementation which does not
 include a particular option MUST be prepared to interoperate with
 another implementation which does include the option, though perhaps
-with reduced functionality. In the same vein an implementation which
-does include a particular option MUST be prepared to interoperate with
+with reduced functionality. Similarly, an implementation which does
+include a particular option MUST be prepared to interoperate with
 another implementation which does not include the option (except, of
 course, for the feature the option provides.)
 
@@ -100,73 +101,75 @@ interoperability.
 3. TRD Structure
 ====================================================================
 
-TRDs have two major parts, a header and a body. The header states
-document metadata, for management and status. The body contains the 
-content of the proposal.
+A TRD MUST begin with a title, and then follow with a header and a
+body. The header states document metadata, for management and status.
+The body contains the content of the proposal.
 
-All TRDs MUST conform to Markdown standards [Markdown] to enable translation
-from reStructuredText to HTML and LaTeX, and for useful display in
-web tools.
+All TRDs MUST conform to Markdown syntax
+<a href="#markdown">[markdown]</a> to enable translation to HTML and
+LaTeX, and for useful display in web tools.
 
 3.1 TRD Header
 --------------------------------------------------------------------
 
 The TRD header has several fields which MUST be included, as well as
-others which MAY be included. The TRD header MUST NOT include headers
+others which MAY be included. The TRD header MUST NOT include fields
 which are not specified in TRD 1 or supplementary Best Common Practice
 TRDs. The first five header fields MUST be included in all TRDs, in
-the order stated here.
+the order stated below.  The Markdown syntax to use when composing a
+header is modeled by this document's header.
 
 The first field is "TRD," and specifies the TRD number of the
-document. A TRD's number is unique.. This document is TRD 1. The 
-TRD type (discussed below) determines TEP number assignment. Generally,
+document. A TRD's number is unique. This document is TRD 1. The
+TRD type (discussed below) determines TRD number assignment. Generally,
 when a document is ready to be a TRD, it is assigned the smallest
 available number. BCP TRDs start at 1 and all other TRDs
 (Documentary, Experimental, and Informational) start at 101.
 
-The second field states the name of the working group that produced
-the document. This document was produced by the Kernel Working Group.
+The second field, "Working Group," states the name of the working
+group that produced the document. This document was produced by the
+Kernel Working Group.
 
 The third field is "Type," and specifies the type of TRD the document
 is. There are four types of TRD: Best Current Practice (BCP),
 Documentary, Informational, and Experimental. This document's type is Best
 Current Practice.
 
-Best Current Practice is the closest thing TRDs have to a standard: it
+*Best Current Practice* is the closest thing TRDs have to a standard: it
 represents conclusions from significant experience and work by its
 authors. Developers desiring to add code (or TRDs) to Tock SHOULD
 follow all current BCPs. 
 
-Documentary TRDs describe a system or protocol that exists; a
+*Documentary* TRDs describe a system or protocol that exists; a
 documentary TRD MUST reference an implementation that a reader can
 easily obtain.  Documentary TRDs simplify interoperability when 
 needed, and document Tock implementations.
 
-Informational TRDs provide information that is of interest to the
+*Informational* TRDs provide information that is of interest to the
 community. Informational TRDs include data gathered on radio behavior,
 hardware characteristics, other aspects of Tock software/hardware,
 organizational and logistic information,
 or experiences which could help the community achieve its goals.  
 
-Experimental TRDs describe a completely experimental approach to a
-problem, which are outside the Tock release and will not necessarily
-become part of it.  Unlike Documentary TRDs, Experimental TRDs may 
-describe systems that do not have a reference implementation.
+*Experimental* TRDs describe a completely experimental approach to a
+problem, which are outside the Tock release stream and will not
+necessarily become part of it.  Unlike Documentary TRDs, Experimental
+TRDs may describe systems that do not have a reference implementation.
 
 The fourth field is "Status," which specifies the status of the TRD.
-A TRD status can either be "Draft," which means it is a work in
-progress, "Final," which means it is complete and will not change. 
+A TRD's status can be either "Draft," which means it is a work in
+progress, or "Final," which means it is complete and will not change.
 Once a TRD has the status "Final," the only change allowed is the
 addition of an "Obsoleted By" field.
 
 The "Obsoletes" field is a backward pointer to an earlier TRD which
 the current TRD renders obsolete. An Obsoletes field MAY have multiple
-TRDs listed.  For example, if TRD 121 were to replace TEPs 111 and 116, it
-would have the field "Obsoletes: 111, 116".
+TRDs listed.  For example, if TRD 121 were to replace TRDs 111 and
+116, it would have the field "Obsoletes: 111, 116".
 
 The "Obsoleted By" field is added to a Final TRD when another TRD has
 rendered it obsolete. The field contains the number of the obsoleting
-TRD. For example, if TEP 111 were obsoleted by TEP 121, it would have
+TRD. For example, if TRD 111 were obsoleted by TRD 121, it would have
 the field "Obsoleted By: 121".
 
 "Obsoletes" and "Obsoleted By" fields MUST agree. For a TRD to list another
@@ -177,7 +180,7 @@ The obsoletion fields are used to keep track of evolutions and modifications
 of a single abstraction. They are not intended to force a single approach or
 mechanism over alternative possibilities.
 
-The final required field is "Author," which states the names of the
+The final required field is "Authors," which states the names of the
 authors of the document. Full contact information should not be listed
 here (see Section 3.2).
 
@@ -193,18 +196,17 @@ Draft-Created states the date the document was created, Draft-Modified
 states when it was last modified. Draft-Version specifies the version
 of the draft, which MUST increase every time a modification is
 made. Draft-Discuss specifies the email address of a mailing list
-where the draft is being discussed. Final and Obsolete TEPs MUST NOT
+where the draft is being discussed. Final and Obsolete TRDs MUST NOT
 have these fields, which are for Drafts only.
 
 3.2 TRD Body
 --------------------------------------------------------------------
 
-The first element of the TRD body MUST be the title of the document. A
-TRD SHOULD follow the title with an Abstract, which gives a brief
-overview of the content of the TRD. Longer TEPs MAY, after the
-Abstract, have a Table of Contents. After the Abstract and Table of
-Contents there SHOULD be an Introduction, stating the problem the TRD
-seeks to solve and providing needed background information.
+A TRD body SHOULD begin with an Abstract, which gives a brief overview
+of the content of the TRD. A longer TRD MAY, after the Abstract, have
+a Table of Contents. After the Abstract and Table of Contents there
+SHOULD be an Introduction, stating the problem the TRD seeks to solve
+and providing needed background information.
 
 If a TRD is Documentary, it MUST have a section entitled
 "Implementation," which instructs the reader how to obtain the
@@ -247,23 +249,24 @@ from TinyOS Enhancement Proposal 1 (TEP 1).
 7. Author's Address
 ====================================================================
 
-```
-Philip Levis
-409 Gates Hall
-Stanford University 
-Stanford, CA 94305
+    Philip Levis
+    409 Gates Hall
+    Stanford University
+    Stanford, CA 94305
 
-phone - +1 650 725 9046
+    phone - +1 650 725 9046
 
-email - pal@cs.stanford.edu
-```
+    email - pal@cs.stanford.edu
 
 
 8. Citations
 ====================================================================
 
-[TRD1]: <trd1-trds.md>
-[Markdown]: <https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links>
+<a name="TRD1" />[TRD1]
+  <a href="trd1-trds.md">Tock Reference Document (TRD) Structure and Keywords</a>
+
+<a name="markdown" />[markdown]
+  <a href="https://daringfireball.net/projects/markdown/">Markdown</a>
  
 
 Appendix A. Example Appendix


### PR DESCRIPTION
Here are the style issues addressed:

3. TRD Structure

- Adopt the ordering of elements as necessary for markdown:
    title, header, body.

- Cite the "authoritative" description of markdown syntax:

    https://daringfireball.net/projects/markdown/

3.1 Header

- Change header field "Author" to "Authors"

7. Author's Address

- Instead of non-standard triple-tics to format the address
  information (which means rendering it may require github), it's just
  as easy to use a markdown "code block", which is a paragraph with
  every line indented by at least 4 spaces or 1 tab.

  (See: https://daringfireball.net/projects/markdown/syntax#block)

8. Citations

- Use HTML anchors