### PR TITLE
Consistent struct representation for nrf51dk

### DIFF
--- a/chips/nrf51/src/nvic.rs
+++ b/chips/nrf51/src/nvic.rs
@@ -3,7 +3,7 @@ use kernel::common::VolatileCell;
 use peripheral_interrupts::NvicIdx;
 
 const NVIC_BASE: usize = 0xE000E100;
-#[repr(packed)]
+#[repr(C, packed)]
 struct NVIC {
     pub iser: [VolatileCell<u32>; 7],
     _reserved1: [u32; 25],

--- a/chips/nrf51/src/peripheral_registers.rs
+++ b/chips/nrf51/src/peripheral_registers.rs
@@ -3,6 +3,7 @@
 use kernel::common::VolatileCell;
 
 pub const RTC1_BASE: usize = 0x40011000;
+#[repr(C, packed)]
 pub struct RTC1 {
     pub tasks_start: VolatileCell<u32>,
     pub tasks_stop: VolatileCell<u32>,
@@ -30,6 +31,7 @@ pub struct RTC1 {
 }
 
 pub const GPIO_BASE: usize = 0x50000000;
+#[repr(C, packed)]
 pub struct GPIO {
     _reserved1: [u32; 321],
     pub out: VolatileCell<u32>,
@@ -79,7 +81,6 @@ pub struct RNG_REGS {
 }
 
 pub const AESECB_BASE: usize = 0x4000E000;
-#[no_mangle]
 #[allow(non_snake_case)]
 #[repr(C, packed)]
 pub struct AESECB_REGS {


### PR DESCRIPTION
Minor refactoring, changed all memory-mapped I/O structs to have memory layout _#[repr(C, packed)]_ for nrf51dk.

_$ find -type f -exec grep -H 'repr' {} \;
./src/timer.rs:#[repr(C, packed)]
./src/clock.rs:#[repr(C, packed)]
./src/peripheral_registers.rs:#[repr(C, packed)]
./src/peripheral_registers.rs:#[repr(C, packed)]
./src/peripheral_registers.rs:#[repr(C, packed)]
./src/peripheral_registers.rs:#[repr(C, packed)]
./src/peripheral_registers.rs:#[repr(C, packed)]
./src/uart.rs:#[repr(C, packed)]
Binary file ./src/.gpio.rs.swp matches
./src/nvic.rs:#[repr(C, packed)]
./src/gpio.rs:#[repr(C, packed)]_
