### PR TITLE
Proposed implementation of ADC continuous sampling with different clocks.

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -43,9 +43,7 @@ struct Imix {
     button: &'static capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
     spi: &'static capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
     ipc: kernel::ipc::IPC,
-    fxos8700_cq: &'static capsules::fxos8700_cq::Fxos8700cq<'static,
-                                                    VirtualMuxAlarm<'static,
-                                                                    sam4l::ast::Ast<'static>>>,
+    fxos8700_cq: &'static capsules::fxos8700_cq::Fxos8700cq<'static>,
     radio: &'static capsules::radio::RadioDriver<'static,
                                                  capsules::rf233::RF233<'static,
                                                  VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>>,
@@ -100,8 +98,8 @@ unsafe fn set_pin_primary_functions() {
 
     // Right column: Imix pin name
     // Left  column: SAM4L peripheral function
-    PA[04].configure(Some(A)); // AD0         --  ADCIFE AD0
-    PA[05].configure(Some(A)); // AD1         --  ADCIFE AD1
+    PA[04].configure(Some(C)); // LI_INT      --  EIC EXTINT2
+    PA[05].configure(Some(A)); // AD0         --  ADCIFE AD1
     PA[06].configure(Some(C)); // EXTINT1     --  EIC EXTINT1
     PA[07].configure(Some(A)); // AD1         --  ADCIFE AD2
     PA[08].configure(None); //... RF233 IRQ   --  GPIO pin
@@ -111,17 +109,16 @@ unsafe fn set_pin_primary_functions() {
     PA[14].configure(None); //... TRNG_OUT    --  GPIO pin
     PA[17].configure(None); //... NRF INT     -- GPIO pin
     PA[18].configure(Some(A)); // NRF CLK     -- USART2_CLK
-    PA[20].configure(None);    // D8          -- GPIO pin
     PA[21].configure(Some(E)); // TWI2 SDA    -- TWIM2_SDA
     PA[22].configure(Some(E)); // TWI2 SCL    --  TWIM2 TWCK
     PA[25].configure(Some(A)); // USB_N       --  USB DM
     PA[26].configure(Some(A)); // USB_P       --  USB DP
     PB[00].configure(Some(A)); // TWI1_SDA    --  TWIMS1 TWD
     PB[01].configure(Some(A)); // TWI1_SCL    --  TWIMS1 TWCK
-    PB[02].configure(Some(A)); // AD3         --  ADCIFE AD3
-    PB[03].configure(Some(A)); // AD4         --  ADCIFE AD4
-    PB[04].configure(Some(A)); // AD5         --  ADCIFE AD5
-    PB[05].configure(Some(A)); // VHIGHSAMPLE --  ADCIFE AD6
+    PB[02].configure(Some(A)); // AD2         --  ADCIFE AD3
+    PB[03].configure(Some(A)); // AD3         --  ADCIFE AD4
+    PB[04].configure(Some(A)); // AD4         --  ADCIFE AD5
+    PB[05].configure(Some(A)); // AD5         --  ADCIFE AD6
     PB[06].configure(Some(A)); // RTS3        --  USART3 RTS
     PB[07].configure(None); //... NRF RESET   --  GPIO
     PB[09].configure(Some(A)); // RX3         --  USART3 RX
@@ -132,7 +129,7 @@ unsafe fn set_pin_primary_functions() {
     PB[14].configure(Some(A)); // RX0         --  USART0 RX
     PB[15].configure(Some(A)); // TX0         --  USART0 TX
     PC[00].configure(Some(A)); // CS2         --  SPI NPCS2
-    PC[01].configure(Some(A)); // CS3 (RF233) --  SPI NPCS3
+    PC[01].configure(Some(A)); // CS3 (RF233) -- SPI NPCS3
     PC[02].configure(Some(A)); // CS1         --  SPI NPCS1
     PC[03].configure(Some(A)); // CS0         --  SPI NPCS0
     PC[04].configure(Some(A)); // MISO        --  SPI MISO
@@ -150,9 +147,8 @@ unsafe fn set_pin_primary_functions() {
     PC[17].configure(None); //... NRF_PWR     --  GPIO pin
     PC[18].configure(None); //... RF233_PWR   --  GPIO pin
     PC[19].configure(None); //... TRNG_PWR    -- GPIO Pin
-    PC[22].configure(None); //... KERNEL LED  -- GPIO Pin
     PC[24].configure(None); //... USER_BTN    -- GPIO Pin
-    PC[25].configure(Some(B)); // LI_INT      --  EIC EXTINT2
+    PC[25].configure(None); //... D8          -- GPIO Pin
     PC[26].configure(None); //... D7          -- GPIO Pin
     PC[27].configure(None); //... D6          -- GPIO Pin
     PC[28].configure(None); //... D5          -- GPIO Pin
@@ -165,8 +161,7 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
-    sam4l::pm::setup_system_clock(sam4l::pm::SystemClockSource::ExternalOscillatorPll,
-                                 48000000);
+    sam4l::pm::setup_system_clock(sam4l::pm::SystemClockSource::DfllRc32k, 48000000);
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);
@@ -294,18 +289,11 @@ pub unsafe fn reset_handler() {
 
     // FXOS8700CQ accelerometer
     let fx0_i2c = static_init!(I2CDevice, I2CDevice::new(mux_i2c, 0x1e), 32);
-    let fx0_virtual_alarm = static_init!(
-        VirtualMuxAlarm<'static, sam4l::ast::Ast>,
-        VirtualMuxAlarm::new(mux_alarm),
-        192/8);
     let fx0 = static_init!(
-        capsules::fxos8700_cq::Fxos8700cq<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
-        capsules::fxos8700_cq::Fxos8700cq::new(fx0_i2c,
-                                               fx0_virtual_alarm,
-                                               &mut capsules::fxos8700_cq::BUF),
-        384/8);
+        capsules::fxos8700_cq::Fxos8700cq<'static>,
+        capsules::fxos8700_cq::Fxos8700cq::new(fx0_i2c, &mut capsules::fxos8700_cq::BUF),
+        352/8);
     fx0_i2c.set_client(fx0);
-    fx0_virtual_alarm.set_client(fx0);
 
     // Clear sensors enable pin to enable sensor rail
     // sam4l::gpio::PC[16].enable_output();
@@ -317,26 +305,22 @@ pub unsafe fn reset_handler() {
     let adc = static_init!(
         capsules::adc::ADC<'static, sam4l::adc::Adc>,
         capsules::adc::ADC::new(&mut sam4l::adc::ADC, kernel::Container::create()),
-        128/8);
+        128/8 /* was 96/8 */);
     sam4l::adc::ADC.set_client(adc);
 
     // # GPIO
     // set GPIO driver controlling remaining GPIO pins
     let gpio_pins = static_init!(
-        [&'static sam4l::gpio::GPIOPin; 11],
+        [&'static sam4l::gpio::GPIOPin; 8],
         [&sam4l::gpio::PC[31], // P2
          &sam4l::gpio::PC[30], // P3
          &sam4l::gpio::PC[29], // P4
          &sam4l::gpio::PC[28], // P5
          &sam4l::gpio::PC[27], // P6
          &sam4l::gpio::PC[26], // P7
-         &sam4l::gpio::PA[20], // P8
-         &sam4l::gpio::PC[16], // SENSE_PWR_EN
-         &sam4l::gpio::PC[17], // NRF_PWR_EN
-         &sam4l::gpio::PC[18], // RF233_PWR_EN
-         &sam4l::gpio::PC[19]  // TRNG_PWR_EN
-         ],
-        11 * 4
+         &sam4l::gpio::PC[25], // P8
+         &sam4l::gpio::PC[25]], // Dummy Pin (regular GPIO)
+        8 * 4
     );
 
     let gpio = static_init!(
@@ -349,11 +333,9 @@ pub unsafe fn reset_handler() {
 
     // # LEDs
     let led_pins = static_init!(
-        [(&'static sam4l::gpio::GPIOPin, capsules::led::ActivationMode); 2],
-        [(&sam4l::gpio::PC[22], capsules::led::ActivationMode::ActiveHigh),
-         (&sam4l::gpio::PC[10], capsules::led::ActivationMode::ActiveHigh)
-        ],
-        128/8);
+        [(&'static sam4l::gpio::GPIOPin, capsules::led::ActivationMode); 1],
+        [(&sam4l::gpio::PC[10], capsules::led::ActivationMode::ActiveHigh)],
+        64/8);
     let led = static_init!(
         capsules::led::LED<'static, sam4l::gpio::GPIOPin>,
         capsules::led::LED::new(led_pins),

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -43,7 +43,9 @@ struct Imix {
     button: &'static capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
     spi: &'static capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
     ipc: kernel::ipc::IPC,
-    fxos8700_cq: &'static capsules::fxos8700_cq::Fxos8700cq<'static>,
+    fxos8700_cq: &'static capsules::fxos8700_cq::Fxos8700cq<'static,
+                                                    VirtualMuxAlarm<'static,
+                                                                    sam4l::ast::Ast<'static>>>,
     radio: &'static capsules::radio::RadioDriver<'static,
                                                  capsules::rf233::RF233<'static,
                                                  VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>>,
@@ -98,8 +100,8 @@ unsafe fn set_pin_primary_functions() {
 
     // Right column: Imix pin name
     // Left  column: SAM4L peripheral function
-    PA[04].configure(Some(C)); // LI_INT      --  EIC EXTINT2
-    PA[05].configure(Some(A)); // AD0         --  ADCIFE AD1
+    PA[04].configure(Some(A)); // AD0         --  ADCIFE AD0
+    PA[05].configure(Some(A)); // AD1         --  ADCIFE AD1
     PA[06].configure(Some(C)); // EXTINT1     --  EIC EXTINT1
     PA[07].configure(Some(A)); // AD1         --  ADCIFE AD2
     PA[08].configure(None); //... RF233 IRQ   --  GPIO pin
@@ -109,16 +111,17 @@ unsafe fn set_pin_primary_functions() {
     PA[14].configure(None); //... TRNG_OUT    --  GPIO pin
     PA[17].configure(None); //... NRF INT     -- GPIO pin
     PA[18].configure(Some(A)); // NRF CLK     -- USART2_CLK
+    PA[20].configure(None);    // D8          -- GPIO pin
     PA[21].configure(Some(E)); // TWI2 SDA    -- TWIM2_SDA
     PA[22].configure(Some(E)); // TWI2 SCL    --  TWIM2 TWCK
     PA[25].configure(Some(A)); // USB_N       --  USB DM
     PA[26].configure(Some(A)); // USB_P       --  USB DP
     PB[00].configure(Some(A)); // TWI1_SDA    --  TWIMS1 TWD
     PB[01].configure(Some(A)); // TWI1_SCL    --  TWIMS1 TWCK
-    PB[02].configure(Some(A)); // AD2         --  ADCIFE AD3
-    PB[03].configure(Some(A)); // AD3         --  ADCIFE AD4
-    PB[04].configure(Some(A)); // AD4         --  ADCIFE AD5
-    PB[05].configure(Some(A)); // AD5         --  ADCIFE AD6
+    PB[02].configure(Some(A)); // AD3         --  ADCIFE AD3
+    PB[03].configure(Some(A)); // AD4         --  ADCIFE AD4
+    PB[04].configure(Some(A)); // AD5         --  ADCIFE AD5
+    PB[05].configure(Some(A)); // VHIGHSAMPLE --  ADCIFE AD6
     PB[06].configure(Some(A)); // RTS3        --  USART3 RTS
     PB[07].configure(None); //... NRF RESET   --  GPIO
     PB[09].configure(Some(A)); // RX3         --  USART3 RX
@@ -129,7 +132,7 @@ unsafe fn set_pin_primary_functions() {
     PB[14].configure(Some(A)); // RX0         --  USART0 RX
     PB[15].configure(Some(A)); // TX0         --  USART0 TX
     PC[00].configure(Some(A)); // CS2         --  SPI NPCS2
-    PC[01].configure(Some(A)); // CS3 (RF233) -- SPI NPCS3
+    PC[01].configure(Some(A)); // CS3 (RF233) --  SPI NPCS3
     PC[02].configure(Some(A)); // CS1         --  SPI NPCS1
     PC[03].configure(Some(A)); // CS0         --  SPI NPCS0
     PC[04].configure(Some(A)); // MISO        --  SPI MISO
@@ -147,8 +150,9 @@ unsafe fn set_pin_primary_functions() {
     PC[17].configure(None); //... NRF_PWR     --  GPIO pin
     PC[18].configure(None); //... RF233_PWR   --  GPIO pin
     PC[19].configure(None); //... TRNG_PWR    -- GPIO Pin
+    PC[22].configure(None); //... KERNEL LED  -- GPIO Pin
     PC[24].configure(None); //... USER_BTN    -- GPIO Pin
-    PC[25].configure(None); //... D8          -- GPIO Pin
+    PC[25].configure(Some(B)); // LI_INT      --  EIC EXTINT2
     PC[26].configure(None); //... D7          -- GPIO Pin
     PC[27].configure(None); //... D6          -- GPIO Pin
     PC[28].configure(None); //... D5          -- GPIO Pin
@@ -161,7 +165,8 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
-    sam4l::pm::setup_system_clock(sam4l::pm::SystemClockSource::DfllRc32k, 48000000);
+    sam4l::pm::setup_system_clock(sam4l::pm::SystemClockSource::ExternalOscillatorPll,
+                                 48000000);
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);
@@ -289,11 +294,18 @@ pub unsafe fn reset_handler() {
 
     // FXOS8700CQ accelerometer
     let fx0_i2c = static_init!(I2CDevice, I2CDevice::new(mux_i2c, 0x1e), 32);
+    let fx0_virtual_alarm = static_init!(
+        VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+        VirtualMuxAlarm::new(mux_alarm),
+        192/8);
     let fx0 = static_init!(
-        capsules::fxos8700_cq::Fxos8700cq<'static>,
-        capsules::fxos8700_cq::Fxos8700cq::new(fx0_i2c, &mut capsules::fxos8700_cq::BUF),
-        352/8);
+        capsules::fxos8700_cq::Fxos8700cq<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
+        capsules::fxos8700_cq::Fxos8700cq::new(fx0_i2c,
+                                               fx0_virtual_alarm,
+                                               &mut capsules::fxos8700_cq::BUF),
+        384/8);
     fx0_i2c.set_client(fx0);
+    fx0_virtual_alarm.set_client(fx0);
 
     // Clear sensors enable pin to enable sensor rail
     // sam4l::gpio::PC[16].enable_output();
@@ -305,22 +317,26 @@ pub unsafe fn reset_handler() {
     let adc = static_init!(
         capsules::adc::ADC<'static, sam4l::adc::Adc>,
         capsules::adc::ADC::new(&mut sam4l::adc::ADC, kernel::Container::create()),
-        96/8);
+        128/8);
     sam4l::adc::ADC.set_client(adc);
 
     // # GPIO
     // set GPIO driver controlling remaining GPIO pins
     let gpio_pins = static_init!(
-        [&'static sam4l::gpio::GPIOPin; 8],
+        [&'static sam4l::gpio::GPIOPin; 11],
         [&sam4l::gpio::PC[31], // P2
          &sam4l::gpio::PC[30], // P3
          &sam4l::gpio::PC[29], // P4
          &sam4l::gpio::PC[28], // P5
          &sam4l::gpio::PC[27], // P6
          &sam4l::gpio::PC[26], // P7
-         &sam4l::gpio::PC[25], // P8
-         &sam4l::gpio::PC[25]], // Dummy Pin (regular GPIO)
-        8 * 4
+         &sam4l::gpio::PA[20], // P8
+         &sam4l::gpio::PC[16], // SENSE_PWR_EN
+         &sam4l::gpio::PC[17], // NRF_PWR_EN
+         &sam4l::gpio::PC[18], // RF233_PWR_EN
+         &sam4l::gpio::PC[19]  // TRNG_PWR_EN
+         ],
+        11 * 4
     );
 
     let gpio = static_init!(
@@ -333,9 +349,11 @@ pub unsafe fn reset_handler() {
 
     // # LEDs
     let led_pins = static_init!(
-        [(&'static sam4l::gpio::GPIOPin, capsules::led::ActivationMode); 1],
-        [(&sam4l::gpio::PC[10], capsules::led::ActivationMode::ActiveHigh)],
-        64/8);
+        [(&'static sam4l::gpio::GPIOPin, capsules::led::ActivationMode); 2],
+        [(&sam4l::gpio::PC[22], capsules::led::ActivationMode::ActiveHigh),
+         (&sam4l::gpio::PC[10], capsules::led::ActivationMode::ActiveHigh)
+        ],
+        128/8);
     let led = static_init!(
         capsules::led::LED<'static, sam4l::gpio::GPIOPin>,
         capsules::led::LED::new(led_pins),

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -122,7 +122,7 @@ impl<'a, A: AdcSingle + AdcContinuous + 'a> Driver for ADC<'a, A> {
                 // FREQUENCY are used, leaving 8 bits for CHANNEL.
                 let channel = (data & 0xFF) as u8;
                 let frequency = (data >> 8) as u32;
-                self.sample_continuous(channel, frequency)
+                self.sample_continuous(channel, frequency, appid)
             },
 
             // default

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -5,22 +5,23 @@
 
 use core::cell::Cell;
 use kernel::{AppId, Callback, Container, Driver, ReturnCode};
-use kernel::hil::adc::{Client, AdcSingle, AdcContinuous};
+use kernel::hil::adc::{Client, AdcSingle, AdcContinuous, AdcContinuousFast, AdcContinuousVeryFast};
 
 #[derive(Default)]
 pub struct AppData {
     channel: Option<u8>,
-    callback: Option<Callback>,
+    sd_callback: Option<Callback>,
+    int_callback: Option<Callback>,
 }
 
-pub struct ADC<'a, A: AdcSingle + AdcContinuous + 'a> {
+pub struct ADC<'a, A: AdcSingle + AdcContinuous + AdcContinuousFast + AdcContinuousVeryFast + 'a> {
     adc: &'a A,
     channel: Cell<Option<u8>>,
     app: Container<AppData>,
     mode: Cell<bool>,
 }
 
-impl<'a, A: AdcSingle + AdcContinuous + 'a> ADC<'a, A> {
+impl<'a, A: AdcSingle + AdcContinuous + AdcContinuousFast + AdcContinuousVeryFast + 'a> ADC<'a, A> {
     pub fn new(adc: &'a A, container: Container<AppData>) -> ADC<'a, A> {
         ADC {
             adc: adc,
@@ -50,7 +51,7 @@ impl<'a, A: AdcSingle + AdcContinuous + 'a> ADC<'a, A> {
             .unwrap_or(ReturnCode::ENOMEM)
     }
 
-    fn sample_continuous (&self, channel: u8, frequency: u32, appid: AppId) -> ReturnCode {
+    fn sample_continuous (&self, channel: u8, interval: u32, appid: AppId) -> ReturnCode {
         self.mode.set(true);
         self.app
             .enter(appid, |app, _| {
@@ -58,7 +59,39 @@ impl<'a, A: AdcSingle + AdcContinuous + 'a> ADC<'a, A> {
 
                 if self.channel.get().is_none() {
                     self.channel.set(Some(channel));
-                    self.adc.sample_continuous(channel, frequency)
+                    self.adc.sample_continuous(channel, interval)
+                } else {
+                    ReturnCode::SUCCESS
+                }
+            })
+            .unwrap_or(ReturnCode::ENOMEM)
+    }
+
+    fn sample_continuous_fast (&self, channel: u8, interval: u32, appid: AppId) -> ReturnCode {
+        self.mode.set(true);
+        self.app
+            .enter(appid, |app, _| {
+                app.channel = Some(channel);
+
+                if self.channel.get().is_none() {
+                    self.channel.set(Some(channel));
+                    self.adc.sample_continuous_fast(channel, interval)
+                } else {
+                    ReturnCode::SUCCESS
+                }
+            })
+            .unwrap_or(ReturnCode::ENOMEM)
+    }
+
+    fn sample_continuous_very_fast (&self, channel: u8, interval: u32, appid: AppId) -> ReturnCode {
+        self.mode.set(true);
+        self.app
+            .enter(appid, |app, _| {
+                app.channel = Some(channel);
+
+                if self.channel.get().is_none() {
+                    self.channel.set(Some(channel));
+                    self.adc.sample_continuous_very_fast(channel, interval)
                 } else {
                     ReturnCode::SUCCESS
                 }
@@ -70,17 +103,20 @@ impl<'a, A: AdcSingle + AdcContinuous + 'a> ADC<'a, A> {
         self.adc.cancel_sampling()
     }
 
-    fn nearest_interval (&self, interval: u32) -> ReturnCode {
+    fn compute_interval (&self, interval: u32) -> u32{
+        self.adc.compute_interval(interval)
+    }
 
-        // TODO: Unsure if this is the correct way to call sample_frequency
-        //       (unsure how callback for return value gets called).
+    fn compute_interval_fast (&self, interval: u32) -> u32{
+        self.adc.compute_interval_fast(interval)
+    }
 
-        self.adc.nearest_interval(interval)
+    fn compute_interval_very_fast (&self, interval: u32) -> u32{
+        self.adc.compute_interval_very_fast(interval)
     }
 }
 
-// The if statements are a hacky way to discriminate. Figure out a better way.
-impl<'a, A: AdcSingle + AdcContinuous + 'a> Client for ADC<'a, A> {
+impl<'a, A: AdcSingle + AdcContinuous + AdcContinuousFast + AdcContinuousVeryFast + 'a> Client for ADC<'a, A> {
     fn sample_done(&self, sample: u16) {
         self.channel.get().map(|cur_channel| {
             if !self.mode.get() {
@@ -90,7 +126,7 @@ impl<'a, A: AdcSingle + AdcContinuous + 'a> Client for ADC<'a, A> {
                 if !self.mode.get() {
                     app.channel = None;
                 }
-                app.callback.map(|mut cb| cb.schedule(0, cur_channel as usize, sample as usize));
+                app.sd_callback.map(|mut cb| cb.schedule(0, cur_channel as usize, sample as usize));
             } else if app.channel.is_some() {
                 self.channel.set(app.channel);
             });
@@ -99,35 +135,27 @@ impl<'a, A: AdcSingle + AdcContinuous + 'a> Client for ADC<'a, A> {
             self.channel.get().map(|next_channel| { self.adc.sample(next_channel); });
         }
     }
-
-    fn interval_computed(&self, interval: u32) {
-        self.channel.get().map(|cur_channel| {
-            if !self.mode.get() {
-                self.channel.set(None);
-            }
-            self.app.each(|app| if app.channel == Some(cur_channel) {
-                if !self.mode.get() {
-                    app.channel = None;
-                }
-                app.callback.map(|mut cb| cb.schedule(0, cur_channel as usize, interval as usize));
-            } else if app.channel.is_some() {
-                self.channel.set(app.channel);
-            });
-        });
-    }
 }
 
-impl<'a, A: AdcSingle + AdcContinuous + 'a> Driver for ADC<'a, A> {
+impl<'a, A: AdcSingle + AdcContinuous + AdcContinuousFast + AdcContinuousVeryFast + 'a> Driver for ADC<'a, A> {
     fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             // subscribe to ADC sample done
             0 => {
                 self.app
                     .enter(callback.app_id(),
-                           |app, _| { app.callback = Some(callback); })
+                           |app, _| { app.sd_callback = Some(callback); })
+                    .unwrap_or(());
+                ReturnCode::SUCCESS
+            },
+            1 => {
+                self.app
+                    .enter(callback.app_id(),
+                           |app, _| { app.int_callback = Some(callback); })
                     .unwrap_or(());
                 ReturnCode::SUCCESS
             }
+                        
 
             // default
             _ => ReturnCode::ENOSUPPORT,
@@ -147,16 +175,35 @@ impl<'a, A: AdcSingle + AdcContinuous + 'a> Driver for ADC<'a, A> {
             3 => {
                 // Due to the 32-bit limit of the data parameter to the
                 // `command()' system call, only the lower 24 bits of
-                // FREQUENCY are used, leaving 8 bits for CHANNEL.
+                // interval are used, leaving 8 bits for CHANNEL.
                 let channel = (data & 0xFF) as u8;
-                let frequency = (data >> 8) as u32;
-                self.sample_continuous(channel, frequency, appid)
+                let interval = (data >> 8) as u32;
+                if self.compute_interval(0) <= interval {
+                    self.sample_continuous(channel, interval, appid)
+                } else if self.compute_interval_fast(0) <= interval {
+                    self.sample_continuous_fast(channel, interval, appid)
+                } else {
+                    self.sample_continuous_very_fast(channel, interval, appid)
+                }
+            
             },
             4 => {
                 self.cancel_sampling()
             },
             5 => {
-                self.nearest_interval(data as u32)
+                let interval = data as u32;
+                let precise_interval;
+                if self.compute_interval(0) <= interval {
+                    precise_interval = self.compute_interval(interval) 
+                } else if self.compute_interval_fast(0) <= interval {
+                    precise_interval = self.compute_interval_fast(interval) 
+                } else {
+                    precise_interval = self.compute_interval_very_fast(interval) 
+                }
+                self.app.each(|app| { 
+                    app.int_callback.map(|mut cb| cb.schedule(0, 0, precise_interval as usize));
+                });
+                ReturnCode::SUCCESS
             },
 
             // default

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -65,6 +65,10 @@ impl<'a, A: AdcSingle + AdcContinuous + 'a> ADC<'a, A> {
             })
             .unwrap_or(ReturnCode::ENOMEM)
     }
+
+    fn cancel_sampling (&self) -> ReturnCode {
+        self.adc.cancel_sampling()
+    }
 }
 
 // The if statements are a hacky way to discriminate. Figure out a better way.
@@ -123,6 +127,9 @@ impl<'a, A: AdcSingle + AdcContinuous + 'a> Driver for ADC<'a, A> {
                 let channel = (data & 0xFF) as u8;
                 let frequency = (data >> 8) as u32;
                 self.sample_continuous(channel, frequency, appid)
+            },
+            4 => {
+                self.cancel_sampling()
             },
 
             // default

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -190,15 +190,41 @@ impl adc::AdcSingle for Adc {
 }
 
 /// Not implemented yet. -pal 12/22/16
-impl adc::AdcContinuous for Adc {
+impl adc::AdcContinuous for Adc { 
+    // Three different frequencies 1kHz 32kHz 1MHz, do we select at boot or 
+    // do we allow runtime change?
     type Frequency = adc::Freq1KHz;
 
     fn compute_interval(&self, interval: u32) -> u32 {
         interval
+        // How should we round sample interval?
+        // The interval time unit is 1/Frequency? We return the most precise 
+        // alignment with the actual clock.
+        // The system clock rate can be sampled from?
+        //      - get_system_frequency()? chips/sam4l/src/pm.rs
+        // Do we have to use RCSYS or can we use RC32K, RCFAST( how do we specify
+        // frequency), et cetera.
+        // Why do you never disable the clocks ? 
+        // line 125: What is this fixed delay?
     }
 
     fn sample_continuous(&self, _channel: u8, _interval: u32) -> ReturnCode {
         ReturnCode::FAIL
+        // Initialize clocks, just like in ADCSingle::initialize().
+        // Probably insert fixed delay.
+        // Enable the ADC.
+        // Wait till Ready.
+        // Config + Enable
+        // Basically combine the code from initialize() and sample() above.
+        // Difference: handle_interrupt() SHOULD NOT disable interrupt after it
+        // is done. Do that in cancel_sampling.
+        //
+        // handle_interrupt(): Do we add it to the AdcSingle and AdcContinuous
+        // traits since it needs to be different for both of them.
+        //
+        // How to sample: If the client wants to sample once per `n conversions,
+        // we add a counter to handle_interrupt() and when it hits `n we reset it
+        // and callback the client with sample_done().
     }
 
     fn cancel_sampling(&self) -> ReturnCode {

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -325,6 +325,12 @@ impl adc::AdcContinuous for Adc {
         // TODO should disable clocks
         ReturnCode::SUCCESS
     }
+
+    fn nearest_interval(&self, interval: u32) -> ReturnCode {
+        let interval = self.compute_interval(interval);
+        self.client.get().map(|client| { client.interval_computed(interval); });
+        ReturnCode::SUCCESS
+    }
 }
 
 interrupt_handler!(adcife_handler, ADCIFE);

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -250,7 +250,12 @@ impl adc::AdcContinuous for Adc {
             let cr2: u32 = (1 << 10) | (1 << 8) | (1 << 4);
             regs.cr.set(cr2);
 
-            // 6. Configure the ADCIFE
+        }
+
+        if _channel > 14 {
+            return ReturnCode::EINVAL;
+        } else {
+            // Configure the ADCIFE
             unsafe{
                 let freq = Self::Frequency::frequency();
 
@@ -266,14 +271,9 @@ impl adc::AdcContinuous for Adc {
                 self.max_frequency.set(sys_freq / (1 << (clock_divider + 2)));
             }
 
-
-
             while regs.sr.get() & (0x51000000) != 0x51000000 {}
-        }
 
-        if _channel > 14 {
-            return ReturnCode::EINVAL;
-        } else {
+            
             self.last_sample.set(false);
             self.channel.set(_channel);
 

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -205,19 +205,19 @@ impl adc::AdcContinuous for Adc {
     // do we allow runtime change?
     type Frequency = adc::Freq1KHz;
 
-    fn compute_interval(&self, interval: u32) -> u32 {
+    fn compute_frequency(&self, frequency: u32) -> u32 {
         // Internal Timer Trigger Period= (ITMC+1)*T(CLK_ADC)
         // f(itimer_timeout) = f(GCLK) / (ITMC + 1)
         // ITMC = (f(GCLK)/F(itimer_timeout) - 1)
-        if interval == 0 {
+        if frequency == 0 {
             return 1; // Minimum possible frequency
         }
 
-        if interval > Self::Frequency::frequency() { // Maximum possible frequency
+        if frequency > Self::Frequency::frequency() { // Maximum possible frequency
             return Self::Frequency::frequency();
         }
 
-        let itmc: u32 = (self.max_frequency.get() / interval ) - 1;
+        let itmc: u32 = (self.max_frequency.get() / frequency ) - 1;
         return self.max_frequency.get() / (itmc + 1);
     }
 
@@ -292,8 +292,8 @@ impl adc::AdcContinuous for Adc {
             regs.cr.set(2); // stop timer before setting it up
 
             // Set interrupt timeout
-            let actual_interval = self.compute_interval(_interval);
-            let itmc = (self.max_frequency.get() / actual_interval ) - 1;
+            let actual_frequency = self.compute_frequency(_interval);    // TODO: Should be either frequency or interval, not both.
+            let itmc = (self.max_frequency.get() / actual_frequency ) - 1;
             regs.itimer.set(cmp::max(cmp::min(itmc, 0x0000FFFF), 0));
             // Enable end of conversion interrupt
             regs.ier.set(1);

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -201,9 +201,26 @@ impl adc::AdcSingle for Adc {
 
 /// Not implemented yet. -pal 12/22/16
 impl adc::AdcContinuous for Adc { 
-    // Three different frequencies 1kHz 32kHz 1MHz, do we select at boot or 
-    // do we allow runtime change?
+    
+    // Unit is Hz.
     type Frequency = adc::Freq1KHz;
+
+    // Unit is microsecond for parameter `interval` and return value.
+    fn compute_interval(&self, interval: u32) -> u32 {
+
+        // (1000000 microsecond / 1 sec) * (1 sec / FREQUENCY samples)
+        // gives minimum supported interval.
+        let min_interval: u32 = cmp::max(1000000 / Self::Frequency::frequency(), 1);
+        if interval <= min_interval {
+            return min_interval;
+        }
+
+        if interval % min_interval > 0 {
+            return (interval / min_interval + 1) * min_interval;
+        } else {
+            return interval;
+        }
+    }
 
     fn compute_frequency(&self, frequency: u32) -> u32 {
         // Internal Timer Trigger Period= (ITMC+1)*T(CLK_ADC)

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -32,6 +32,7 @@ impl Frequency for Freq1KHz {
 
 pub trait AdcContinuous {
     type Frequency: Frequency;
+    fn compute_interval(&self, interval: u32) -> u32;
     fn compute_frequency(&self, frequency: u32) -> u32;
     fn sample_continuous(&self, channel: u8, interval: u32) -> ReturnCode;
     fn cancel_sampling(&self) -> ReturnCode;

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -4,7 +4,6 @@ use returncode::ReturnCode;
 pub trait Client {
     /// Called when a sample is ready.
     fn sample_done(&self, sample: u16);
-    fn interval_computed(&self, interval: u32);
 }
 
 /// Simple interface for reading a single ADC sample on any channel.
@@ -31,11 +30,35 @@ impl Frequency for Freq1KHz {
     }
 }
 
+pub struct Freq3KHz;
+impl Frequency for Freq3KHz {
+    fn frequency() -> u32 {
+        3350
+    }
+}
+
+pub struct Freq33KHz;
+impl Frequency for Freq33KHz {
+    fn frequency() -> u32 {
+        33000
+    }
+}
+
 pub trait AdcContinuous {
     type Frequency: Frequency;
     fn compute_interval(&self, interval: u32) -> u32;
-    fn compute_frequency(&self, frequency: u32) -> u32;
     fn sample_continuous(&self, channel: u8, interval: u32) -> ReturnCode;
     fn cancel_sampling(&self) -> ReturnCode;
-    fn nearest_interval (&self, interval: u32) -> ReturnCode;
+}
+
+pub trait AdcContinuousFast: AdcContinuous {
+    type FrequencyFast: Frequency;
+    fn compute_interval_fast(&self, interval: u32) -> u32;
+    fn sample_continuous_fast(&self, channel: u8, interval: u32) -> ReturnCode;
+}
+
+pub trait AdcContinuousVeryFast: AdcContinuous {
+    type FrequencyVeryFast: Frequency;
+    fn compute_interval_very_fast(&self, interval: u32) -> u32;
+    fn sample_continuous_very_fast(&self, channel: u8, interval: u32) -> ReturnCode;
 }

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -32,7 +32,7 @@ impl Frequency for Freq1KHz {
 
 pub trait AdcContinuous {
     type Frequency: Frequency;
-    fn compute_interval(&self, interval: u32) -> u32;
+    fn compute_frequency(&self, frequency: u32) -> u32;
     fn sample_continuous(&self, channel: u8, interval: u32) -> ReturnCode;
     fn cancel_sampling(&self) -> ReturnCode;
 }

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -4,6 +4,7 @@ use returncode::ReturnCode;
 pub trait Client {
     /// Called when a sample is ready.
     fn sample_done(&self, sample: u16);
+    fn interval_computed(&self, interval: u32);
 }
 
 /// Simple interface for reading a single ADC sample on any channel.
@@ -36,4 +37,5 @@ pub trait AdcContinuous {
     fn compute_frequency(&self, frequency: u32) -> u32;
     fn sample_continuous(&self, channel: u8, interval: u32) -> ReturnCode;
     fn cancel_sampling(&self) -> ReturnCode;
+    fn nearest_interval (&self, interval: u32) -> ReturnCode;
 }

--- a/userland/examples/adc_cont/Makefile
+++ b/userland/examples/adc_cont/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/adc_cont/main.c
+++ b/userland/examples/adc_cont/main.c
@@ -29,22 +29,23 @@ void cb(int value) {
 int main(void) {
   putstr("[Tock] ADC Continuous Test\n");
 
+  // 10000 microsecond sampling interval.
+  // 100 Hz sampling frequency
+  uint32_t interval = 400;
+  uint32_t actual_interval = adc_nearest_interval(interval);
   // Read this asynchronously
   // Sample channel 1 at 100 Hz. This is pin A1.
-  adc_read_cont_sample(1, 100, cb);
+  adc_read_cont_sample(1, interval, cb);
 
-  // 100 Hz sampling frequency means
-  // 10000 microsecond sampling interval.
-  uint32_t interval = 10000;
-  uint32_t actual_interval = adc_nearest_interval(interval);
 
-  printf("Requested sampling interval %" PRIu32 " microsecond. Nearest supported interval is %" PRIu32 " microsecond.\n",
+  printf("Requested sampling interval %" PRIu32 " microseconds. Nearest "
+         "supported interval is %" PRIu32 " microseconds.\n",
          interval, actual_interval);
 
   while (1) {
-    // sample for 5 seconds and then stop.
-    delay_ms(5000);
-    adc_cancel_sampling();
+    // sample for 5 seconds and then stop. XXX fix
+    delay_ms(1000);
+   // adc_cancel_sampling();
     printf("Measured average of %d over %d samples.\nLast sample is %i mV\n",
             total/num_samples, num_samples, last_sample);
     total = 0;

--- a/userland/examples/adc_cont/main.c
+++ b/userland/examples/adc_cont/main.c
@@ -8,6 +8,8 @@
 #include <timer.h>
 #include <adc.h>
 
+#include <inttypes.h>
+
 void cb(int value);
 
 // Race conditions possible 
@@ -28,8 +30,16 @@ int main(void) {
   putstr("[Tock] ADC Continuous Test\n");
 
   // Read this asynchronously
-  // Sample channel 1. This is pin A1.
+  // Sample channel 1 at 100 Hz. This is pin A1.
   adc_read_cont_sample(1, 100, cb);
+
+  // 100 Hz sampling frequency means
+  // 10000 microsecond sampling interval.
+  uint32_t interval = 10000;
+  uint32_t actual_interval = adc_nearest_interval(interval);
+
+  printf("Requested sampling interval %" PRIu32 " microsecond. Nearest supported interval is %" PRIu32 " microsecond.\n",
+         interval, actual_interval);
 
   while (1) {
     // sample for 5 seconds and then stop.

--- a/userland/examples/adc_cont/main.c
+++ b/userland/examples/adc_cont/main.c
@@ -16,26 +16,26 @@ static int last_sample = 0;
 static int num_samples = 0;
 
 void cb(int value) {
-  total += value;
+  // 12 bit, reference = VCC/2, gain = 0.5
+  // millivolts = ((reading * 2) / (2^12 - 1)) * (3.3 V / 2) * 1000
+  int millivolts = (value * 3300) / 4095;
+  total += millivolts;
   ++num_samples;
-  last_sample = value;
+  last_sample = millivolts;
 }
 
 int main(void) {
   putstr("[Tock] ADC Continuous Test\n");
 
-  // Setup the ADC. TODO no, don't do that!
-  // Unless you make init common for both?
- // adc_initialize();
- // delay_ms(1000);
-  
   // Read this asynchronously
   // Sample channel 1. This is pin A1.
-  adc_read_cont_sample(1, 1001, cb);
+  adc_read_cont_sample(1, 100, cb);
 
   while (1) {
-    delay_ms(1000);
-    printf("Measured average of %d over %d samples. Last sample is %d\n",
+    // sample for 5 seconds and then stop.
+    delay_ms(5000);
+    adc_cancel_sampling();
+    printf("Measured average of %d over %d samples.\nLast sample is %i mV\n",
             total/num_samples, num_samples, last_sample);
     total = 0;
     num_samples = 0;

--- a/userland/examples/adc_cont/main.c
+++ b/userland/examples/adc_cont/main.c
@@ -1,0 +1,44 @@
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <tock.h>
+#include <console.h>
+#include <timer.h>
+#include <adc.h>
+
+
+// RACE CONDITIONS!
+static int total = 0;
+static int last_sample = 0;
+static int num_samples = 0;
+
+void cb(int value) {
+  total += value;
+  ++num_samples;
+  last_sample = value;
+}
+
+int main(void) {
+  putstr("[Tock] ADC Continuous Test\n");
+
+  // Setup the ADC
+  adc_initialize();
+  delay_ms(1000);
+  
+  // Read this asynchronously
+  // Sample channel 1. This is pin A1.
+  adc_read_cont_sample(1, 0, cb);
+
+  while (1) {
+    delay_ms(1000);
+    printf("Measured average of %d over %d samples. Last sample is %d\n",
+            total/num_samples, num_samples, last_sample);
+    num_samples = 0;
+    total = 0;
+
+  }
+
+  return 0;
+}

--- a/userland/examples/adc_cont/main.c
+++ b/userland/examples/adc_cont/main.c
@@ -8,8 +8,9 @@
 #include <timer.h>
 #include <adc.h>
 
+void cb(int value);
 
-// RACE CONDITIONS!
+// Race conditions possible 
 static int total = 0;
 static int last_sample = 0;
 static int num_samples = 0;
@@ -23,20 +24,21 @@ void cb(int value) {
 int main(void) {
   putstr("[Tock] ADC Continuous Test\n");
 
-  // Setup the ADC
-  adc_initialize();
-  delay_ms(1000);
+  // Setup the ADC. TODO no, don't do that!
+  // Unless you make init common for both?
+ // adc_initialize();
+ // delay_ms(1000);
   
   // Read this asynchronously
   // Sample channel 1. This is pin A1.
-  adc_read_cont_sample(1, 0, cb);
+  adc_read_cont_sample(1, 1001, cb);
 
   while (1) {
     delay_ms(1000);
     printf("Measured average of %d over %d samples. Last sample is %d\n",
             total/num_samples, num_samples, last_sample);
-    num_samples = 0;
     total = 0;
+    num_samples = 0;
 
   }
 

--- a/userland/libtock/adc.c
+++ b/userland/libtock/adc.c
@@ -9,8 +9,14 @@ struct adc_data {
   bool fired;
 };
 
+struct adc_interval {
+  int value;
+  bool computed;
+};
+
 static struct adc_data result = { .fired = false };
 static void(*cont_cb)(int);
+
 // Internal callback for faking synchronous reads
 static void adc_cb(__attribute__ ((unused)) int callback_type,
                    __attribute__ ((unused)) int channel,
@@ -25,8 +31,25 @@ static void adc_cb(__attribute__ ((unused)) int callback_type,
       cont_cb(reading);
 }
 
+static struct adc_interval interval_result = { .computed = false };
+
+// Internal callback for determining closest sampling interval
+// to that requested by user.
+static void adc_interval_cb(__attribute__ ((unused)) int callback_type,
+                            __attribute__ ((unused)) int channel,
+                            int value,
+                            void* ud) {
+  struct adc_interval *interval = (struct adc_data*) ud;
+  interval->value = value;
+  interval->computed = true;
+}
+
 int adc_set_callback(subscribe_cb callback, void* callback_args) {
     return subscribe(DRIVER_NUM_ADC, 0, callback, callback_args);
+}
+
+int adc_set_interval_callback(subscribe_cb callback, void* callback_args) {
+  return subscribe(DRIVER_NUM_ADC, 1, callback, callback_args);
 }
 
 int adc_initialize(void) {
@@ -40,6 +63,14 @@ int adc_single_sample(uint8_t channel) {
 int adc_cont_sample(uint8_t channel, uint32_t frequency) {
   uint32_t chan_freq = (frequency << 8) | (channel);
   return command(DRIVER_NUM_ADC, 3, chan_freq);
+}
+
+int adc_cancel_sampling(void) {
+    return command(DRIVER_NUM_ADC, 4, 0);
+}
+
+int adc_compute_interval(uint32_t interval) {
+  return command(DRIVER_NUM_ADC, 5, interval);
 }
 
 int adc_read_single_sample(uint8_t channel) {
@@ -71,6 +102,20 @@ int adc_read_cont_sample(uint8_t channel, uint32_t frequency, void (*cb)(int)) {
   return err;
 }
 
-int adc_cancel_sampling(void) {
-    return command(DRIVER_NUM_ADC, 4, 0);
+uint32_t adc_nearest_interval(uint32_t interval) {
+  int err;
+
+  interval_result.computed = false;
+  // Callback used as a mechanism for retrieving the value
+  // of the nearest achievable sampling interval.
+  err = adc_set_interval_callback(adc_interval_cb, (void*) &interval_result);
+  if (err < 0) return err;
+
+  err = adc_compute_interval(interval);
+  if (err < 0) return err;
+
+  // Wait for callback.
+  yield_for(&interval_result.computed);
+
+  return interval_result.value;
 }

--- a/userland/libtock/adc.c
+++ b/userland/libtock/adc.c
@@ -59,7 +59,7 @@ int adc_read_single_sample(uint8_t channel) {
   return result.reading;
 }
 
-int adc_read_cont_sample(uint8_t channel, uint8_t frequency, void (*cb)(int)) {
+int adc_read_cont_sample(uint8_t channel, uint32_t frequency, void (*cb)(int)) {
   int err;
 
   cont_cb = cb;

--- a/userland/libtock/adc.c
+++ b/userland/libtock/adc.c
@@ -70,3 +70,7 @@ int adc_read_cont_sample(uint8_t channel, uint32_t frequency, void (*cb)(int)) {
 
   return err;
 }
+
+int adc_cancel_sampling(void) {
+    return command(DRIVER_NUM_ADC, 4, 0);
+}

--- a/userland/libtock/adc.c
+++ b/userland/libtock/adc.c
@@ -37,9 +37,9 @@ int adc_single_sample(uint8_t channel) {
     return command(DRIVER_NUM_ADC, 2, channel);
 }
 
-int adc_cont_sample(uint8_t channel, uint32_t interval) {
-    // TODO change signature to include interval
-    return command(DRIVER_NUM_ADC, 3, channel);
+int adc_cont_sample(uint8_t channel, uint32_t frequency) {
+  uint32_t chan_freq = (frequency << 8) | (channel);
+  return command(DRIVER_NUM_ADC, 3, chan_freq);
 }
 
 int adc_read_single_sample(uint8_t channel) {
@@ -59,14 +59,14 @@ int adc_read_single_sample(uint8_t channel) {
   return result.reading;
 }
 
-int adc_read_cont_sample(uint8_t channel, uint32_t interval, void (*cb)(int)) {
+int adc_read_cont_sample(uint8_t channel, uint8_t frequency, void (*cb)(int)) {
   int err;
 
   cont_cb = cb;
   err = adc_set_callback(adc_cb, (void*) &result);
   if (err < 0) return err;
 
-  err = adc_cont_sample(channel, interval);
+  err = adc_cont_sample(channel, frequency);
 
   return err;
 }

--- a/userland/libtock/adc.c
+++ b/userland/libtock/adc.c
@@ -39,7 +39,7 @@ static void adc_interval_cb(__attribute__ ((unused)) int callback_type,
                             __attribute__ ((unused)) int channel,
                             int value,
                             void* ud) {
-  struct adc_interval *interval = (struct adc_data*) ud;
+  struct adc_interval *interval = (struct adc_interval*) ud;
   interval->value = value;
   interval->computed = true;
 }

--- a/userland/libtock/adc.h
+++ b/userland/libtock/adc.h
@@ -11,6 +11,7 @@ extern "C" {
 #define DRIVER_NUM_ADC 7
 
 int adc_set_callback(subscribe_cb callback, void* callback_args);
+int adc_set_interval_callback(subscribe_cb callback, void* callback_args);
 int adc_initialize(void);
 int adc_single_sample(uint8_t channel);
 
@@ -18,6 +19,9 @@ int adc_single_sample(uint8_t channel);
 // `command()' system call, only the lower 24 bits of
 // FREQUENCY are used, leaving 8 bits for CHANNEL.
 int adc_cont_sample(uint8_t channel, uint32_t frequency);
+int adc_cancel_sampling(void);
+
+int adc_compute_interval(uint32_t interval);
 
 // Synchronous function to read a single ADC sample.
 int adc_read_single_sample(uint8_t channel);
@@ -28,7 +32,7 @@ int adc_read_single_sample(uint8_t channel);
 // `command()' system call, only the lower 24 bits of
 // FREQUENCY are used, leaving 8 bits for CHANNEL.
 int adc_read_cont_sample(uint8_t channel, uint32_t frequency, void (*cb)(int));
-int adc_cancel_sampling(void);
+uint32_t adc_nearest_interval(uint32_t interval);
 
 #ifdef __cplusplus
 }

--- a/userland/libtock/adc.h
+++ b/userland/libtock/adc.h
@@ -13,13 +13,21 @@ extern "C" {
 int adc_set_callback(subscribe_cb callback, void* callback_args);
 int adc_initialize(void);
 int adc_single_sample(uint8_t channel);
-int adc_cont_sample(uint8_t channel, uint32_t interval);
+
+// Due to the 32-bit limit of the data parameter to the
+// `command()' system call, only the lower 24 bits of
+// FREQUENCY are used, leaving 8 bits for CHANNEL.
+int adc_cont_sample(uint8_t channel, uint32_t frequency);
 
 // Synchronous function to read a single ADC sample.
 int adc_read_single_sample(uint8_t channel);
 
-// Asynchronous function to read samples at the given interval
-int adc_read_cont_sample(uint8_t channel, uint32_t interval, void (*cb)(int));
+// Asynchronous function to read samples at the given FREQUENCY,
+// with units of Hz.
+// Due to the 32-bit limit of the data parameter to the
+// `command()' system call, only the lower 24 bits of
+// FREQUENCY are used, leaving 8 bits for CHANNEL.
+int adc_read_cont_sample(uint8_t channel, uint32_t frequency, void (*cb)(int));
 
 #ifdef __cplusplus
 }

--- a/userland/libtock/adc.h
+++ b/userland/libtock/adc.h
@@ -13,9 +13,13 @@ extern "C" {
 int adc_set_callback(subscribe_cb callback, void* callback_args);
 int adc_initialize(void);
 int adc_single_sample(uint8_t channel);
+int adc_cont_sample(uint8_t channel, uint32_t interval);
 
 // Synchronous function to read a single ADC sample.
 int adc_read_single_sample(uint8_t channel);
+
+// Asynchronous function to read samples at the given interval
+int adc_read_cont_sample(uint8_t channel, uint32_t interval, void (*cb)(int));
 
 #ifdef __cplusplus
 }

--- a/userland/libtock/adc.h
+++ b/userland/libtock/adc.h
@@ -28,6 +28,7 @@ int adc_read_single_sample(uint8_t channel);
 // `command()' system call, only the lower 24 bits of
 // FREQUENCY are used, leaving 8 bits for CHANNEL.
 int adc_read_cont_sample(uint8_t channel, uint32_t frequency, void (*cb)(int));
+int adc_cancel_sampling(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hello, we are Mateo Garcia and Petar Penkov, CURIS students at Stanford.

We propose an implementation of ADC Continuous based on Philip Levis' proposed interface. The implementation uses configurable clocks (RCSYS/RC32K) rather than the internal timer and currently supports two modes. The first is based on the RC32K clock and supports sampling at maximum frequency of 1KHz, and the other one is based on the RCSYS clock and supports sampling at maximum frequency of 3.35KHz. 

We also include an implementation under at third mode that uses the RCFAST clock but we found that when the ADC is configured to use that clock, no interrupts happen. We are hoping to get feedback on our implementation and ideas about resolving the RCFAST clock issue. 

Notes on our implementation:

- The "Freq33KHz" defined in /kernel/src/hil/adc.rs that AdcContinuousVeryFast is based on is arbitrary as we could not find the maximum sampling frequency under RCFAST. 

- The code at capsules level will select the slowest clock that grants sampling at an interval at least as large as the requested interval. Example: sampling at an interval of 1000 microseconds will use the RC32K clock, and sampling at an interval of 750 microseconds will use the RCSYS clock because the best that RC32k can give is 1000 microseconds.

- The rounding of interval in `compute_interval()` in /chips/sam4l/src/adc.rs is done to the floor of the requested interval, meaning if intervals of 1000 microseconds and 2000 microseconds are available, and an interval of 1999 microseconds is requested, 1000 microseconds will be granted.

- Further on intervals - the unit of all intervals is a microsecond, and the unit of all frequencies is a hertz.

- We use a different version of the main file to test. The reason is that with the master branch main file, usb prints garbage. What we use instead the main file in Shane Leonard's fork. It can be found [here](https://github.com/shaneleonard/tock) under the imix-v2_0 branch.


