### PR TITLE
ADC: Starting on TRD updates

### DIFF
--- a/doc/reference/trd102-adc.md
+++ b/doc/reference/trd102-adc.md
@@ -5,10 +5,10 @@ Kernel Analog-to-Digital Conversion HIL
 **Working Group:** Kernel<br/>
 **Type:** Documentary<br/>
 **Status:** Draft <br/>
-**Author:** Philip Levis <br/>
+**Author:** Philip Levis and Branden Ghena<br/>
 **Draft-Created:** Dec 18, 2016<br/>
-**Draft-Modified:** Jan 30, 2017<br/>
-**Draft-Version:** 1<br/>
+**Draft-Modified:** May 5, 2017<br/>
+**Draft-Version:** 2<br/>
 **Draft-Discuss:** tock-dev@googlegroups.com</br>
 
 **Warning:** Out of Date. Needs to be updated. See
@@ -250,6 +250,12 @@ Stanford, CA 94305
 phone - +1 650 725 9046
 
 email - pal@cs.stanford.edu
+```
+
+```
+Branden Ghena
+
+email - brghena@umich.edu
 ```
 
 7 Citations

--- a/doc/reference/trd102-adc.md
+++ b/doc/reference/trd102-adc.md
@@ -7,7 +7,7 @@ Kernel Analog-to-Digital Conversion HIL
 **Status:** Draft <br/>
 **Author:** Philip Levis and Branden Ghena<br/>
 **Draft-Created:** Dec 18, 2016<br/>
-**Draft-Modified:** May 5, 2017<br/>
+**Draft-Modified:** June 12, 2017<br/>
 **Draft-Version:** 2<br/>
 **Draft-Discuss:** tock-dev@googlegroups.com</br>
 
@@ -45,7 +45,9 @@ The rest of this document discusses each in turn.
 ========================================
 
 The Adc trait is for requesting individual analog to digital conversions,
-either one-shot or repeatedly. It has four functions and one associated type:
+either one-shot or repeatedly. It is implemented by chip drivers to provide ADC
+functionality. Data is provided through the Client trait. It has four functions
+and one associated type:
 
 ```
 /// Simple interface for reading an ADC sample on any channel.
@@ -98,174 +100,271 @@ analog conversions have been started,  EOFF if the ADC is not initialized or
 enabled, EBUSY if a conversion is already in progress, or EINVAL if the
 specified channel or frequency are invalid.
 
+The `stop_sampling` function can be used to stop any sampling operation,
+single, continuous, or high speed. Conversions which have already begun are
+canceled. `stop_sampling` MUST be safe to call from any callback in the Client
+or HighSpeedClient traits. The function MUST return SUCCESS, EOFF, or EINVAL.
+SUCCESS indicates that all conversions are stopped and no further callbacks
+will occur, EOFF means the ADC is not initialized or enabled, and EINVAL means
+the ADC was not active.
 
-The `cancel_sample` function may be used to try to cancel an outstanding
-conversion request. Because the conversion may have already begun, or
-even have already completed but be enqueued within the kernel, this
-call may not succeed and the ADC may still issue a callback with the
-sample via the `Client` trait. This function MUST return SUCCESS, ERESERVE
-or FAIL. SUCCESS indicates that a callback WILL NOT be issued, while
-a failure code (FAIL or ERESERVE) indicate that the callback WILL be
-issued normally.
+The `channel` type is used to signify which ADC channel to sample data on for
+various commands. What it maps to is implementation-specific, possibly an I/O
+pin number or abstract notion of a channel. One approach used for channels by
+the SAM4L implementation is for the capsule to keep an array of possible
+channels, which are connected to pins by the board `main.rs` file, and selected
+from by userland applications.
 
 
-
-3 AdcContinuous
+3 Client trait
 ========================================
 
-The AdcContinuous trait is for requesting a stream of ADC conversions
-at a fixed frequency. These samples are expected to be taken with
-low jitter (e.g., clocked by an underyling hardware clock and not
-controlled by software).
+The Client trait handles responses from Adc trait sampling commands. It is
+implemented by capsules to receive chip driver responses. It has one function:
 
-Because the AdcContinuous trait takes an interval between samples,
-it needs a specify a time unit for this interval. As platforms can
-vary by orders of magnitude in the interval they can support, the
-trait instance should specify the time unit that represents the
-highest possible precision. For example, if an ADC can sample at
-maximum rate of 10kHz, the time unit should be 10kHz or less.
-Software trying to sample at a significantly higher precision
-(e.g., 1MHz ticks) should not be able to compile.
+```
+/// Trait for handling callbacks from simple ADC calls.
+pub trait Client {
+    /// Called when a sample is ready.
+    fn sample_ready(&self, sample: u16);
+}
+```
 
-The `Frequency` trait specifies the time unit of continuous
-sampling precision.
+The `sample_ready` function is called whenever data is available from a
+`sample` or `sample_continuous` call. It is safe to call `stop_sampling` within
+the `sample_ready` callback. The sample data returned is a maximum of 16 bits
+in resolution, with the exact data resolution being chip-specific. If data is
+less than 16 bits (for example 12-bits on the SAM4L), it SHOULD be placed in
+the least significant bits of the `sample` value.
 
-    pub trait Frequency {
-        fn frequency() -> u32;
-    }
 
-    pub trait AdcContinuous {
-        type Frequency: Frequency;
-        fn compute_interval(&self, interval:u32) -> u32;
-        fn sample_continuous(&self, channel: u8, interval:u32) -> Result;
-        fn cancel_sampling(&self) -> Result;
-    }
-
-The AdcContinuous trait has three functions. The first,
-`compute_interval` takes a specified interval and returns
-the actual interval that the ADC will provide. Whenever
-possible, `compute_interval` SHOULD be the identity function.
-However, underlying clock rates and hardware details MAY cause
-it to be a slightly different value.
-
-The second, `sample_continuous`, starts a series of continuous
-samples on `channel` with an interval of `interval`. The
-ADC might not sample at exactly the interval specified, due
-to underlying clock rates and hardware details. The value
-passed in `interval` is effectively passed to `compute_interval`
-to calculate the actual interval used. If a call to `sample_continuous`
-is passed an `interval` generated by calling `compute_interval`,
-then the implementation SHOULD match this interval exactly.
-
-The third, `cancel_sampling`, stops the continuous sampling.
-
-The `Frequency` type defines the frequency of the intervals. There
-are three default values of `Frequency`:
-  * 1kHz
-  * 32kHz
-  * 1MHz
-
-4 Client
+4 AdcHighSpeed trait
 ========================================
 
-The Client trait is how a caller provides a callback to the ADC
-implementation. Using a function defined outside the ADC trait, it
-registers a reference implementing the Client trait with the ADC
-implementation.
+The AdcHighSpeed trait is used for sampling data at high frequencies such that
+receiving individual samples would be untenable. Instead, it provides an
+interface that returns buffers filled with samples. This trait relies on the
+Adc trait being implemented as well in order to provide primitives like
+`intialize` and `stop_sampling` which are used for ADCs in this mode as well.
+While we expect many chips to support the Adc trait, we expect the AdcHighSpeed
+trait to be implemented due to a high-speed sampling need on a platform. The
+trait has three functions:
 
-    pub trait Client {
-        /// Called when a sample is ready.
-        fn sample_done(&self, sample: u16, result: Result);
-    }
+```
+/// Interface for continuously sampling at a given frequency on a channel.
+/// Requires the AdcSimple interface to have been implemented as well.
+pub trait AdcHighSpeed: Adc {
+    /// Start sampling continuously into buffers.
+    /// Samples are double-buffered, going first into `buffer1` and then into
+    /// `buffer2`. A callback is performed to the client whenever either buffer
+    /// is full, which expects either a second buffer to be sent via the
+    /// `provide_buffer` call. Length fields correspond to the number of
+    /// samples that should be collected in each buffer. If an error occurs,
+    /// the buffers will be returned.
+    fn sample_highspeed(&self,
+                        channel: &Self::Channel,
+                        frequency: u32,
+                        buffer1: &'static mut [u16],
+                        length1: usize,
+                        buffer2: &'static mut [u16],
+                        length2: usize)
+                        -> (ReturnCode, Option<&'static mut [u16]>,
+                            Option<&'static mut [u16]>);
 
-Whenever the ADC completes a sample, it invokes the `sample_done`
-function. If the sample was taken successfully, then `sample` MUST
-contain the value and `result` MUST be SUCCESS. If `sample` contains a
-value, the value MUST be left shifted so the most significant bit of
-`sample` is the most significant bit of the value. Possible values for
-`result` are SUCCESS, FAIL, EBUSY, EOFF, ERESERVE, EINVAL, or ECANCEL.
+    /// Provide a new buffer to fill with the ongoing `sample_continuous`
+    /// configuration.
+    /// Expected to be called in a `buffer_ready` callback. Note that if this
+    /// is not called before the second buffer is filled, samples will be
+    /// missed. Length field corresponds to the number of samples that should
+    /// be collected in the buffer. If an error occurs, the buffer will be
+    /// returned.
+    fn provide_buffer(&self,
+                      buf: &'static mut [u16],
+                      length: usize)
+                      -> (ReturnCode, Option<&'static mut [u16]>);
+
+    /// Reclaim ownership of buffers.
+    /// Can only be called when the ADC is inactive, which occurs after a
+    /// successful `stop_sampling`. Used to reclaim buffers after a sampling
+    /// operation is complete. Returns success if the ADC was inactive, but
+    /// there may still be no buffers that are `some` if the driver had already
+    /// returned all buffers.
+    fn retrieve_buffers(&self)
+                        -> (ReturnCode, Option<&'static mut [u16]>,
+                            Option<&'static mut [u16]>);
+}
+```
+
+The `sample_highspeed` function is used to perform high-speed double-buffered
+sampling. After the first buffer is filled with samples, the `samples_ready`
+function will be called and sampling will immediately continue into the second
+buffer in order to reduce jitter between samples. Additional buffers SHOULD be
+passed through the `provide_buffer` call. However, if none are provided, the
+driver MUST cease sampling once it runs out of buffers. In case of an error,
+the buffers will be immediately returned from the function. The channels and
+frequencies acceptable are chip-specific. The return code MUST be SUCCESS if
+sampling has begun successfully, EOFF if the ADC is not enabled or initialized,
+EBUSY if the ADC is in use, or EINVAL if the channel or frequency are invalid.
+
+The `provide_buffer` function is used to provide additional buffers to an
+ongoing high-speed sampling operation. It is expected to be called within a
+`samples_ready` callback in order to keep sampling running without delay. In
+case of an error, the buffer will be immediately returned from the function. It
+is not an error to fail to call `provide_buffer` and the underlying driver MUST
+cease sampling if no buffers are remaining. It is an error to call
+`provide_buffer` twice without having received a buffer through
+`samples_ready`. The prior settings for channel and frequency will persist. The
+return code MUST be SUCCESS if the buffer has been saved for later use, EOFF if
+the ADC is not initialized or enabled, EINVAL if there is no currently running
+continuous sampling operation, or EBUSY if an additional buffer has already
+been provided.
+
+The `retrieve_buffers` function returns ownership of all buffers owned by the
+chip implementation. All ADC operations MUST be stopped before buffers are
+returned. Any data within the buffers SHOULD be considered invalid. It is
+expected that `retrieve_buffers` will be called from within a `samples_ready`
+callback after calling `stop_sampling`. Up to two buffers will be returned by
+the function. The return code MUST be SUCCESS if the ADC is not in operation
+(although as few as zero buffers may be returned), EINVAL MUST be returned if
+an ADC operation is still in progress.
 
 
-5 Example Implementation: SAM4L
+5 HighSpeedClient trait
 ========================================
 
-The SAM4L ADC has a flexible ADC, supporting differential
-and single-ended inputs, 8 or 12 bit samples, configurable clocks, 
-reference voltages, and grounds. It supports periodic sampling supported
-by an internal timer.  The SAM4L ADC uses generic clock 10 (GCLK10). 
-The ADC is peripheral 38, so its control registers are found at
-address 0x40038000. A complete description of the ADC can be
-found in chapter 38 of the SAM4L datasheet.
+The HighSpeedClient trait is used to receive samples from a call to
+`sample_highspeed`. It is implemented by a capsule to receive chip driver
+responses. It has one function:
+
+```
+/// Trait for handling callbacks from high-speed ADC calls.
+pub trait HighSpeedClient {
+    /// Called when a buffer is full.
+    /// The length provided will always be less than or equal to the length of
+    /// the buffer. Expects an additional call to either provide another buffer
+    /// or stop sampling
+    fn samples_ready(&self, buf: &'static mut [u16], length: usize);
+}
+```
+
+The `samples_ready` function receives a buffer filled with up to `length`
+number of samples. Each sample MAY be up to 16 bits in size. Smaller samples
+SHOULD be aligned such that the data is in the least significant bits of each
+value. The length field MUST match the length passed in with the buffer
+(through either `sample_highspeed` or `provide_buffer`). Within the
+`samples_ready` callback, the capsule SHOULD call `provide_buffer` if it wishes
+to continue sampling. Alternatively, `stop_sampling` and `retrieve_buffers`
+SHOULD be called to stop the ongoing ADC operation. 
+
+
+6 Example Implementation: SAM4L
+========================================
+
+The SAM4L ADC has a flexible ADC, supporting differential and single-ended
+inputs, 8 or 12 bit samples, configurable clocks, reference voltages, and
+grounds. It supports periodic sampling supported by an internal timer.  The
+SAM4L ADC uses generic clock 10 (GCLK10). The ADC is peripheral 38, so its
+control registers are found at address 0x40038000. A complete description of
+the ADC can be found in Chapter 38 (Page 995) of the
+[SAM4L datasheet](http://www.atmel.com/images/atmel-42023-arm-microcontroller-atsam4l-low-power-lcd_datasheet.pdf).
 
 The current implementation, found in `chips/sam4l/adc.rs`, implements 
-the `AdcSingle` trait.
+the `Adc` and `AdcHighSpeed` traits.
 
-
-5.1 Initialization
+6.1 ADC Channels
 ---------------------------------
 
-Initialization follows the process outlined in section 38.6.1 of the 
-SAM4L datasheet.  The first step of initialization is to configure 
-the ADC's clock.  The implementation configures GCLK10 to use the 
-RCSYS clock, which operates at 115kHz.
+In order to provide a list of ADC channels to the capsule and userland, the
+SAM4L implementation creates an AdcChannel struct which contains and enum
+defining its value. Each possible ADC channel is then statically created. Other
+chips may want to consider a similar system.
 
-    unsafe {
-        pm::enable_clock(Clock::PBA(PBAClock::ADCIFE));
-        nvic::enable(nvic::NvicIdx::ADCIFE);
-        scif::generic_clock_enable(scif::GenericClock::GCLK10, scif::ClockSource::RCSYS);
-    }
+```
+/// Representation of an ADC channel on the SAM4L.
+pub struct AdcChannel {
+    chan_num: u32,
+    internal: u32,
+}
 
-It then has a fixed delay, to ensure the ADC cell is ready. Next,
-it enables the ADC and waits until it is ready. Once the ADC
-is ready, it turns on the bandgap and reference buffers. Once
-those buffers are enabled, it sets the ADC to takes samples against a
-reference voltage of VCC/2 and the clock divider to be 4. Since
-the clock frequency is 115kHz and it takes 6 clock cyles to 
-take a 12-bit sample, the maximum default sampling rate is
-115kHz / (4 * 6) ~= 4800ksps.
+/// SAM4L ADC channels.
+#[derive(Copy,Clone,Debug)]
+#[repr(u8)]
+enum Channel {
+    AD0 = 0x00,
+    AD1 = 0x01,
+    ...
+    ReferenceGround = 0x17,
+}
 
-5.2 AdcSingle: Taking a sample
----------------------------------
-
-A call to `AdcSingle.sample` has a few basic checks before
-initiating a sample. It checks that the channel is valid
-and that the ADC is enabled.
-
-The sample configures the ADC to use the ground pad as the
-ground (for reference to VCC/2) and take a 12-bit sample.
-The sample is not left-justified (it is in the 12 least
-significant bits).
-
-The implementation does not support cancelling outstanding
-samples: `cancel_sample` always returns `ReturnCode::FAIL`.
-
-5.3 AdcSingle: Handling a sample
----------------------------------
-
-The ADCIFE interrupt registers `handle_interrupt` bottom half
-to run on `Adc`. This function clears the interrupt, reads
-the sample result from the LCV register, and issues a callback
-to an ADC client, if one has ben registered with `set_client`:
-
-    pub fn handle_interrupt(&mut self) {
-        let val: u16;
-        let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
-        // Make sure this is the SEOC (Sequencer end-of-conversion) interrupt
-        let status = regs.sr.get();
-        if status & 0x01 == 0x01 {
-            // Clear SEOC interrupt
-            regs.scr.set(0x0000001);
-            // Disable SEOC interrupt
-            regs.idr.set(0x00000001);
-            // Read the value from the LCV register.
-            // The sample is 16 bits wide
-            val = (regs.lcv.get() & 0xffff) as u16;
-            self.client.get().map(|client| { client.sample_done(val); });
+/// Initialization of an ADC channel.
+impl AdcChannel {
+    /// Create a new ADC channel.
+    /// channel - Channel enum representing the channel number and whether it is
+    ///           internal
+    const fn new(channel: Channel) -> AdcChannel {
+        AdcChannel {
+            chan_num: ((channel as u8) & 0x0F) as u32,
+            internal: (((channel as u8) >> 4) & 0x01) as u32,
         }
     }
+}
+
+/// Statically allocated ADC channels. Used in board configurations to specify
+/// which channels are used on the platform.
+pub static mut CHANNEL_AD0: AdcChannel = AdcChannel::new(Channel::AD0);
+pub static mut CHANNEL_AD1: AdcChannel = AdcChannel::new(Channel::AD1);
+...
+pub static mut CHANNEL_REFERENCE_GROUND: AdcChannel = AdcChannel::new(Channel::ReferenceGround);
+```
+
+6.2 Client Type
+---------------------------------
+
+It is difficult in Rust to require a argument that implements two types.
+However, it is convenient for the implementation to expect a single client that
+implements both the `adc::Client` and `adc::HighSpeedClient` interfaces. It is
+possible to do so by defining a new trait that requires each.
+
+```
+/// Create a trait of both client types to allow a single client reference to
+/// act as both
+pub trait EverythingClient: hil::adc::Client + hil::adc::HighSpeedClient {}
+impl<C: hil::adc::Client + hil::adc::HighSpeedClient> EverythingClient for C {}
+```
+
+6.3 Clock Initialization
+---------------------------------
+
+The ADC clock on the SAM4L is poorly documented. It is required to both
+generate a clock based on the PBA clock as well as GCLK10. However, the clock
+used for samples by the ADC run at 1.5 MHz at the highest (for single sampling
+mode). In order to handle this, the SAM4L ADC implementation first divides down
+the clock to reach a value less than or equal to 1.5 MHz (exactly 1.5 MHz in
+practice for a CPU clock running at 48 MHz).
+
+6.4 ADC Initialization
+---------------------------------
+
+The process of initializing the ADC is well documented in the SAM4L datasheet,
+unfortunately it seems to be entirely false. While following the documentation
+allows for single sampling, high speed sampling fails in practice after a small
+number of samples (order less than 100) have been collected. After much
+experimentation and comparison to other SAM4L code available online, it was
+determined that the initialization process should be:
+
+1. Enable clock
+2. Configure ADC
+3. Reset ADC
+4. Enable ADC
+5. Wait until ADC status is set to enabled
+6. Enable the Bandgap and Reference Buffers
+7. Wait until the buffers are enabled
+
+It is quite possible that other orders of initialization are valid, however
+proceed with caution.
 
 
-6 Authors' Address
+7 Authors' Address
 ========================================
 
 ```
@@ -285,7 +384,7 @@ Branden Ghena
 email - brghena@umich.edu
 ```
 
-7 Citations
+8 Citations
 ========================================
 
 <a name="trd1"/>[TRD1] <a href="trd1-trds.md">Tock Reference Document (TRD) Structure and Keywords</a>


### PR DESCRIPTION
Updates to TRD documentation for the ADC.

Pulling this apart from the main ADC PR so that we can have back and forth on it, but still get the ADC stuff merged into Tock to start using it.