### PR TITLE
Add MCP23008 Capsule

### DIFF
--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -1,0 +1,164 @@
+//! Provide userspace applications with a driver interface to asynchronous
+//! GPIO pins. These are pins that exist on something like a GPIO extender or
+//! a radio that has controllable GPIOs.
+
+use core::cell::Cell;
+use kernel::{AppId, Callback, Driver};
+use kernel::ReturnCode;
+
+use kernel::hil;
+
+pub struct GPIOAsync<'a, Port: hil::gpio_async::Port + 'a> {
+    ports: &'a [&'a Port],
+    callback: Cell<Option<Callback>>,
+    interrupt_callback: Cell<Option<Callback>>,
+}
+
+impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
+    pub fn new(ports: &'a [&'a Port]) -> GPIOAsync<'a, Port> {
+        GPIOAsync {
+            ports: ports,
+            callback: Cell::new(None),
+            interrupt_callback: Cell::new(None),
+        }
+    }
+
+    fn configure_input_pin(&self, port: usize, pin: usize, config: usize) -> ReturnCode {
+        let ports = self.ports.as_ref();
+        let mode = match config {
+            0 => hil::gpio::InputMode::PullUp,
+            1 => hil::gpio::InputMode::PullDown,
+            2 => hil::gpio::InputMode::PullNone,
+            _ => return ReturnCode::EINVAL,
+        };
+        ports[port].make_input(pin, mode)
+    }
+
+    fn configure_interrupt(&self, port: usize, pin: usize, config: usize) -> ReturnCode {
+        let ports = self.ports.as_ref();
+        let mode = match config {
+            0 => hil::gpio::InterruptMode::EitherEdge,
+            1 => hil::gpio::InterruptMode::RisingEdge,
+            2 => hil::gpio::InterruptMode::FallingEdge,
+            _ => return ReturnCode::EINVAL,
+        };
+        ports[port].enable_interrupt(pin, mode, port)
+    }
+}
+
+impl<'a, Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'a, Port> {
+    fn fired(&self, pin: usize, identifier: usize) {
+        self.interrupt_callback.get().map(|mut cb| cb.schedule(identifier, pin, 0));
+    }
+
+    fn done(&self, value: usize) {
+        self.callback.get().map(|mut cb| cb.schedule(0, value, 0));
+    }
+}
+
+impl<'a, Port: hil::gpio_async::Port> Driver for GPIOAsync<'a, Port> {
+    /// Setup callbacks for gpio_async events.
+    ///
+    /// subscribe_num 0: Setup a callback for when split-phase operations
+    ///                  complete. This callback gets called from the gpio_async
+    ///                  `done()` event and signals the end of operations like
+    ///                  asserting a GPIO pin or configuring an interrupt pin.
+    ///                  The callback will be called with two valid arguments.
+    ///                  The first is the callback type, which is currently 0
+    ///                  for all done() events. The second is a value, which
+    ///                  is only useful for operations which should return
+    ///                  something, like a GPIO read.
+    ///
+    /// subscribe_num 1: Setup a callback for when a GPIO interrupt occurs.
+    ///                  This callback will be called with two arguments,
+    ///                  the first being the port number of the interrupting
+    ///                  pin, and the second being the pin number.
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+        match subscribe_num {
+            // Set callback for `done()` events
+            0 => {
+                self.callback.set(Some(callback));
+                ReturnCode::SUCCESS
+            }
+
+            // Set callback for pin interrupts
+            1 => {
+                self.interrupt_callback.set(Some(callback));
+                ReturnCode::SUCCESS
+            }
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Configure and read GPIO pins.
+    ///
+    /// `data` is a 32 bit value packed with the lowest 8 bits as the port
+    /// number, the next lowest 8 bits as the pin number, and the remaining
+    /// upper bits as a command-specific value.
+    ///
+    /// command_num 0: Driver check and get number of GPIO ports supported.
+    /// command_num 1: Set a pin as an output.
+    /// command_num 2: Set a pin high by setting it to 1.
+    /// command_num 3: Clear a pin by setting it to 0.
+    /// command_num 4: Toggle a pin.
+    /// command_num 5: Set a pin as an input and configure its pull-up or
+    ///                pull-down state. The command-specific field should be
+    ///                set to 0 for a pull-up, 1 for a pull-down, or 2 for
+    ///                neither.
+    /// command_num 6: Read a GPIO pin state, and have its value returned
+    ///                in the done() callback.
+    /// command_num 7: Enable an interrupt on a GPIO pin. The command-specific
+    ///                data should be 0 for an either-edge interrupt, 1 for
+    ///                a rising edge interrupt, and 2 for a falling edge
+    ///                interrupt.
+    /// command_num 8: Disable an interrupt on a pin.
+    /// command_num 9: Disable a GPIO pin.
+    fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
+        let port = data & 0xFF;
+        let pin = (data >> 8) & 0xFF;
+        let other = (data >> 16) & 0xFFFF;
+        let ports = self.ports.as_ref();
+
+        // On any command other than 0, we check for ports length.
+        if command_num != 0 && port >= ports.len() {
+            return ReturnCode::EINVAL;
+        }
+
+        match command_num {
+            // How many ports
+            0 => ReturnCode::SuccessWithValue { value: ports.len() as usize },
+
+            // enable output
+            1 => ports[port].make_output(pin),
+
+            // set pin
+            2 => ports[port].set(pin),
+
+            // clear pin
+            3 => ports[port].clear(pin),
+
+            // toggle pin
+            4 => ports[port].toggle(pin),
+
+            // enable and configure input
+            5 => self.configure_input_pin(port, pin, other & 0xFF),
+
+            // read input
+            6 => ports[port].read(pin),
+
+            // enable interrupt on pin
+            7 => self.configure_interrupt(port, pin, other & 0xFF),
+
+            // disable interrupt on pin
+            8 => ports[port].disable_interrupt(pin),
+
+            // disable pin
+            9 => ports[port].disable(pin),
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -34,3 +34,5 @@ pub mod temp_nrf51dk;
 pub mod symmetric_encryption;
 pub mod ninedof;
 pub mod ltc294x;
+pub mod mcp23008;
+pub mod gpio_async;

--- a/capsules/src/mcp23008.rs
+++ b/capsules/src/mcp23008.rs
@@ -1,0 +1,547 @@
+//! Driver for the Microchip MCP23008 I2C GPIO Extender
+//!
+//! http://www.microchip.com/wwwproducts/en/MCP23008
+//!
+//! Paraphrased from the website:
+//! "The MCP23008 device provides 8-bit, general purpose, parallel I/O expansion
+//! for I2C bus applications. The MCP23008 has three address pins and consists
+//! of multiple 8-bit configuration registers for input, output and polarity
+//! selection. The system master can enable the I/Os as either inputs or outputs
+//! by writing the I/O configuration bits. The data for each input or output is
+//! kept in the corresponding Input or Output register. The polarity of the
+//! Input Port register can be inverted with the Polarity Inversion register.
+//! All registers can be read by the system master."
+//!
+//! Usage
+//! -----
+//! This capsule can either be used inside of the kernel or as an input to
+//! the `gpio_async` capsule because it implements the `hil::gpio_async::Port`
+//! trait.
+//!
+//! Example usage:
+//! ```rust
+//! // Configure the MCP23008. Device address 0x20.
+//! let mcp23008_i2c = static_init!(
+//!     capsules::virtual_i2c::I2CDevice,
+//!     capsules::virtual_i2c::I2CDevice::new(i2c_mux, 0x20),
+//!     32);
+//! let mcp23008 = static_init!(
+//!     capsules::mcp23008::MCP23008<'static>,
+//!     capsules::mcp23008::MCP23008::new(mcp23008_i2c,
+//!                                       Some(&sam4l::gpio::PA[04]),
+//!                                       &mut capsules::mcp23008::BUFFER),
+//!     352/8);
+//! mcp23008_i2c.set_client(mcp23008);
+//! sam4l::gpio::PA[04].set_client(mcp23008);
+//!
+//! // Create an array of the GPIO extenders so we can pass them to an
+//! // administrative layer that provides a single interface to them all.
+//! let async_gpio_ports = static_init!(
+//!     [&'static capsules::mcp23008::MCP23008; 1],
+//!     [mcp23008],
+//!     32/8
+//! );
+//!
+//! // `gpio_async` is the object that manages all of the extenders.
+//! let gpio_async = static_init!(
+//!     capsules::gpio_async::GPIOAsync<'static, capsules::mcp23008::MCP23008<'static>>,
+//!     capsules::gpio_async::GPIOAsync::new(async_gpio_ports),
+//!     384/8
+//! );
+//! // Setup the clients correctly.
+//! for port in async_gpio_ports.iter() {
+//!     port.set_client(gpio_async);
+//! }
+//! ```
+//! Note that if interrupts are not needed, a `None` can be passed in when the
+//! `mcp23008` object is created.
+
+use core::cell::Cell;
+use kernel::ReturnCode;
+
+use kernel::common::take_cell::TakeCell;
+use kernel::hil;
+
+// Buffer to use for I2C messages
+pub static mut BUFFER: [u8; 7] = [0; 7];
+
+#[allow(dead_code)]
+#[derive(Debug)]
+enum Registers {
+    IoDir = 0x00,
+    IPol = 0x01,
+    GpIntEn = 0x02,
+    DefVal = 0x03,
+    IntCon = 0x04,
+    IoCon = 0x05,
+    GpPu = 0x06,
+    IntF = 0x07,
+    IntCap = 0x08,
+    Gpio = 0x09,
+    OLat = 0x0a,
+}
+
+/// States of the I2C protocol with the MCP23008.
+#[derive(Clone,Copy,Debug,PartialEq)]
+enum State {
+    Idle,
+
+    // Setup input/output
+    SelectIoDir(u8, Direction),
+    ReadIoDir(u8, Direction),
+    SelectGpPu(u8, bool),
+    ReadGpPu(u8, bool),
+    SetGpPu(u8),
+    SelectGpio(u8, PinState),
+    ReadGpio(u8, PinState),
+    SelectGpioToggle(u8),
+    ReadGpioToggle(u8),
+    SelectGpioRead(u8),
+    ReadGpioRead(u8),
+    EnableInterruptSettings,
+    ReadInterruptSetup,
+    ReadInterruptValues,
+
+    /// Disable I2C and release buffer
+    Done,
+}
+
+#[derive(Clone,Copy,Debug,PartialEq)]
+enum Direction {
+    Input = 0x01,
+    Output = 0x00,
+}
+
+#[derive(Clone,Copy,Debug,PartialEq)]
+enum PinState {
+    High = 0x01,
+    Low = 0x00,
+}
+
+pub struct MCP23008<'a> {
+    i2c: &'a hil::i2c::I2CDevice,
+    state: Cell<State>,
+    buffer: TakeCell<'static, [u8]>,
+    interrupt_pin: Option<&'static hil::gpio::Pin>,
+    interrupt_settings: Cell<u32>, // Whether the pin interrupt is enabled, and what mode it's in.
+    identifier: Cell<usize>,
+    client: Cell<Option<&'static hil::gpio_async::Client>>,
+}
+
+impl<'a> MCP23008<'a> {
+    pub fn new(i2c: &'a hil::i2c::I2CDevice,
+               interrupt_pin: Option<&'static hil::gpio::Pin>,
+               buffer: &'static mut [u8])
+               -> MCP23008<'a> {
+        MCP23008 {
+            i2c: i2c,
+            state: Cell::new(State::Idle),
+            buffer: TakeCell::new(buffer),
+            interrupt_pin: interrupt_pin,
+            interrupt_settings: Cell::new(0),
+            identifier: Cell::new(0),
+            client: Cell::new(None),
+        }
+    }
+
+    /// Set the client of this MCP23008 when commands finish or interrupts
+    /// occur. The `identifier` is simply passed back with the callback
+    /// so that the upper layer can keep track of which device triggered.
+    pub fn set_client<C: hil::gpio_async::Client>(&self, client: &'static C) {
+        self.client.set(Some(client));
+    }
+
+    fn enable_host_interrupt(&self) -> ReturnCode {
+        // We configure the MCP23008 to use an active high interrupt.
+        // If we don't have an interrupt pin mapped to this driver then we
+        // obviously can't do interrupts.
+        self.interrupt_pin.map_or(ReturnCode::FAIL, |interrupt_pin| {
+            interrupt_pin.make_input();
+            interrupt_pin.enable_interrupt(0, hil::gpio::InterruptMode::RisingEdge);
+            ReturnCode::SUCCESS
+        })
+    }
+
+    fn set_direction(&self, pin_number: u8, direction: Direction) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::EBUSY, |buffer| {
+            self.i2c.enable();
+
+            buffer[0] = Registers::IoDir as u8;
+            self.i2c.write(buffer, 1);
+            self.state.set(State::SelectIoDir(pin_number, direction));
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    /// Set the pull-up on the pin also configure it to be an input.
+    fn configure_pullup(&self, pin_number: u8, enabled: bool) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::EBUSY, |buffer| {
+            self.i2c.enable();
+
+            buffer[0] = Registers::IoDir as u8;
+            self.i2c.write(buffer, 1);
+            self.state.set(State::SelectGpPu(pin_number, enabled));
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    fn set_pin(&self, pin_number: u8, value: PinState) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::EBUSY, |buffer| {
+            self.i2c.enable();
+
+            buffer[0] = Registers::Gpio as u8;
+            self.i2c.write(buffer, 1);
+            self.state.set(State::SelectGpio(pin_number, value));
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    fn toggle_pin(&self, pin_number: u8) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::EBUSY, |buffer| {
+            self.i2c.enable();
+
+            buffer[0] = Registers::Gpio as u8;
+            self.i2c.write(buffer, 1);
+            self.state.set(State::SelectGpioToggle(pin_number));
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    fn read_pin(&self, pin_number: u8) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::EBUSY, |buffer| {
+            self.i2c.enable();
+
+            buffer[0] = Registers::Gpio as u8;
+            self.i2c.write(buffer, 1);
+            self.state.set(State::SelectGpioRead(pin_number));
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    fn enable_interrupt_pin(&self,
+                            pin_number: u8,
+                            direction: hil::gpio::InterruptMode)
+                            -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::EBUSY, |buffer| {
+            self.i2c.enable();
+
+            // Mark the settings that we have for this interrupt.
+            // Since the MCP23008 only seems to support level interrupts
+            // and both edge interrupts, we choose to use both edge interrupts
+            // and then filter here in the driver if the user only asked
+            // for one direction interrupts. To do this, we need to know what
+            // the user asked for.
+            self.save_pin_interrupt_state(pin_number, true, direction);
+
+            // Setup interrupt configs that are true of all interrupts
+            buffer[0] = Registers::IntCon as u8;
+            buffer[1] = 0; // Make all pins toggle on every change.
+            buffer[2] = 0b00000010; // Make MCP23008 interrupt pin active high.
+            self.i2c.write(buffer, 3);
+            self.state.set(State::EnableInterruptSettings);
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    fn disable_interrupt_pin(&self, pin_number: u8) -> ReturnCode {
+        self.buffer.take().map_or(ReturnCode::EBUSY, |buffer| {
+            self.i2c.enable();
+
+            // Clear this interrupt from our setup.
+            self.remove_pin_interrupt_state(pin_number);
+
+            // Just have to write the new interrupt settings.
+            buffer[0] = Registers::GpIntEn as u8;
+            buffer[1] = self.get_pin_interrupt_enabled_state();
+            self.i2c.write(buffer, 2);
+            self.state.set(State::Done);
+
+            ReturnCode::SUCCESS
+        })
+    }
+
+    /// Helper function for keeping track of which interrupts are currently
+    /// enabled.
+    fn save_pin_interrupt_state(&self,
+                                pin_number: u8,
+                                enabled: bool,
+                                direction: hil::gpio::InterruptMode) {
+        let mut current_state = self.interrupt_settings.get();
+        // Clear out existing settings
+        current_state &= !(0x0F << (4 * pin_number));
+        // Generate new settings
+        let new_settings = (((enabled as u8) | ((direction as u8) << 1)) & 0x0F) as u32;
+        // Update settings
+        current_state |= new_settings << (4 * pin_number);
+        self.interrupt_settings.set(current_state);
+    }
+
+    fn remove_pin_interrupt_state(&self, pin_number: u8) {
+        let new_settings = self.interrupt_settings.get() & !(0x0F << (4 * pin_number));
+        self.interrupt_settings.set(new_settings);
+    }
+
+    /// Create an 8 bit bitmask of which interrupts are enabled.
+    fn get_pin_interrupt_enabled_state(&self) -> u8 {
+        let current_state = self.interrupt_settings.get();
+        let mut interrupts_enabled: u8 = 0;
+        for i in 0..8 {
+            if ((current_state >> (4 * i)) & 0x01) == 0x01 {
+                interrupts_enabled |= 1 << i;
+            }
+        }
+        interrupts_enabled
+    }
+
+    fn check_pin_interrupt_enabled(&self, pin_number: u8) -> bool {
+        (self.interrupt_settings.get() >> (pin_number * 4)) & 0x01 == 0x01
+    }
+
+    fn get_pin_interrupt_direction(&self, pin_number: u8) -> hil::gpio::InterruptMode {
+        let direction = self.interrupt_settings.get() >> ((pin_number * 4) + 1) & 0x03;
+        match direction {
+            0 => hil::gpio::InterruptMode::RisingEdge,
+            1 => hil::gpio::InterruptMode::FallingEdge,
+            _ => hil::gpio::InterruptMode::EitherEdge,
+        }
+    }
+}
+
+impl<'a> hil::i2c::I2CClient for MCP23008<'a> {
+    fn command_complete(&self, buffer: &'static mut [u8], _error: hil::i2c::Error) {
+        match self.state.get() {
+            State::SelectIoDir(pin_number, direction) => {
+                self.i2c.read(buffer, 1);
+                self.state.set(State::ReadIoDir(pin_number, direction));
+            }
+            State::ReadIoDir(pin_number, direction) => {
+                if direction == Direction::Input {
+                    buffer[1] = buffer[0] | (1 << pin_number);
+                } else {
+                    buffer[1] = buffer[0] & !(1 << pin_number);
+                }
+                buffer[0] = Registers::IoDir as u8;
+                self.i2c.write(buffer, 2);
+                self.state.set(State::Done);
+            }
+            State::SelectGpPu(pin_number, enabled) => {
+                self.i2c.read(buffer, 7);
+                self.state.set(State::ReadGpPu(pin_number, enabled));
+            }
+            State::ReadGpPu(pin_number, enabled) => {
+                // Make sure the pin is enabled.
+                buffer[1] = buffer[0] | (1 << pin_number);
+                // Configure the pullup status and save it in the buffer.
+                let pullup = match enabled {
+                    true => buffer[6] | (1 << pin_number),
+                    false => buffer[6] & !(1 << pin_number),
+                };
+                buffer[0] = Registers::IoDir as u8;
+                self.i2c.write(buffer, 2);
+                self.state.set(State::SetGpPu(pullup));
+            }
+            State::SetGpPu(pullup) => {
+                // Now write the pull up settings to the chip.
+                buffer[0] = Registers::GpPu as u8;
+                buffer[1] = pullup;
+                self.i2c.write(buffer, 2);
+                self.state.set(State::Done);
+            }
+            State::SelectGpio(pin_number, value) => {
+                self.i2c.read(buffer, 1);
+                self.state.set(State::ReadGpio(pin_number, value));
+            }
+            State::ReadGpio(pin_number, value) => {
+                buffer[1] = match value {
+                    PinState::High => buffer[0] | (1 << pin_number),
+                    PinState::Low => buffer[0] & !(1 << pin_number),
+                };
+                buffer[0] = Registers::Gpio as u8;
+                self.i2c.write(buffer, 2);
+                self.state.set(State::Done);
+            }
+            State::SelectGpioToggle(pin_number) => {
+                self.i2c.read(buffer, 1);
+                self.state.set(State::ReadGpioToggle(pin_number));
+            }
+            State::ReadGpioToggle(pin_number) => {
+                buffer[1] = buffer[0] ^ (1 << pin_number);
+                buffer[0] = Registers::Gpio as u8;
+                self.i2c.write(buffer, 2);
+                self.state.set(State::Done);
+            }
+            State::SelectGpioRead(pin_number) => {
+                self.i2c.read(buffer, 1);
+                self.state.set(State::ReadGpioRead(pin_number));
+            }
+            State::ReadGpioRead(pin_number) => {
+                let pin_value = (buffer[0] >> pin_number) & 0x01;
+
+                self.client.get().map(|client| { client.done(pin_value as usize); });
+
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+            }
+            State::EnableInterruptSettings => {
+                // Rather than read the current interrupts and write those
+                // back, just write the entire register with our saved state.
+                buffer[0] = Registers::GpIntEn as u8;
+                buffer[1] = self.get_pin_interrupt_enabled_state();
+                self.i2c.write(buffer, 2);
+                self.state.set(State::Done);
+            }
+            State::ReadInterruptSetup => {
+                // Now read the interrupt flags and the state of the lines
+                self.i2c.read(buffer, 3);
+                self.state.set(State::ReadInterruptValues);
+            }
+            State::ReadInterruptValues => {
+                let interrupt_flags = buffer[0];
+                let pins_status = buffer[2];
+                // Check each bit to see if that pin triggered an interrupt.
+                for i in 0..8 {
+                    // Check that this pin is actually enabled.
+                    if !self.check_pin_interrupt_enabled(i) {
+                        continue;
+                    }
+                    if (interrupt_flags >> i) & 0x01 == 0x01 {
+                        // Use the GPIO register to determine which way the
+                        // interrupt went.
+                        let pin_status = (pins_status >> i) & 0x01;
+                        let interrupt_direction = self.get_pin_interrupt_direction(i);
+                        // Check to see if this was an interrupt we want
+                        // to report.
+                        let fire_interrupt = match interrupt_direction {
+                            hil::gpio::InterruptMode::EitherEdge => true,
+                            hil::gpio::InterruptMode::RisingEdge => pin_status == 0x01,
+                            hil::gpio::InterruptMode::FallingEdge => pin_status == 0x00,
+                        };
+                        if fire_interrupt {
+                            // Signal this interrupt to the application.
+                            self.client.get().map(|client| {
+                                // Return both the pin that interrupted and
+                                // the identifier that was passed for
+                                // enable_interrupt.
+                                client.fired(i as usize, self.identifier.get());
+                            });
+                            break;
+                        }
+                    }
+                }
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+            }
+            State::Done => {
+                self.client.get().map(|client| { client.done(0); });
+
+                self.buffer.replace(buffer);
+                self.i2c.disable();
+                self.state.set(State::Idle);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'a> hil::gpio::Client for MCP23008<'a> {
+    fn fired(&self, _: usize) {
+        self.buffer.take().map(|buffer| {
+            self.i2c.enable();
+
+            // Need to read the IntF register which marks which pins
+            // interrupted.
+            buffer[0] = Registers::IntF as u8;
+            self.i2c.write(buffer, 1);
+            self.state.set(State::ReadInterruptSetup);
+        });
+    }
+}
+
+impl<'a> hil::gpio_async::Port for MCP23008<'a> {
+    fn disable(&self, pin: usize) -> ReturnCode {
+        // Best we can do is make this an input.
+        self.set_direction(pin as u8, Direction::Input)
+    }
+
+    fn make_output(&self, pin: usize) -> ReturnCode {
+        if pin > 7 {
+            return ReturnCode::EINVAL;
+        }
+        self.set_direction(pin as u8, Direction::Output)
+    }
+
+    fn make_input(&self, pin: usize, mode: hil::gpio::InputMode) -> ReturnCode {
+        if pin > 7 {
+            return ReturnCode::EINVAL;
+        }
+        match mode {
+            hil::gpio::InputMode::PullUp => self.configure_pullup(pin as u8, true),
+            hil::gpio::InputMode::PullDown => {
+                // No support for this
+                self.configure_pullup(pin as u8, false)
+            }
+            hil::gpio::InputMode::PullNone => self.configure_pullup(pin as u8, false),
+        }
+    }
+
+    fn read(&self, pin: usize) -> ReturnCode {
+        if pin > 7 {
+            return ReturnCode::EINVAL;
+        }
+        self.read_pin(pin as u8)
+    }
+
+    fn toggle(&self, pin: usize) -> ReturnCode {
+        if pin > 7 {
+            return ReturnCode::EINVAL;
+        }
+        self.toggle_pin(pin as u8)
+    }
+
+    fn set(&self, pin: usize) -> ReturnCode {
+        if pin > 7 {
+            return ReturnCode::EINVAL;
+        }
+        self.set_pin(pin as u8, PinState::High)
+    }
+
+    fn clear(&self, pin: usize) -> ReturnCode {
+        if pin > 7 {
+            return ReturnCode::EINVAL;
+        }
+        self.set_pin(pin as u8, PinState::Low)
+    }
+
+    fn enable_interrupt(&self,
+                        pin: usize,
+                        mode: hil::gpio::InterruptMode,
+                        identifier: usize)
+                        -> ReturnCode {
+        if pin > 7 {
+            return ReturnCode::EINVAL;
+        }
+        let ret = self.enable_host_interrupt();
+        match ret {
+            ReturnCode::SUCCESS => {
+                self.identifier.set(identifier);
+                self.enable_interrupt_pin(pin as u8, mode)
+            }
+            _ => ret,
+        }
+    }
+
+    fn disable_interrupt(&self, pin: usize) -> ReturnCode {
+        if pin > 7 {
+            return ReturnCode::EINVAL;
+        }
+        self.disable_interrupt_pin(pin as u8)
+    }
+}

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -233,6 +233,7 @@ functionality that is handled by the kernel. `command`, `subscribe`, and
 | 16            | CRC              | Cyclic Redundancy Check computation        |
 | 17            | AES              | AES encryption and decryption              |
 | 18            | LTC294X          | Battery gauge IC                           |
+| 20            | GPIO Async       | Asynchronous GPIO pins                     |
 | 22            | LPS25HB          | Pressure sensor                            |
 | 154           | Radio            | 15.4 radio interface                       |
 | 255           | IPC              | Inter-process communication                |

--- a/kernel/src/hil/gpio_async.rs
+++ b/kernel/src/hil/gpio_async.rs
@@ -1,0 +1,65 @@
+use hil;
+use returncode::ReturnCode;
+
+/// Interface for banks of asynchronous GPIO pins. GPIO pins are asynchronous
+/// when there is an asynchronous interface used to control them. The most
+/// common example is when using a GPIO extender on an I2C or SPI bus. With
+/// asynchronous GPIO functions, every config action results in an eventual
+/// callback function that indicates that the configuration has finished
+/// (unless the initial function call returns an error code, then no callback
+/// will be generated).
+///
+/// Asynchronous GPIO pins are grouped into ports because it is assumed that
+/// the remote entity that is controlling the pins can control multiple pins.
+/// Typically, a port will be provided by a particular driver.
+///
+/// The API for the Port mirrors the synchronous GPIO interface.
+pub trait Port {
+    /// Try to disable a GPIO pin. This cannot be supported for all devices.
+    fn disable(&self, pin: usize) -> ReturnCode;
+
+    /// Configure a pin as an ouput GPIO.
+    fn make_output(&self, pin: usize) -> ReturnCode;
+
+    /// Configure a pin as an input GPIO. Not all InputMode settings may
+    /// be supported by a given device.
+    fn make_input(&self, pin: usize, mode: hil::gpio::InputMode) -> ReturnCode;
+
+    /// Get the state (0 or 1) of an input pin. The value will be returned
+    /// via a callback.
+    fn read(&self, pin: usize) -> ReturnCode;
+
+    /// Toggle an output GPIO pin.
+    fn toggle(&self, pin: usize) -> ReturnCode;
+
+    /// Assert a GPIO pin high.
+    fn set(&self, pin: usize) -> ReturnCode;
+
+    /// Clear a GPIO pin low.
+    fn clear(&self, pin: usize) -> ReturnCode;
+
+    /// Setup an interrupt on a GPIO input pin. The identifier should be
+    /// the port number and will be returned when the interrupt callback
+    /// fires.
+    fn enable_interrupt(&self,
+                        pin: usize,
+                        mode: hil::gpio::InterruptMode,
+                        identifier: usize)
+                        -> ReturnCode;
+
+    /// Disable an interrupt on a GPIO input pin.
+    fn disable_interrupt(&self, pin: usize) -> ReturnCode;
+}
+
+/// The gpio_async Client interface is used to both receive callbacks
+/// when a configuration command finishes and to handle interrupt events
+/// from pins with interrupts enabled.
+pub trait Client {
+    /// Called when an interrupt occurs. The pin that interrupted is included,
+    /// and the identifier that was passed with the call to `enable_interrupt`
+    /// is also returned.
+    fn fired(&self, pin: usize, identifier: usize);
+
+    /// Done is called when a configuration command finishes.
+    fn done(&self, value: usize);
+}

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -13,6 +13,7 @@ pub mod temperature;
 pub mod crc;
 pub mod symmetric_encryption;
 pub mod ninedof;
+pub mod gpio_async;
 
 pub trait Controller {
     type Config;

--- a/userland/examples/tests/gpio_async/Makefile
+++ b/userland/examples/tests/gpio_async/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/gpio_async/README.md
+++ b/userland/examples/tests/gpio_async/README.md
@@ -1,0 +1,23 @@
+GPIO Async Test App
+===================
+
+This is a basic test application for asynchronous GPIO support. The
+`async_gpio` interface mirrors the `gpio` interface, but is designed for
+uses where there is an asynchronous request needed to control the GPIO, as would
+be common with an I2C GPIO extender.
+
+Example Output
+--------------
+
+```
+GPIO Async Test App
+Enabling rising edge interrupt on port 0 pin 1
+Toggling port 0 pin 0
+INTERRUPT
+INTERRUPT
+INTERRUPT
+INTERRUPT
+INTERRUPT
+INTERRUPT
+Now disabling interrupt
+```

--- a/userland/examples/tests/gpio_async/main.c
+++ b/userland/examples/tests/gpio_async/main.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+
+#include <gpio.h>
+#include <gpio_async.h>
+#include <timer.h>
+
+int interrupt_count = 0;
+
+static void gpio_async_cb(__attribute__ ((unused)) int callback_type,
+                          __attribute__ ((unused)) int value,
+                          __attribute__ ((unused)) int unused,
+                          __attribute__ ((unused)) void* ud) {
+  printf("INTERRUPT\n");
+  interrupt_count++;
+
+  if (interrupt_count > 5) {
+    printf("Now disabling interrupt\n");
+    gpio_async_disable_interrupt(0, 1);
+  }
+}
+
+int main (void) {
+  printf("GPIO Async Test App\n");
+
+  printf("Enabling rising edge interrupt on port 0 pin 1\n");
+  gpio_async_interrupt_callback(gpio_async_cb, NULL);
+  gpio_async_make_input_sync(0, 1, PullNone);
+  gpio_async_enable_interrupt(0, 1, RisingEdge);
+
+  printf("Toggling port 0 pin 0\n");
+  gpio_async_make_output_sync(0, 0);
+
+  while (1) {
+    gpio_async_set(0, 0);
+    delay_ms(500);
+    gpio_async_clear(0, 0);
+    delay_ms(500);
+  }
+
+  return 0;
+}

--- a/userland/libtock/gpio_async.c
+++ b/userland/libtock/gpio_async.c
@@ -1,0 +1,218 @@
+#include "tock.h"
+#include "gpio_async.h"
+
+#define CONCAT_PORT_PIN(port, pin) (((pin & 0xFF)<<8) | (port & 0xFF))
+#define CONCAT_PORT_PIN_DATA(port, pin, data) (((data & 0xFFFF)<<16) | ((pin & 0xFF)<<8) | (port & 0xFF))
+
+
+struct gpio_async_data {
+  bool fired;
+  int value;
+  int callback_type;
+};
+
+static struct gpio_async_data result = { .fired = false };
+
+// Internal callback for faking synchronous reads
+static void gpio_async_cb(__attribute__ ((unused)) int callback_type,
+                          __attribute__ ((unused)) int value,
+                          __attribute__ ((unused)) int unused,
+                          void* ud) {
+  struct gpio_async_data* myresult = (struct gpio_async_data*) ud;
+  myresult->callback_type = callback_type;
+  myresult->value = value;
+  myresult->fired = true;
+}
+
+
+int gpio_async_set_callback (subscribe_cb callback, void* callback_args) {
+  return subscribe(DRIVER_NUM_GPIO_ASYNC, 0, callback, callback_args);
+}
+
+int gpio_async_make_output(uint32_t port, uint8_t pin) {
+  return command(DRIVER_NUM_GPIO_ASYNC, 1, CONCAT_PORT_PIN(port, pin));
+}
+
+int gpio_async_set(uint32_t port, uint8_t pin) {
+  return command(DRIVER_NUM_GPIO_ASYNC, 2, CONCAT_PORT_PIN(port, pin));
+}
+
+int gpio_async_clear(uint32_t port, uint8_t pin) {
+  return command(DRIVER_NUM_GPIO_ASYNC, 3, CONCAT_PORT_PIN(port, pin));
+}
+
+int gpio_async_toggle(uint32_t port, uint8_t pin) {
+  return command(DRIVER_NUM_GPIO_ASYNC, 4, CONCAT_PORT_PIN(port, pin));
+}
+
+int gpio_async_make_input(uint32_t port, uint8_t pin, GPIO_InputMode_t pin_config) {
+  return command(DRIVER_NUM_GPIO_ASYNC, 5, CONCAT_PORT_PIN_DATA(port, pin, pin_config));
+}
+
+int gpio_async_read(uint32_t port, uint8_t pin) {
+  return command(DRIVER_NUM_GPIO_ASYNC, 6, CONCAT_PORT_PIN(port, pin));
+}
+
+int gpio_async_enable_interrupt(uint32_t port, uint8_t pin, GPIO_InterruptMode_t irq_config) {
+  return command(DRIVER_NUM_GPIO_ASYNC, 7, CONCAT_PORT_PIN_DATA(port, pin, irq_config));
+}
+
+int gpio_async_disable_interrupt(uint32_t port, uint8_t pin) {
+  return command(DRIVER_NUM_GPIO_ASYNC, 8, CONCAT_PORT_PIN(port, pin));
+}
+
+int gpio_async_disable(uint32_t port, uint8_t pin) {
+  return command(DRIVER_NUM_GPIO_ASYNC, 9, CONCAT_PORT_PIN(port, pin));
+}
+
+int gpio_async_interrupt_callback(subscribe_cb callback, void* callback_args) {
+  return subscribe(DRIVER_NUM_GPIO_ASYNC, 1, callback, callback_args);
+}
+
+
+
+
+int gpio_async_make_output_sync(uint32_t port, uint8_t pin) {
+  int err;
+  result.fired = false;
+
+  err = gpio_async_set_callback(gpio_async_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = gpio_async_make_output(port, pin);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}
+
+int gpio_async_set_sync(uint32_t port, uint8_t pin) {
+  int err;
+  result.fired = false;
+
+
+  err = gpio_async_set_callback(gpio_async_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = gpio_async_set(port, pin);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}
+
+int gpio_async_clear_sync(uint32_t port, uint8_t pin) {
+  int err;
+  result.fired = false;
+
+  err = gpio_async_set_callback(gpio_async_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = gpio_async_clear(port, pin);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}
+
+int gpio_async_toggle_sync(uint32_t port, uint8_t pin) {
+  int err;
+  result.fired = false;
+
+  err = gpio_async_set_callback(gpio_async_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = gpio_async_toggle(port, pin);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}
+
+int gpio_async_make_input_sync(uint32_t port, uint8_t pin, GPIO_InputMode_t pin_config) {
+  int err;
+  result.fired = false;
+
+  err = gpio_async_set_callback(gpio_async_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = gpio_async_make_input(port, pin, pin_config);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}
+
+int gpio_async_read_sync(uint32_t port, uint8_t pin) {
+  int err;
+  result.fired = false;
+
+  err = gpio_async_set_callback(gpio_async_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = gpio_async_read(port, pin);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}
+
+int gpio_async_enable_interrupt_sync(uint32_t port, uint8_t pin, GPIO_InterruptMode_t irq_config) {
+  int err;
+  result.fired = false;
+
+  err = gpio_async_set_callback(gpio_async_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = gpio_async_enable_interrupt(port, pin, irq_config);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}
+
+int gpio_async_disable_interrupt_sync(uint32_t port, uint8_t pin) {
+  int err;
+  result.fired = false;
+
+  err = gpio_async_set_callback(gpio_async_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = gpio_async_disable_interrupt(port, pin);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}
+
+int gpio_async_disable_sync(uint32_t port, uint8_t pin) {
+  int err;
+  result.fired = false;
+
+  err = gpio_async_set_callback(gpio_async_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = gpio_async_disable(port, pin);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.value;
+}

--- a/userland/libtock/gpio_async.h
+++ b/userland/libtock/gpio_async.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "tock.h"
+#include "gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DRIVER_NUM_GPIO_ASYNC 20
+
+// Callback for operation done events.
+// int arg1: callback type
+// int arg2: optional value
+// int arg3: unused
+int gpio_async_set_callback (subscribe_cb callback, void* callback_args);
+
+// Callback for when GPIO interrupts occur.
+// int arg1: port number
+// int arg2: pin number
+// int arg3: unused
+int gpio_async_interrupt_callback(subscribe_cb callback, void* callback_args);
+
+int gpio_async_make_output(uint32_t port, uint8_t pin);
+int gpio_async_set(uint32_t port, uint8_t pin);
+int gpio_async_clear(uint32_t port, uint8_t pin);
+int gpio_async_toggle(uint32_t port, uint8_t pin);
+int gpio_async_make_input(uint32_t port, uint8_t pin, GPIO_InputMode_t pin_config);
+int gpio_async_read(uint32_t port, uint8_t pin);
+int gpio_async_enable_interrupt(uint32_t port, uint8_t pin, GPIO_InterruptMode_t irq_config);
+int gpio_async_disable_interrupt(uint32_t port, uint8_t pin);
+int gpio_async_disable(uint32_t port, uint8_t pin);
+
+// Synchronous Versions
+int gpio_async_make_output_sync(uint32_t port, uint8_t pin);
+int gpio_async_set_sync(uint32_t port, uint8_t pin);
+int gpio_async_clear_sync(uint32_t port, uint8_t pin);
+int gpio_async_toggle_sync(uint32_t port, uint8_t pin);
+int gpio_async_make_input_sync(uint32_t port, uint8_t pin, GPIO_InputMode_t pin_config);
+int gpio_async_read_sync(uint32_t port, uint8_t pin);
+int gpio_async_enable_interrupt_sync(uint32_t port, uint8_t pin, GPIO_InterruptMode_t irq_config);
+int gpio_async_disable_interrupt_sync(uint32_t port, uint8_t pin);
+int gpio_async_disable_sync(uint32_t port, uint8_t pin);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This is the GPIO extender from signpost. This driver also includes interrupt support which I tested separately because interrupts are not used on the Signpost platform.