### PR TITLE
travis: check markdown files for TOC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,14 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then brew install arm-none-eabi-gcc; fi
 
-before_script: (cargo install rustfmt || true)
+before_script:
+  - (cargo install rustfmt || true)
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then npm install -g markdown-toc; fi
 
 script:
   - export PATH=$HOME/.cargo/bin:$PATH
   - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then tools/run_cargo_fmt.sh diff; fi
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then tools/toc.sh; fi
   - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then make allboards; fi
   - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then pushd userland/examples && ./build_all.sh; fi
 

--- a/tools/toc.sh
+++ b/tools/toc.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Run `markdown-toc` on all Markdown files with tables of contents
+# to see if any of them need an updated TOC.
+#
+# As a side effect, if you run this locally it will generate
+# all needed TOC and update the markdown documents.
+
+let ERROR=0
+
+# Find all markdown files
+for f in $(find . | grep .md); do
+
+	# Only use ones that include a table of contents
+	grep '<!-- toc -->' $f > /dev/null
+	let rc=$?
+
+	if [[ $rc == 0 ]]; then
+		# Try running the TOC tool and see if anything changes
+		before=`cat $f`
+		markdown-toc -i $f
+		after=`cat $f`
+
+		if [[ "$before" != "$after" ]]; then
+			echo "$f has an outdated table of contents"
+			ERROR=1
+		fi
+	fi
+
+done
+
+# Make sure to return with an error if anything changes
+# so that Travis will fail.
+if [[ $ERROR == 1 ]]; then
+	exit -1
+fi


### PR DESCRIPTION
When editing markdown files with tables of contents, it is very easy to change a heading but forget to re-generate the TOC. This adds support to travis to check to see if any TOC need updating.

This should also fail in Travis for exactly the reason why this PR exists.