### PR TITLE
Print the `TOCK_KERNEL_VERSION` on faults

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -33,6 +33,8 @@ Q=@
 VERBOSE =
 endif
 
+export TOCK_KERNEL_VERSION := $(shell git describe --always || echo notgit)
+
 # Check that rustc is the right nightly - warn not error if wrong, sometimes useful to test others
 RUSTC_VERSION_STRING := rustc 1.16.0-nightly (83c2d9523 2017-01-24)
 ifneq ($(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VERSION_STRING))

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -55,6 +55,9 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
     let _ = write(writer, args);
     let _ = writer.write_str("\"\r\n");
 
+    // Print version of the kernel
+    let _ = writer.write_fmt(format_args!("\tKernel version {}\r\n", env!("TOCK_KERNEL_VERSION")));
+
     // Print fault status once
     let procs = &mut process::PROCS;
     if procs.len() > 0 {

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -55,6 +55,9 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
     let _ = write(writer, args);
     let _ = writer.write_str("\"\r\n");
 
+    // Print version of the kernel
+    let _ = writer.write_fmt(format_args!("\tKernel version {}\r\n", env!("TOCK_KERNEL_VERSION")));
+
     // Print fault status once
     let procs = &mut process::PROCS;
     if procs.len() > 0 {

--- a/boards/nrf51dk/src/io.rs
+++ b/boards/nrf51dk/src/io.rs
@@ -67,6 +67,9 @@ pub unsafe extern "C" fn rust_begin_unwind(_args: Arguments,
     let _ = write(writer, _args);
     let _ = writer.write_str("\"\r\n");
 
+    // Print version of the kernel
+    let _ = writer.write_fmt(format_args!("\tKernel version {}\r\n", env!("TOCK_KERNEL_VERSION")));
+
     // Print fault status once
     let procs = &mut process::PROCS;
     if procs.len() > 0 {

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -267,6 +267,7 @@ unsafe extern "C" fn hard_fault_handler() {
         let forced = (hfsr & 0x40000000) == 0x40000000;
 
         panic!("{} HardFault.\n\
+               \tKernel version {}\n\
                \tr0  0x{:x}\n\
                \tr1  0x{:x}\n\
                \tr2  0x{:x}\n\
@@ -304,6 +305,7 @@ unsafe extern "C" fn hard_fault_handler() {
                \tBus Fault Address:       (valid: {}) {:#010X}\n\
                ",
                mode_str,
+               env!("TOCK_KERNEL_VERSION"),
                stacked_r0,
                stacked_r1,
                stacked_r2,


### PR DESCRIPTION
This one is pretty experimental. I'm looking for opinions on whether this is the "best" way to do this.

The goal is to hopefully make it easier for us to test reported bugs by knowing what version of the kernel they occurred on

Currently the `TOCK_KERNEL_VERSION` is set to the `git describe` result, usually some combination of a tag and commit hash. https://git-scm.com/docs/git-describe#_examples