### PR TITLE
Capsules: Make `struct App {}` consistent

### DIFF
--- a/boards/imix/src/spi_dummy.rs
+++ b/boards/imix/src/spi_dummy.rs
@@ -1,6 +1,7 @@
 //! A dummy SPI client to test the SPI implementation
 
 extern crate kernel;
+use kernel::ReturnCode;
 use kernel::hil::gpio;
 use kernel::hil::gpio::Pin;
 use kernel::hil::spi::{self, SpiMaster};
@@ -65,7 +66,7 @@ pub unsafe fn spi_dummy_test() {
     sam4l::spi::SPI.enable();
     sam4l::spi::SPI.set_baud_rate(1000000);
     let len = BUF2.len();
-    if sam4l::spi::SPI.read_write_bytes(&mut BUF2, Some(&mut BUF1), len) == false {
+    if sam4l::spi::SPI.read_write_bytes(&mut BUF2, Some(&mut BUF1), len) != ReturnCode::SUCCESS {
         loop {
             sam4l::spi::SPI.write_byte(0xA5);
         }

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -1,6 +1,7 @@
 //! Virtualize a Spi Master bus to enable multiple users of the Spi bus.
 
 use core::cell::Cell;
+use kernel::ReturnCode;
 use kernel::common::{List, ListLink, ListNode};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
@@ -147,12 +148,12 @@ impl<'a, Spi: hil::spi::SpiMaster> hil::spi::SpiMasterDevice for VirtualSpiMaste
                         write_buffer: &'static mut [u8],
                         read_buffer: Option<&'static mut [u8]>,
                         len: usize)
-                        -> bool {
+                        -> ReturnCode {
         self.txbuffer.replace(write_buffer);
         self.rxbuffer.put(read_buffer);
         self.operation.set(Op::ReadWriteBytes(len));
         self.mux.do_next_op();
-        true
+        ReturnCode::SUCCESS
     }
 
     fn set_polarity(&self, cpol: hil::spi::ClockPolarity) {

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -5,6 +5,7 @@ use core::mem;
 use dma::DMAChannel;
 use dma::DMAClient;
 use dma::DMAPeripheral;
+use kernel::ReturnCode;
 
 use kernel::common::volatile_cell::VolatileCell;
 
@@ -292,11 +293,11 @@ impl spi::SpiMaster for Spi {
                         write_buffer: &'static mut [u8],
                         read_buffer: Option<&'static mut [u8]>,
                         len: usize)
-                        -> bool {
+                        -> ReturnCode {
         self.enable();
         // If busy, don't start.
         if self.is_busy() {
-            return false;
+            return ReturnCode::EBUSY;
         }
 
         // We will have at least a write transfer in progress
@@ -332,7 +333,7 @@ impl spi::SpiMaster for Spi {
                 read.do_xfer(DMAPeripheral::SPI_RX, rbuf, count);
             });
         });
-        true
+        ReturnCode::SUCCESS
     }
 
     fn set_rate(&self, rate: u32) -> u32 {

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -2,6 +2,7 @@ use core::cell::Cell;
 use core::cmp;
 use core::mem;
 use dma;
+use kernel::ReturnCode;
 use kernel::common::volatile_cell::VolatileCell;
 // other modules
 use kernel::hil;
@@ -705,7 +706,7 @@ impl hil::spi::SpiMaster for USART {
                         mut write_buffer: &'static mut [u8],
                         read_buffer: Option<&'static mut [u8]>,
                         len: usize)
-                        -> bool {
+                        -> ReturnCode {
 
         self.enable_tx();
         self.enable_rx();
@@ -742,7 +743,7 @@ impl hil::spi::SpiMaster for USART {
             });
         });
 
-        true
+        ReturnCode::SUCCESS
     }
 
     fn write_byte(&self, val: u8) {

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -2,6 +2,8 @@
 
 use core::option::Option;
 
+use returncode::ReturnCode;
+
 /// Values for the ordering of bits
 #[derive(Copy, Clone, Debug)]
 pub enum DataOrder {
@@ -87,7 +89,7 @@ pub trait SpiMaster {
                         write_buffer: &'static mut [u8],
                         read_buffer: Option<&'static mut [u8]>,
                         len: usize)
-                        -> bool;
+                        -> ReturnCode;
     fn write_byte(&self, val: u8);
     fn read_byte(&self) -> u8;
     fn read_write_byte(&self, val: u8) -> u8;
@@ -135,7 +137,7 @@ pub trait SpiMasterDevice {
                         write_buffer: &'static mut [u8],
                         read_buffer: Option<&'static mut [u8]>,
                         len: usize)
-                        -> bool;
+                        -> ReturnCode;
 
     fn set_polarity(&self, cpol: ClockPolarity);
     fn set_phase(&self, cpal: ClockPhase);


### PR DESCRIPTION
We've gone through a couple iterations for how application-specific state is held in capsules. This PR updates all non-virtualized capsules to the

```rust
impl Default for App {
    fn default() -> App {
        App {
            callback: None,
            buffer: None,
            remaining: 0,
            idx: 0,
        }
    }
}
```

method. It also makes the naming consistent.

Along the way I noticed that the SPI HIL returns a `bool`. I updated that to `ReturnCode`.