### PR TITLE
Remove unused `disable-redzone` option

### DIFF
--- a/boards/hail/sam4l.json
+++ b/boards/hail/sam4l.json
@@ -11,7 +11,6 @@
     "relocation-model": "static",
     "linker": "arm-none-eabi-gcc",
     "linker-is-gnu": true,
-    "disable-redzone": true,
     "pre-link-args": [
         "-mcpu=cortex-m4", "-mthumb",
         "-mfloat-abi=soft",

--- a/boards/imix/sam4l.json
+++ b/boards/imix/sam4l.json
@@ -11,7 +11,6 @@
     "relocation-model": "static",
     "linker": "arm-none-eabi-gcc",
     "linker-is-gnu": true,
-    "disable-redzone": true,
     "pre-link-args": [
         "-mcpu=cortex-m4", "-mthumb",
         "-mfloat-abi=soft",

--- a/boards/nrf51dk/nrf51.json
+++ b/boards/nrf51dk/nrf51.json
@@ -11,7 +11,6 @@
     "relocation-model": "static",
     "linker": "arm-none-eabi-gcc",
     "linker-is-gnu": true,
-    "disable-redzone": true,
     "features": "+strict-align",
     "pre-link-args": [
         "-mcpu=cortex-m0", "-mthumb",


### PR DESCRIPTION
`arm-none-eabi` doesn't have a redzone (ARM docs here, but dense:
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.subset.swdev.abi/index.html)

`arm-windows-eabi` deos have an 8-byte redzone, and helpfully succinctly
clarifies that the standard ARM EABI doesn't have one:
https://msdn.microsoft.com/en-us/library/dn736986.aspx

This is a step towards unifying our target and the built-in Rust target
(with the goal of eliminating ours)