### PR TITLE
Clean up many userland compile warnings

### DIFF
--- a/userland/examples/nrf51_temp_sensor/temperature.c
+++ b/userland/examples/nrf51_temp_sensor/temperature.c
@@ -1,9 +1,9 @@
 #include "temperature.h"
 
-int temperature_init(subscribe_cb callback, void *ud) {
+int temperature_init(subscribe_cb callback, __attribute__ ((unused)) void *ud) {
   return subscribe(DRIVER_TEMP, 0, callback, NULL);
 }
 
-int temperature_measure() {
+int temperature_measure(void) {
   return command(DRIVER_TEMP, 0, 0);
 }

--- a/userland/examples/nrf51_temp_sensor/temperature.h
+++ b/userland/examples/nrf51_temp_sensor/temperature.h
@@ -9,7 +9,7 @@ extern "C" {
 #define DRIVER_TEMP 36
 
 int temperature_init(subscribe_cb callback, void *ud);
-int temperature_measure();
+int temperature_measure(void);
 
 #ifdef __cplusplus
 }

--- a/userland/examples/rf233/rf233.c
+++ b/userland/examples/rf233/rf233.c
@@ -22,7 +22,6 @@
 #define RADIO_RST 9
 #define RADIO_IRQ 10
 
-#define RF233_STATUS()                    rf233_status()
 /*---------------------------------------------------------------------------*/
 static int on(void);
 static int off(void);
@@ -81,10 +80,6 @@ int rf233_pending_packet(void);
 #define DEBUG_PRINTDATA       0    /* print frames to/from the radio; requires DEBUG == 1 */
 #if _DEBUG_
 #define PRINTF(...)       printf(__VA_ARGS__)
-#else
-#define PRINTF(...)
-#endif
-
 
 // Used for debugging output
 static const char* state_str(uint8_t state) {
@@ -120,10 +115,15 @@ static const char* state_str(uint8_t state) {
   }
 }
 
+#else
+#define PRINTF(...)
+#endif
+
 
 // Section 9.8 of the RF233 manual suggests recalibrating filters at
 // least every 5 minutes of operation. Transitioning out of sleep
 // resets the filters automatically.
+#pragma GCC diagnostic ignored "-Wunused-function"
 static void calibrate_filters(void) {
   PRINTF("RF233: Calibrating filters.\n");
   trx_reg_write(RF233_REG_FTN_CTRL, 0x80);

--- a/userland/examples/sensors/main.c
+++ b/userland/examples/sensors/main.c
@@ -21,13 +21,13 @@ static void timer_fired(__attribute__ ((unused)) int arg0,
                  __attribute__ ((unused)) int arg1,
                  __attribute__ ((unused)) int arg2,
                  __attribute__ ((unused)) void* ud) {
-  int light;
-  int16_t tmp006_temp;
-  int tsl2561_lux;
-  int lps25hb_pressure;
-  int si7021_temp;
-  unsigned si7021_humi;
-  int ninedof_x, ninedof_y, ninedof_z;
+  int light = 0;
+  int16_t tmp006_temp = 0;
+  int tsl2561_lux = 0;
+  int lps25hb_pressure = 0;
+  int si7021_temp = 0;
+  unsigned si7021_humi = 0;
+  int ninedof_x = 0, ninedof_y = 0, ninedof_z = 0;
 
   if (isl29035)   light = isl29035_read_light_intensity();
   if (tmp006)     tmp006_read_sync(&tmp006_temp);

--- a/userland/examples/tests/crash_dummy/main.c
+++ b/userland/examples/tests/crash_dummy/main.c
@@ -4,11 +4,11 @@
 
 volatile int* nullptr = 0;
 
-static void button_callback(int btn_num,
-                            int val,
+static void button_callback(__attribute__ ((unused)) int btn_num,
+                            __attribute__ ((unused)) int val,
                             __attribute__ ((unused)) int arg2,
                             __attribute__ ((unused)) void *ud) {
-  volatile int k = *nullptr;
+  __attribute__ ((unused)) volatile int k = *nullptr;
 }
 
 int main(void) {

--- a/userland/examples/tests/gpio/main.c
+++ b/userland/examples/tests/gpio/main.c
@@ -85,10 +85,14 @@ int main(void) {
   putstr("*********************\n");
   putstr("GPIO Test Application\n");
 
-  // uncomment whichever example you want
-  // gpio_output();
-  // gpio_input();
-  gpio_interrupt();
+  // Set mode to which test you want
+  uint8_t mode = 0;
+
+  switch (mode) {
+    case 0: gpio_interrupt(); break;
+    case 1: gpio_output(); break;
+    case 2: gpio_input(); break;
+  }
 
   return 0;
 }

--- a/userland/examples/tests/hail/main.c
+++ b/userland/examples/tests/hail/main.c
@@ -29,6 +29,7 @@ simple_ble_config_t ble_config = {
 };
 
 // Empty handler for setting BLE addresses
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
 void ble_address_set (void) {
   // nop
 }

--- a/userland/examples/tests/tmp006/main.c
+++ b/userland/examples/tests/tmp006/main.c
@@ -83,7 +83,11 @@ static void read_periodic (void) {
 int main(void) {
   putstr("Welcome to Tock in C (with libc)\nReading temperature...\n");
 
-  // uncomment whichever example you want
-  read_sync();
-  //read_periodic();
+  // Set mode to whichever example you want
+  uint8_t mode = 0;
+
+  switch (mode) {
+    case 0: read_sync(); break;
+    case 1: read_periodic(); break;
+  }
 }

--- a/userland/examples/tutorials/03_ble_scan/main.c
+++ b/userland/examples/tutorials/03_ble_scan/main.c
@@ -24,6 +24,7 @@ simple_ble_config_t ble_config = {
   .max_conn_interval = MSEC_TO_UNITS(1250, UNIT_1_25_MS)
 };
 
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
 void app_error_fault_handler(__attribute__ ((unused)) uint32_t error_code,
                              __attribute__ ((unused)) uint32_t line_num,
                              __attribute__ ((unused)) uint32_t info) {
@@ -32,6 +33,7 @@ void app_error_fault_handler(__attribute__ ((unused)) uint32_t error_code,
   // The application can continue.
 }
 
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
 void ble_address_set (void) {
   // Need to redefine this function so that we do not try to set the address
   // on the main processor.


### PR DESCRIPTION
There are still some warnings in `examples/rf233` that I'm not sure how to fix (including two unimplemented functions).