### PR TITLE
Use public kernel path on `use`s

### DIFF
--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -1,6 +1,6 @@
 use kernel;
+use kernel::common::VolatileCell;
 use kernel::common::math::PowerOfTwo;
-use kernel::common::volatile_cell::VolatileCell;
 
 /// Indicates whether the MPU is present and, if so, how many regions it
 /// supports.

--- a/arch/cortex-m4/src/scb.rs
+++ b/arch/cortex-m4/src/scb.rs
@@ -1,6 +1,6 @@
 // Based on: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CIHFDJCA.html
 
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 
 #[repr(C, packed)]
 struct ScbRegisters {

--- a/arch/cortex-m4/src/systick.rs
+++ b/arch/cortex-m4/src/systick.rs
@@ -1,5 +1,5 @@
 use kernel;
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 
 pub struct SysTick {
     control: VolatileCell<u32>,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -30,7 +30,7 @@ mod test_take_map_cell;
 static mut SPI_READ_BUF: [u8; 64] = [0; 64];
 static mut SPI_WRITE_BUF: [u8; 64] = [0; 64];
 
-unsafe fn load_processes() -> &'static mut [Option<kernel::process::Process<'static>>] {
+unsafe fn load_processes() -> &'static mut [Option<kernel::Process<'static>>] {
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
@@ -44,18 +44,16 @@ unsafe fn load_processes() -> &'static mut [Option<kernel::process::Process<'sta
     #[link_section = ".app_memory"]
     static mut APP_MEMORY: [u8; 49152] = [0; 49152];
 
-    static mut PROCESSES: [Option<kernel::process::Process<'static>>; NUM_PROCS] = [None, None,
-                                                                                    None, None];
+    static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None, None, None];
 
     let mut apps_in_flash_ptr = &_sapps as *const u8;
     let mut app_memory_ptr = APP_MEMORY.as_mut_ptr();
     let mut app_memory_size = APP_MEMORY.len();
     for i in 0..NUM_PROCS {
-        let (process, flash_offset, memory_offset) =
-            kernel::process::Process::create(apps_in_flash_ptr,
-                                             app_memory_ptr,
-                                             app_memory_size,
-                                             FAULT_RESPONSE);
+        let (process, flash_offset, memory_offset) = kernel::Process::create(apps_in_flash_ptr,
+                                                                             app_memory_ptr,
+                                                                             app_memory_size,
+                                                                             FAULT_RESPONSE);
 
         if process.is_none() {
             break;

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -427,7 +427,7 @@ pub unsafe fn reset_handler() {
     kernel::main(&imix, &mut chip, load_processes(), &imix.ipc);
 }
 
-unsafe fn load_processes() -> &'static mut [Option<kernel::process::Process<'static>>] {
+unsafe fn load_processes() -> &'static mut [Option<kernel::Process<'static>>] {
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
@@ -441,17 +441,16 @@ unsafe fn load_processes() -> &'static mut [Option<kernel::process::Process<'sta
     #[link_section = ".app_memory"]
     static mut APP_MEMORY: [u8; 16384] = [0; 16384];
 
-    static mut PROCESSES: [Option<kernel::process::Process<'static>>; NUM_PROCS] = [None, None];
+    static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None];
 
     let mut apps_in_flash_ptr = &_sapps as *const u8;
     let mut app_memory_ptr = APP_MEMORY.as_mut_ptr();
     let mut app_memory_size = APP_MEMORY.len();
     for i in 0..NUM_PROCS {
-        let (process, flash_offset, memory_offset) =
-            kernel::process::Process::create(apps_in_flash_ptr,
-                                             app_memory_ptr,
-                                             app_memory_size,
-                                             FAULT_RESPONSE);
+        let (process, flash_offset, memory_offset) = kernel::Process::create(apps_in_flash_ptr,
+                                                                             app_memory_ptr,
+                                                                             app_memory_size,
+                                                                             FAULT_RESPONSE);
 
         if process.is_none() {
             break;

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -66,7 +66,7 @@ const BUTTON2_PIN: usize = 18;
 const BUTTON3_PIN: usize = 19;
 const BUTTON4_PIN: usize = 20;
 
-unsafe fn load_process() -> &'static mut [Option<kernel::process::Process<'static>>] {
+unsafe fn load_process() -> &'static mut [Option<kernel::Process<'static>>] {
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
@@ -80,17 +80,16 @@ unsafe fn load_process() -> &'static mut [Option<kernel::process::Process<'stati
     #[link_section = ".app_memory"]
     static mut APP_MEMORY: [u8; 8192] = [0; 8192];
 
-    static mut PROCESSES: [Option<kernel::process::Process<'static>>; NUM_PROCS] = [None];
+    static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None];
 
     let mut apps_in_flash_ptr = &_sapps as *const u8;
     let mut app_memory_ptr = APP_MEMORY.as_mut_ptr();
     let mut app_memory_size = APP_MEMORY.len();
     for i in 0..NUM_PROCS {
-        let (process, flash_offset, memory_offset) =
-            kernel::process::Process::create(apps_in_flash_ptr,
-                                             app_memory_ptr,
-                                             app_memory_size,
-                                             FAULT_RESPONSE);
+        let (process, flash_offset, memory_offset) = kernel::Process::create(apps_in_flash_ptr,
+                                                                             app_memory_ptr,
+                                                                             app_memory_size,
+                                                                             FAULT_RESPONSE);
 
         if process.is_none() {
             break;

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -13,10 +13,10 @@
 use core::cell::Cell;
 use core::cmp;
 use kernel::{AppId, AppSlice, Callback, Driver, Shared};
+use kernel::ReturnCode;
 
 use kernel::common::take_cell::{TakeCell, MapCell};
 use kernel::hil;
-use kernel::returncode::ReturnCode;
 
 pub static mut BUFFER1: [u8; 256] = [0; 256];
 pub static mut BUFFER2: [u8; 256] = [0; 256];

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -66,10 +66,10 @@
 use core::cell::Cell;
 
 use kernel::{AppId, Callback, Driver};
+use kernel::ReturnCode;
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::returncode::ReturnCode;
 
 pub static mut BUFFER: [u8; 20] = [0; 20];
 

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -2,8 +2,8 @@
 
 use core::cell::Cell;
 use kernel::{AppId, Callback, Container, Driver};
+use kernel::ReturnCode;
 use kernel::hil;
-use kernel::returncode::ReturnCode;
 
 #[derive(Clone,Copy,PartialEq)]
 pub enum NineDofCommand {

--- a/capsules/src/radio.rs
+++ b/capsules/src/radio.rs
@@ -10,9 +10,9 @@
 
 use core::cell::Cell;
 use kernel::{AppId, Driver, Callback, AppSlice, Shared};
+use kernel::ReturnCode;
 use kernel::common::take_cell::{MapCell, TakeCell};
 use kernel::hil::radio;
-use kernel::returncode::ReturnCode;
 
 struct App {
     tx_callback: Option<Callback>,

--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -21,11 +21,11 @@
 //
 
 use core::cell::Cell;
+use kernel::ReturnCode;
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::radio;
 use kernel::hil::spi;
-use kernel::returncode::ReturnCode;
 use rf233_const::*;
 
 const INTERRUPT_ID: usize = 0x2154;

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -18,11 +18,11 @@
 use core::{cmp, mem, slice};
 use core::cell::Cell;
 use dma;
+use kernel::ReturnCode;
+use kernel::common::VolatileCell;
 use kernel::common::math;
 use kernel::common::take_cell::TakeCell;
-use kernel::common::volatile_cell::VolatileCell;
 use kernel::hil;
-use kernel::returncode::ReturnCode;
 use nvic;
 use pm::{self, Clock, PBAClock};
 use scif;

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -6,7 +6,7 @@
 //
 
 use core::cell::Cell;
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 use kernel::hil::Controller;
 use kernel::hil::time::{self, Alarm, Time, Freq16KHz};
 use nvic;

--- a/chips/sam4l/src/bpm.rs
+++ b/chips/sam4l/src/bpm.rs
@@ -1,4 +1,4 @@
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 
 #[repr(C, packed)]
 struct BpmRegisters {

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -49,8 +49,8 @@
 // - Support continuous-mode CRC
 
 use core::cell::Cell;
+use kernel::ReturnCode;
 use kernel::hil::crc::{self, CrcAlg};
-use kernel::returncode::ReturnCode;
 use nvic;
 use pm::{Clock, HSBClock, PBBClock, enable_clock, disable_clock};
 

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -1,8 +1,8 @@
 use core::{cmp, intrinsics, mem};
 use core::cell::Cell;
+use kernel::common::VolatileCell;
 
 use kernel::common::take_cell::TakeCell;
-use kernel::common::volatile_cell::VolatileCell;
 use nvic;
 use pm;
 

--- a/chips/sam4l/src/gpio.rs
+++ b/chips/sam4l/src/gpio.rs
@@ -4,7 +4,7 @@ use self::Pin::*;
 use core::cell::Cell;
 use core::mem;
 use core::ops::{Index, IndexMut};
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 use kernel::hil;
 use nvic;
 use nvic::NvicIdx::*;

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -14,8 +14,8 @@
 use core::cell::Cell;
 use core::mem;
 use dma::{DMAChannel, DMAClient, DMAPeripheral};
+use kernel::common::VolatileCell;
 use kernel::common::take_cell::TakeCell;
-use kernel::common::volatile_cell::VolatileCell;
 
 use kernel::hil;
 use nvic;

--- a/chips/sam4l/src/nvic.rs
+++ b/chips/sam4l/src/nvic.rs
@@ -1,5 +1,5 @@
 use core::intrinsics;
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 
 #[repr(C, packed)]
 struct Nvic {

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -1,4 +1,4 @@
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 
 #[repr(C, packed)]
 struct PmRegisters {

--- a/chips/sam4l/src/scif.rs
+++ b/chips/sam4l/src/scif.rs
@@ -8,7 +8,7 @@
 // Date: Aug 2, 2015
 //
 
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 
 pub enum Register {
     IER = 0x00,

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -7,7 +7,7 @@ use dma::DMAClient;
 use dma::DMAPeripheral;
 use kernel::ReturnCode;
 
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 
 use kernel::hil::spi;
 use kernel::hil::spi::ClockPhase;

--- a/chips/sam4l/src/trng.rs
+++ b/chips/sam4l/src/trng.rs
@@ -1,7 +1,7 @@
 //! TRNG driver for the SAM4L
 
 use core::cell::Cell;
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 use kernel::hil::rng::{self, Continue};
 use nvic;
 use pm;

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -3,7 +3,7 @@ use core::cmp;
 use core::mem;
 use dma;
 use kernel::ReturnCode;
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 // other modules
 use kernel::hil;
 // local modules

--- a/chips/sam4l/src/wdt.rs
+++ b/chips/sam4l/src/wdt.rs
@@ -1,6 +1,6 @@
 use core::cell::Cell;
 use core::mem;
-use kernel::common::volatile_cell::VolatileCell;
+use kernel::common::VolatileCell;
 use kernel::hil;
 use pm::{self, Clock, PBDClock};
 


### PR DESCRIPTION
This unifies things so that if a lib/mod.rs file has `pub use` we use that path instead of the absolute one.