### PR TITLE
TBF Header Version 2

### DIFF
--- a/boards/hail/README.md
+++ b/boards/hail/README.md
@@ -32,8 +32,8 @@ any standard serial program (set to 115200 baud), Tock ships with the
 install tockloader, use pip:
 
 ```bash
-(Linux): sudo pip3 install tockloader==0.6.1
-(MacOS): pip3 install tockloader==0.6.1
+(Linux): sudo pip3 install tockloader==0.7.1
+(MacOS): pip3 install tockloader==0.7.1
 ```
 
 Tockloader can read attributes from connected serial devices, and will

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -203,7 +203,7 @@ Tock boards, such as easy to manage serial connections, and the ability to
 list, add, replace, and remove applications over JTAG (or USB if a bootloader
 is installed).
 
-1. [tockloader](https://github.com/helena-project/tockloader) (version 0.6.1)
+1. [tockloader](https://github.com/helena-project/tockloader) (version 0.7.1)
 
 Installing applications over JTAG, depending on your JTAG Debugger, you will
 need one of:
@@ -216,8 +216,8 @@ need one of:
 Tock requires `tockloader` version `0.6.1`. To install:
 
 ```bash
-(Linux): sudo pip3 install tockloader==0.6.1
-(MacOS): pip3 install tockloader==0.6.1
+(Linux): sudo pip3 install tockloader==0.7.1
+(MacOS): pip3 install tockloader==0.7.1
 ```
 
 #### `openocd`

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -141,9 +141,13 @@ pub struct FunctionCall {
     pub pc: usize,
 }
 
+/// Legacy Tock Binary Format header.
+///
+/// Version 1 of the header is deprecated but can still be parsed by the kernel
+/// to support any apps that were compiled with an older version of elf2tbf.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-struct LoadInfo {
+struct TbfHeaderV1 {
     version: u32,
     total_size: u32,
     entry_offset: u32,
@@ -165,33 +169,396 @@ struct LoadInfo {
     checksum: u32,
 }
 
-/// Converts a pointer to memory to a LoadInfo struct
+/// TBF fields that must be present in all v2 headers.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct TbfHeaderV2Base {
+    version: u16,
+    header_size: u16,
+    total_size: u32,
+    flags: u32,
+    checksum: u32,
+}
+
+/// Types in TLV structures for each optional block of the header.
+#[repr(u16)]
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
+enum TbfHeaderTypes {
+    TbfHeaderMain = 1,
+    TbfHeaderWriteableFlashRegions = 2,
+    TbfHeaderPackageName = 3,
+    TbfHeaderPicOption1 = 4,
+    Unused = 5,
+}
+
+/// The TLV header (T and L).
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct TbfHeaderTlv {
+    tipe: TbfHeaderTypes,
+    length: u16,
+}
+
+/// The v2 main section for apps.
 ///
-/// This function takes a pointer to arbitrary memory and Optionally returns a
-/// LoadInfo struct. This function will validate the header checksum, but does
-/// not perform sanity or security checking on the structure
-unsafe fn parse_and_validate_load_info(address: *const u8) -> Option<&'static LoadInfo> {
-    let load_info = &*(address as *const LoadInfo);
+/// All apps must have a main section. Without it, the header is considered as
+/// only padding.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct TbfHeaderV2Main {
+    init_fn_offset: u32,
+    protected_size: u32,
+    minimum_ram_size: u32,
+}
 
-    if load_info.version != 1 {
-        return None;
+/// Writeable flash regions only need an offset and size.
+///
+/// There can be multiple (or zero) flash regions defined, so this is its own
+/// struct.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct TbfHeaderV2WriteableFlashRegion {
+    writeable_flash_region_offset: u32,
+    writeable_flash_region_size: u32,
+}
+
+/// PIC fields for kernel provided PIC fixup.
+///
+/// If an app wants the kernel to do the PIC fixup for it, it must pass this
+/// block so the kernel knows where sections are in the app binary.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct PicOption1Fields {
+    text_offset: u32,
+    data_offset: u32,
+    data_size: u32,
+    bss_memory_offset: u32,
+    bss_size: u32,
+    relocation_data_offset: u32,
+    relocation_data_size: u32,
+    got_offset: u32,
+    got_size: u32,
+    minimum_stack_length: u32,
+}
+
+/// Single header that can contain all parts of a v2 header.
+#[derive(Clone, Copy, Debug)]
+struct TbfHeaderV2 {
+    base: &'static TbfHeaderV2Base,
+    main: &'static TbfHeaderV2Main,
+    pic_values: Option<&'static PicOption1Fields>,
+    package_name: Option<&'static str>,
+    writeable_regions: Option<&'static [TbfHeaderV2WriteableFlashRegion]>,
+}
+
+/// Type that represents the fields of the Tock Binary Format header.
+///
+/// This specifies the locations of the different code and memory sections
+/// in the tock binary, as well as other information about the application.
+/// The kernel can also use this header to keep persistent state about
+/// the application.
+#[derive(Debug)]
+enum TbfHeader {
+    TbfHeaderV1(&'static TbfHeaderV1),
+    TbfHeaderV2(TbfHeaderV2),
+    Padding(&'static TbfHeaderV2Base),
+}
+
+impl TbfHeader {
+    /// Return whether this is an app or just padding between apps.
+    fn is_app(&self) -> bool {
+        match *self {
+            TbfHeader::TbfHeaderV1(_) => true,
+            TbfHeader::TbfHeaderV2(_) => true,
+            TbfHeader::Padding(_) => false,
+        }
     }
 
-    let checksum =
-        load_info.version ^ load_info.total_size ^ load_info.entry_offset ^
-        load_info.rel_data_offset ^ load_info.rel_data_size ^ load_info.text_offset ^
-        load_info.text_size ^ load_info.got_offset ^
-        load_info.got_size ^
-        load_info.data_offset ^ load_info.data_size ^ load_info.bss_mem_offset ^
-        load_info.bss_size ^
-        load_info.min_stack_len ^ load_info.min_app_heap_len ^
-        load_info.min_kernel_heap_len ^ load_info.pkg_name_offset ^ load_info.pkg_name_size;
-
-    if checksum != load_info.checksum {
-        return None;
+    /// Return whether the application is enabled or not.
+    /// Disabled applications are not started by the kernel.
+    fn enabled(&self) -> bool {
+        match *self {
+            // Header v1 has no flag for this, and therefore all apps are
+            // always enabled.
+            TbfHeader::TbfHeaderV1(_) => true,
+            TbfHeader::TbfHeaderV2(hd) => {
+                // Bit 1 of flags is the enable/disable bit.
+                hd.base.flags & 0x00000001 == 1
+            }
+            TbfHeader::Padding(_) => false,
+        }
     }
 
-    Some(load_info)
+    /// Get the total size in flash of this app or padding.
+    fn get_total_size(&self) -> u32 {
+        match *self {
+            TbfHeader::TbfHeaderV1(hd) => hd.total_size,
+            TbfHeader::TbfHeaderV2(hd) => hd.base.total_size,
+            TbfHeader::Padding(hd) => hd.total_size,
+        }
+    }
+
+    /// Return whether we want the kernel to do PIC fixup for this app. If
+    /// we ever add more than one kernel PIC fixup method this would have to
+    /// get extended to support that.
+    fn needs_pic_fixup(&self) -> bool {
+        match *self {
+            TbfHeader::TbfHeaderV1(_) => true,
+            TbfHeader::TbfHeaderV2(hd) => hd.pic_values.is_some(),
+            _ => false,
+        }
+    }
+
+    /// Return the PIC config fields in a standard format.
+    fn get_pic_fields(&self) -> Option<PicOption1Fields> {
+        match *self {
+            TbfHeader::TbfHeaderV1(hd) => {
+                let pic_values = PicOption1Fields {
+                    text_offset: hd.text_offset,
+                    data_offset: hd.data_offset,
+                    data_size: hd.data_size,
+                    bss_memory_offset: hd.bss_mem_offset,
+                    bss_size: hd.bss_size,
+                    relocation_data_offset: hd.rel_data_offset,
+                    relocation_data_size: hd.rel_data_size,
+                    got_offset: hd.got_offset,
+                    got_size: hd.got_size,
+                    minimum_stack_length: hd.min_stack_len,
+                };
+                Some(pic_values)
+            }
+            TbfHeader::TbfHeaderV2(hd) => {
+                hd.pic_values.map_or(None, |pv| {
+                    let pic_values = PicOption1Fields {
+                        text_offset: pv.text_offset,
+                        data_offset: pv.data_offset,
+                        data_size: pv.data_size,
+                        bss_memory_offset: pv.bss_memory_offset,
+                        bss_size: pv.bss_size,
+                        relocation_data_offset: pv.relocation_data_offset,
+                        relocation_data_size: pv.relocation_data_size,
+                        got_offset: pv.got_offset,
+                        got_size: pv.got_size,
+                        minimum_stack_length: pv.minimum_stack_length,
+                    };
+                    Some(pic_values)
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// Add up all of the relevant fields in header version 1, or just used the
+    /// app provided value in version 2 to get the total amount of RAM that is
+    /// needed for this app.
+    fn get_minimum_app_ram_size(&self) -> u32 {
+        match *self {
+            TbfHeader::TbfHeaderV1(hd) => {
+                let heap_len = align8!(hd.min_app_heap_len) + align8!(hd.min_kernel_heap_len);
+                let data_len = hd.data_size + hd.got_size + hd.bss_size;
+                let stack_size = align8!(hd.min_stack_len);
+                align8!(data_len + stack_size) + heap_len
+            }
+            TbfHeader::TbfHeaderV2(hd) => hd.main.minimum_ram_size,
+            _ => 0,
+        }
+    }
+
+    /// Get the number of bytes from the start of the app's region in flash that
+    /// is for kernel use only. The app cannot write this region.
+    fn get_protected_size(&self) -> u32 {
+        match *self {
+            TbfHeader::TbfHeaderV1(_) => mem::size_of::<TbfHeaderV1>() as u32,
+            TbfHeader::TbfHeaderV2(hd) => hd.main.protected_size,
+            _ => 0,
+        }
+    }
+
+    /// Get the offset from the beginning of the app's flash region where the
+    /// app should start executing.
+    fn get_init_function_offset(&self) -> u32 {
+        match *self {
+            TbfHeader::TbfHeaderV1(hd) => hd.entry_offset,
+            TbfHeader::TbfHeaderV2(hd) => hd.main.init_fn_offset,
+            _ => 0,
+        }
+    }
+
+    /// Get the name of the app.
+    fn get_package_name(&self, flash_start_addr: *const u8) -> &'static str {
+        match *self {
+            TbfHeader::TbfHeaderV1(hd) => {
+                unsafe {
+                    let package_name_byte_array =
+                        slice::from_raw_parts(flash_start_addr.offset(hd.pkg_name_offset as isize),
+                                              hd.pkg_name_size as usize);
+                    let mut app_name_str = "";
+                    let _ = str::from_utf8(package_name_byte_array).map(|name_str| {
+                        app_name_str = name_str;
+                    });
+                    app_name_str
+                }
+            }
+            TbfHeader::TbfHeaderV2(hd) => hd.package_name.unwrap_or(""),
+            _ => "",
+        }
+    }
+}
+
+/// Converts a pointer to memory to a TbfHeader struct
+///
+/// This function takes a pointer to arbitrary memory and optionally returns a
+/// TBF header struct. This function will validate the header checksum, but does
+/// not perform sanity or security checking on the structure.
+unsafe fn parse_and_validate_tbf_header(address: *const u8) -> Option<TbfHeader> {
+    let version = *(address as *const u16);
+
+    match version {
+        1 => {
+            let tbf_header = &*(address as *const TbfHeaderV1);
+
+            let checksum =
+                tbf_header.version             ^ tbf_header.total_size      ^ tbf_header.entry_offset ^
+                tbf_header.rel_data_offset     ^ tbf_header.rel_data_size   ^ tbf_header.text_offset ^
+                tbf_header.text_size           ^ tbf_header.got_offset      ^ tbf_header.got_size ^
+                tbf_header.data_offset         ^ tbf_header.data_size       ^ tbf_header.bss_mem_offset ^
+                tbf_header.bss_size            ^ tbf_header.min_stack_len   ^ tbf_header.min_app_heap_len ^
+                tbf_header.min_kernel_heap_len ^ tbf_header.pkg_name_offset ^ tbf_header.pkg_name_size;
+
+            if checksum != tbf_header.checksum {
+                None
+            } else {
+                Some(TbfHeader::TbfHeaderV1(tbf_header))
+            }
+        }
+
+        2 => {
+            let tbf_header_base = &*(address as *const TbfHeaderV2Base);
+
+            // Some sanity checking. Make sure the header isn't longer than the
+            // total app. Make sure the total app fits inside a reasonable size
+            // of flash.
+            if tbf_header_base.header_size as u32 >= tbf_header_base.total_size ||
+               tbf_header_base.total_size > 0x010000000 {
+                return None;
+            }
+
+            // Calculate checksum. The checksum is the XOR of each 4 byte word
+            // in the header.
+            let mut chunks = tbf_header_base.header_size as usize / 4;
+            let mut leftover_bytes = 0;
+            if chunks * 4 != tbf_header_base.header_size as usize {
+                chunks += 1;
+                leftover_bytes = tbf_header_base.header_size as usize - (chunks * 4);
+            }
+            let mut checksum: u32 = 0;
+            let header = slice::from_raw_parts(address as *const u32, chunks);
+            for (i, chunk) in header.iter().enumerate() {
+                if i == 3 {
+                    // Skip the checksum field.
+                } else if i == chunks - 1 && leftover_bytes != 0 {
+                    // In this case, we don't want to use the entire word.
+                    checksum ^= *chunk & (0xFFFFFFFF >> (4 - leftover_bytes));
+                } else {
+                    checksum ^= *chunk;
+                }
+            }
+
+            if checksum != tbf_header_base.checksum {
+                return None;
+            }
+
+            // Skip the base of the header.
+            let mut offset = mem::size_of::<TbfHeaderV2Base>() as isize;
+            let mut remaining_length = tbf_header_base.header_size as usize - offset as usize;
+
+            // Check if this is a real app or just padding. Padding apps are
+            // identified by not having any options.
+            if remaining_length == 0 {
+                // Just padding.
+                if checksum == tbf_header_base.checksum {
+                    Some(TbfHeader::Padding(tbf_header_base))
+                } else {
+                    None
+                }
+
+            } else {
+                // This is an actual app.
+
+                // Places to save fields that we parse out of the header
+                // options.
+                let mut main_pointer: Option<&TbfHeaderV2Main> = None;
+                let mut pic1_pointer: Option<&PicOption1Fields> = None;
+                let mut wfr_pointer: Option<&'static [TbfHeaderV2WriteableFlashRegion]> = None;
+                let mut app_name_str = "";
+
+                // Loop through the header looking for known options.
+                while remaining_length > mem::size_of::<TbfHeaderTlv>() {
+                    let tbf_tlv_header = &*(address.offset(offset) as *const TbfHeaderTlv);
+
+                    remaining_length -= mem::size_of::<TbfHeaderTlv>();
+                    offset += mem::size_of::<TbfHeaderTlv>() as isize;
+
+                    // Only parse known TLV blocks. There is no type 0.
+                    if (tbf_tlv_header.tipe as u16) < TbfHeaderTypes::Unused as u16 && (tbf_tlv_header.tipe as u16) > 0 {
+                        // This lets us skip unknown header types.
+
+                        match tbf_tlv_header.tipe {
+                            TbfHeaderTypes::TbfHeaderMain => /* Main */ {
+                                if remaining_length >= mem::size_of::<TbfHeaderV2Main>() &&
+                                   tbf_tlv_header.length as usize == mem::size_of::<TbfHeaderV2Main>() {
+                                    let tbf_main = &*(address.offset(offset) as *const TbfHeaderV2Main);
+                                    main_pointer = Some(tbf_main);
+                                }
+                            }
+                            TbfHeaderTypes::TbfHeaderWriteableFlashRegions => /* Writeable Flash Regions */ {
+                                // Length must be a multiple of the size of a region definition.
+                                if tbf_tlv_header.length as usize % mem::size_of::<TbfHeaderV2WriteableFlashRegion>() == 0 {
+                                    let number_regions = tbf_tlv_header.length as usize / mem::size_of::<TbfHeaderV2WriteableFlashRegion>();
+                                    let region_start = &*(address.offset(offset) as *const TbfHeaderV2WriteableFlashRegion);
+                                    let regions = slice::from_raw_parts(region_start, number_regions);
+                                    wfr_pointer = Some(regions);
+                                }
+                            }
+                            TbfHeaderTypes::TbfHeaderPackageName => /* Package Name */ {
+                                if remaining_length >= tbf_tlv_header.length as usize {
+                                    let package_name_byte_array =
+                                        slice::from_raw_parts(address.offset(offset), tbf_tlv_header.length as usize);
+                                    let _ = str::from_utf8(package_name_byte_array).map(|name_str| { app_name_str = name_str; });
+                                }
+                            }
+                            TbfHeaderTypes::TbfHeaderPicOption1 => /* PIC Option 1 */ {
+                                if remaining_length >= mem::size_of::<PicOption1Fields>() &&
+                                   tbf_tlv_header.length as usize == mem::size_of::<PicOption1Fields>() {
+                                    let tbf_pic1 = &*(address.offset(offset) as *const PicOption1Fields);
+                                    pic1_pointer = Some(tbf_pic1);
+                                }
+                            }
+                            TbfHeaderTypes::Unused => {}
+                        }
+                    }
+
+                    remaining_length -= tbf_tlv_header.length as usize;
+                    offset += tbf_tlv_header.length as isize;
+                }
+
+                main_pointer.map_or(None, |mp| {
+                    let tbf_header = TbfHeaderV2 {
+                        base: tbf_header_base,
+                        main: mp,
+                        pic_values: pic1_pointer,
+                        package_name: Some(app_name_str),
+                        writeable_regions: wfr_pointer,
+                    };
+
+                    Some(TbfHeader::TbfHeaderV2(tbf_header))
+                })
+            }
+        }
+
+        _ => None
+    }
 }
 
 #[derive(Default)]
@@ -206,57 +573,88 @@ struct StoredRegs {
     r11: usize,
 }
 
+/// State for helping with debugging apps.
+///
+/// These pointers and counters are not strictly required for kernel operation,
+/// but provide helpful information when an app crashes.
+struct ProcessDebug {
+    /// Where the process has started its heap in RAM.
+    app_heap_start_pointer: Option<*const u8>,
+
+    /// Where the start of the stack is for the process. If the kernel does the
+    /// PIC setup for this app then we know this, otherwise we need the app to
+    /// tell us where it put its stack.
+    app_stack_start_pointer: Option<*const u8>,
+
+    /// How low have we ever seen the stack pointer.
+    min_stack_pointer: *const u8,
+
+    /// How many syscalls have occurred since the process started.
+    syscall_count: Cell<usize>,
+
+    /// What was the most recent syscall.
+    last_syscall: Cell<Option<Syscall>>,
+}
+
 pub struct Process<'a> {
     /// Application memory layout:
     ///
-    ///     |======== <- memory[memory.len()]
-    ///  ╔═ | Grant
-    ///     |   ↓
-    ///  D  |  ----   <- kernel_memory_break
-    ///  Y  |
-    ///  N  |  ----   <- app_heap_break
-    ///  A  |
-    ///  M  |   ↑
-    ///     |  Heap
-    ///  ╠═ |  ----   <- app_heap_start
-    ///     |  Data
-    ///  F  |  ----   <- stack_data_boundary
-    ///  I  | Stack
-    ///  X  |   ↓
-    ///  E  |
-    ///  D  |  ----   <- cur_stack
-    ///     |
-    ///  ╚═ |======== <- memory[0]
-
+    /// ```text
+    ///     ╒════════ ← memory[memory.len()]
+    ///  ╔═ │ Grant
+    ///     │   ↓
+    ///  D  │ ──────  ← kernel_memory_break
+    ///  Y  │
+    ///  N  │ ──────  ← app_break
+    ///  A  │
+    ///  M  │   ↑
+    ///     │  Heap
+    ///  ╠═ │ ──────  ← app_heap_start
+    ///     │  Data
+    ///  F  │ ──────  ← data_start_pointer
+    ///  I  │ Stack
+    ///  X  │   ↓
+    ///  E  │
+    ///  D  │ ──────  ← current_stack_pointer
+    ///     │
+    ///  ╚═ ╘════════ ← memory[0]
+    /// ```
+    ///
     /// The process's memory.
     memory: &'static mut [u8],
 
+    /// Pointer to the end of the allocated (and MPU protected) grant region.
     kernel_memory_break: *const u8,
-    app_heap_break: *const u8,
-    app_heap_start: *const u8,
-    stack_data_boundary: *const u8,
-    cur_stack: *const u8,
 
-    /// How low have we ever seen the stack pointer
-    min_stack_pointer: *const u8,
+    /// Pointer to the end of process RAM that has been sbrk'd to the process.
+    app_break: *const u8,
 
-    /// How many syscalls have occurred since the process started
-    syscall_count: Cell<usize>,
+    /// Saved when the app switches to the kernel.
+    current_stack_pointer: *const u8,
 
-    /// What was the most recent syscall
-    last_syscall: Cell<Option<Syscall>>,
+    /// Needed only the first time the app is run to set R9 if the kernel did
+    /// the PIC setup for the app.
+    data_start_pointer: *const u8,
 
     /// Process text segment
     text: &'static [u8],
 
+    /// Collection of pointers to the TBF header in flash.
+    header: TbfHeader,
+
+    /// Saved each time the app switches to the kernel.
     stored_regs: StoredRegs,
 
+    /// The PC to jump to when switching back to the app.
     yield_pc: usize,
+
+    /// Process State Register.
     psr: usize,
 
+    /// Whether the scheduler can schedule this app.
     state: State,
 
-    /// How to deal with Faults occuring in the process
+    /// How to deal with Faults occurring in the process
     fault_response: FaultResponse,
 
     /// MPU regions are saved as a pointer-size pair.
@@ -266,16 +664,21 @@ pub struct Process<'a> {
     ///
     /// A null pointer represents an empty region.
     ///
-    /// # Invariants
+    /// #### Invariants
     ///
     /// The pointer must be aligned to the size. E.g. if the size is 32 bytes, the pointer must be
     /// 32-byte aligned.
-    ///
     mpu_regions: [Cell<(*const u8, math::PowerOfTwo)>; 5],
 
+    /// Essentially a list of callbacks that want to call functions in the
+    /// process.
     tasks: RingBuffer<'a, Task>,
 
+    /// Name of the app. Public so that IPC can use it.
     pub package_name: &'static str,
+
+    /// Values kept so that we can print useful debug messages when apps fault.
+    debug: ProcessDebug,
 }
 
 // Stores the current number of callbacks enqueued + processes in Running state
@@ -472,80 +875,97 @@ impl<'a> Process<'a> {
                          remaining_app_memory_size: usize,
                          fault_response: FaultResponse)
                          -> (Option<Process<'a>>, usize, usize) {
-        if let Some(load_info) = parse_and_validate_load_info(app_flash_address) {
-            let app_flash_size = load_info.total_size as usize;
+        if let Some(tbf_header) = parse_and_validate_tbf_header(app_flash_address) {
+            let app_flash_size = tbf_header.get_total_size() as usize;
+
+            // If this isn't an app (i.e. it is padding) or it is an app but it
+            // isn't enabled, then we can skip it but increment past its flash.
+            if !tbf_header.is_app() || !tbf_header.enabled() {
+                return (None, app_flash_size, 0);
+            }
+
+            // Otherwise, actually load the app.
+            let min_app_ram_size = tbf_header.get_minimum_app_ram_size();
+            let package_name = tbf_header.get_package_name(app_flash_address);
+            let init_fn = app_flash_address.offset(tbf_header.get_init_function_offset() as isize) as usize;
+            let needs_pic_fixup = tbf_header.needs_pic_fixup();
 
             // Load the process into memory
             if let Some(load_result) =
-                load(load_info,
+                load(tbf_header,
                      app_flash_address,
                      remaining_app_memory,
                      remaining_app_memory_size) {
-                let app_heap_len = align8!(load_info.min_app_heap_len);
-                let kernel_heap_len = align8!(load_info.min_kernel_heap_len);
 
-                let app_slice_size_unaligned = load_result.fixed_len + app_heap_len +
-                                               kernel_heap_len;
-                let app_slice_size = math::closest_power_of_two(app_slice_size_unaligned) as usize;
-                // TODO round app_slice_size up to a closer MPU unit.
+                // TODO round app_ram_size up to a closer MPU unit.
                 // This is a very conservative approach that rounds up to power of
                 // two. We should be able to make this closer to what we actually need.
+                let app_ram_size = math::closest_power_of_two(min_app_ram_size) as usize;
 
-                if app_slice_size > remaining_app_memory_size {
+                if app_ram_size > remaining_app_memory_size {
                     panic!("{:?} failed to load. Insufficient memory. Requested {} have {}",
-                           load_result.package_name,
-                           app_slice_size,
+                           package_name,
+                           app_ram_size,
                            remaining_app_memory_size);
                 }
 
-                let app_memory = slice::from_raw_parts_mut(remaining_app_memory, app_slice_size);
+                let app_memory = slice::from_raw_parts_mut(remaining_app_memory, app_ram_size);
 
-                // Set up initial grant region
+                // Set up initial grant region.
                 let mut kernel_memory_break = app_memory.as_mut_ptr()
                     .offset(app_memory.len() as isize);
 
-                // make room for container pointers
+                // Make room for container pointers.
                 let pointer_size = mem::size_of::<*const usize>();
                 let num_ctrs = read_volatile(&container::CONTAINER_COUNTER);
                 let container_ptrs_size = num_ctrs * pointer_size;
                 kernel_memory_break = kernel_memory_break.offset(-(container_ptrs_size as isize));
 
-                // set all pointers to null
+                // Set all pointers to null.
                 let opts = slice::from_raw_parts_mut(kernel_memory_break as *mut *const usize,
                                                      num_ctrs);
                 for opt in opts.iter_mut() {
                     *opt = ptr::null()
                 }
 
-                // Allocate memory for callback ring buffer
+                // Allocate memory for callback ring buffer.
                 let callback_size = mem::size_of::<Task>();
                 let callback_len = 10;
                 let callback_offset = callback_len * callback_size;
                 kernel_memory_break = kernel_memory_break.offset(-(callback_offset as isize));
 
-                // Set up ring buffer
+                // Set up ring buffer.
                 let callback_buf = slice::from_raw_parts_mut(kernel_memory_break as *mut Task,
                                                              callback_len);
                 let tasks = RingBuffer::new(callback_buf);
 
+                // Determine the debug information to the best of our
+                // understanding. If the app is doing all of the PIC fixup and
+                // memory management we don't know much.
+                let mut app_heap_start_pointer = None;
+                let mut app_stack_start_pointer = None;
+                if needs_pic_fixup {
+                    app_heap_start_pointer = Some(load_result.initial_sbrk_pointer);
+                    app_stack_start_pointer = Some(load_result.initial_stack_pointer);
+                }
+
                 let mut process = Process {
                     memory: app_memory,
 
+                    header: load_result.header,
+
                     kernel_memory_break: kernel_memory_break,
-                    app_heap_break: load_result.app_heap_start,
-                    app_heap_start: load_result.app_heap_start,
-                    stack_data_boundary: load_result.stack_data_boundary,
-                    cur_stack: load_result.stack_data_boundary,
+                    app_break: load_result.initial_sbrk_pointer,
+                    current_stack_pointer: load_result.initial_stack_pointer,
 
-                    min_stack_pointer: load_result.stack_data_boundary,
-
-                    syscall_count: Cell::new(0),
-                    last_syscall: Cell::new(None),
+                    // We need to keep this to set R9 the first time we switch
+                    // to the process.
+                    data_start_pointer: load_result.data_start_pointer,
 
                     text: slice::from_raw_parts(app_flash_address, app_flash_size),
 
                     stored_regs: Default::default(),
-                    yield_pc: load_result.init_fn,
+                    yield_pc: init_fn,
                     // Set the Thumb bit and clear everything else
                     psr: 0x01000000,
 
@@ -558,34 +978,42 @@ impl<'a> Process<'a> {
                                   Cell::new((ptr::null(), math::PowerOfTwo::zero())),
                                   Cell::new((ptr::null(), math::PowerOfTwo::zero()))],
                     tasks: tasks,
-                    package_name: load_result.package_name,
+                    package_name: package_name,
+
+                    debug: ProcessDebug {
+                        app_heap_start_pointer: app_heap_start_pointer,
+                        app_stack_start_pointer: app_stack_start_pointer,
+                        min_stack_pointer: load_result.initial_stack_pointer,
+                        syscall_count: Cell::new(0),
+                        last_syscall: Cell::new(None),
+                    }
                 };
 
-                if (load_result.init_fn & 0x1) != 1 {
+                if (init_fn & 0x1) != 1 {
                     panic!("{:?} process image invalid. \
                            init_fn address must end in 1 to be Thumb, got {:#X}",
-                           load_result.package_name,
-                           load_result.init_fn);
+                           package_name,
+                           init_fn);
                 }
 
                 process.tasks.enqueue(Task::FunctionCall(FunctionCall {
-                    pc: load_result.init_fn,
+                    pc: init_fn,
                     r0: process.memory.as_ptr() as usize,
-                    r1: process.app_heap_break as usize,
+                    r1: process.app_break as usize,
                     r2: process.kernel_memory_break as usize,
                     r3: 0,
                 }));
 
                 HAVE_WORK.set(HAVE_WORK.get() + 1);
 
-                return (Some(process), app_flash_size, app_slice_size);
+                return (Some(process), app_flash_size, app_ram_size);
             }
         }
         (None, 0, 0)
     }
 
     pub fn sbrk(&mut self, increment: isize) -> Result<*const u8, Error> {
-        let new_break = unsafe { self.app_heap_break.offset(increment) };
+        let new_break = unsafe { self.app_break.offset(increment) };
         self.brk(new_break)
     }
 
@@ -595,8 +1023,8 @@ impl<'a> Process<'a> {
         } else if new_break > self.kernel_memory_break {
             Err(Error::OutOfMemory)
         } else {
-            let old_break = self.app_heap_break;
-            self.app_heap_break = new_break;
+            let old_break = self.app_break;
+            self.app_break = new_break;
             Ok(old_break)
         }
     }
@@ -610,7 +1038,7 @@ impl<'a> Process<'a> {
 
     pub unsafe fn alloc(&mut self, size: usize) -> Option<&mut [u8]> {
         let new_break = self.kernel_memory_break.offset(-(size as isize));
-        if new_break < self.app_heap_break {
+        if new_break < self.app_break {
             None
         } else {
             self.kernel_memory_break = new_break;
@@ -647,13 +1075,13 @@ impl<'a> Process<'a> {
 
 
     pub fn pop_syscall_stack(&mut self) {
-        let pspr = self.cur_stack as *const usize;
+        let pspr = self.current_stack_pointer as *const usize;
         unsafe {
             self.yield_pc = read_volatile(pspr.offset(6));
             self.psr = read_volatile(pspr.offset(7));
-            self.cur_stack = (self.cur_stack as *mut usize).offset(8) as *mut u8;
-            if self.cur_stack < self.min_stack_pointer {
-                self.min_stack_pointer = self.cur_stack;
+            self.current_stack_pointer = (self.current_stack_pointer as *mut usize).offset(8) as *mut u8;
+            if self.current_stack_pointer < self.debug.min_stack_pointer {
+                self.debug.min_stack_pointer = self.current_stack_pointer;
             }
         }
     }
@@ -665,7 +1093,7 @@ impl<'a> Process<'a> {
         self.state = State::Running;
         // Fill in initial stack expected by SVC handler
         // Top minus 8 u32s for r0-r3, r12, lr, pc and xPSR
-        let stack_bottom = (self.cur_stack as *mut usize).offset(-8);
+        let stack_bottom = (self.current_stack_pointer as *mut usize).offset(-8);
         write_volatile(stack_bottom.offset(7), self.psr);
         write_volatile(stack_bottom.offset(6), callback.pc | 1);
 
@@ -678,9 +1106,9 @@ impl<'a> Process<'a> {
         write_volatile(stack_bottom.offset(2), callback.r2);
         write_volatile(stack_bottom.offset(3), callback.r3);
 
-        self.cur_stack = stack_bottom as *mut u8;
-        if self.cur_stack < self.min_stack_pointer {
-            self.min_stack_pointer = self.cur_stack;
+        self.current_stack_pointer = stack_bottom as *mut u8;
+        if self.current_stack_pointer < self.debug.min_stack_pointer {
+            self.debug.min_stack_pointer = self.current_stack_pointer;
         }
     }
 
@@ -695,17 +1123,17 @@ impl<'a> Process<'a> {
     /// Context switch to the process.
     pub unsafe fn switch_to(&mut self) {
         write_volatile(&mut SYSCALL_FIRED, 0);
-        let psp = switch_to_user(self.cur_stack,
-                                 self.stack_data_boundary,
+        let psp = switch_to_user(self.current_stack_pointer,
+                                 self.data_start_pointer,
                                  mem::transmute(&mut self.stored_regs));
-        self.cur_stack = psp;
-        if self.cur_stack < self.min_stack_pointer {
-            self.min_stack_pointer = self.cur_stack;
+        self.current_stack_pointer = psp;
+        if self.current_stack_pointer < self.debug.min_stack_pointer {
+            self.debug.min_stack_pointer = self.current_stack_pointer;
         }
     }
 
     pub fn svc_number(&self) -> Option<Syscall> {
-        let psp = self.cur_stack as *const *const u16;
+        let psp = self.current_stack_pointer as *const *const u16;
         unsafe {
             let pcptr = read_volatile((psp as *const *const u16).offset(6));
             let svc_instr = read_volatile(pcptr.offset(-1));
@@ -722,26 +1150,26 @@ impl<'a> Process<'a> {
     }
 
     pub fn incr_syscall_count(&self) {
-        self.syscall_count.set(self.syscall_count.get() + 1);
-        self.last_syscall.set(self.svc_number());
+        self.debug.syscall_count.set(self.debug.syscall_count.get() + 1);
+        self.debug.last_syscall.set(self.svc_number());
     }
 
     pub fn sp(&self) -> usize {
-        self.cur_stack as usize
+        self.current_stack_pointer as usize
     }
 
     pub fn lr(&self) -> usize {
-        let pspr = self.cur_stack as *const usize;
+        let pspr = self.current_stack_pointer as *const usize;
         unsafe { read_volatile(pspr.offset(5)) }
     }
 
     pub fn pc(&self) -> usize {
-        let pspr = self.cur_stack as *const usize;
+        let pspr = self.current_stack_pointer as *const usize;
         unsafe { read_volatile(pspr.offset(6)) }
     }
 
     pub fn r0(&self) -> usize {
-        let pspr = self.cur_stack as *const usize;
+        let pspr = self.current_stack_pointer as *const usize;
         unsafe { read_volatile(pspr) }
     }
 
@@ -751,32 +1179,32 @@ impl<'a> Process<'a> {
     }
 
     pub fn set_r0(&mut self, val: isize) {
-        let pspr = self.cur_stack as *mut isize;
+        let pspr = self.current_stack_pointer as *mut isize;
         unsafe { write_volatile(pspr, val) }
     }
 
     pub fn r1(&self) -> usize {
-        let pspr = self.cur_stack as *const usize;
+        let pspr = self.current_stack_pointer as *const usize;
         unsafe { read_volatile(pspr.offset(1)) }
     }
 
     pub fn r2(&self) -> usize {
-        let pspr = self.cur_stack as *const usize;
+        let pspr = self.current_stack_pointer as *const usize;
         unsafe { read_volatile(pspr.offset(2)) }
     }
 
     pub fn r3(&self) -> usize {
-        let pspr = self.cur_stack as *const usize;
+        let pspr = self.current_stack_pointer as *const usize;
         unsafe { read_volatile(pspr.offset(3)) }
     }
 
     pub fn r12(&self) -> usize {
-        let pspr = self.cur_stack as *const usize;
+        let pspr = self.current_stack_pointer as *const usize;
         unsafe { read_volatile(pspr.offset(4)) }
     }
 
     pub fn xpsr(&self) -> usize {
-        let pspr = self.cur_stack as *const usize;
+        let pspr = self.current_stack_pointer as *const usize;
         unsafe { read_volatile(pspr.offset(7)) }
     }
 
@@ -930,124 +1358,100 @@ impl<'a> Process<'a> {
     }
 
     pub unsafe fn statistics_str<W: Write>(&mut self, writer: &mut W) {
+        // Flash
+        let flash_end = self.text.as_ptr().offset(self.text.len() as isize) as usize;
+        let flash_start = self.text.as_ptr() as usize;
+        let flash_protected_size = self.header.get_protected_size() as usize;
+        let flash_app_start = flash_start + flash_protected_size;
+        let flash_app_size = flash_end - flash_app_start;
+        let flash_init_fn = flash_start + self.header.get_init_function_offset() as usize;
 
-        if let Some(load_info) = parse_and_validate_load_info(self.text.as_ptr()) {
-            // Flash addresses
-            let flash_end = self.text.as_ptr().offset(self.text.len() as isize) as usize;
-            let flash_data_end = self.text
-                .as_ptr()
-                .offset(load_info.pkg_name_offset as isize + load_info.pkg_name_size as isize) as
-                                 usize;
-            let flash_data_start = self.text.as_ptr().offset(load_info.got_offset as isize) as
-                                   usize;
-            let flash_text_start = self.text.as_ptr().offset(load_info.text_offset as isize) as
-                                   usize;
-            let flash_start = self.text.as_ptr() as usize;
+        // SRAM addresses
+        let sram_end = self.memory.as_ptr().offset(self.memory.len() as isize) as usize;
+        let sram_grant_start = self.kernel_memory_break as usize;
+        let sram_heap_end = self.app_break as usize;
+        let sram_heap_start = self.debug.app_heap_start_pointer.unwrap_or(ptr::null()) as usize;
+        let sram_stack_start = self.debug.app_stack_start_pointer.unwrap_or(ptr::null()) as usize;
+        let sram_stack_bottom = self.debug.min_stack_pointer as usize;
+        let sram_start = self.memory.as_ptr() as usize;
 
-            // Flash sizes
-            let flash_data_size = load_info.got_size + load_info.data_size +
-                                  load_info.pkg_name_size;
-            let flash_text_size = load_info.text_size;
-            let flash_header_size = mem::size_of::<LoadInfo>() + load_info.rel_data_size as usize;
+        // SRAM sizes
+        let sram_grant_size = sram_end - sram_grant_start;
+        let sram_heap_size = sram_heap_end - sram_heap_start;
+        let sram_data_size = sram_heap_start - sram_heap_start;
+        let sram_stack_size = sram_heap_start - sram_stack_bottom;
+        let sram_grant_allocated = sram_end - sram_grant_start;
+        let sram_heap_allocated = sram_grant_start - sram_heap_start;
+        let sram_stack_allocated = sram_stack_start - sram_start;
+        let sram_data_allocated = sram_data_size as usize;
 
-            // SRAM addresses
-            let sram_end = self.memory.as_ptr().offset(self.memory.len() as isize) as usize;
-            let sram_grant_start = self.kernel_memory_break as usize;
-            let sram_heap_end = self.app_heap_break as usize;
-            let sram_heap_start = self.app_heap_start as usize;
-            let sram_stack_data_boundary = self.stack_data_boundary as usize;
-            let sram_stack_bottom = self.min_stack_pointer as usize;
-            let sram_start = self.memory.as_ptr() as usize;
+        // checking on sram
+        let mut sram_grant_error_str = "          ";
+        if sram_grant_size > sram_grant_allocated {
+            sram_grant_error_str = " EXCEEDED!"
+        }
+        let mut sram_heap_error_str = "          ";
+        if sram_heap_size > sram_heap_allocated {
+            sram_heap_error_str = " EXCEEDED!"
+        }
+        let mut sram_stack_error_str = "          ";
+        if sram_stack_size > sram_stack_allocated {
+            sram_stack_error_str = " EXCEEDED!"
+        }
 
-            // SRAM sizes
-            let sram_grant_size = sram_end - sram_grant_start;
-            let sram_heap_size = sram_heap_end - sram_heap_start;
-            let sram_data_size = sram_heap_start - sram_stack_data_boundary;
-            let sram_stack_size = sram_stack_data_boundary - sram_stack_bottom;
-            let sram_grant_allocated = load_info.min_kernel_heap_len as usize;
-            let sram_heap_allocated = load_info.min_app_heap_len as usize;
-            let sram_stack_allocated = load_info.min_stack_len as usize;
-            let sram_data_allocated = sram_data_size as usize;
+        // application statistics
+        let events_queued = self.tasks.len();
+        let syscall_count = self.debug.syscall_count.get();
+        let last_syscall = self.debug.last_syscall.get();
 
-            // checking on sram
-            let mut sram_grant_error_str = "          ";
-            if sram_grant_size > sram_grant_allocated {
-                sram_grant_error_str = " EXCEEDED!"
-            }
-            let mut sram_heap_error_str = "          ";
-            if sram_heap_size > sram_heap_allocated {
-                sram_heap_error_str = " EXCEEDED!"
-            }
-            let mut sram_stack_error_str = "          ";
-            if sram_stack_size > sram_stack_allocated {
-                sram_stack_error_str = " EXCEEDED!"
-            }
+        // register values
+        let (r0, r1, r2, r3, r12, sp, lr, pc, xpsr) = (self.r0(),
+                                                       self.r1(),
+                                                       self.r2(),
+                                                       self.r3(),
+                                                       self.r12(),
+                                                       self.sp(),
+                                                       self.lr(),
+                                                       self.pc(),
+                                                       self.xpsr());
 
-            // application statistics
-            let events_queued = self.tasks.len();
-            let syscall_count = self.syscall_count.get();
-            let last_syscall = self.last_syscall.get();
+        let _ = writer.write_fmt(format_args!("\
+        App: {}   -   [{:?}]\
+        \r\n Events Queued: {}   Syscall Count: {}   ",
+                                              self.package_name,
+                                              self.state,
+                                              events_queued,
+                                              syscall_count,
+                                              ));
 
-            // register values
-            let (r0, r1, r2, r3, r12, sp, lr, pc, xpsr) = (self.r0(),
-                                                           self.r1(),
-                                                           self.r2(),
-                                                           self.r3(),
-                                                           self.r12(),
-                                                           self.sp(),
-                                                           self.lr(),
-                                                           self.pc(),
-                                                           self.xpsr());
+        let _ = match last_syscall {
+            Some(syscall) => writer.write_fmt(format_args!("Last Syscall: {:?}", syscall)),
+            None => writer.write_fmt(format_args!("Last Syscall: None")),
+        };
 
-            // lst-file relative LR and PC
-            let lr_lst_relative = 0x80000000 | (0xFFFFFFFE & (lr - flash_text_start as usize));
-            let pc_lst_relative = 0x80000000 | (0xFFFFFFFE & (pc - flash_text_start as usize));
-
-            let ypc_lst_relative = 0x80000000 |
-                                   (0xFFFFFFFE & (self.yield_pc - flash_text_size as usize));
-
-
-            let _ = writer.write_fmt(format_args!("\
-            App: {}   -   [{:?}]\
-            \r\n Events Queued: {}   Syscall Count: {}   ",
-                                                  self.package_name,
-                                                  self.state,
-                                                  events_queued,
-                                                  syscall_count,
-                                                  ));
-
-            let _ = match last_syscall {
-                Some(syscall) => writer.write_fmt(format_args!("Last Syscall: {:?}", syscall)),
-                None => writer.write_fmt(format_args!("Last Syscall: None")),
-            };
-
-            let _ = writer.write_fmt(format_args!("\
+        let _ = writer.write_fmt(format_args!("\
 \r\n\
 \r\n ╔═══════════╤══════════════════════════════════════════╗\
 \r\n ║  Address  │ Region Name    Used | Allocated (bytes)  ║\
 \r\n ╚{:#010X}═╪══════════════════════════════════════════╝\
 \r\n             │ ▼ Grant      {:6} | {:6}{}\
-  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈\
+  \r\n  {:#010X} ┼───────────────────────────────────────────\
 \r\n             │ Unused\
-  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈\
-\r\n             │ ▲ Heap       {:6} | {:6}{}    S\
-  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ R\
-\r\n             │ Data         {:6} | {:6}              A\
-  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ M\
+  \r\n  {:#010X} ┼───────────────────────────────────────────\
+\r\n             │ ▲ Heap       {:6} | {:6}{}     S\
+  \r\n  {:#010X} ┼─────────────────────────────────────────── R\
+\r\n             │ Data         {:6} | {:6}               A\
+  \r\n  {:#010X} ┼─────────────────────────────────────────── M\
 \r\n             │ ▼ Stack      {:6} | {:6}{}\
-  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈\
+  \r\n  {:#010X} ┼───────────────────────────────────────────\
 \r\n             │ Unused\
   \r\n  {:#010X} ┴───────────────────────────────────────────\
 \r\n             .....\
-  \r\n  {:#010X} ┬───────────────────────────────────────────\
-\r\n             │ Unused\
-  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ F\
-\r\n             │ Data         {:6}                       L\
-  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ A\
-\r\n             │ Text         {:6}                       S\
-  \r\n  {:#010X} ┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ H\
-\r\n             │ Header       {:6}\
-  \r\n  {:#010X} ┴───────────────────────────────────────────\
+  \r\n  {:#010X} ┬─────────────────────────────────────────── F\
+\r\n             │ App Flash    {:6}                        L\
+  \r\n  {:#010X} ┼─────────────────────────────────────────── A\
+\r\n             │ Protected    {:6}                        S\
+  \r\n  {:#010X} ┴─────────────────────────────────────────── H\
 \r\n\
   \r\n  R0 : {:#010X}    R6 : {:#010X}\
   \r\n  R1 : {:#010X}    R7 : {:#010X}\
@@ -1057,9 +1461,9 @@ impl<'a> Process<'a> {
   \r\n  R5 : {:#010X}    R12: {:#010X}\
   \r\n  R9 : {:#010X} (Static Base Register)\
   \r\n  SP : {:#010X} (Process Stack Pointer)\
-  \r\n  LR : {:#010X} [{:#010X} in lst file]\
-  \r\n  PC : {:#010X} [{:#010X} in lst file]\
-  \r\n YPC : {:#010X} [{:#010X} in lst file]\
+  \r\n  LR : {:#010X}\
+  \r\n  PC : {:#010X}\
+  \r\n YPC : {:#010X}\
 \r\n",
   sram_end,
   sram_grant_size, sram_grant_allocated, sram_grant_error_str,
@@ -1068,17 +1472,14 @@ impl<'a> Process<'a> {
   sram_heap_size, sram_heap_allocated, sram_heap_error_str,
   sram_heap_start,
   sram_data_size, sram_data_allocated,
-  sram_stack_data_boundary,
+  sram_stack_start,
   sram_stack_size, sram_stack_allocated, sram_stack_error_str,
   sram_stack_bottom,
   sram_start,
   flash_end,
-  flash_data_end,
-  flash_data_size,
-  flash_data_start,
-  flash_text_size,
-  flash_text_start,
-  flash_header_size,
+  flash_app_size,
+  flash_app_start,
+  flash_protected_size,
   flash_start,
   r0, self.stored_regs.r6,
   r1, self.stored_regs.r7,
@@ -1088,61 +1489,55 @@ impl<'a> Process<'a> {
   self.stored_regs.r5, r12,
   self.stored_regs.r9,
   sp,
-  lr, lr_lst_relative,
-  pc, pc_lst_relative,
-  self.yield_pc, ypc_lst_relative,
+  lr,
+  pc,
+  self.yield_pc,
   ));
-            let _ = writer.write_fmt(format_args!("\
-            \r\n APSR: N {} Z {} C {} V {} Q {}\
-            \r\n       GE {} {} {} {}",
-            (xpsr >> 31) & 0x1,
-            (xpsr >> 30) & 0x1,
-            (xpsr >> 29) & 0x1,
-            (xpsr >> 28) & 0x1,
-            (xpsr >> 27) & 0x1,
-            (xpsr >> 19) & 0x1,
-            (xpsr >> 18) & 0x1,
-            (xpsr >> 17) & 0x1,
-            (xpsr >> 16) & 0x1,
-            ));
-            let _ = writer.write_fmt(format_args!("\
-            \r\n IPSR: Exception Type - {}",
-            ipsr_isr_number_to_str(xpsr & 0x1ff)
-            ));
-            let ici_it = (((xpsr >> 25) & 0x3) << 6) | ((xpsr >> 10) & 0x3f);
-            let thumb_bit = ((xpsr >> 24) & 0x1) == 1;
-            let _ = writer.write_fmt(format_args!("\
-            \r\n EPSR: ICI.IT {:#04x}\
-            \r\n       ThumbBit {} {}",
-            ici_it,
-            thumb_bit,
-            if thumb_bit { "" } else { "!!ERROR - Cortex M Thumb only!" },
-            ));
-        } else {
-            let _ = writer.write_fmt(format_args!("Unknown Load Info\r\n"));
-        }
-        let _ = writer.write_fmt(format_args!("\r\n\r\n"));
+        let _ = writer.write_fmt(format_args!("\
+        \r\n APSR: N {} Z {} C {} V {} Q {}\
+        \r\n       GE {} {} {} {}",
+        (xpsr >> 31) & 0x1,
+        (xpsr >> 30) & 0x1,
+        (xpsr >> 29) & 0x1,
+        (xpsr >> 28) & 0x1,
+        (xpsr >> 27) & 0x1,
+        (xpsr >> 19) & 0x1,
+        (xpsr >> 18) & 0x1,
+        (xpsr >> 17) & 0x1,
+        (xpsr >> 16) & 0x1,
+        ));
+        let _ = writer.write_fmt(format_args!("\
+        \r\n IPSR: Exception Type - {}",
+        ipsr_isr_number_to_str(xpsr & 0x1ff)
+        ));
+        let ici_it = (((xpsr >> 25) & 0x3) << 6) | ((xpsr >> 10) & 0x3f);
+        let thumb_bit = ((xpsr >> 24) & 0x1) == 1;
+        let _ = writer.write_fmt(format_args!("\
+        \r\n EPSR: ICI.IT {:#04x}\
+        \r\n       ThumbBit {} {}",
+        ici_it,
+        thumb_bit,
+        if thumb_bit { "" } else { "!!ERROR - Cortex M Thumb only!" },
+        ));
+        let _ = writer.write_fmt(format_args!("\r\n To debug, run "));
+        let _ = writer.write_fmt(format_args!("`make debug RAM_START={:#x} FLASH_INIT={:#x}`", sram_start, flash_init_fn));
+        let _ = writer.write_fmt(format_args!("\r\n in the app's folder and open the .lst file.\r\n\r\n"));
     }
 }
 
 #[derive(Debug)]
 struct LoadResult {
-    /// The absolute address of the process entry point (i.e. `_start`).
-    init_fn: usize,
+    /// Where the stack pointer was initially set.
+    initial_stack_pointer: *const u8,
 
-    /// The lowest free address in process memory after allocating space for
-    /// the stack, loading the GOT, data and BSS
-    app_heap_start: *const u8,
+    /// Where the sbrk initial end of process memory is set.
+    initial_sbrk_pointer: *const u8,
 
-    /// The initial stack pointer
-    stack_data_boundary: *const u8,
+    /// Where the data section is.
+    data_start_pointer: *const u8,
 
-    /// The length of the fixed segment, including the stack, GOT, .data, /
-    /// BSS, and any necessary alignment
-    fixed_len: u32,
-
-    /// The process's package name (used for IPC)
-    package_name: &'static str,
+    // Pass the header back to the caller.
+    header: TbfHeader,
 }
 
 /// Loads the process into memory
@@ -1151,120 +1546,133 @@ struct LoadResult {
 /// region beginning at `mem_base`. The process binary must fit within
 /// `mem_size` bytes.
 ///
-/// This function will copy the GOT and data segment into memory as well as
-/// zero out the BSS section. It performs relocation on the GOT and on
-/// variables named in the relocation section of the binary.
+/// This function will optionally copy the GOT and data segment into memory as
+/// well as zero out the BSS section. It also optionally performs relocation on
+/// the GOT and on variables named in the relocation section of the binary.
 ///
-/// Note: We place the stack at the bottom of the memory space so that a stack
-/// overflow will trigger an MPU violation rather than overwriting GOT/BSS/.data
-/// sections. The stack is not included in the flash data, however, which means
-/// that the offset values for everything above the stack in the elf header need
-/// to have the stack offset added.
+/// Note: If we are doing the relocation, we place the stack at the bottom of
+/// the memory space so that a stack overflow will trigger an MPU violation
+/// rather than overwriting GOT/BSS/.data sections. The stack is not included in
+/// the flash data, however, which means that the offset values for everything
+/// above the stack in the elf header need to have the stack offset added.
 ///
 /// The function returns a `LoadResult` containing metadata about the loaded
 /// process or None if loading failed.
-unsafe fn load(load_info: &'static LoadInfo,
+unsafe fn load(tbf_header: TbfHeader,
                flash_start_addr: *const u8,
                mem_base: *mut u8,
                mem_size: usize)
                -> Option<LoadResult> {
-    let package_name_byte_array =
-        slice::from_raw_parts(flash_start_addr.offset(load_info.pkg_name_offset as isize),
-                              load_info.pkg_name_size as usize);
-    let mut app_name_str = "";
-    let _ = str::from_utf8(package_name_byte_array).map(|name_str| { app_name_str = name_str; });
+    if tbf_header.needs_pic_fixup() {
+        // This app requested that the kernel do the PIC fixups for it.
 
-    let mut load_result = LoadResult {
-        init_fn: 0,
-        app_heap_start: ptr::null(),
-        stack_data_boundary: ptr::null(),
-        fixed_len: 0,
-        package_name: app_name_str,
-    };
+        // Get all of the sizes and offsets that are required.
+        if let Some(pic_values) = tbf_header.get_pic_fields() {
 
-    let text_start = flash_start_addr.offset(load_info.text_offset as isize);
+            let text_start = flash_start_addr.offset(pic_values.text_offset as isize);
 
-    let rel_data: &[u32] =
-        slice::from_raw_parts(flash_start_addr.offset(load_info.rel_data_offset as isize) as
-                              *const u32,
-                              (load_info.rel_data_size as usize) / mem::size_of::<u32>());
+            let rel_data: &[u32] =
+                slice::from_raw_parts(flash_start_addr.offset(pic_values.relocation_data_offset as isize) as *const u32,
+                                      (pic_values.relocation_data_size as usize) / mem::size_of::<u32>());
 
-    let aligned_stack_len = align8!(load_info.min_stack_len);
+            let aligned_stack_len = align8!(pic_values.minimum_stack_length);
 
-    let got: &[u8] =
-        slice::from_raw_parts(flash_start_addr.offset(load_info.got_offset as isize),
-                              load_info.got_size as usize) as &[u8];
+            let got: &[u8] =
+                slice::from_raw_parts(flash_start_addr.offset(pic_values.got_offset as isize),
+                                      pic_values.got_size as usize) as &[u8];
 
-    let data: &[u8] =
-        slice::from_raw_parts(flash_start_addr.offset(load_info.data_offset as isize),
-                              load_info.data_size as usize);
+            let data: &[u8] =
+                slice::from_raw_parts(flash_start_addr.offset(pic_values.data_offset as isize),
+                                      pic_values.data_size as usize);
 
-    let got_base = mem_base.offset(aligned_stack_len as isize);
-    let got_andthen_data: &mut [u8] =
-        slice::from_raw_parts_mut(got_base,
-                                  (load_info.got_size + load_info.data_size) as usize);
+            let got_base = mem_base.offset(aligned_stack_len as isize);
+            let got_andthen_data_ram: &mut [u8] =
+                slice::from_raw_parts_mut(got_base, (pic_values.got_size + pic_values.data_size) as usize);
 
-    let bss = mem_base.offset(aligned_stack_len as isize + load_info.bss_mem_offset as isize);
+            let bss = mem_base.offset(aligned_stack_len as isize + pic_values.bss_memory_offset as isize);
 
-    // Total size of fixed segment
-    let aligned_fixed_len = align8!(aligned_stack_len + load_info.data_size + load_info.got_size +
-                                    load_info.bss_size);
+            // Total size of fixed segment
+            let aligned_fixed_len = align8!(aligned_stack_len + pic_values.data_size +
+                                            pic_values.got_size + pic_values.bss_size);
 
-    // Verify target data fits in memory before writing anything
-    if (aligned_fixed_len) > mem_size as u32 {
-        // When a kernel warning mechanism exists, this panic should be
-        // replaced with that, but for now it seems more useful to bail out to
-        // alert developers of why the app failed to load
-        panic!("{:?} failed to load. Stack + Data + GOT + BSS ({}) > available memory ({})",
-               load_result.package_name,
-               aligned_fixed_len,
-               mem_size);
-    }
+            // Verify target data fits in memory before writing anything
+            if (aligned_fixed_len) > mem_size as u32 {
+                // When a kernel warning mechanism exists, this panic should be
+                // replaced with that, but for now it seems more useful to bail out to
+                // alert developers of why the app failed to load
+                panic!("{:?} failed to load. Stack + Data + GOT + BSS ({}) > available memory ({})",
+                       tbf_header.get_package_name(flash_start_addr),
+                       aligned_fixed_len,
+                       mem_size);
+            }
 
-    // Copy the GOT and data into base memory
-    for (orig, dest) in got.iter().chain(data.iter()).zip(got_andthen_data.iter_mut()) {
-        *dest = *orig
-    }
+            // Copy the GOT and data into base memory
+            for (orig, dest) in got.iter().chain(data.iter()).zip(got_andthen_data_ram.iter_mut()) {
+                *dest = *orig
+            }
 
-    // Zero out BSS
-    intrinsics::write_bytes(bss, 0, load_info.bss_size as usize);
+            // Zero out BSS
+            intrinsics::write_bytes(bss, 0, pic_values.bss_size as usize);
 
+            // Helper function that fixes up GOT entries
+            let fixup = |addr: &mut u32| {
+                let entry = *addr;
+                if (entry & 0x80000000) == 0 {
+                    // Regular data (memory relative)
+                    *addr = entry + (got_base as u32);
+                } else {
+                    // rodata or function pointer (code relative)
+                    *addr = (entry ^ 0x80000000) + (text_start as u32);
+                }
+            };
 
-    // Helper function that fixes up GOT entries
-    let fixup = |addr: &mut u32| {
-        let entry = *addr;
-        if (entry & 0x80000000) == 0 {
-            // Regular data (memory relative)
-            *addr = entry + (got_base as u32);
+            // Fixup Global Offset Table
+            let mem_got: &mut [u32] = slice::from_raw_parts_mut(got_base as *mut u32,
+                                                                (pic_values.got_size as usize) /
+                                                                mem::size_of::<u32>());
+
+            for got_cur in mem_got {
+                fixup(got_cur);
+            }
+
+            // Fixup relocation data
+            for (i, addr) in rel_data.iter().enumerate() {
+                if i % 2 == 0 {
+                    // Only the first of every 2 entries is an address
+                    fixup(&mut *(got_base.offset(*addr as isize) as *mut u32));
+                }
+            }
+
+            let load_result = LoadResult {
+                // Since we set these up on behalf of the process we know right
+                // where the are.
+                initial_stack_pointer: mem_base.offset(aligned_stack_len as isize),
+                initial_sbrk_pointer: mem_base.offset(aligned_fixed_len as isize),
+                // Also need to keep track of where we put the data portion in
+                // RAM so that we can correctly set R9 when we first switch to
+                // the app.
+                data_start_pointer: got_base,
+                header: tbf_header,
+            };
+
+            Some(load_result)
         } else {
-            // rodata or function pointer (code relative)
-            *addr = (entry ^ 0x80000000) + (text_start as u32);
+            // If we don't have any pic values, we can't do the fixup.
+            None
         }
-    };
+    } else {
+        // No PIC fixup requested from the kernel. We only need to set an
+        // initial stack pointer and sbrk size. The app will do the rest on its
+        // own.
 
-    // Fixup Global Offset Table
-    let mem_got: &mut [u32] = slice::from_raw_parts_mut(got_base as *mut u32,
-                                                        (load_info.got_size as usize) /
-                                                        mem::size_of::<u32>());
+        let load_result = LoadResult {
+            // Set the initial stack and process memory size to 64 bytes.
+            initial_stack_pointer: mem_base.offset(64),
+            initial_sbrk_pointer: mem_base.offset(64),
+            data_start_pointer: ptr::null(),
+            header: tbf_header,
+        };
 
-    for got_cur in mem_got {
-        fixup(got_cur);
+        Some(load_result)
     }
-
-    // Fixup relocation data
-    for (i, addr) in rel_data.iter().enumerate() {
-        if i % 2 == 0 {
-            // Only the first of every 2 entries is an address
-            fixup(&mut *(got_base.offset(*addr as isize) as *mut u32));
-        }
-    }
-
-    // Entry point is offset from app code
-    load_result.init_fn = flash_start_addr.offset(load_info.entry_offset as isize) as usize;
-
-    load_result.app_heap_start = mem_base.offset(aligned_fixed_len as isize);
-    load_result.stack_data_boundary = mem_base.offset(aligned_stack_len as isize);
-    load_result.fixed_len = aligned_fixed_len;
-
-    Some(load_result)
 }

--- a/userland/examples/tests/writeable_flash_regions/Makefile
+++ b/userland/examples/tests/writeable_flash_regions/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/writeable_flash_regions/README.md
+++ b/userland/examples/tests/writeable_flash_regions/README.md
@@ -1,0 +1,8 @@
+Writeable Flash Region Test App
+===============================
+
+This app simply uses the `memop` syscalls relevant to app-specific flash regions
+and prints the address of the regions that are defined in the Tock Binary Format
+header for the app. See the
+[documentation](https://github.com/helena-project/tock/blob/master/doc/Compilation.md#tock-binary-format)
+for more about these regions.

--- a/userland/examples/tests/writeable_flash_regions/main.c
+++ b/userland/examples/tests/writeable_flash_regions/main.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+#include <tock.h>
+
+int main (void) {
+  int num_regions = tock_app_number_writeable_flash_regions();
+  if (num_regions == 0) {
+    printf("No writeable flash regions defined in this app's header.\n");
+  } else {
+    for (int i = 0; i < num_regions; i++) {
+      void* start = tock_app_writeable_flash_region_begins_at(i);
+      void* end   = tock_app_writeable_flash_region_ends_at(i);
+      printf("Writeable flash region %i starts at %p and ends at %p\n", i, start, end);
+    }
+  }
+}

--- a/userland/libtock/tock.c
+++ b/userland/libtock/tock.c
@@ -155,6 +155,21 @@ void* tock_app_grant_begins_at(void) {
   return memop(6, 0);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wbad-function-cast"
+int tock_app_number_writeable_flash_regions(void) {
+  return (int) memop(7, 0);
+}
+#pragma GCC diagnostic pop
+
+void* tock_app_writeable_flash_region_begins_at(int region_index) {
+  return memop(8, region_index);
+}
+
+void* tock_app_writeable_flash_region_ends_at(int region_index) {
+  return memop(9, region_index);
+}
+
 bool driver_exists(uint32_t driver) {
   int ret = command(driver, 0, 0);
   return ret >= 0;

--- a/userland/libtock/tock.h
+++ b/userland/libtock/tock.h
@@ -36,6 +36,10 @@ void* tock_app_memory_ends_at(void);
 void* tock_app_flash_begins_at(void);
 void* tock_app_flash_ends_at(void);
 void* tock_app_grant_begins_at(void);
+int tock_app_number_writeable_flash_regions(void);
+void* tock_app_writeable_flash_region_begins_at(int region_index);
+void* tock_app_writeable_flash_region_ends_at(int region_index);
+
 
 // Checks to see if the given driver number exists on this platform.
 bool driver_exists(uint32_t driver);

--- a/userland/tools/elf2tbf/Cargo.lock
+++ b/userland/tools/elf2tbf/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "elf2tbf"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "elf 0.0.6 (git+https://github.com/cole14/rust-elf)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/userland/tools/elf2tbf/Cargo.toml
+++ b/userland/tools/elf2tbf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elf2tbf"
-version = "0.1.0"
+version = "0.2.0"
 description = "Compiles from ELF to TBF (the Tock Binary Format)"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 

--- a/userland/tools/elf2tbf/src/main.rs
+++ b/userland/tools/elf2tbf/src/main.rs
@@ -7,78 +7,122 @@ use std::env;
 use std::fmt;
 use std::fs::File;
 use std::io;
-use std::io::Write;
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::mem;
 use std::path::Path;
 use std::slice;
 
+/// Takes a value and rounds it up to be aligned % 4
+macro_rules! align8 {
+    ( $e:expr ) => ( ($e) + ((8 - (($e) % 8)) % 8 ) );
+}
+
+#[repr(u16)]
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
+enum TbfHeaderTypes {
+    TbfHeaderMain = 1,
+    TbfHeaderWriteableFlashRegions = 2,
+    TbfHeaderPackageName = 3,
+    TbfHeaderPicOption1 = 4,
+}
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-struct LoadInfo {
-    version: u32,
+struct TbfHeaderTlv {
+    tipe: TbfHeaderTypes,
+    length: u16,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct TbfHeaderBase {
+    version: u16,
+    header_size: u16,
     total_size: u32,
-    entry_offset: u32,
-    rel_data_offset: u32,
-    rel_data_size: u32,
-    text_offset: u32,
-    text_size: u32,
-    got_offset: u32,
-    got_size: u32,
-    data_offset: u32,
-    data_size: u32,
-    bss_mem_offset: u32,
-    bss_size: u32,
-    min_stack_len: u32,
-    min_app_heap_len: u32,
-    min_kernel_heap_len: u32,
-    package_name_offset: u32,
-    package_name_size: u32,
+    flags: u32,
     checksum: u32,
 }
 
-impl fmt::Display for LoadInfo {
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct TbfHeaderMain {
+    base: TbfHeaderTlv,
+    init_fn_offset: u32,
+    protected_size: u32,
+    minimum_ram_size: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct TbfHeaderPicOption1Fields {
+    base: TbfHeaderTlv,
+    text_offset: u32,
+    data_offset: u32,
+    data_size: u32,
+    bss_memory_offset: u32,
+    bss_size: u32,
+    relocation_data_offset: u32,
+    relocation_data_size: u32,
+    got_offset: u32,
+    got_size: u32,
+    minimum_stack_length: u32,
+}
+
+impl fmt::Display for TbfHeaderBase {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "
-            version: {:>8} {:>#10X}
-         total_size: {:>8} {:>#10X}
-       entry_offset: {:>8} {:>#10X}
-    rel_data_offset: {:>8} {:>#10X}
-      rel_data_size: {:>8} {:>#10X}
-        text_offset: {:>8} {:>#10X}
-          text_size: {:>8} {:>#10X}
-         got_offset: {:>8} {:>#10X}
-           got_size: {:>8} {:>#10X}
-        data_offset: {:>8} {:>#10X}
-          data_size: {:>8} {:>#10X}
-     bss_mem_offset: {:>8} {:>#10X}
-           bss_size: {:>8} {:>#10X}
-      min_stack_len: {:>8} {:>#10X}
-   min_app_heap_len: {:>8} {:>#10X}
-min_kernel_heap_len: {:>8} {:>#10X}
-package_name_offset: {:>8} {:>#10X}
-  package_name_size: {:>8} {:>#10X}
-           checksum: {:>8} {:>#10X}
+               version: {:>8} {:>#10X}
+           header_size: {:>8} {:>#10X}
+            total_size: {:>8} {:>#10X}
+                 flags: {:>8} {:>#10X}
 ",
         self.version, self.version,
+        self.header_size, self.header_size,
         self.total_size, self.total_size,
-        self.entry_offset, self.entry_offset,
-        self.rel_data_offset, self.rel_data_offset,
-        self.rel_data_size, self.rel_data_size,
+        self.flags, self.flags,
+        )
+    }
+}
+
+impl fmt::Display for TbfHeaderMain {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "
+        init_fn_offset: {:>8} {:>#10X}
+        protected_size: {:>8} {:>#10X}
+      minimum_ram_size: {:>8} {:>#10X}
+",
+        self.init_fn_offset, self.init_fn_offset,
+        self.protected_size, self.protected_size,
+        self.minimum_ram_size, self.minimum_ram_size,
+        )
+    }
+}
+
+impl fmt::Display for TbfHeaderPicOption1Fields {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "
+           text_offset: {:>8} {:>#10X}
+           data_offset: {:>8} {:>#10X}
+             data_size: {:>8} {:>#10X}
+     bss_memory_offset: {:>8} {:>#10X}
+              bss_size: {:>8} {:>#10X}
+relocation_data_offset: {:>8} {:>#10X}
+  relocation_data_size: {:>8} {:>#10X}
+            got_offset: {:>8} {:>#10X}
+              got_size: {:>8} {:>#10X}
+  minimum_stack_length: {:>8} {:>#10X}
+",
         self.text_offset, self.text_offset,
-        self.text_size, self.text_size,
-        self.got_offset, self.got_offset,
-        self.got_size, self.got_size,
         self.data_offset, self.data_offset,
         self.data_size, self.data_size,
-        self.bss_mem_offset, self.bss_mem_offset,
+        self.bss_memory_offset, self.bss_memory_offset,
         self.bss_size, self.bss_size,
-        self.min_stack_len, self.min_stack_len,
-        self.min_app_heap_len, self.min_app_heap_len,
-        self.min_kernel_heap_len, self.min_kernel_heap_len,
-        self.package_name_offset, self.package_name_offset,
-        self.package_name_size, self.package_name_size,
-        self.checksum, self.checksum,
+        self.relocation_data_offset, self.relocation_data_offset,
+        self.relocation_data_size, self.relocation_data_size,
+        self.got_offset, self.got_offset,
+        self.got_size, self.got_size,
+        self.minimum_stack_length, self.minimum_stack_length,
         )
     }
 }
@@ -170,7 +214,7 @@ fn do_work(input: &elf::File,
            verbose: bool)
            -> io::Result<()> {
     let package_name = package_name.unwrap_or(String::new());
-    let (rel_data_size, rel_data) = match input.sections
+    let (relocation_data_size, rel_data) = match input.sections
         .iter()
         .find(|section| section.shdr.name == ".rel.data".as_ref()) {
         Some(section) => (section.shdr.size, section.data.as_ref()),
@@ -187,76 +231,166 @@ fn do_work(input: &elf::File,
     let app_heap_len = get_section(input, ".app_heap").data.len() as u32;
     let kernel_heap_len = get_section(input, ".kernel_heap").data.len() as u32;
 
-    let mut total_size = (mem::size_of::<LoadInfo>() + rel_data.len() + text.data.len() +
-                          got.data.len() +
-                          data.data.len() + package_name.len()) as u32;
+    // Need to calculate lengths ahead of time.
+    // Need the base and the main section.
+    let mut header_length = mem::size_of::<TbfHeaderBase>() + mem::size_of::<TbfHeaderMain>();
 
-    let pad = if total_size.count_ones() > 1 {
+    // If we have a package name, add that section.
+    if package_name.len() > 0 {
+        header_length += mem::size_of::<TbfHeaderTlv>() + package_name.len();
+    }
+
+    // If we need the kernel to do PIC fixup for us add the space for that.
+    header_length += mem::size_of::<TbfHeaderPicOption1Fields>();
+
+    // Now we can calculate the entire size of the app in flash.
+    let mut total_size = (header_length + rel_data.len() + text.data.len() + got.data.len() +
+                          data.data.len()) as u32;
+
+    let ending_pad = if total_size.count_ones() > 1 {
         let power2len = cmp::max(1 << (32 - total_size.leading_zeros()), 512);
         power2len - total_size
     } else {
         0
     };
-    total_size = total_size + pad;
+    total_size += ending_pad;
 
-    let rel_data_offset = mem::size_of::<LoadInfo>() as u32;
-    let text_offset = rel_data_offset + (rel_data_size as u32);
+    // Calculate the offset between the start of the flash region and the actual
+    // app code. Also need to get the padding size.
+    let relocation_data_offset = align8!(header_length) as u32;
+    let post_header_pad = relocation_data_offset as usize - header_length;
+
+    // To start we just restrict the app from writing all of the space before
+    // its actual code and whatnot.
+    let protected_size = relocation_data_offset;
+
+    let text_offset = relocation_data_offset + (relocation_data_size as u32);
     let text_size = text.shdr.size as u32;
-    let entry_offset = (input.ehdr.entry ^ 0x80000000) as u32 + text_offset;
+    let init_fn_offset = (input.ehdr.entry ^ 0x80000000) as u32 + text_offset;
     let got_offset = text_offset + text_size;
     let got_size = got.shdr.size as u32;
     let data_offset = got_offset + got_size;
     let data_size = data.shdr.size as u32;
-    let package_name_offset = data_offset + data_size;
-    let package_name_size = package_name.len() as u32;
+    let bss_size = bss.shdr.size as u32;
+    let bss_memory_offset = bss.shdr.addr as u32;
+    let minimum_ram_size = stack_len + app_heap_len + kernel_heap_len + got_size + data_size +
+                           bss_size;
 
-    let load_info_version = 1;
+    // Flags default to app is enabled.
+    let flags = 0x00000001;
 
-    let load_info = LoadInfo {
-        version: load_info_version,
+    let tbf_header_version = 2;
+
+    let tbf_header = TbfHeaderBase {
+        version: tbf_header_version,
+        header_size: header_length as u16,
         total_size: total_size,
-        entry_offset: entry_offset,
-        rel_data_offset: rel_data_offset,
-        rel_data_size: rel_data_size as u32,
+        flags: flags,
+        checksum: 0,
+    };
+
+    let tbf_main = TbfHeaderMain {
+        base: TbfHeaderTlv {
+            tipe: TbfHeaderTypes::TbfHeaderMain,
+            length: (mem::size_of::<TbfHeaderMain>() - mem::size_of::<TbfHeaderTlv>()) as u16,
+        },
+        init_fn_offset: init_fn_offset,
+        protected_size: protected_size,
+        minimum_ram_size: minimum_ram_size,
+    };
+
+    let tbf_pic = TbfHeaderPicOption1Fields {
+        base: TbfHeaderTlv {
+            tipe: TbfHeaderTypes::TbfHeaderPicOption1,
+            length: (mem::size_of::<TbfHeaderPicOption1Fields>() -
+                     mem::size_of::<TbfHeaderTlv>()) as u16,
+        },
         text_offset: text_offset,
-        text_size: text_size,
-        got_offset: got_offset,
-        got_size: got_size,
         data_offset: data_offset,
         data_size: data_size,
-        bss_mem_offset: bss.shdr.addr as u32,
-        bss_size: bss.shdr.size as u32,
-        min_stack_len: stack_len,
-        min_app_heap_len: app_heap_len,
-        min_kernel_heap_len: kernel_heap_len,
-        package_name_offset: package_name_offset,
-        package_name_size: package_name_size,
-        checksum: load_info_version ^ total_size ^ entry_offset ^ rel_data_offset ^
-                  rel_data_size as u32 ^ text_offset ^ text_size ^ got_offset ^
-                  got_size ^
-                  data_offset ^ data_size ^ bss.shdr.addr as u32 ^
-                  bss.shdr.size as u32 ^
-                  stack_len ^ app_heap_len ^
-                  kernel_heap_len ^ package_name_offset ^ package_name_size,
+        bss_memory_offset: bss_memory_offset,
+        bss_size: bss_size,
+        relocation_data_offset: relocation_data_offset,
+        relocation_data_size: relocation_data_size as u32,
+        got_offset: got_offset,
+        got_size: got_size,
+        minimum_stack_length: stack_len,
+    };
+
+    let tbf_package_name_tlv = TbfHeaderTlv {
+        tipe: TbfHeaderTypes::TbfHeaderPackageName,
+        length: package_name.len() as u16,
     };
 
     if verbose {
-        print!("{}", load_info);
+        print!("{}", tbf_header);
+        print!("{}", tbf_main);
+        print!("{}", tbf_pic);
     }
 
-    try!(output.write_all(unsafe { as_byte_slice(&load_info) }));
+    // Calculate the header checksum.
+    let mut header_buf = Cursor::new(Vec::new());
+
+    // Write all bytes to an in-memory file for the header.
+    try!(header_buf.write_all(unsafe { as_byte_slice(&tbf_header) }));
+    try!(header_buf.write_all(unsafe { as_byte_slice(&tbf_main) }));
+    try!(header_buf.write_all(unsafe { as_byte_slice(&tbf_package_name_tlv) }));
+    try!(header_buf.write_all(package_name.as_ref()));
+    try!(header_buf.write_all(unsafe { as_byte_slice(&tbf_pic) }));
+
+    // Start from the beginning and iterate through the buffer as words.
+    try!(header_buf.seek(SeekFrom::Start(0)));
+    let mut wordbuf = [0u8; 4];
+    let mut checksum: u32 = 0;
+    loop {
+        let ret = header_buf.read(&mut wordbuf);
+        match ret {
+            Ok(count) => {
+                // Combine the bytes back into a word, handling if we don't
+                // get a full word.
+                let mut word = 0;
+                for i in 0..count {
+                    word |= (wordbuf[i] as u32) << (8 * i);
+                }
+                checksum ^= word;
+                if count != 4 {
+                    break;
+                }
+            }
+            Err(_) => println!("Error calculating checksum."),
+        }
+    }
+
+    // Now we need to insert the checksum into the correct position in the
+    // header.
+    try!(header_buf.seek(SeekFrom::Start(12)));
+    wordbuf[0] = ((checksum >> 0) & 0xFF) as u8;
+    wordbuf[1] = ((checksum >> 8) & 0xFF) as u8;
+    wordbuf[2] = ((checksum >> 16) & 0xFF) as u8;
+    wordbuf[3] = ((checksum >> 24) & 0xFF) as u8;
+    try!(header_buf.write(&wordbuf));
+    try!(header_buf.seek(SeekFrom::Start(0)));
+
+    fn do_pad(output: &mut Write, length: usize) -> io::Result<()> {
+        let mut pad = length;
+        let zero_buf = [0u8; 512];
+        while pad > 0 {
+            let amount_to_write = cmp::min(zero_buf.len(), pad);
+            pad -= try!(output.write(&zero_buf[..amount_to_write]));
+        }
+        Ok(())
+    }
+
+    // Write the header and actual app to a binary file.
+    try!(output.write_all(header_buf.get_ref()));
+    try!(do_pad(output, post_header_pad as usize));
     try!(output.write_all(rel_data.as_ref()));
     try!(output.write_all(text.data.as_ref()));
     try!(output.write_all(got.data.as_ref()));
     try!(output.write_all(data.data.as_ref()));
-    try!(output.write_all(package_name.as_ref()));
 
-    let mut pad = pad as usize;
-    let zero_buf = [0u8; 512];
-    while pad > 0 {
-        let amount_to_write = cmp::min(zero_buf.len(), pad);
-        pad -= try!(output.write(&zero_buf[..amount_to_write]));
-    }
+    // Pad to get a power of 2 sized flash app.
+    try!(do_pad(output, ending_pad as usize));
 
     Ok(())
 }


### PR DESCRIPTION
This updates the kernel with a new Tock Binary Format header (version 2). The new header includes a `flags` field which can provide app-specific configs for flashed apps.

The two supported flags are:

1. Enable/disable. Tells the kernel to run or not run an application at boot.
2. Sticky. Tells tockloader to not erase the app without --force.

Tockloader has been updated to support this new header.

This PR is marked as blocked so that we can see if there are other changes to the header format we want to add for version 2.