### PR TITLE
Add PCA9544a Capsule

### DIFF
--- a/capsules/README.md
+++ b/capsules/README.md
@@ -44,6 +44,7 @@ These drivers provide support for various ICs.
 - **[LTC294X](src/ltc294x.rs)**: LTC294X series of coulomb counters.
 - **[MAX17205](src/max17205.rs)**: Battery fuel gauge.
 - **[MCP23008](src/mcp23008.rs)**: I2C GPIO extender.
+- **[PCA9544A](src/pca9544a.rs)**: Multiple port I2C selector.
 - **[SD Card](src/sdcard.rs)**: Support for SD cards.
 
 

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -38,3 +38,4 @@ pub mod ltc294x;
 pub mod mcp23008;
 pub mod gpio_async;
 pub mod max17205;
+pub mod pca9544a;

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -1,0 +1,197 @@
+//! Driver for the PCA9544A I2C Selector.
+//!
+//! This chip allows for multiple I2C devices with the same addresses to
+//! sit on the same I2C bus.
+//!
+//! http://www.ti.com/product/PCA9544A
+//!
+//! > The PCA9544A is a quad bidirectional translating switch controlled via the
+//! > I2C bus. The SCL/SDA upstream pair fans out to four downstream pairs, or
+//! > channels. One SCL/SDA pair can be selected at a time, and this is
+//! > determined by the contents of the programmable control register. Four
+//! > interrupt inputs (INT3–INT0), one for each of the downstream pairs, are
+//! > provided. One interrupt output (INT) acts as an AND of the four interrupt
+//! > inputs.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let pca9544a_i2c = static_init!(
+//!     capsules::virtual_i2c::I2CDevice,
+//!     capsules::virtual_i2c::I2CDevice::new(i2c_bus, 0x70));
+//! let pca9544a = static_init!(
+//!     capsules::pca9544a::PCA9544A<'static>,
+//!     capsules::pca9544a::PCA9544A::new(pca9544a_i2c, &mut capsules::pca9544a::BUFFER));
+//! pca9544a_i2c.set_client(pca9544a);
+//! ```
+
+use core::cell::Cell;
+
+use kernel::{AppId, Callback, Driver, ReturnCode};
+use kernel::common::take_cell::TakeCell;
+use kernel::hil::i2c;
+
+pub static mut BUFFER: [u8; 5] = [0; 5];
+
+#[derive(Clone,Copy,PartialEq)]
+enum State {
+    Idle,
+
+    /// Read the control register and return the specified data field.
+    ReadControl(ControlField),
+
+    Done,
+}
+
+#[derive(Clone,Copy,PartialEq)]
+enum ControlField {
+    InterruptMask,
+    SelectedChannels,
+}
+
+
+pub struct PCA9544A<'a> {
+    i2c: &'a i2c::I2CDevice,
+    state: Cell<State>,
+    buffer: TakeCell<'static, [u8]>,
+    callback: Cell<Option<Callback>>,
+}
+
+impl<'a> PCA9544A<'a> {
+    pub fn new(i2c: &'a i2c::I2CDevice, buffer: &'static mut [u8]) -> PCA9544A<'a> {
+        PCA9544A {
+            i2c: i2c,
+            state: Cell::new(State::Idle),
+            buffer: TakeCell::new(buffer),
+            callback: Cell::new(None),
+        }
+    }
+
+    /// Choose which channel(s) are active. Channels are encoded with a bitwise
+    /// mask (0x01 means enable channel 0, 0x0F means enable all channels).
+    /// Send 0 to disable all channels.
+    fn select_channels(&self, channel_bitmask: u8) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+            self.i2c.enable();
+
+            // Always clear the settings so we get to a known state
+            buffer[0] = 0;
+
+            // Iterate the bit array to send the correct channel enables
+            let mut index = 1;
+            for i in 0..4 {
+                if channel_bitmask & (0x01 << i) != 0 {
+                    // B2 B1 B0 are set starting at 0x04
+                    buffer[index] = i + 4;
+                    index += 1;
+                }
+            }
+
+            self.i2c.write(buffer, index as u8);
+            self.state.set(State::Done);
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    fn read_interrupts(&self) -> ReturnCode {
+        self.read_control(ControlField::InterruptMask)
+    }
+
+    fn read_selected_channels(&self) -> ReturnCode {
+        self.read_control(ControlField::SelectedChannels)
+    }
+
+    fn read_control(&self, field: ControlField) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::ENOMEM, |buffer| {
+            self.i2c.enable();
+
+            // Just issuing a read to the selector reads its control register.
+            self.i2c.read(buffer, 1);
+            self.state.set(State::ReadControl(field));
+
+            ReturnCode::SUCCESS
+        })
+    }
+}
+
+impl<'a> i2c::I2CClient for PCA9544A<'a> {
+    fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
+        match self.state.get() {
+            State::ReadControl(field) => {
+                let ret = match field {
+                    ControlField::InterruptMask => (buffer[0] >> 4) & 0x0F,
+                    ControlField::SelectedChannels => buffer[0] & 0x07,
+                };
+
+                self.callback
+                    .get()
+                    .map(|mut cb| cb.schedule((field as usize) + 1, ret as usize, 0));
+
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+            }
+            State::Done => {
+                self.callback.get().map(|mut cb| cb.schedule(0, 0, 0));
+
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'a> Driver for PCA9544A<'a> {
+    /// Setup callback for event done.
+    ///
+    /// ### `subscribe_num`
+    ///
+    /// - `0`: Callback is triggered when a channel is finished being selected
+    ///   or when the current channel setup is returned.
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+        match subscribe_num {
+            0 => {
+                self.callback.set(Some(callback));
+                ReturnCode::SUCCESS
+            }
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Control the I2C selector.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Driver check.
+    /// - `1`: Choose which channels are active.
+    /// - `2`: Disable all channels.
+    /// - `3`: Read the list of fired interrupts.
+    /// - `4`: Read which channels are selected.
+    fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
+        match command_num {
+            // Check if present.
+            0 => ReturnCode::SUCCESS,
+
+            // Select channels.
+            1 => self.select_channels(data as u8),
+
+            // Disable all channels.
+            2 => self.select_channels(0),
+
+            // Read the current interrupt fired mask.
+            3 => self.read_interrupts(),
+
+            // Read the current selected channels.
+            4 => self.read_selected_channels(),
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -233,6 +233,7 @@ functionality that is handled by the kernel. `command`, `subscribe`, and
 | 16            | CRC              | Cyclic Redundancy Check computation        |
 | 17            | AES              | AES encryption and decryption              |
 | 18            | LTC294X          | Battery gauge IC                           |
+| 19            | PCA9544A         | I2C address multiplexing                   |
 | 20            | GPIO Async       | Asynchronous GPIO pins                     |
 | 21            | MAX17205         | Battery gauge IC                           |
 | 22            | LPS25HB          | Pressure sensor                            |

--- a/userland/libtock/pca9544a.c
+++ b/userland/libtock/pca9544a.c
@@ -1,0 +1,106 @@
+#include "pca9544a.h"
+#include "tock.h"
+
+struct pca9544a_data {
+  bool fired;
+  int value;
+};
+
+static struct pca9544a_data result = { .fired = false };
+
+// Internal callback for faking synchronous reads
+static void pca9544a_cb(__attribute__ ((unused)) int value,
+                        __attribute__ ((unused)) int unused1,
+                        __attribute__ ((unused)) int unused2,
+                        void* ud) {
+  struct pca9544a_data* data = (struct pca9544a_data*) ud;
+  data->value = value;
+  data->fired = true;
+}
+
+
+int pca9544a_set_callback(subscribe_cb callback, void* callback_args) {
+  return subscribe(DRIVER_NUM_PCA9544A, 0, callback, callback_args);
+}
+
+int pca9544a_select_channels(uint32_t channels) {
+  return command(DRIVER_NUM_PCA9544A, 1, channels);
+}
+
+int pca9544a_disable_all_channels(void) {
+  return command(DRIVER_NUM_PCA9544A, 2, 0);
+}
+
+int pca9544a_read_interrupts(void) {
+  return command(DRIVER_NUM_PCA9544A, 3, 0);
+}
+
+int pca9544a_read_selected(void) {
+  return command(DRIVER_NUM_PCA9544A, 4, 0);
+}
+
+
+
+int pca9544a_select_channels_sync(uint32_t channels) {
+  int err;
+  result.fired = false;
+
+  err = pca9544a_set_callback(pca9544a_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = pca9544a_select_channels(channels);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return 0;
+}
+
+int pca9544a_disable_all_channels_sync(void) {
+  int err;
+  result.fired = false;
+
+  err = pca9544a_set_callback(pca9544a_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = pca9544a_disable_all_channels();
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return 0;
+}
+
+int pca9544a_read_interrupts_sync(void) {
+  int err;
+  result.fired = false;
+
+  err = pca9544a_set_callback(pca9544a_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = pca9544a_read_interrupts();
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}
+
+int pca9544a_read_selected_sync(void) {
+  int err;
+  result.fired = false;
+
+  err = pca9544a_set_callback(pca9544a_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = pca9544a_read_selected();
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}

--- a/userland/libtock/pca9544a.h
+++ b/userland/libtock/pca9544a.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "tock.h"
+
+#define DRIVER_NUM_PCA9544A 19
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int pca9544a_set_callback(subscribe_cb callback, void* callback_args);
+
+// Set which of the I2C selector's channels are active.
+// channels is an 8 bit bitmask
+int pca9544a_select_channels(uint32_t channels);
+
+// Disable all channels on the I2C selector.
+int pca9544a_disable_all_channels(void);
+
+// Get which channels are asserting interrupts.
+int pca9544a_read_interrupts(void);
+
+// Get which channels are currently selected.
+int pca9544a_read_selected(void);
+
+
+//
+// Synchronous Versions
+//
+int pca9544a_select_channels_sync(uint32_t channels);
+int pca9544a_disable_all_channels_sync(void);
+int pca9544a_read_interrupts_sync(void);
+int pca9544a_read_selected_sync(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Driver for an I2C address multiplexing chip.

Signpost uses this to handle having several battery gauges which all have the same I2C address.