### PR TITLE
nrf51/aes_refactor2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then brew install arm-none-eabi-gcc; fi
 
 before_script:
-  - (cargo install --vers 0.7.1 --force rustfmt || true)
+  - (cargo install --vers 0.7.1 rustfmt || true)
   - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then npm install -g markdown-toc; fi
 
 script:

--- a/capsules/src/symmetric_encryption.rs
+++ b/capsules/src/symmetric_encryption.rs
@@ -132,7 +132,11 @@ impl<'a, E: SymmetricEncryptionDriver + 'a> Crypto<'a, E> {
 }
 
 impl<'a, E: SymmetricEncryptionDriver + 'a> Client for Crypto<'a, E> {
-    fn crypt_done(&self, data: &'static mut [u8], dmy: &'static mut [u8], len: u8) -> ReturnCode {
+    fn crypt_done(&self,
+                  data: &'static mut [u8],
+                  dmy: &'static mut [u8],
+                  len: usize)
+                  -> ReturnCode {
         for cntr in self.apps.iter() {
             cntr.enter(|app, _| {
                 if app.data_buf.is_some() {
@@ -153,7 +157,7 @@ impl<'a, E: SymmetricEncryptionDriver + 'a> Client for Crypto<'a, E> {
         ReturnCode::SUCCESS
     }
 
-    fn set_key_done(&self, key: &'static mut [u8], _: u8) -> ReturnCode {
+    fn set_key_done(&self, key: &'static mut [u8]) -> ReturnCode {
         for cntr in self.apps.iter() {
             cntr.enter(|app, _| { app.callback.map(|mut cb| { cb.schedule(0, 0, 0); }); });
         }

--- a/capsules/src/symmetric_encryption.rs
+++ b/capsules/src/symmetric_encryption.rs
@@ -68,7 +68,7 @@ use kernel::hil::symmetric_encryption::{SymmetricEncryptionDriver, Client};
 use kernel::process::Error;
 
 pub static mut BUF: [u8; 128] = [0; 128];
-pub static mut KEY: [u8; 32] = [0; 32];
+pub static mut KEY: [u8; 16] = [0; 16];
 pub static mut IV: [u8; 16] = [0; 16];
 
 

--- a/chips/nrf51/src/aes.rs
+++ b/chips/nrf51/src/aes.rs
@@ -13,43 +13,46 @@
 //! static mut...
 //!
 //! FIXME:
-//!     - replace static mut with TakeCell or something similar
-//!     (I had problem to use because it can only be used one with take() )
 //!     - maybe move some stuff to capsule instead
+//!     - OUTPUT and INIT_CTR can be replaced with TakeCell
+//!     - ECB_DATA must be a static mut [u8]
+//!       and can't be located in the struct
+//!     - PAYLOAD size is restricted to 128 bytes
 //!
 //! Author: Niklas Adolfsson <niklasadolfsson1@gmail.com>
 //! Author: Fredrik Nilsson <frednils@student.chalmers.se>
-//! Date: March 31, 2017
+//! Date: April 21, 2017
 
 
 use chip;
 use core::cell::Cell;
-// use kernel::common::take_cell::TakeCell;
+use kernel::common::take_cell::TakeCell;
 use kernel::hil::symmetric_encryption::{SymmetricEncryptionDriver, Client};
 use nvic;
 use peripheral_interrupts::NvicIdx;
 use peripheral_registers::{AESECB_REGS, AESECB_BASE};
 
-#[deny(no_mangle_const_items)]
-
+// array that the AES-CHIP will mutate during AES-ECB
+// key 0-15     cleartext 16-32     ciphertext 32-47
 static mut ECB_DATA: [u8; 48] = [0; 48];
-// key 0-15
-// cleartext 16-32
-// ciphertext 32-47
 
-static mut BUF: [u8; 128] = [0; 128];
-static mut DATA: [u8; 128] = [0; 128];
-static mut DMY: [u8; 16] = [0; 16];
+// the final output i.e. either encrypted or decrypted
+static mut OUTPUT: [u8; 128] = [0; 128];
 
-#[no_mangle]
+// data to replace TakeCell initial counter in the capsule
+static mut INIT_CTR: [u8; 16] = [0; 16];
+
 pub struct AesECB {
     regs: *mut AESECB_REGS,
     client: Cell<Option<&'static Client>>,
     ctr: Cell<[u8; 16]>,
-    // data: TakeCell<'static, [u8]>,
-    remaining: Cell<u8>,
-    len: Cell<u8>,
-    offset: Cell<u8>,
+    // input either plaintext or ciphertext to be encrypted or decrypted
+    input: TakeCell<'static, [u8]>,
+    // keystream to be XOR:ed with the input
+    keystream: Cell<[u8; 128]>,
+    remaining: Cell<usize>,
+    len: Cell<usize>,
+    offset: Cell<usize>,
 }
 
 pub static mut AESECB: AesECB = AesECB::new();
@@ -60,7 +63,8 @@ impl AesECB {
             regs: AESECB_BASE as *mut AESECB_REGS,
             client: Cell::new(None),
             ctr: Cell::new([0; 16]),
-            // data: TakeCell::empty(),
+            input: TakeCell::empty(),
+            keystream: Cell::new([0; 128]),
             remaining: Cell::new(0),
             len: Cell::new(0),
             offset: Cell::new(0),
@@ -89,9 +93,7 @@ impl AesECB {
 
     fn crypt(&self) {
         let regs = unsafe { &*self.regs };
-
         let ctr = self.ctr.get();
-
         for i in 0..16 {
             unsafe {
                 ECB_DATA[i + 16] = ctr[i];
@@ -113,10 +115,9 @@ impl AesECB {
             }
         }
 
-        unsafe {
-            self.client.get().map(|client| client.set_key_done(&mut BUF[0..16], 16));
-        }
-
+        self.client
+            .get()
+            .map(|client| unsafe { client.set_key_done(&mut OUTPUT[0..16]) });
     }
 
     pub fn handle_interrupt(&self) {
@@ -129,59 +130,49 @@ impl AesECB {
 
         if regs.ENDECB.get() == 1 {
 
-            let rem = self.remaining.get() as usize;
-            let offset = self.offset.get() as usize;
+            let rem = self.remaining.get();
+            let offset = self.offset.get();
             let take = if rem >= 16 { 16 } else { rem };
+            let mut ks = self.keystream.get();
 
-
-            // THIS DON'T WORK FOR MORE THAN 1 BLOCK BECAUSE TAKE EATS UP THE ENTIRE BUF
-            // ------------------------------------------------------------------------------------
-            // guard that more bytes exist
-            // if self.data.is_some() && take > 0 {
-            //     self.data.take().map(|buf| {
-            //         if buf.len() >= offset + take {
-            //             // take at most 16 bytes and XOR with the keystream
-            //             for (i, c) in buf.as_ref()[offset .. offset+take].iter().enumerate() {
-            //                 // m XOR ECB(k || ctr)
-            //                 unsafe { BUF[i] = ECB_DATA[i-offset+32] ^ *c; }
-            //                 debug!("{}\r\n", i);
-            //             }
-            //             self.offset.set( (offset + take) as u8 );
-            //             self.remaining.set( (rem - take) as u8 );
-            //         }
-            //     });
-            // }
-
-            // TEMP solution
+            // Append keystream to the KEYSTREAM array
             if take > 0 {
                 for i in offset..offset + take {
-                    unsafe {
-                        BUF[i] = ECB_DATA[i - offset + 32] ^ DATA[i];
-                    }
+                    ks[i] = unsafe { ECB_DATA[i - offset + 32] }
                 }
-                self.offset.set((offset + take) as u8);
-                self.remaining.set((rem - take) as u8);
+                self.offset.set(offset + take);
+                self.remaining.set(rem - take);
                 self.update_ctr();
             }
-
-            // USE THIS PRINT TO TEST THAT THE CTR UPDATES ACCORDINGLY
-            // debug!("ctr {:?}\r\n", self.ctr.get());
 
             // More bytes to encrypt!!!
             if self.remaining.get() > 0 {
                 self.crypt();
             }
-            // DONE
-            else {
+            // Entire Keystream generate now XOR with the date
+            else if self.input.is_some() {
+                self.input
+                    .take()
+                    .map(|buf| {
+                        // take at most 16 bytes and XOR with the keystream
+                        for (i, c) in buf.as_ref()[0..self.len.get()].iter().enumerate() {
+                            // m XOR ECB(k || ctr)
+                            unsafe {
+                                OUTPUT[i] = ks[i] ^ *c;
+                            }
+                        }
+                    });
+
                 // ugly work-around to replace buffers in the capsule;
-                unsafe {
-                    self.client.get().map(|client| {
-                        client.crypt_done(&mut BUF[0..self.len.get() as usize],
-                                          &mut DMY,
+                self.client
+                    .get()
+                    .map(|client| unsafe {
+                        client.crypt_done(&mut OUTPUT[0..self.len.get()],
+                                          &mut INIT_CTR,
                                           self.len.get())
                     });
-                }
             }
+            self.keystream.set(ks);
         }
         // else ERROR encrypt error do nothing
     }
@@ -231,17 +222,10 @@ impl SymmetricEncryptionDriver for AesECB {
     }
 
     fn aes128_crypt_ctr(&self, data: &'static mut [u8], iv: &'static mut [u8], len: usize) {
-        self.remaining.set(len as u8);
-        self.len.set(len as u8);
+        self.remaining.set(len);
+        self.len.set(len);
         self.offset.set(0);
-        // self.data.replace(data);
-
-        // append data to "enc/dec" to a the global buf
-        for (i, c) in data.as_ref()[0..len as usize].iter().enumerate() {
-            unsafe {
-                DATA[i] = *c;
-            }
-        }
+        self.input.replace(data);
         self.set_initial_ctr(iv);
         self.crypt();
     }
@@ -252,5 +236,7 @@ impl SymmetricEncryptionDriver for AesECB {
 pub unsafe extern "C" fn ECB_Handler() {
     use kernel::common::Queue;
     nvic::disable(NvicIdx::ECB);
-    chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(NvicIdx::ECB);
+    chip::INTERRUPT_QUEUE.as_mut()
+        .unwrap()
+        .enqueue(NvicIdx::ECB);
 }

--- a/chips/nrf51/src/aes.rs
+++ b/chips/nrf51/src/aes.rs
@@ -158,8 +158,8 @@ impl AesECB {
                         self.client
                             .get()
                             .map(move |client| unsafe {
-                                     client.crypt_done(buf, &mut INIT_CTR, self.len.get())
-                                 });
+                                client.crypt_done(buf, &mut INIT_CTR, self.len.get())
+                            });
                     });
 
             }
@@ -227,8 +227,7 @@ impl SymmetricEncryptionDriver for AesECB {
 pub unsafe extern "C" fn ECB_Handler() {
     use kernel::common::Queue;
     nvic::disable(NvicIdx::ECB);
-    chip::INTERRUPT_QUEUE
-        .as_mut()
+    chip::INTERRUPT_QUEUE.as_mut()
         .unwrap()
         .enqueue(NvicIdx::ECB);
 }

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -337,8 +337,10 @@ unsafe extern "C" fn hard_fault_handler() {
                divbysero,
                vecttbl,
                forced,
-               mmfarvalid, mmfar,
-               bfarvalid, bfar);
+               mmfarvalid,
+               mmfar,
+               bfarvalid,
+               bfar);
     } else {
         // hard fault occurred in an app, not the kernel. The app should be
         //  marked as in an error state and handled by the kernel

--- a/kernel/src/hil/symmetric_encryption.rs
+++ b/kernel/src/hil/symmetric_encryption.rs
@@ -30,9 +30,13 @@ pub trait Client {
     /// send back to result of the encryption/decryption to the capsule
     /// this should be hardware independent if the cryptostate is used for all
     /// implementations
-    fn crypt_done(&self, data: &'static mut [u8], dmy: &'static mut [u8], len: u8) -> ReturnCode;
+    fn crypt_done(&self,
+                  data: &'static mut [u8],
+                  dmy: &'static mut [u8],
+                  len: usize)
+                  -> ReturnCode;
 
     /// once the key has been configure trigger call-back to indicate to the capsule
     /// that now it's possible to begin to encrypt and decrypt data
-    fn set_key_done(&self, key: &'static mut [u8], len: u8) -> ReturnCode;
+    fn set_key_done(&self, key: &'static mut [u8]) -> ReturnCode;
 }

--- a/userland/examples/tests/aes/main.c
+++ b/userland/examples/tests/aes/main.c
@@ -127,7 +127,7 @@ static void callback(int cb,
     }
     // PASS
     else {
-      printf("CTR test #1 (encryption SP 800-38a tests PASSED\r\n"); 
+      printf("CTR test #1 (encryption SP 800-38a tests): PASSED\r\n"); 
     }
 
     if(aes128_decrypt_ctr(data, sizeof(data), ctr, sizeof(ctr)) < 0) {

--- a/userland/examples/tests/crash_dummy/Makefile
+++ b/userland/examples/tests/crash_dummy/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/crash_dummy/README.md
+++ b/userland/examples/tests/crash_dummy/README.md
@@ -1,0 +1,7 @@
+Generate a Crash Test App
+=========================
+
+Adding this app to a board makes it easy to cause the kernel to print
+out the application memory debug information. Simply press the first
+user button the board to generate an application fault.
+

--- a/userland/examples/tests/crash_dummy/main.c
+++ b/userland/examples/tests/crash_dummy/main.c
@@ -1,0 +1,19 @@
+// Crash on button press.
+
+#include <button.h>
+
+volatile int* nullptr = 0;
+
+static void button_callback(int btn_num,
+                            int val,
+                            __attribute__ ((unused)) int arg2,
+                            __attribute__ ((unused)) void *ud) {
+  volatile int k = *nullptr;
+}
+
+int main(void) {
+  button_subscribe(button_callback, NULL);
+  button_enable_interrupt(0);
+
+  return 0;
+}


### PR DESCRIPTION
Hi guys, the following changes have been made:
* moved two static mut [u8] into the struct instead
* re-named variables for more clarity
* removed some unsafe code thanks to moving two static mut  [u8] into the struct
* changed all primitive data types into usize within the struct
* handle_interrupt() slightly modified and comments removed.
* removed unsed return value for set_key_done()

/Niklas A