### PR TITLE
userland: add crash dummy app

### DIFF
--- a/userland/examples/tests/crash_dummy/Makefile
+++ b/userland/examples/tests/crash_dummy/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/crash_dummy/README.md
+++ b/userland/examples/tests/crash_dummy/README.md
@@ -1,0 +1,7 @@
+Generate a Crash Test App
+=========================
+
+Adding this app to a board makes it easy to cause the kernel to print
+out the application memory debug information. Simply press the first
+user button the board to generate an application fault.
+

--- a/userland/examples/tests/crash_dummy/main.c
+++ b/userland/examples/tests/crash_dummy/main.c
@@ -1,0 +1,19 @@
+// Crash on button press.
+
+#include <button.h>
+
+volatile int* nullptr = 0;
+
+static void button_callback(int btn_num,
+                            int val,
+                            __attribute__ ((unused)) int arg2,
+                            __attribute__ ((unused)) void *ud) {
+  volatile int k = *nullptr;
+}
+
+int main(void) {
+  button_subscribe(button_callback, NULL);
+  button_enable_interrupt(0);
+
+  return 0;
+}


### PR DESCRIPTION
This app simply uses a press of the first button to trigger an app fault. This can be used for debugging to force the app state printouts.