### PR TITLE
Fix compilation issues on NRF51 resulting from Rust nightly upgrade

### DIFF
--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -118,6 +118,17 @@ pub struct Platform {
 
 
 impl kernel::Platform for Platform {
+    // TODO: Why is this not inlined, you might ask? Well... we seem to be
+    // hitting some sort of LLVM codegen issue (maybe a bug in LLVM, maybe a bug
+    // in Tock), where certain compilation variants of the below match
+    // statement, when inlined, result in totally unexpected assembly that
+    // results in trying to jump to an instruction that doesn't exist. It _only_
+    // appears in thumbv6, only when the 17-valued branch below is not commented
+    // out, only with optimization level 2 or higher, and only when inlined. So
+    // for now, we're not inlining it until we resolve the issue. So far it's
+    // been raised as an issue on the Rust project:
+    // https://github.com/rust-lang/rust/issues/42248
+    #[inline(never)]
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
         where F: FnOnce(Option<&kernel::Driver>) -> R
     {

--- a/chips/nrf51/src/clock.rs
+++ b/chips/nrf51/src/clock.rs
@@ -11,6 +11,7 @@ use core::cell::Cell;
 use core::mem;
 use kernel::common::VolatileCell;
 
+#[repr(C, packed)]
 struct Registers {
     pub tasks_hfclkstart: VolatileCell<u32>,
     pub tasks_hfclkstop: VolatileCell<u32>,

--- a/chips/nrf51/src/gpio.rs
+++ b/chips/nrf51/src/gpio.rs
@@ -19,7 +19,7 @@ use peripheral_registers::{GPIO_BASE, GPIO};
 /// (GPIO Task and Event) channel, and bind the channel to the desired
 /// pin. There are 4 channels. This means that requesting an interrupt
 /// can fail, if there are already 4 allocated.
-
+#[repr(C, packed)]
 struct GpioteRegisters {
     pub out0: VolatileCell<u32>, // 0x0
     pub out1: VolatileCell<u32>, // 0x4

--- a/chips/nrf51/src/nvic.rs
+++ b/chips/nrf51/src/nvic.rs
@@ -3,6 +3,7 @@ use kernel::common::VolatileCell;
 use peripheral_interrupts::NvicIdx;
 
 const NVIC_BASE: usize = 0xE000E100;
+#[repr(packed)]
 struct NVIC {
     pub iser: [VolatileCell<u32>; 7],
     _reserved1: [u32; 25],


### PR DESCRIPTION
There were two issues, one is our fault one is (maybe) LLVM's/Rust's:

  1. A few of the register structs were not marked `repr(C)`, which allows Rust/LLVM to freely re-arrange or compress fields and it appears newer versions start doing so.

  2. As noted in rust-lang/rust#42248, the resulting assembly from the switch statement in nrf51dk's `with_driver` makes no sense (and causes a hard-fault when `driver_num` is 3) when it's optimized and inlined, so we're marking it `inline(never)` for now until we get to the bottom of it.