### PR TITLE
Dont special case libtock

### DIFF
--- a/userland/TockLibrary.mk
+++ b/userland/TockLibrary.mk
@@ -4,43 +4,69 @@
 # specify `all` as our default rule
 all:
 
-# directory for built output
-LIB_BUILDDIR ?= build
-
 # Build settings
 include $(TOCK_USERLAND_BASE_DIR)/Configuration.mk
 
 # Helper functions
 include $(TOCK_USERLAND_BASE_DIR)/Helpers.mk
 
+# Okay.. so here's what the goals are:
+#
+#  - LIBNAME should be the name of the _current_ library that's including this file
+#  - We'd like to set this automatically based on the current directory
+#  --- But at the same time not trample over a user-specified definition
+#  - We'd like to allow multiple different libraries to include this file
+#
+# So, our approach is to keep track of all the SEEN_LIBNAMES, and if the
+# current LIBNAME is in the list of SEEN_LIBNAMES, assume that this variable
+# is simply still set from a previous inclusion of this file and overwrite it
+
+CURRENT_DIRNAME := $(notdir $(shell pwd))
+ifdef SEEN_LIBNAMES
+  ifneq ($(filter $(LIBNAME),$(SEEN_LIBNAMES)),"")
+    # LIBNAME in SEEN_LIBNAMES, replace
+    LIBNAME := $(CURRENT_DIRNAME)
+  endif
+else
+  ifndef LIBNAME
+    LIBNAME := $(CURRENT_DIRNAME)
+  endif
+endif
+SEEN_LIBNAMES += $(LIBNAME)
+
+# Grab the directory this library is in
+$(LIBNAME)_DIR ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# directory for built output
+$(LIBNAME)_BUILDDIR ?= $($(LIBNAME)_DIR)build
+
+
+$(LIBNAME)_SRCS = $(AS_SRCS) $(C_SRCS) $(CXX_SRCS) $(LIB_SRCS)
 
 # Rules to generate libraries for a given Architecture
 # These will be used to create the different architecture versions of LibNRFSerialization
 # Argument $(1) is the Architecture (e.g. cortex-m0) to build for
 define LIB_RULES
 
-$$(LIB_BUILDDIR)/$(1):
+$$($(LIBNAME)_BUILDDIR)/$(1):
 	$$(Q)mkdir -p $$@
 
-$$(LIB_BUILDDIR)/$(1)/%.o: %.c | $$(LIB_BUILDDIR)/$(1)
+$$($(LIBNAME)_BUILDDIR)/$(1)/%.o: %.c | $$($(LIBNAME)_BUILDDIR)/$(1)
 	$$(TRACE_DEP)
 	$$(Q)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
 	$$(TRACE_CC)
 	$$(Q)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) -c -o $$@ $$<
 
-$$(LIB_BUILDDIR)/$(1)/%.o: %.S | $$(LIB_BUILDDIR)/$(1)
+$$($(LIBNAME)_BUILDDIR)/$(1)/%.o: %.S | $$($(LIBNAME)_BUILDDIR)/$(1)
 	$$(TRACE_AS)
 	$$(Q)$$(AS) $$(ASFLAGS) -mcpu=$(1) $$(CPPFLAGS) -c -o $$@ $$<
 
-LIB_OBJS_$(1) += $$(patsubst %.c,$$(LIB_BUILDDIR)/$(1)/%.o,$$(C_SRCS))
-LIB_OBJS_$(1) += $$(patsubst %.cc,$$(LIB_BUILDDIR)/$(1)/%.o,$$(filter %.cc, $$(CXX_SRCS)))
-LIB_OBJS_$(1) += $$(patsubst %.cpp,$$(LIB_BUILDDIR)/$(1)/%.o,$$(filter %.cpp, $$(CXX_SRCS)))
+$(LIBNAME)_OBJS_$(1) += $$(patsubst %.s,$$($(LIBNAME)_BUILDDIR)/$(1)/%.o,$$(filter %.s, $$($(LIBNAME)_SRCS)))
+$(LIBNAME)_OBJS_$(1) += $$(patsubst %.c,$$($(LIBNAME)_BUILDDIR)/$(1)/%.o,$$(filter %.c, $$($(LIBNAME)_SRCS)))
+$(LIBNAME)_OBJS_$(1) += $$(patsubst %.cc,$$($(LIBNAME)_BUILDDIR)/$(1)/%.o,$$(filter %.cc, $$($(LIBNAME)_SRCS)))
+$(LIBNAME)_OBJS_$(1) += $$(patsubst %.cpp,$$($(LIBNAME)_BUILDDIR)/$(1)/%.o,$$(filter %.cpp, $$($(LIBNAME)_SRCS)))
 
-LIB_OBJS_$(1) += $$(patsubst %.c,$$(LIB_BUILDDIR)/$(1)/%.o,$$(filter %.c, $$(LIB_SRCS)))
-LIB_OBJS_$(1) += $$(patsubst %.cc,$$(LIB_BUILDDIR)/$(1)/%.o,$$(filter %.cc, $$(LIB_SRCS)))
-LIB_OBJS_$(1) += $$(patsubst %.cpp,$$(LIB_BUILDDIR)/$(1)/%.o,$$(filter %.cpp, $$(LIB_SRCS)))
-
-$$(LIB_BUILDDIR)/$(1)/$$(PACKAGE_NAME).a: $$(LIB_OBJS_$(1)) | $$(LIB_BUILDDIR)/$(1)
+$$($(LIBNAME)_BUILDDIR)/$(1)/$$(LIBNAME).a: $$($(LIBNAME)_OBJS_$(1)) | $$($(LIBNAME)_BUILDDIR)/$(1)
 	$$(TRACE_AR)
 	$$(Q)$$(AR) rc $$@ $$^
 	$$(Q)$$(RANLIB) $$@
@@ -52,4 +78,9 @@ endef
 $(foreach arch,$(TOCK_ARCHS),$(eval $(call LIB_RULES,$(arch))))
 
 # add each architecture as a target
-all: $(foreach arch, $(TOCK_ARCHS),$(LIB_BUILDDIR)/$(arch)/$(PACKAGE_NAME).a)
+.PHONY: all
+all: $(foreach arch, $(TOCK_ARCHS),$($(LIBNAME)_BUILDDIR)/$(arch)/$(LIBNAME).a)
+
+.PHONY: clean
+clean::
+	rm -Rf $($(LIBNAME)_BUILDDIR)

--- a/userland/libnrfserialization/Makefile
+++ b/userland/libnrfserialization/Makefile
@@ -1,8 +1,10 @@
 TOCK_USERLAND_BASE_DIR ?= ..
+LIBNAME=libnrfserialization
+$(LIBNAME)_DIR=.
 
 include NRFMakefile.mk
 
-LIB_SRCS += $(SYSTEM_FILE) $(notdir $(APPLICATION_SRCS))
+$(LIBNAME)_SRCS += $(SYSTEM_FILE) $(notdir $(APPLICATION_SRCS))
 
 
 ##############################################################################################

--- a/userland/libnrfserialization/Makefile
+++ b/userland/libnrfserialization/Makefile
@@ -1,33 +1,28 @@
 TOCK_USERLAND_BASE_DIR ?= ..
-LIBNRFSERIALIZATION_DIR ?= .
-LIBNRFSERIALIZATION_BUILDDIR ?= $(LIBNRFSERIALIZATION_DIR)/build
 
 include NRFMakefile.mk
 
 LIB_SRCS += $(SYSTEM_FILE) $(notdir $(APPLICATION_SRCS))
 
-# Top-level rules
-.PHONY: all
-all: headers.tar.gz
 
-.PHONY: clean
-clean::
-	rm -Rf $(LIBNRFSERIALIZATION_BUILDDIR)
-	rm -Rf headers/
-	rm -Rf headers.tar.gz
-
+##############################################################################################
+## Rules to create libnrfserialization
+include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk
 
 
 ##############################################################################################
 ## Rules to create libnrfserialization headers
 
-$(LIBNRFSERIALIZATION_BUILDDIR)/headers:
+# Require all to build this too
+all: headers.tar.gz
+
+$($(LIBNAME)_BUILDDIR)/headers:
 	$(Q)mkdir -p $@
 
-HDRS += $(patsubst %.c,$(LIBNRFSERIALIZATION_BUILDDIR)/headers/%.headers, $(LIB_SRCS))
-HDRS += $(addprefix $(LIBNRFSERIALIZATION_BUILDDIR)/headers/,$(APPLICATION_LIBS))
+HDRS += $(patsubst %.c,$($(LIBNAME)_BUILDDIR)/headers/%.headers, $($(LIBNAME)_SRCS))
+HDRS += $(addprefix $($(LIBNAME)_BUILDDIR)/headers/,$(APPLICATION_LIBS))
 
-$(LIBNRFSERIALIZATION_BUILDDIR)/headers/%.headers: %.c | $(LIBNRFSERIALIZATION_BUILDDIR)/headers
+$($(LIBNAME)_BUILDDIR)/headers/%.headers: %.c | $($(LIBNAME)_BUILDDIR)/headers
 	$(TRACE_CCM)
 	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -MM $< > $@
 
@@ -36,7 +31,7 @@ headers.tar.gz: $(HDRS)
 	cat build/headers/*.headers | awk '{$$1=$$1};1' | awk '{print $$1}' | sort | grep '\.h' | grep -v libtock | uniq | xargs -IFOO cp FOO headers/
 	tar czf headers.tar.gz headers
 
-
-##############################################################################################
-## Rules to create libnrfserialization
-include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk
+.PHONY: clean
+clean::
+	rm -Rf headers/
+	rm -Rf headers.tar.gz

--- a/userland/libtock/Makefile
+++ b/userland/libtock/Makefile
@@ -3,77 +3,10 @@
 
 # Base folder definitions
 TOCK_USERLAND_BASE_DIR ?= ..
-LIBTOCK_DIR := $(TOCK_USERLAND_BASE_DIR)/libtock
-LIBTOCK_BUILDDIR ?= $(LIBTOCK_DIR)/build
-
-# Build settings
-include $(TOCK_USERLAND_BASE_DIR)/Configuration.mk
-
-# Helper functions
-include $(TOCK_USERLAND_BASE_DIR)/Helpers.mk
-
-# Check that required variables are already defined
-# (they should be in Configuration.mk)
-$(call check_defined, TOCK_USERLAND_BASE_DIR)
-$(call check_defined, TOCK_ARCHS)
-$(call check_defined, AR)
-$(call check_defined, CC)
-$(call check_defined, RANLIB)
-
-# Flags for building C files
-CFLAGS += -I$(LIBTOCK_DIR)
+LIBNAME=libtock
+$(LIBNAME)_DIR=$(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
 
 # List all C and Assembly files
-LIBTOCK_C_SRCS  := $(wildcard $(LIBTOCK_DIR)/*.c)
-LIBTOCK_AS_SRCS := $(wildcard $(LIBTOCK_DIR)/*.s)
+$(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_DIR)/*.c) $(wildcard $($(LIBNAME)_DIR)/*.s)
 
-# Rules for building libtock
-.PHONY: all
-all: $(foreach arch, $(TOCK_ARCHS),$(LIBTOCK_BUILDDIR)/$(arch)/libtock.a)
-
-.PHONY: clean
-clean::
-	rm -Rf $(LIBTOCK_BUILDDIR)
-
-
-# Rules to generate LibTock for a given Architecture
-# These will be used to create the different architecture versions of LibTock
-# Argument $(1) is the Architecture (e.g. cortex-m0) to build for
-#
-# Note: all variables, other than $(1), used within this block must be double
-# dollar-signed so that their values will be evaluated when run, not when
-# generated
-#
-# To see the generated rules, run:
-# $(info $(foreach arch,$(TOCK_ARCHS),$(call LIBTOCK_RULES,$(arch))))
-define LIBTOCK_RULES
-
-$$(LIBTOCK_BUILDDIR)/$(1):
-	$$(Q)mkdir -p $$@
-
-$$(LIBTOCK_BUILDDIR)/$(1)/%.o: $$(LIBTOCK_DIR)/%.c | $$(LIBTOCK_BUILDDIR)/$(1)
-	$$(TRACE_DEP)
-	$$(Q)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) -MF"$$(@:.o=.d)" -MG -MM -MP -MT"$$(@:.o=.d)@" -MT"$$@" "$$<"
-	$$(TRACE_CC)
-	$$(Q)$$(CC) $$(CFLAGS) -mcpu=$(1) $$(CPPFLAGS) -c -o $$@ $$<
-
-$$(LIBTOCK_BUILDDIR)/$(1)/%.o: %.S | $$(LIBTOCK_BUILDDIR)/$(1)
-	$$(TRACE_AS)
-	$$(Q)$$(AS) $$(ASFLAGS) -mcpu=$(1) $$(CPPFLAGS) -c -o $$@ $$<
-
-LIBTOCK_OBJS_$(1) += $$(patsubst $$(LIBTOCK_DIR)/%.s,$$(LIBTOCK_BUILDDIR)/$(1)/%.o,$$(LIBTOCK_AS_SRCS))
-LIBTOCK_OBJS_$(1) += $$(patsubst $$(LIBTOCK_DIR)/%.c,$$(LIBTOCK_BUILDDIR)/$(1)/%.o,$$(LIBTOCK_C_SRCS))
-
-$$(LIBTOCK_BUILDDIR)/$(1)/libtock.a: $$(LIBTOCK_OBJS_$(1)) | $$(LIBTOCK_BUILDDIR)/$(1)
-	$$(TRACE_AR)
-	$$(Q)$$(AR) rc $$@ $$^
-	$$(Q)$$(RANLIB) $$@
-endef
-
-# actually generate the rules for each architecture
-$(foreach arch,$(TOCK_ARCHS),$(eval $(call LIBTOCK_RULES,$(arch))))
-
-
-# Include dependency rules for picking up header changes (by convention at bottom of makefile)
-LIBTOCK_OBJS_NO_ARCHIVES += $(filter %.o,$(foreach arch, $(TOCK_ARCHS), $(LIBTOCK_OBJS_$(arch))))
--include $(LIBTOCK_OBJS_NO_ARCHIVES:.o=.d)
+include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk


### PR DESCRIPTION
This was motivated by looking at pulling signpost up to latest tock, and realizing that I'd have to basically copy over the Makefile from libtock and duplicate it, which itself was already duplicating stuff in TockLibrary.mk...

Now all libraries use one set of Make rules and it should be very lightweight to add new libraries into the build