### PR TITLE
be consistent about our defintion of `main`

### DIFF
--- a/doc/Userland.md
+++ b/doc/Userland.md
@@ -3,6 +3,22 @@ This document explains how application code works in Tock. This is not a guide
 to creating your own applications, but rather documentation of the design
 thoughts behind how applications function.
 
+<!-- npm i -g markdown-toc; markdown-toc -i Userland.md -->
+
+<!-- toc -->
+
+- [Overview of Applications in Tock](#overview-of-applications-in-tock)
+- [System Calls](#system-calls)
+- [Callbacks](#callbacks)
+- [Inter-Process Communication](#inter-process-communication)
+- [Stack and Heap](#stack-and-heap)
+- [Debugging](#debugging)
+- [Libraries](#libraries)
+  * [Newlib](#newlib)
+  * [libtock](#libtock)
+- [Related](#related)
+
+<!-- tocstop -->
 
 ## Overview of Applications in Tock
 Applications in Tock are the user-level code meant to accomplish some type of
@@ -88,6 +104,20 @@ return from execution (for example, an application that returns from `main`).
 
 ## Inter-Process Communication
  * **TODO:** how does this work?
+
+## Application Entry Point
+
+__Warning: Unstable__
+
+Applications should define a `main` method:
+
+    int main(void)
+
+Currently, main receives no arguments and its return value is ignored.
+Applications **should** return 0 from `main`.  Applications are not terminated
+when `main` returns, rather an implicit `while (1) { yield(); }` follows
+`main`, allowing applications to set up a series of event subscriptions in
+their `main` method and then return.
 
 ## Stack and Heap
 Applications can specify their required stack and heap sizes by defining the

--- a/userland/examples/tests/mpu_stack_growth/main.c
+++ b/userland/examples/tests/mpu_stack_growth/main.c
@@ -64,14 +64,19 @@ static void start(
   grow_stack();
 }
 
-// our main isn't normal
-#pragma GCC diagnostic ignored "-Wmain"
 
-int main(
+// override default _start symbol to access memory regions
+//
+// Note: parameters passed from the kernel to _start are considered unstable and
+// subject to change in the future
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+__attribute__ ((section(".start"), used))
+__attribute__ ((noreturn))
+void _start(
     void* mem_start,
     void* app_heap_break,
     void* kernel_memory_break) {
   register uint32_t* sp asm ("sp");
   start(mem_start, app_heap_break, kernel_memory_break, sp);
-  return 0;
+  while(1) { yield(); }
 }

--- a/userland/examples/tests/mpu_walk_region/main.c
+++ b/userland/examples/tests/mpu_walk_region/main.c
@@ -68,15 +68,18 @@ static void start(
   dowork(0x20000000, 0x20004000, 0x100);
 }
 
-// our main isn't normal
-#pragma GCC diagnostic ignored "-Wmain"
-#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
-
-int main(
+// override default _start symbol to access memory regions
+//
+// Note: parameters passed from the kernel to _start are considered unstable and
+// subject to change in the future
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+__attribute__ ((section(".start"), used))
+__attribute__ ((noreturn))
+void _start(
     void* mem_start,
     void* app_heap_break,
     void* kernel_memory_break) {
   register uint32_t* sp asm ("sp");
   start(mem_start, app_heap_break, kernel_memory_break, sp);
-  return 0;
+  while(1) { yield(); }
 }

--- a/userland/libtock/crt1.c
+++ b/userland/libtock/crt1.c
@@ -6,18 +6,19 @@ extern unsigned int* _got;
 extern unsigned int* _egot;
 extern unsigned int* _bss;
 extern unsigned int* _ebss;
-extern int main(void*, void*, void*);
+extern int main(void);
 
 // Allow _start to go undeclared
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 
 __attribute__ ((section(".start"), used))
+__attribute__ ((weak))
 __attribute__ ((noreturn))
 void _start(
-    void* mem_start,
-    void* app_heap_break,
-    void* kernel_memory_break) {
-  main(mem_start, app_heap_break, kernel_memory_break);
+    void* mem_start __attribute__((unused)),
+    void* app_heap_break __attribute__((unused)),
+    void* kernel_memory_break __attribute__((unused))) {
+  main();
   while(1) { yield(); }
 }
 


### PR DESCRIPTION
Closes #338.

This mostly implements the discussion from the issue thread, it:

  - marks our `_start` in crt1 as weak
  - overrides `_start` in tests where access memory regions is nice
     - I view this as somewhat niche and a non-binding interface for now
  - defines that standard main prototype as `int main(void)`

In the original issue thread, we'd suggested a prototype of `void main(void)`,
as Tock currently ignores the return value of processes. Unfortuntely, `-Wall`
turns on `-Wmain` by default, which results in

    main.c:6:6: warning: return type of 'main' is not 'int' [-Wmain]
     void main(void) {
          ^~~~

while we could explicitly turn this off (`-Wno-main`), my current feeling is
that writing `int main` is pretty stock for C, and having a return value from a
process may be useful someday (i.e. returning 0 means this process meant to
exit). Sure, most things probably won't ever return, but I don't think it hurts
to stick with C convention here and let things return a value.