### PR TITLE
Add LTC294X Driver

### DIFF
--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -32,3 +32,4 @@ pub mod radio;
 pub mod rng;
 pub mod temp_nrf51dk;
 pub mod symmetric_encryption;
+pub mod ltc294x;

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -1,0 +1,528 @@
+//! Driver for the LTC294X line of coloumb counters.
+//!
+//! http://www.linear.com/product/LTC2941
+//! http://www.linear.com/product/LTC2942
+//! http://www.linear.com/product/LTC2943
+//!
+//! From the website:
+//!  "The LTC2941 measures battery charge state in battery-supplied handheld PC
+//!  and portable product applications. Its operating range is perfectly suited
+//!  for single-cell Li-Ion batteries. A precision coulomb counter integrates
+//!  current through a sense resistor between the battery’s positive terminal
+//!  and the load or charger. The measured charge is stored in internal
+//!  registers. An SMBus/I2C interface accesses and configures the device."
+//!
+//! ### Capsule Structure
+//!
+//! This file implements the LTC294X driver in two objects. First is the
+//! `LTC294X` struct. This implements all of the actual logic for the
+//! chip. The second is the `LTC294XDriver` struct. This implements the
+//! userland facing syscall interface. These are split to allow the kernel
+//! to potentially interface with the LTC294X chip rather than only provide
+//! it to userspace.
+//!
+//! ### Instantiating the LTC294X capsule
+//!
+//! Here is a sample usage of this capsule in a board's main.rs file:
+//!
+//! ```rust
+//! let ltc294x_i2c = static_init!(
+//!     capsules::virtual_i2c::I2CDevice,
+//!     capsules::virtual_i2c::I2CDevice::new(i2c_mux, 0x64),
+//!     32);
+//! let ltc294x = static_init!(
+//!     capsules::ltc294x::LTC294X<'static>,
+//!     capsules::ltc294x::LTC294X::new(ltc294x_i2c, None, &mut capsules::ltc294x::BUFFER),
+//!     288/8);
+//! ltc294x_i2c.set_client(ltc294x);
+//!
+//! // Optionally create the object that provides an interface for the coulomb
+//! // counter for applications.
+//! let ltc294x_driver = static_init!(
+//!     capsules::ltc294x::LTC294XDriver<'static>,
+//!     capsules::ltc294x::LTC294XDriver::new(ltc294x),
+//!     192/8);
+//! ltc294x.set_client(ltc294x_driver);
+//! ```
+//!
+//! ### System call interface
+//!
+//! ```
+//! Command Number     Description
+//! ------------------------------
+//! 0                  Check if this driver exists
+//! 1                  Read the status of the LTC294X
+//! 2                  Configure the LTC294X
+//! 3                  Reset the accumulated charge to 0
+//! 4                  Set a high threshold for charge usage
+//! 5                  Set a low threshold for charge usage
+//! 6                  Get the current charge usage
+//! 7                  Shutdown the LTC294X
+//! 8                  Get the current voltage (only on 42 and 43)
+//! 9                  Get the current current (only on 43)
+//! 10                 Set the current LTC294X model in this capsule
+//! ```
+
+use core::cell::Cell;
+
+use kernel::{AppId, Callback, Driver};
+use kernel::common::take_cell::TakeCell;
+use kernel::hil::gpio;
+use kernel::hil::i2c;
+use kernel::returncode::ReturnCode;
+
+pub static mut BUFFER: [u8; 20] = [0; 20];
+
+#[allow(dead_code)]
+enum Registers {
+    Status = 0x00,
+    Control = 0x01,
+    AccumulatedChargeMSB = 0x02,
+    AccumulatedChargeLSB = 0x03,
+    ChargeThresholdHighMSB = 0x04,
+    ChargeThresholdHighLSB = 0x05,
+    ChargeThresholdLowMSB = 0x06,
+    ChargeThresholdLowLSB = 0x07,
+    VoltageMSB = 0x08,
+    VoltageLSB = 0x09,
+    CurrentMSB = 0x0E,
+    CurrentLSB = 0x0F,
+}
+
+#[derive(Clone,Copy,PartialEq)]
+enum State {
+    Idle,
+
+    /// Simple read states
+    ReadStatus,
+    ReadCharge,
+    ReadVoltage,
+    ReadCurrent,
+    ReadShutdown,
+
+    Done,
+}
+
+#[derive(Clone,Copy)]
+pub enum ChipModel {
+    LTC2941 = 1,
+    LTC2942 = 2,
+    LTC2943 = 3,
+}
+
+pub enum InterruptPinConf {
+    Disabled = 0x00,
+    ChargeCompleteMode = 0x01,
+    AlertMode = 0x02,
+}
+
+pub enum VBatAlert {
+    Off = 0x00,
+    Threshold2V8 = 0x01,
+    Threshold2V9 = 0x02,
+    Threshold3V0 = 0x03,
+}
+
+pub trait LTC294XClient {
+    fn interrupt(&self);
+    fn status(&self,
+              undervolt_lockout: bool,
+              vbat_alert: bool,
+              charge_alert_low: bool,
+              charge_alert_high: bool,
+              accumulated_charge_overflow: bool);
+    fn charge(&self, charge: u16);
+    fn voltage(&self, voltage: u16);
+    fn current(&self, current: u16);
+    fn done(&self);
+}
+
+pub struct LTC294X<'a> {
+    i2c: &'a i2c::I2CDevice,
+    interrupt_pin: Option<&'a gpio::Pin>,
+    model: Cell<ChipModel>,
+    state: Cell<State>,
+    buffer: TakeCell<'static, [u8]>,
+    client: Cell<Option<&'static LTC294XClient>>,
+}
+
+impl<'a> LTC294X<'a> {
+    pub fn new(i2c: &'a i2c::I2CDevice,
+               interrupt_pin: Option<&'a gpio::Pin>,
+               buffer: &'static mut [u8])
+               -> LTC294X<'a> {
+        LTC294X {
+            i2c: i2c,
+            interrupt_pin: interrupt_pin,
+            model: Cell::new(ChipModel::LTC2941),
+            state: Cell::new(State::Idle),
+            buffer: TakeCell::new(buffer),
+            client: Cell::new(None),
+        }
+    }
+
+    pub fn set_client<C: LTC294XClient>(&self, client: &'static C) {
+        self.client.set(Some(client));
+
+        self.interrupt_pin.map(|interrupt_pin| {
+            interrupt_pin.make_input();
+            interrupt_pin.enable_interrupt(0, gpio::InterruptMode::FallingEdge);
+        });
+    }
+
+    pub fn read_status(&self) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+            self.i2c.enable();
+
+            // Address pointer automatically resets to the status register.
+            self.i2c.read(buffer, 1);
+            self.state.set(State::ReadStatus);
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    fn configure(&self,
+                 int_pin_conf: InterruptPinConf,
+                 prescaler: u8,
+                 vbat_alert: VBatAlert)
+                 -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+            buffer[0] = Registers::Control as u8;
+            buffer[1] = ((int_pin_conf as u8) << 1) | (prescaler << 3) | ((vbat_alert as u8) << 6);
+
+            self.i2c.write(buffer, 2);
+            self.state.set(State::Done);
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    /// Set the accumulated charge to 0
+    fn reset_charge(&self) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+            self.i2c.enable();
+
+            buffer[0] = Registers::AccumulatedChargeMSB as u8;
+            buffer[1] = 0;
+            buffer[2] = 0;
+
+            self.i2c.write(buffer, 3);
+            self.state.set(State::Done);
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    fn set_high_threshold(&self, threshold: u16) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+            self.i2c.enable();
+
+            buffer[0] = Registers::ChargeThresholdHighMSB as u8;
+            buffer[1] = ((threshold & 0xFF00) >> 8) as u8;
+            buffer[2] = (threshold & 0xFF) as u8;
+
+            self.i2c.write(buffer, 3);
+            self.state.set(State::Done);
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    fn set_low_threshold(&self, threshold: u16) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+            self.i2c.enable();
+
+            buffer[0] = Registers::ChargeThresholdLowMSB as u8;
+            buffer[1] = ((threshold & 0xFF00) >> 8) as u8;
+            buffer[2] = (threshold & 0xFF) as u8;
+
+            self.i2c.write(buffer, 3);
+            self.state.set(State::Done);
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    /// Get the cumulative charge as measured by the LTC2941.
+    fn get_charge(&self) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+            self.i2c.enable();
+
+            // Read all of the first four registers rather than wasting
+            // time writing an address.
+            self.i2c.read(buffer, 4);
+            self.state.set(State::ReadCharge);
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    /// Get the voltage at sense+
+    fn get_voltage(&self) -> ReturnCode {
+        // Not supported on all versions
+        match self.model.get() {
+            ChipModel::LTC2942 |
+            ChipModel::LTC2943 => {
+                self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+                    self.i2c.enable();
+
+                    self.i2c.read(buffer, 10);
+                    self.state.set(State::ReadVoltage);
+
+                    ReturnCode::SUCCESS
+                })
+            }
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Get the current sensed by the resistor
+    fn get_current(&self) -> ReturnCode {
+        // Not supported on all versions
+        match self.model.get() {
+            ChipModel::LTC2943 => {
+                self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+                    self.i2c.enable();
+
+                    self.i2c.read(buffer, 16);
+                    self.state.set(State::ReadCurrent);
+
+                    ReturnCode::SUCCESS
+                })
+            }
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Put the LTC294X in a low power state.
+    fn shutdown(&self) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+            self.i2c.enable();
+
+            // Read both the status and control register rather than
+            // writing an address.
+            self.i2c.read(buffer, 2);
+            self.state.set(State::ReadShutdown);
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    /// Set the LTC294X model actually on the board.
+    fn set_model(&self, model_num: usize) -> ReturnCode {
+        match model_num {
+            1 => {
+                self.model.set(ChipModel::LTC2941);
+                ReturnCode::SUCCESS
+            }
+            2 => {
+                self.model.set(ChipModel::LTC2942);
+                ReturnCode::SUCCESS
+            }
+            3 => {
+                self.model.set(ChipModel::LTC2943);
+                ReturnCode::SUCCESS
+            }
+            _ => ReturnCode::FAIL,
+        }
+    }
+}
+
+impl<'a> i2c::I2CClient for LTC294X<'a> {
+    fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
+        match self.state.get() {
+            State::ReadStatus => {
+                let status = buffer[0];
+                let uvlock = (status & 0x01) > 0;
+                let vbata = (status & 0x02) > 0;
+                let ca_low = (status & 0x04) > 0;
+                let ca_high = (status & 0x08) > 0;
+                let accover = (status & 0x20) > 0;
+                self.client
+                    .get()
+                    .map(|client| { client.status(uvlock, vbata, ca_low, ca_high, accover); });
+
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+            }
+            State::ReadCharge => {
+                // Charge is calculated in user space
+                let charge = ((buffer[2] as u16) << 8) | (buffer[3] as u16);
+                self.client.get().map(|client| { client.charge(charge); });
+
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+            }
+            State::ReadVoltage => {
+                let voltage = ((buffer[8] as u16) << 8) | (buffer[9] as u16);
+                self.client.get().map(|client| { client.voltage(voltage); });
+
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+            }
+            State::ReadCurrent => {
+                let current = ((buffer[14] as u16) << 8) | (buffer[15] as u16);
+                self.client.get().map(|client| { client.current(current); });
+
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+            }
+            State::ReadShutdown => {
+                // Set the shutdown pin to 1
+                buffer[1] |= 0x01;
+
+                // Write the control register back but with a 1 in the shutdown
+                // bit.
+                buffer[0] = Registers::Control as u8;
+                self.i2c.write(buffer, 2);
+                self.state.set(State::Done);
+            }
+            State::Done => {
+                self.client.get().map(|client| { client.done(); });
+
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'a> gpio::Client for LTC294X<'a> {
+    fn fired(&self, _: usize) {
+        self.client.get().map(|client| { client.interrupt(); });
+    }
+}
+
+
+/// Default implementation of the LTC2941 driver that provides a Driver
+/// interface for providing access to applications.
+pub struct LTC294XDriver<'a> {
+    ltc294x: &'a LTC294X<'a>,
+    callback: Cell<Option<Callback>>,
+}
+
+impl<'a> LTC294XDriver<'a> {
+    pub fn new(ltc: &'a LTC294X) -> LTC294XDriver<'a> {
+        LTC294XDriver {
+            ltc294x: ltc,
+            callback: Cell::new(None),
+        }
+    }
+}
+
+impl<'a> LTC294XClient for LTC294XDriver<'a> {
+    fn interrupt(&self) {
+        self.callback.get().map(|mut cb| { cb.schedule(0, 0, 0); });
+    }
+
+    fn status(&self,
+              undervolt_lockout: bool,
+              vbat_alert: bool,
+              charge_alert_low: bool,
+              charge_alert_high: bool,
+              accumulated_charge_overflow: bool) {
+        self.callback.get().map(|mut cb| {
+            let ret = (undervolt_lockout as usize) | ((vbat_alert as usize) << 1) |
+                      ((charge_alert_low as usize) << 2) |
+                      ((charge_alert_high as usize) << 3) |
+                      ((accumulated_charge_overflow as usize) << 4);
+            cb.schedule(1, ret, self.ltc294x.model.get() as usize);
+        });
+    }
+
+    fn charge(&self, charge: u16) {
+        self.callback.get().map(|mut cb| { cb.schedule(2, charge as usize, 0); });
+    }
+
+    fn done(&self) {
+        self.callback.get().map(|mut cb| { cb.schedule(3, 0, 0); });
+    }
+
+    fn voltage(&self, voltage: u16) {
+        self.callback.get().map(|mut cb| { cb.schedule(4, voltage as usize, 0); });
+    }
+
+    fn current(&self, current: u16) {
+        self.callback.get().map(|mut cb| { cb.schedule(5, current as usize, 0); });
+    }
+}
+
+impl<'a> Driver for LTC294XDriver<'a> {
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+        match subscribe_num {
+            0 => {
+                self.callback.set(Some(callback));
+                ReturnCode::SUCCESS
+            }
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
+        match command_num {
+            // Check this driver exists.
+            0 => ReturnCode::SUCCESS,
+
+            // Get status.
+            1 => self.ltc294x.read_status(),
+
+            // Configure.
+            2 => {
+                let int_pin_raw = data & 0x03;
+                let prescaler = (data >> 2) & 0x07;
+                let vbat_raw = (data >> 5) & 0x03;
+                let int_pin_conf = match int_pin_raw {
+                    0 => InterruptPinConf::Disabled,
+                    1 => InterruptPinConf::ChargeCompleteMode,
+                    2 => InterruptPinConf::AlertMode,
+                    _ => InterruptPinConf::Disabled,
+                };
+                let vbat_alert = match vbat_raw {
+                    0 => VBatAlert::Off,
+                    1 => VBatAlert::Threshold2V8,
+                    2 => VBatAlert::Threshold2V9,
+                    3 => VBatAlert::Threshold3V0,
+                    _ => VBatAlert::Off,
+                };
+
+                self.ltc294x.configure(int_pin_conf, prescaler as u8, vbat_alert)
+            }
+
+            // Reset charge.
+            3 => self.ltc294x.reset_charge(),
+
+            // Set high threshold
+            4 => self.ltc294x.set_high_threshold(data as u16),
+
+            // Set low threshold
+            5 => self.ltc294x.set_low_threshold(data as u16),
+
+            // Get charge
+            6 => self.ltc294x.get_charge(),
+
+            // Shutdown
+            7 => self.ltc294x.shutdown(),
+
+            // Get voltage
+            8 => self.ltc294x.get_voltage(),
+
+            // Get current
+            9 => self.ltc294x.get_current(),
+
+            // Set the current chip model
+            10 => self.ltc294x.set_model(data),
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -231,6 +231,7 @@ functionality that is handled by the kernel. `command`, `subscribe`, and
 | 15            | SDCard           | Raw block access to an SD card             |
 | 16            | CRC              | Cyclic Redundancy Check computation        |
 | 17            | AES              | AES encryption and decryption              |
+| 18            | LTC294X          | Battery gauge IC                           |
 | 22            | LPS25HB          | Pressure sensor                            |
 | 154           | Radio            | 15.4 radio interface                       |
 | 255           | IPC              | Inter-process communication                |

--- a/userland/libtock/ltc294x.c
+++ b/userland/libtock/ltc294x.c
@@ -1,0 +1,246 @@
+#include "tock.h"
+#include "ltc294x.h"
+
+
+struct ltc294x_data {
+  int charge;
+  bool fired;
+};
+
+static struct ltc294x_data result = { .fired = false, .charge = 0 };
+
+// Internal callback for faking synchronous reads
+static void ltc294x_cb(__attribute__ ((unused)) int callback_type,
+                       __attribute__ ((unused)) int value,
+                       __attribute__ ((unused)) int chip,
+                       void* ud) {
+  struct ltc294x_data* data = (struct ltc294x_data*) ud;
+  data->charge = value;
+  data->fired = true;
+}
+
+int ltc294x_set_callback (subscribe_cb callback, void* callback_args) {
+  return subscribe(DRIVER_NUM_LTC294X, 0, callback, callback_args);
+}
+
+int ltc294x_read_status(void) {
+  return command(DRIVER_NUM_LTC294X, 1, 0);
+}
+
+int ltc294x_configure(ltc294x_model_e model,
+                      interrupt_pin_conf_e int_pin,
+                      uint16_t prescaler,
+                      vbat_alert_adc_mode_e vbat) {
+  uint8_t M = 0;
+  if (model == LTC2941 || model == LTC2942) {
+    // ltc2941/2 expects log_2 of prescaler value
+    for(int i = 0; i < 8; i++) {
+      if ((1<<i) & prescaler) {
+        M = i;
+      }
+    }
+  } else if (model == LTC2943) {
+    // See Table 3 in the datasheet.
+    switch(prescaler) {
+      case 1:    M = 0; break;
+      case 4:    M = 1; break;
+      case 16:   M = 2; break;
+      case 64:   M = 3; break;
+      case 256:  M = 4; break;
+      case 1024: M = 5; break;
+      case 4096: M = 7; break;
+      default:   M = 4; break;
+    }
+  }
+  uint8_t cmd = (int_pin & 0x03) | ((M & 0x07) << 2) | ((vbat & 0x03) << 5);
+  return command(DRIVER_NUM_LTC294X, 2, cmd);
+}
+
+int ltc294x_reset_charge(void) {
+  return command(DRIVER_NUM_LTC294X, 3, 0);
+}
+
+int ltc294x_set_high_threshold(uint16_t threshold) {
+  return command(DRIVER_NUM_LTC294X, 4, threshold);
+}
+
+int ltc294x_set_low_threshold(uint16_t threshold) {
+  return command(DRIVER_NUM_LTC294X, 5, threshold);
+}
+
+int ltc294x_get_charge(void) {
+  return command(DRIVER_NUM_LTC294X, 6, 0);
+}
+
+int ltc294x_get_voltage(void) {
+  return command(DRIVER_NUM_LTC294X, 8, 0);
+}
+
+int ltc294x_get_current(void) {
+  return command(DRIVER_NUM_LTC294X, 9, 0);
+}
+
+int ltc294x_shutdown(void) {
+  return command(DRIVER_NUM_LTC294X, 7, 0);
+}
+
+int ltc294x_set_model(ltc294x_model_e model) {
+  return command(DRIVER_NUM_LTC294X, 10, model);
+}
+
+
+
+int ltc294x_read_status_sync(void) {
+  int err;
+  result.fired = false;
+
+  err = ltc294x_set_callback(ltc294x_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = ltc294x_read_status();
+  if (err < 0) return err;
+
+  // Wait for the ADC callback.
+  yield_for(&result.fired);
+
+  return 0;
+}
+
+int ltc294x_configure_sync(ltc294x_model_e model,
+                           interrupt_pin_conf_e int_pin,
+                           uint16_t prescaler,
+                           vbat_alert_adc_mode_e vbat) {
+  int err;
+  result.fired = false;
+
+  err = ltc294x_set_callback(ltc294x_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = ltc294x_configure(model, int_pin, prescaler, vbat);
+  if (err < 0) return err;
+
+  // Wait for the ADC callback.
+  yield_for(&result.fired);
+
+  return 0;
+}
+
+int ltc294x_reset_charge_sync(void) {
+  int err;
+  result.fired = false;
+
+  err = ltc294x_set_callback(ltc294x_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = ltc294x_reset_charge();
+  if (err < 0) return err;
+
+  // Wait for the ADC callback.
+  yield_for(&result.fired);
+
+  return 0;
+}
+
+int ltc294x_set_high_threshold_sync(uint16_t threshold) {
+  int err;
+  result.fired = false;
+
+  err = ltc294x_set_callback(ltc294x_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = ltc294x_set_high_threshold(threshold);
+  if (err < 0) return err;
+
+  // Wait for the ADC callback.
+  yield_for(&result.fired);
+
+  return 0;
+}
+
+int ltc294x_set_low_threshold_sync(uint16_t threshold) {
+  int err;
+  result.fired = false;
+
+  err = ltc294x_set_callback(ltc294x_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = ltc294x_set_low_threshold(threshold);
+  if (err < 0) return err;
+
+  // Wait for the ADC callback.
+  yield_for(&result.fired);
+
+  return 0;
+}
+
+int ltc294x_get_charge_sync(void) {
+  int err;
+  result.fired = false;
+
+  err = ltc294x_set_callback(ltc294x_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = ltc294x_get_charge();
+  if (err < 0) return err;
+
+  // Wait for the ADC callback.
+  yield_for(&result.fired);
+
+  return result.charge;
+}
+
+int ltc294x_get_voltage_sync(void) {
+  int err;
+  result.fired = false;
+
+  err = ltc294x_set_callback(ltc294x_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = ltc294x_get_voltage();
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.charge;
+}
+
+int ltc294x_get_current_sync(void) {
+  int err;
+  result.fired = false;
+
+  err = ltc294x_set_callback(ltc294x_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = ltc294x_get_current();
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.charge;
+}
+
+int ltc294x_shutdown_sync(void) {
+  int err;
+  result.fired = false;
+
+  err = ltc294x_set_callback(ltc294x_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = ltc294x_shutdown();
+  if (err < 0) return err;
+
+  // Wait for the ADC callback.
+  yield_for(&result.fired);
+
+  return 0;
+}
+
+int ltc294x_convert_to_voltage_mv (int v) {
+  return 23.6*(v/(float)0xFFFF)*1000;
+}
+
+int ltc294x_convert_to_current_ua (int c, int Rsense) {
+  return (int)((60.0/Rsense)*((c-0x7FFF)/(float)0x7FFF)*1000000.0);
+}

--- a/userland/libtock/ltc294x.h
+++ b/userland/libtock/ltc294x.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#define DRIVER_NUM_LTC294X 18
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  InterruptPinDisabled = 0,
+  InterruptPinChargeCompleteMode = 1,
+  InterruptPinAlertMode = 2,
+} interrupt_pin_conf_e;
+
+typedef enum {
+  // LTC2941
+  VbatAlertOff = 0,
+  VbatAlert2V8 = 1,
+  VbatAlert2V9 = 2,
+  VbatAlert3V0 = 3,
+  // LTC29412/3
+  ADCSleep = 0,
+  ADCManual = 1,
+  ADCScan = 2,
+  ADCAuto = 3,
+} vbat_alert_adc_mode_e;
+
+typedef enum {
+  LTC2941 = 1,
+  LTC2942 = 2,
+  LTC2943 = 3,
+} ltc294x_model_e;
+
+
+// Set a callback for the LTC294X driver.
+//
+// The callback function should look like:
+//
+//     void callback (int callback_type, int data, int data2, void* callback_args)
+//
+// callback_type is one of:
+//    0: If the interrupt pin is setup in the kernel, the interrupt occurred.
+//    1: Got the contents of the status register. `data` is:
+//           bit 0: Undervoltage lockout (bool)
+//           bit 1: VBat Alert (bool)
+//           bit 2: Charge Alert Low (bool)
+//           bit 3: Charge Alert High (bool)
+//           bit 4: Accumulated Charge Overflow/Underflow (bool)
+//        and `data2` is the Chip type:
+//           1 = LTC2941
+//           2 = LTC2942
+//           3 = LTC2943
+//     2: Got the charge value.
+//     3: A write operation finished.
+int ltc294x_set_callback (subscribe_cb callback, void* callback_args);
+
+// Get the current value of the status register. The result will be returned
+// in the callback.
+int ltc294x_read_status(void);
+
+// Setup the LTC294X by configuring its !AL/CC pin, charge counting prescaler,
+// and VBat alert threshold or ADC mode.
+// Will trigger a `done` callback.
+int ltc294x_configure(ltc294x_model_e model,
+                      interrupt_pin_conf_e int_pin,
+                      uint16_t prescaler,
+                      vbat_alert_adc_mode_e vbat);
+
+// Set the current accumulated charge register to 0.
+// Will trigger a `done` callback.
+int ltc294x_reset_charge(void);
+
+// Configure the high charge threshold. This will be triggered when the
+// accumulated charge is greater than this value.
+// Will trigger a `done` callback when the register has been set.
+int ltc294x_set_high_threshold(uint16_t threshold);
+
+// Configure the low charge threshold. This will be triggered when the
+// accumulated charge is lower than this value.
+// Will trigger a `done` callback when the register has been set.
+int ltc294x_set_low_threshold(uint16_t threshold);
+
+// Read the current charge.
+// Will be returned in the callback.
+int ltc294x_get_charge(void);
+
+// Get the current voltage. Not supported on all models.
+// Will be returned in the callback.
+int ltc294x_get_voltage(void);
+
+// Get the current current reading. Not supported on all models.
+// Will be returned in the callback.
+int ltc294x_get_current(void);
+
+// Put the LTC294X in a low power state.
+// Will trigger a `done` callback.
+int ltc294x_shutdown(void);
+
+// Configure which LTC294X chip we are actually using.
+int ltc294x_set_model(ltc294x_model_e model);
+
+
+//
+// Synchronous Versions
+//
+int ltc294x_read_status_sync(void);
+int ltc294x_configure_sync(ltc294x_model_e model,
+                           interrupt_pin_conf_e int_pin,
+                           uint16_t prescaler,
+                           vbat_alert_adc_mode_e vbat);
+int ltc294x_reset_charge_sync(void);
+int ltc294x_set_high_threshold_sync(uint16_t threshold);
+int ltc294x_set_low_threshold_sync(uint16_t threshold);
+int ltc294x_get_charge_sync(void);
+int ltc294x_get_voltage_sync(void);
+int ltc294x_get_current_sync(void);
+int ltc294x_shutdown_sync(void);
+
+//
+// Helpers
+//
+int ltc294x_convert_to_voltage_mv(int v) __attribute__((const));
+int ltc294x_convert_to_current_ua(int c, int Rsense) __attribute__((const));
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
The LTC294X is a line of coulomb counters we use on signpost.

The 2491/2/3 have slightly different register sets and the capsule tries to do the right thing based on which is on the board. The capsule defaults to the ltc2941, and lets the actual chip be set at runtime because it may not be known when the kernel is compiled (as is the case for signpost).