### PR TITLE
Enable MPU subregions for text segment when needed

### DIFF
--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -131,7 +131,7 @@ impl kernel::mpu::MPU for MPU {
         let xn = execute as u32;
         let ap = access as u32;
         let srd = subregion_mask as u32;
-        let size = len.bit::<u32>() - 1;
+        let size = len.exp::<u32>() - 1;
         let region_attributes_and_size = 1 | size << 1 | srd << 8 | ap << 24 | xn << 28;
         regs.region_attributes_and_size.set(region_attributes_and_size);
     }

--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -1,4 +1,5 @@
 use kernel;
+use kernel::common::math::PowerOfTwo;
 use kernel::common::volatile_cell::VolatileCell;
 
 /// Indicates whether the MPU is present and, if so, how many regions it
@@ -118,7 +119,8 @@ impl kernel::mpu::MPU for MPU {
     fn set_mpu(&self,
                region_num: u32,
                start_addr: u32,
-               len: u32,
+               len: PowerOfTwo,
+               subregion_mask: u8,
                execute: kernel::mpu::ExecutePermission,
                access: kernel::mpu::AccessPermission) {
         let regs = unsafe { &*self.0 };
@@ -128,7 +130,9 @@ impl kernel::mpu::MPU for MPU {
 
         let xn = execute as u32;
         let ap = access as u32;
-        let region_attributes_and_size = 1 | len << 1 | ap << 24 | xn << 28;
+        let srd = subregion_mask as u32;
+        let size = len.bit::<u32>() - 1;
+        let region_attributes_and_size = 1 | size << 1 | srd << 8 | ap << 24 | xn << 28;
         regs.region_attributes_and_size.set(region_attributes_and_size);
     }
 }

--- a/kernel/src/common/math.rs
+++ b/kernel/src/common/math.rs
@@ -1,5 +1,5 @@
+use core::convert::{From, Into};
 use core::intrinsics as int;
-use core::convert::{From,Into};
 
 // wrappers for unsafe core::intrinsics math functions
 //  core::intrinsics functions can be found at
@@ -54,7 +54,9 @@ pub fn closest_power_of_two(mut num: u32) -> u32 {
 pub struct PowerOfTwo(u32);
 
 impl PowerOfTwo {
-    pub fn bit<R>(self) -> R where R: From<u32> {
+    pub fn bit<R>(self) -> R
+        where R: From<u32>
+    {
         From::from(self.0)
     }
 

--- a/kernel/src/common/math.rs
+++ b/kernel/src/common/math.rs
@@ -1,4 +1,5 @@
 use core::intrinsics as int;
+use core::convert::{From,Into};
 
 // wrappers for unsafe core::intrinsics math functions
 //  core::intrinsics functions can be found at
@@ -47,6 +48,25 @@ pub fn closest_power_of_two(mut num: u32) -> u32 {
     num |= num >> 16;
     num += 1;
     num
+}
+
+#[derive(Copy,Clone,PartialEq,PartialOrd,Eq,Ord)]
+pub struct PowerOfTwo(u32);
+
+impl PowerOfTwo {
+    pub fn bit<R>(self) -> R where R: From<u32> {
+        From::from(self.0)
+    }
+
+    pub fn zero() -> PowerOfTwo {
+        PowerOfTwo(0)
+    }
+}
+
+impl<F: Into<u32>> From<F> for PowerOfTwo {
+    fn from(f: F) -> PowerOfTwo {
+        PowerOfTwo(log_base_two(f.into()))
+    }
 }
 
 // get log base 2 of a number

--- a/kernel/src/common/math.rs
+++ b/kernel/src/common/math.rs
@@ -60,14 +60,20 @@ impl PowerOfTwo {
         From::from(self.0)
     }
 
+    pub fn floor<F: Into<u32>>(f: F) -> PowerOfTwo {
+        PowerOfTwo(log_base_two(f.into()))
+    }
+
+    pub fn ceiling<F: Into<u32>>(f: F) -> PowerOfTwo {
+        PowerOfTwo(log_base_two(closest_power_of_two(f.into())))
+    }
+
     pub fn zero() -> PowerOfTwo {
         PowerOfTwo(0)
     }
-}
 
-impl<F: Into<u32>> From<F> for PowerOfTwo {
-    fn from(f: F) -> PowerOfTwo {
-        PowerOfTwo(log_base_two(f.into()))
+    pub fn as_num<F: From<u32>>(self) -> F {
+        (1 << self.0).into()
     }
 }
 

--- a/kernel/src/common/math.rs
+++ b/kernel/src/common/math.rs
@@ -50,28 +50,35 @@ pub fn closest_power_of_two(mut num: u32) -> u32 {
     num
 }
 
-#[derive(Copy,Clone,PartialEq,PartialOrd,Eq,Ord)]
+#[derive(Copy,Clone,Debug,PartialEq,PartialOrd,Eq,Ord)]
 pub struct PowerOfTwo(u32);
 
+/// Represents an integral power-of-two as an exponent
 impl PowerOfTwo {
-    pub fn bit<R>(self) -> R
+    /// Returns the base-2 exponent as a numeric type
+    pub fn exp<R>(self) -> R
         where R: From<u32>
     {
         From::from(self.0)
     }
 
+    /// Converts a number two the nearest `PowerOfTwo` less-than-or-equal to it.
     pub fn floor<F: Into<u32>>(f: F) -> PowerOfTwo {
         PowerOfTwo(log_base_two(f.into()))
     }
 
+    /// Converts a number two the nearest `PowerOfTwo` greater-than-or-equal to
+    /// it.
     pub fn ceiling<F: Into<u32>>(f: F) -> PowerOfTwo {
         PowerOfTwo(log_base_two(closest_power_of_two(f.into())))
     }
 
+    /// Creates a new `PowerOfTwo` representing the number zero.
     pub fn zero() -> PowerOfTwo {
         PowerOfTwo(0)
     }
 
+    /// Converts a `PowerOfTwo` to a number.
     pub fn as_num<F: From<u32>>(self) -> F {
         (1 << self.0).into()
     }

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -77,7 +77,7 @@ impl<L, T> AppSlice<L, T> {
         if appid.idx() != self.ptr.process.idx() && ps.len() > appid.idx() {
             ps[appid.idx()]
                 .as_ref()
-                .map(|process| process.add_mpu_region(self.ptr() as *const u8, self.len()))
+                .map(|process| process.add_mpu_region(self.ptr() as *const u8, self.len() as u32))
                 .unwrap_or(false)
         } else {
             false

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -32,7 +32,7 @@ pub trait MPU {
     /// `region_num`: an MPU region number 0-7
     /// `start_addr`: the region base address. Lower bits will be masked
     ///               according to the region size.
-    /// `len`       : region size as a function 2^(len + 1)
+    /// `len`       : region size as a PowerOfTwo (e.g. `16` for 64KB)
     /// `execute`   : whether to enable code execution from this region
     /// `ap`        : access permissions as defined in Table 4.47 of the user
     ///               guide.

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -49,5 +49,12 @@ pub trait MPU {
 impl MPU for () {
     fn enable_mpu(&self) {}
 
-    fn set_mpu(&self, _: u32, _: u32, _: PowerOfTwo, _: u8, _: ExecutePermission, _: AccessPermission) {}
+    fn set_mpu(&self,
+               _: u32,
+               _: u32,
+               _: PowerOfTwo,
+               _: u8,
+               _: ExecutePermission,
+               _: AccessPermission) {
+    }
 }

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,3 +1,4 @@
+use common::math::PowerOfTwo;
 
 #[derive(Debug)]
 pub enum AccessPermission {
@@ -38,7 +39,8 @@ pub trait MPU {
     fn set_mpu(&self,
                region_num: u32,
                start_addr: u32,
-               len: u32,
+               len: PowerOfTwo,
+               subregion_mask: u8,
                execute: ExecutePermission,
                ap: AccessPermission);
 }
@@ -47,5 +49,5 @@ pub trait MPU {
 impl MPU for () {
     fn enable_mpu(&self) {}
 
-    fn set_mpu(&self, _: u32, _: u32, _: u32, _: ExecutePermission, _: AccessPermission) {}
+    fn set_mpu(&self, _: u32, _: u32, _: PowerOfTwo, _: u8, _: ExecutePermission, _: AccessPermission) {}
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -339,6 +339,12 @@ impl<'a> Process<'a> {
             let region_size = subregion_size * 8; // 8 subregions in a region
             let region_start = text_start - (text_start % region_size);
 
+            if region_size + region_start - text_start < text_len {
+                panic!("Infeasible MPU allocation. Base {:#x}, Length: {:#x}",
+                       text_start, text_len);
+            }
+
+
             let min_subregion = (text_start - region_start) / subregion_size;
             let max_subregion = min_subregion + text_len / subregion_size - 1;
 


### PR DESCRIPTION
If the text segment of a process is not aligned to its size, use a larger region size that overlaps the  process region, and use the subregion field to activate only the text segment subregions.

In addition, fixes an off-by-one MPU region size issue, where the MPU's SIZE field is actually meant to be `Math.log2(region_length) - 1` (see section 4.5.5 of the Cortex-M4 User Guide). To codify this, the PR introduces a `PowerOfTwo` wrapper type and moves the logic of encoding the field to the MPU implementation.

Related to #297 