### PR TITLE
Fix GFM quirks with setext headings and empty listed items

### DIFF
--- a/doc/reference/trd-radio.md
+++ b/doc/reference/trd-radio.md
@@ -20,8 +20,8 @@ the Rust traits and other definitions for this service as well as the
 reasoning behind them. This document is in full compliance
 with <a href="#trd1">TRD1</a>.
 
-1. Introduction
--------------------------------
+1 Introduction
+========================================
 
 Wireless communication is an integral component of sensor networks and
 the Internet of Things (IoT). 802.15.4 is low-power link layer that is
@@ -45,8 +45,8 @@ in the kernel create, in model hil::radio. It provides four traits:
 
 The rest of this document discusses each in turn.
 
-2. Configuration constants and buffer management
--------------------------------
+2 Configuration constants and buffer management
+========================================
 
 To avoid extra buffers and memory copies, the radio stack requires that
 callers provide it with memory buffers that are larger than the maximum
@@ -69,8 +69,8 @@ Note that MAX_BUF_SIZE can be larger (but not smaller) than MAX_PACKET_SIZE.
 A radio must be given receive buffers that are MAX_BUF_SIZE in order to 
 ensure that it can receive maximum length packets. 
 
-3. RadioControl trait
--------------------------------
+3 RadioControl trait
+========================================
 
 The RadioControl trait provides functions to initialize an 802.15.4 radio,
 turn it on/off and configure it.
@@ -135,7 +135,7 @@ cannot accept reconfiguration or packet transmission requests, it
 MUST return true.
 
 
-3.1 Configuring the radio
+3.2 Configuring the radio
 -------------------------------
 
 Re-configuring an 802.15.4 radio is an asynchronous operation.
@@ -177,8 +177,8 @@ power value in dBm. Therefore, it is possible that the return value of
 `config_tx_power` returns a different (but close) value than what it set
 in `config_set_tx_power`.
 
-4. Radio trait for sending and receiving packets 
--------------------------------
+4 Radio trait for sending and receiving packets 
+========================================
 
 The Radio trait implements the radio data path: it allows clients to 
 send and receive packets as well as accessors for packet fields. 
@@ -230,8 +230,8 @@ has a transmission pending), then `transmit` MUST return EBUSY. If
 the stack accepts a packet for transmission (returns SUCCESS), it
 MUST return EBUSY until it issues a transmission completion callback.
 
-4. TxClient, RxClient, and ConfigClient traits
--------------------------------
+5 TxClient, RxClient, and ConfigClient traits
+========================================
 
 An 802.15.4 radio provides three callbacks: packet transmission completion,
 packet reception, and when a change to the radio's configuration has completed.
@@ -269,8 +269,8 @@ or FAIL to indicate another failure.
     }
 
 
-5. Example Implementation: RF233
----------------------------------
+6 Example Implementation: RF233
+========================================
 
 An implementation of the radio HIL for the Atmel RF233 radio can be found 
 in capsules::rf233. This implementation interacts with an RF233 radio over
@@ -317,9 +317,10 @@ when transmissions are interrupted by packet reception, the stack simply marks t
 packet as pending and waits for the reception to complete, then retries the
 transmission.
 
-6. Authors' Address
----------------------------------
+7 Authors' Address
+========================================
 
+```
 Philip Levis
 409 Gates Hall
 Stanford University
@@ -328,9 +329,10 @@ Stanford, CA 94305
 phone - +1 650 725 9046
 
 email - pal@cs.stanford.edu
+```
 
-7. Citations
----------------------------------
+8 Citations
+========================================
 
 <a name="trd1"/>[TRD1] <a href="trd1-trds.md">Tock Reference Document (TRD) Structure and Keywords</a>
 

--- a/doc/reference/trd1-trds.md
+++ b/doc/reference/trd1-trds.md
@@ -18,7 +18,7 @@ This document describes the structure of all Tock Reference Documents
 (TRDs) follow, and defines the meaning of several key words in those
 documents.
 
-1. Introduction
+1 Introduction
 ====================================================================
 
 To simplify management, reading, and tracking development,
@@ -28,7 +28,7 @@ implementation interoperability, all TRDs MUST observe the meaning of
 several key words that specify levels of compliance. This document
 describes and follows both.
 
-2. Keywords
+2 Keywords
 ====================================================================
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
@@ -97,7 +97,7 @@ on implementors where the method is not required for
 interoperability.
 
 
-3. TRD Structure
+3 TRD Structure
 ====================================================================
 
 TRDs have two major parts, a header and a body. The header states
@@ -223,7 +223,7 @@ appendices. Appendices MUST immediately follow the citations section,
 or if there is no citations section, the author information section.
 Appendices are lettered.  Please refer to Appendix A for details.
 
-4. File names
+4 File names
 ====================================================================
 
 TRDs MUST be stored in the Tock repository with a file name of
@@ -233,18 +233,18 @@ trd[number]-[desc].md
 Where number is the TRD number and desc is a short, one word description.
 The name of this document is trd1-trds.md.
 
-5. Reference
+5 Reference
 ====================================================================
 The reference use of this document is TRD 1 (itself).
 
-6. Acknowledgments
+6 Acknowledgments
 ====================================================================
 
 The definitions of the compliance terms are a direct copy of
 definitions taken from IETF RFC 2119. This document is heavily copied
 from TinyOS Enhancement Proposal 1 (TEP 1).
 
-7. Author's Address
+7 Author's Address
 ====================================================================
 
 ```
@@ -259,14 +259,14 @@ email - pal@cs.stanford.edu
 ```
 
 
-8. Citations
+8 Citations
 ====================================================================
 
 [TRD1]: <trd1-trds.md>
 [Markdown]: <https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links>
  
 
-Appendix A. Example Appendix
+Appendix A Example Appendix
 ====================================================================
 
 This is an example appendix. Appendices begin with the letter A.

--- a/doc/reference/trd102-adc.md
+++ b/doc/reference/trd102-adc.md
@@ -20,8 +20,8 @@ It describes the Rust traits and other definitions for this service
 as well as the reasoning behind them. This document is in full compliance
 with <a href="#trd1">TRD1</a>.
 
-1. Introduction
--------------------------------
+1 Introduction
+========================================
 
 Analog-to-digital converters (ADCs) are devices that convert analog input
 signals to discrete digital output signals, typically voltage to a binary
@@ -40,8 +40,8 @@ provides three traits:
 The rest of this document discusses each in turn.
 
 
-2. AdcSingle trait
--------------------------------
+2 AdcSingle trait
+========================================
 
 The AdcSingle trait is for requesting a single ADC conversion. It has
 three functions:
@@ -80,8 +80,8 @@ or FAIL. SUCCESS indicates that a callback WILL NOT be issued, while
 a failure code (FAIL or ERESERVE) indicate that the callback WILL be
 issued normally.
 
-3. AdcContinuous
--------------------------------
+3 AdcContinuous
+========================================
 
 The AdcContinuous trait is for requesting a stream of ADC conversions
 at a fixed frequency. These samples are expected to be taken with
@@ -135,8 +135,8 @@ are three default values of `Frequency`:
   * 32kHz
   * 1MHz
 
-4. Client
--------------------------------
+4 Client
+========================================
 
 The Client trait is how a caller provides a callback to the ADC
 implementation. Using a function defined outside the ADC trait, it
@@ -156,8 +156,8 @@ value, the value MUST be left shifted so the most significant bit of
 `result` are SUCCESS, FAIL, EBUSY, EOFF, ERESERVE, EINVAL, or ECANCEL.
 
 
-5. Example Implementation: SAM4L
----------------------------------
+5 Example Implementation: SAM4L
+========================================
 
 The SAM4L ADC has a flexible ADC, supporting differential
 and single-ended inputs, 8 or 12 bit samples, configurable clocks, 
@@ -235,9 +235,10 @@ to an ADC client, if one has ben registered with `set_client`:
     }
 
 
-6. Authors' Address
----------------------------------
+6 Authors' Address
+========================================
 
+```
 Philip Levis
 409 Gates Hall
 Stanford University
@@ -246,8 +247,9 @@ Stanford, CA 94305
 phone - +1 650 725 9046
 
 email - pal@cs.stanford.edu
+```
 
-7. Citations
----------------------------------
+7 Citations
+========================================
 
 <a name="trd1"/>[TRD1] <a href="trd1-trds.md">Tock Reference Document (TRD) Structure and Keywords</a>

--- a/doc/reference/trd103-gpio.md
+++ b/doc/reference/trd103-gpio.md
@@ -19,8 +19,8 @@ General Purpose Input/Output (GPIO) in the Tock operating system kernel.  It
 describes the Rust traits and other definitions for this service as well as the
 reasoning behind them. This document is in full compliance with [TRD1].
 
-1. Introduction
--------------------------------
+1 Introduction
+========================================
 
 General Purpose Input/Output (GPIO) controls generic pins. User code can control
 the output level on the pin (high or low), read the externally drive logic level
@@ -40,8 +40,8 @@ The GPIO HIL is the kernel crate, in module hil::gpio. It provides three traits:
 
 The rest of this document discusses each in turn.
 
-2. `Pin` trait
--------------------------------
+2 `Pin` trait
+========================================
 
 The `Pin` trait is for requesting a single ADC conversion. It has
 three functions:
@@ -125,8 +125,8 @@ The `disable_interrupts` method disables interrupts on the pin. Once
 `disable_interrupts` is called, the implementation MUST NOT deliver interrupts
 to the user via the `Client` trait until `enable_interrupts` is called.
 
-3. PinCtl
--------------------------------
+3 PinCtl
+========================================
 
 The `PinCtl` trait is for controlling the input mode of a particular pin. It is
 OPTIONAL and shoul only be implemented on microcontrollers that provide this
@@ -149,8 +149,8 @@ pub enum InputMode {
 The `set_input_mode` configures whether the microcontroller should apply pull-up
 or pull-down resistence to the pin.
 
-4. Client
--------------------------------
+4 Client
+========================================
 
 The `Client` trait is how a caller provides a callback to the `Pin`
 implementation. Using a function defined outside the `Pin` trait, it registers a
@@ -166,10 +166,11 @@ Whenever an interrupt occurs on the pin it invokes the `fired`
 method. `identifier` MUST contain the value passed to the `Pin` trait's `enable_interrupts` method.
 
 
-5. Example Implementation
----------------------------------
+5 Example Implementation
+========================================
 
-6. Authors' Address
----------------------------------
-
+6 Authors' Address
+========================================
+```
 email - amit@amitlevy.com
+```


### PR DESCRIPTION
The section header formatting for TRDs was broken when rendered on github.com, but not when using [grip]() or other Markdown viewers. The crucial difference is that having the ```.``` means the [setext heading](https://github.github.com/gfm/#setext-heading) is rendered as an [empty list item](https://github.github.com/gfm/#setext-heading) as per the [GitHub Flavored Markdown spec](https://github.github.com/gfm/) and shown below:

<img width="525" alt="screen shot 2017-03-18 at 6 20 32 pm" src="https://cloud.githubusercontent.com/assets/1274255/24076599/39e1d55a-0c0b-11e7-824a-7dfbf7aa89fe.png">
So the ```6. Acknowledgements``` is rendered as plaintext, and the line below that is rendered as a divider.

<img width="951" alt="screen shot 2017-03-18 at 6 20 27 pm" src="https://cloud.githubusercontent.com/assets/1274255/24076600/39ef3f74-0c0b-11e7-876d-3739ab6cedc6.png">


I went through the ```doc/references``` folder and removed `.`'s, made the header sizes uniform, and cleaned up other Markdown around authors' addresses.