### PR TITLE
Generalize MPU subregions and use where possible

### DIFF
--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -208,7 +208,6 @@ impl kernel::mpu::MPU for MPU {
 
             let xn = execute as u32;
             let ap = access as u32;
-            let size = region_len.exp::<u32>() - 1;
             Some(unsafe {
                 Region::new((region_start | 1 << 4 | (region_num & 0xf)) as u32,
                             1 | subregion_mask << 8 | (region_len.exp::<u32>() - 1) << 1 |

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,5 +1,3 @@
-use common::math::PowerOfTwo;
-
 #[derive(Debug)]
 pub enum AccessPermission {
     //                                 Privileged  Unprivileged
@@ -20,14 +18,41 @@ pub enum ExecutePermission {
     ExecutionNotPermitted = 0b1,
 }
 
+pub struct Region {
+    base_address: u32,
+    attributes: u32,
+}
+
+impl Region {
+    pub unsafe fn new(base_address: u32, attributes: u32) -> Region {
+        Region {
+            base_address: base_address,
+            attributes: attributes,
+        }
+    }
+
+    pub fn empty() -> Region {
+        Region {
+            base_address: 0,
+            attributes: 0,
+        }
+    }
+
+    pub fn base_address(&self) -> u32 {
+        self.base_address
+    }
+
+    pub fn attributes(&self) -> u32 {
+        self.attributes
+    }
+}
 
 pub trait MPU {
     /// Enables MPU, allowing privileged software access to the default memory
     /// map.
     fn enable_mpu(&self);
 
-    /// Sets the base address, size and access attributes of the given MPU
-    /// region number.
+    /// Creates a new MPU-specific memory protection region
     ///
     /// `region_num`: an MPU region number 0-7
     /// `start_addr`: the region base address. Lower bits will be masked
@@ -36,25 +61,30 @@ pub trait MPU {
     /// `execute`   : whether to enable code execution from this region
     /// `ap`        : access permissions as defined in Table 4.47 of the user
     ///               guide.
-    fn set_mpu(&self,
-               region_num: u32,
-               start_addr: u32,
-               len: PowerOfTwo,
-               subregion_mask: u8,
-               execute: ExecutePermission,
-               ap: AccessPermission);
+    fn create_region(region_num: usize,
+                     start: usize,
+                     len: usize,
+                     execute: ExecutePermission,
+                     access: AccessPermission)
+                     -> Option<Region>;
+
+    /// Sets the base address, size and access attributes of the given MPU
+    /// region number.
+    fn set_mpu(&self, region: Region);
 }
 
 /// Noop implementation of MPU trait
 impl MPU for () {
     fn enable_mpu(&self) {}
 
-    fn set_mpu(&self,
-               _: u32,
-               _: u32,
-               _: PowerOfTwo,
-               _: u8,
-               _: ExecutePermission,
-               _: AccessPermission) {
+    fn create_region(_: usize,
+                     _: usize,
+                     _: usize,
+                     _: ExecutePermission,
+                     _: AccessPermission)
+                     -> Option<Region> {
+        Some(Region::empty())
     }
+
+    fn set_mpu(&self, _: Region) {}
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -392,7 +392,11 @@ impl<'a> Process<'a> {
                                      region.get().1.as_num::<u32>() as usize,
                                      mpu::ExecutePermission::ExecutionPermitted,
                                      mpu::AccessPermission::ReadWrite) {
-                None => {},
+                None =>
+                    panic!("Unexpected: Infeasible MPU allocation: Num: {}, \
+                           Base: {:#x}, Length: {:#x}", i + 3,
+                               region.get().0 as usize,
+                               region.get().1.as_num::<u32>()),
                 Some(region) => mpu.set_mpu(region)
             }
         }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -340,95 +340,63 @@ impl<'a> Process<'a> {
         // Text segment read/execute (no write)
         let text_start = self.text.as_ptr() as usize;
         let text_len = self.text.len();
-        if text_len.count_ones() != 1 {
-            panic!("Tock MPU does not currently handle complex region sizes");
-        }
 
-        // Invariant: text_len is a power of two
-        if text_start % text_len != 0 {
-            // Text length not aligned to text start
-            let subregion_size = text_start % text_len;
-            let region_size = subregion_size * 8; // 8 subregions in a region
-            let region_start = text_start - (text_start % region_size);
-
-            if region_size + region_start - text_start < text_len {
+        match MPU::create_region(0, text_start, text_len,
+                        mpu::ExecutePermission::ExecutionPermitted,
+                        mpu::AccessPermission::ReadOnly) {
+            None =>
                 panic!("Infeasible MPU allocation. Base {:#x}, Length: {:#x}",
-                       text_start, text_len);
-            }
-
-
-            let min_subregion = (text_start - region_start) / subregion_size;
-            let max_subregion = min_subregion + text_len / subregion_size - 1;
-
-            let region_len = math::PowerOfTwo::floor(region_size as u32);
-
-            let subregion_mask = (min_subregion..(max_subregion + 1))
-                                    .fold(!0, |res, i| res & !(1 << i));
-
-            mpu.set_mpu(0,
-                        region_start as u32,
-                        region_len,
-                        subregion_mask,
-                        mpu::ExecutePermission::ExecutionPermitted,
-                        mpu::AccessPermission::ReadOnly);
-        } else {
-            // Text length aligned to text start
-            let region_len = math::PowerOfTwo::floor(text_len as u32);
-            mpu.set_mpu(0,
-                        text_start as u32,
-                        region_len,
-                        0,
-                        mpu::ExecutePermission::ExecutionPermitted,
-                        mpu::AccessPermission::ReadOnly);
+                           text_start, text_len),
+            Some(region) => mpu.set_mpu(region),
         }
 
         let data_start = self.memory.as_ptr() as usize;
         let data_len = self.memory.len();
-        if data_len.count_ones() != 1 {
-            panic!("Tock MPU does not currently handle complex region sizes");
+
+        match MPU::create_region(1, data_start, data_len,
+                        mpu::ExecutePermission::ExecutionPermitted,
+                        mpu::AccessPermission::ReadWrite) {
+            None =>
+                panic!("Infeasible MPU allocation. Base {:#x}, Length: {:#x}",
+                           data_start, data_len),
+            Some(region) => mpu.set_mpu(region)
         }
-        let data_region_len = math::PowerOfTwo::floor(data_len as u32);
-
-
-        // Data segment read/write/execute
-        mpu.set_mpu(1,
-                    data_start as u32,
-                    data_region_len,
-                    0,
-                    mpu::ExecutePermission::ExecutionPermitted,
-                    mpu::AccessPermission::ReadWrite);
 
         // Disallow access to grant region
-        let grant_size = unsafe {
+        let grant_len = unsafe {
             math::PowerOfTwo::ceiling(
                 self.memory.as_ptr().offset(self.memory.len() as isize) as u32 -
                     (self.kernel_memory_break as u32)
-            )
+            ).as_num::<u32>()
         };
         let grant_base = unsafe {
             self.memory
                 .as_ptr()
                 .offset(self.memory.len() as isize)
-                .offset(-(grant_size.as_num::<u32>() as isize))
+                .offset(-(grant_len as isize))
         };
-        mpu.set_mpu(2,
-                    grant_base as u32,
-                    grant_size,
-                    0,
-                    mpu::ExecutePermission::ExecutionNotPermitted,
-                    mpu::AccessPermission::PrivilegedOnly);
+
+        match MPU::create_region(2, grant_base as usize, grant_len as usize,
+                                 mpu::ExecutePermission::ExecutionNotPermitted,
+                                 mpu::AccessPermission::PrivilegedOnly) {
+            None =>
+                panic!("Infeasible MPU allocation. Base {:#x}, Length: {:#x}",
+                           grant_base as usize, grant_len),
+            Some(region) => mpu.set_mpu(region)
+        }
 
         // Setup IPC MPU regions
         for (i, region) in self.mpu_regions.iter().enumerate() {
-            mpu.set_mpu((i + 3) as u32,
-                        region.get().0 as u32,
-                        region.get().1,
-                        0,
-                        mpu::ExecutePermission::ExecutionPermitted,
-                        mpu::AccessPermission::ReadWrite);
+            match MPU::create_region(i + 3,
+                                     region.get().0 as usize,
+                                     region.get().1.as_num::<u32>() as usize,
+                                     mpu::ExecutePermission::ExecutionPermitted,
+                                     mpu::AccessPermission::ReadWrite) {
+                None => {},
+                Some(region) => mpu.set_mpu(region)
+            }
         }
     }
-
 
     pub fn add_mpu_region(&self, base: *const u8, size: u32) -> bool {
         if size >= 16 && size.count_ones() == 1 && (base as u32) % size == 0 {


### PR DESCRIPTION
E.g. for text sections, data sections, grants and ipc regions.
Unfortunately, this currently makes the MPU hil a bit more Cortex-M MPU
specific... working on it.

This is somewhat in progress, but I think it might be worth merging meanwhile.

At this point, it make sense to makes the `Region` type to an associated of the `MPU` trait so it can be implementation specific and cache `Regions` between calls so the calculation is required each time (should drastically reduce the context switch time). However, both of these introduce to typing issues that call for some non-trivial refactoring of the kernel crate, and I'm still experimenting with.

Fixes #382 