### PR TITLE
Use environment variable for force rustup toolchain version

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -3,6 +3,8 @@
 MAKEFLAGS += -r
 MAKEFLAGS += -R
 
+export RUSTUP_TOOLCHAIN ?= nightly-2017-01-25
+
 TOOLCHAIN ?= arm-none-eabi
 
 SIZE      ?= $(TOOLCHAIN)-size
@@ -33,10 +35,10 @@ endif
 
 # Check that rustc is the right nightly - warn not error if wrong, sometimes useful to test others
 RUSTC_VERSION_STRING := rustc 1.16.0-nightly (83c2d9523 2017-01-24)
-ifneq ($(shell rustc --version),$(RUSTC_VERSION_STRING))
+ifneq ($(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version),$(RUSTC_VERSION_STRING))
     $(warning Unexpected rustc version. Expected $(RUSTC_VERSION_STRING) got $(shell rustc --version))
     $(warning You may experience unexpected compilation warnings or errors)
-    $(warning To fix, run `rustup override set nightly-2017-01-25`)
+    $(warning To fix, install `rustup` from https://rustup.rs/, then run: `rustup install $(RUSTUP_TOOLCHAIN)`)
 endif
 
 .PHONY: all

--- a/Makefile.common
+++ b/Makefile.common
@@ -35,9 +35,8 @@ endif
 
 # Check that rustc is the right nightly - warn not error if wrong, sometimes useful to test others
 RUSTC_VERSION_STRING := rustc 1.16.0-nightly (83c2d9523 2017-01-24)
-ifeq ($(shell rustup -V &> /dev/null && echo success),success)
+ifneq ($(shell RUST_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VERSION_STRING))
   DUMMY := $(shell rustup install $(RUSTUP_TOOLCHAIN))
-else
   ifneq ($(shell RUST_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VERSION_STRING))
     $(warning You do not have the correct version of `rustc` configured, and `rustup` is not installed.)
     $(warning Expected `rustc` version "$(RUSTC_VERSION_STRING)" but got "$(shell rustc --version)")

--- a/Makefile.common
+++ b/Makefile.common
@@ -35,10 +35,15 @@ endif
 
 # Check that rustc is the right nightly - warn not error if wrong, sometimes useful to test others
 RUSTC_VERSION_STRING := rustc 1.16.0-nightly (83c2d9523 2017-01-24)
-ifneq ($(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version),$(RUSTC_VERSION_STRING))
-    $(warning Unexpected rustc version. Expected $(RUSTC_VERSION_STRING) got $(shell rustc --version))
+ifeq ($(shell rustup -V &> /dev/null && echo success),success)
+  DUMMY := $(shell rustup install $(RUSTUP_TOOLCHAIN))
+else
+  ifneq ($(shell RUST_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VERSION_STRING))
+    $(warning You do not have the correct version of `rustc` configured, and `rustup` is not installed.)
+    $(warning Expected `rustc` version "$(RUSTC_VERSION_STRING)" but got "$(shell rustc --version)")
     $(warning You may experience unexpected compilation warnings or errors)
     $(warning To fix, install `rustup` from https://rustup.rs/, then run: `rustup install $(RUSTUP_TOOLCHAIN)`)
+  endif
 endif
 
 .PHONY: all

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -27,17 +27,11 @@ This will install `rustup` in your home directory, so you will need to
 source `~/.profile` or open a new shell to add the `.cargo/bin` directory
 to your `$PATH`.
 
-Then override the default version of Rust to use for Tock by running the
-following from the top-level Tock directory:
+Then install the correct nightly version of Rust:
 
 ```bash
-$ cd tock
-$ rustup override set nightly-2017-01-25
+$ rustup install nightly-2017-01-25
 ```
-
-If you are having trouble with running the correct version of rust, you
-can check the `$HOME/multirust/settings.toml` file for which versions
-are set to which folders.
 
 #### `arm-none-eabi` toolchain
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -63,7 +63,7 @@ Vagrant.configure("2") do |config|
   # Set up rust development environment
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     wget https://sh.rustup.rs -O rustup.sh && sh rustup.sh -y
-    source ~/.profile && cd /tock && rustup override set nightly-2017-01-25
+    source ~/.profile && rustup install nightly-2017-01-25
   SHELL
 
   # Copy git configuration


### PR DESCRIPTION
`rustup` looks at the `RUSTUP_TOOLCHAIN` variable first to figure out
which toolchain to use (e.g. `nightly-2017-01-25`). Using this
environment variable avoids requiring developers building the kernel to
configure toolchain themselves.

Solves #321 