### PR TITLE
NRF51: Fix bug in RTC interrupt handling

### DIFF
--- a/chips/nrf51/src/rtc.rs
+++ b/chips/nrf51/src/rtc.rs
@@ -60,6 +60,7 @@ impl Rtc {
     }
 
     pub fn handle_interrupt(&self) {
+        rtc1().events_compare[0].set(0);
         rtc1().intenclr.set(COMPARE0_EVENT);
         self.callback.get().map(|cb| { cb.fired(); });
     }


### PR DESCRIPTION
`handle_interrupt` isn't actually clearing the interrupt, just prevent
the controller from delivering more interrupts to the PPI.

Address part of #320 