### PR TITLE
sam4l: fix i2c ACKLAST bit

### DIFF
--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -156,7 +156,7 @@ pub static mut I2C3: I2CHw = I2CHw::new(I2C_BASE_ADDRS[3],
 
 pub const START: usize = 1 << 13;
 pub const STOP: usize = 1 << 14;
-pub const ACKLAST: usize = 1 << 24;
+pub const ACKLAST: usize = 1 << 25;
 
 // Need to implement the `new` function on the I2C device as a constructor.
 // This gets called from the device tree.


### PR DESCRIPTION
p727, sec 27.9.4 - ACKLAST is 25th bit not 24th

![image](https://cloud.githubusercontent.com/assets/339422/24773338/b53efc6a-1ae2-11e7-91ef-600a9757b7b6.png)

Nothing was actually using this (yet), but happened to notice