### PR TITLE
Eliminate all userland warnings

### DIFF
--- a/userland/AppMakefile.mk
+++ b/userland/AppMakefile.mk
@@ -53,7 +53,7 @@ EXTERN_LIB_NAME_$(notdir $(1)) := $(notdir $(1))
 
 # If this library has an include directory, add it to search path
 ifneq "$$(wildcard $(1)/include)" ""
-  CPPFLAGS += -I$(1)/include
+  override CPPFLAGS += -I$(1)/include
 endif
 
 # Add arch-specific rules for each library

--- a/userland/Configuration.mk
+++ b/userland/Configuration.mk
@@ -39,9 +39,9 @@ ELF2TBF_ARGS += -n $(PACKAGE_NAME)
 # Flags for building app Assembly, C, C++ files
 # n.b. make convention is that CPPFLAGS are shared for C and C++ sources
 # [CFLAGS is C only, CXXFLAGS is C++ only]
-ASFLAGS += -mthumb
-CFLAGS   += -std=gnu11
-CPPFLAGS += \
+override ASFLAGS += -mthumb
+override CFLAGS  += -std=gnu11
+override CPPFLAGS += \
 	    -frecord-gcc-switches\
 	    -g\
 	    -Os\
@@ -86,29 +86,28 @@ LAYOUT ?= $(TOCK_USERLAND_BASE_DIR)/userland_generic.ld
 #CPPFLAGS += -Wswitch-default #           # switch w/out default (doesn't cover all cases) (maybe annoying?)
 #CFLAGS += -Wstrict-prototypes #          # function defined w/out specifying argument types
 
-CPPFLAGS += -Wdate-time #                # warn if __TIME__, __DATE__, or __TIMESTAMP__ used
+override CPPFLAGS += -Wdate-time #                # warn if __TIME__, __DATE__, or __TIMESTAMP__ used
                                          # ^on b/c flashing assumes same code => no flash, these enforce
-CPPFLAGS += -Wfloat-equal #              # floats used with '=' operator, likely imprecise
-CPPFLAGS += -Wformat-nonliteral #        # can't check format string (maybe disable if annoying)
-CPPFLAGS += -Wformat-security #          # using untrusted format strings (maybe disable)
-CPPFLAGS += -Wformat-y2k #               # use of strftime that assumes two digit years
-CPPFLAGS += -Winit-self #                # { int i = i }
-CPPFLAGS += -Wlogical-op #               # "suspicous use of logical operators in expressions" (a lint)
-CPPFLAGS += -Wmissing-declarations #     # ^same? not sure how these differ
-CPPFLAGS += -Wmissing-field-initializers # if init'ing struct w/out field names, warn if not all used
-CPPFLAGS += -Wmissing-format-attribute # # something looks printf-like but isn't marked as such
-CPPFLAGS += -Wmissing-noreturn #         # __attribute__((noreturn)) like -> ! in Rust, should use it
-CPPFLAGS += -Wmultichar #                # use of 'foo' instead of "foo" (surpised not on by default?)
-CPPFLAGS += -Wpointer-arith #            # sizeof things not define'd (i.e. sizeof(void))
-CPPFLAGS += -Wredundant-decls #          # { int i; int i; } (a lint)
-CPPFLAGS += -Wshadow #                   # int foo(int a) { int a = 1; } inner a shadows outer a
-CPPFLAGS += -Wsuggest-attribute=const    # does what it sounds like
-CPPFLAGS += -Wsuggest-attribute=pure     # does what it sounds like
-CPPFLAGS += -Wtrampolines #              # attempt to generate a trampoline on the NX stack
-CPPFLAGS += -Wunused-macros #            # macro defined in this file not used
-CPPFLAGS += -Wunused-parameter #         # function parameter is unused aside from its declaration
-CXXFLAGS += -Wuseless-cast #             # pretty much what ya think here
-CPPFLAGS += -Wwrite-strings #            # { char* c = "foo"; c[0] = 'b' } <-- "foo" should be r/o
+override CPPFLAGS += -Wfloat-equal #              # floats used with '=' operator, likely imprecise
+override CPPFLAGS += -Wformat-nonliteral #        # can't check format string (maybe disable if annoying)
+override CPPFLAGS += -Wformat-security #          # using untrusted format strings (maybe disable)
+override CPPFLAGS += -Wformat-y2k #               # use of strftime that assumes two digit years
+override CPPFLAGS += -Winit-self #                # { int i = i }
+override CPPFLAGS += -Wlogical-op #               # "suspicous use of logical operators in expressions" (a lint)
+override CPPFLAGS += -Wmissing-declarations #     # ^same? not sure how these differ
+override CPPFLAGS += -Wmissing-field-initializers # if init'ing struct w/out field names, warn if not all used
+override CPPFLAGS += -Wmissing-format-attribute # # something looks printf-like but isn't marked as such
+override CPPFLAGS += -Wmissing-noreturn #         # __attribute__((noreturn)) like -> ! in Rust, should use it
+override CPPFLAGS += -Wmultichar #                # use of 'foo' instead of "foo" (surpised not on by default?)
+override CPPFLAGS += -Wpointer-arith #            # sizeof things not define'd (i.e. sizeof(void))
+override CPPFLAGS += -Wredundant-decls #          # { int i; int i; } (a lint)
+override CPPFLAGS += -Wshadow #                   # int foo(int a) { int a = 1; } inner a shadows outer a
+override CPPFLAGS += -Wsuggest-attribute=const    # does what it sounds like
+override CPPFLAGS += -Wsuggest-attribute=pure     # does what it sounds like
+override CPPFLAGS += -Wtrampolines #              # attempt to generate a trampoline on the NX stack
+override CPPFLAGS += -Wunused-macros #            # macro defined in this file not used
+override CPPFLAGS += -Wunused-parameter #         # function parameter is unused aside from its declaration
+override CPPFLAGS += -Wwrite-strings #            # { char* c = "foo"; c[0] = 'b' } <-- "foo" should be r/o
 
 #CPPFLAGS += -Wabi -Wabi-tag              # inter-compiler abi issues
 #CPPFLAGS += -Waggregate-return           # warn if things return struct's
@@ -142,11 +141,11 @@ CPPFLAGS += -Wwrite-strings #            # { char* c = "foo"; c[0] = 'b' } <-- "
 #CPPFLAGS += -Wvla                  -- XXX Didn't try, but interested
 
 # C-only warnings
-CFLAGS += -Wbad-function-cast #          # not obvious when this would trigger, could drop if annoying
-CFLAGS += -Wjump-misses-init #           # goto or switch skips over a variable initialziation
-CFLAGS += -Wmissing-prototypes #         # global fn defined w/out prototype (should be static or in .h)
-CFLAGS += -Wnested-externs #             # mis/weird-use of extern keyword
-CFLAGS += -Wold-style-definition #       # this garbage: void bar (a) int a; { }
+override CFLAGS += -Wbad-function-cast #          # not obvious when this would trigger, could drop if annoying
+override CFLAGS += -Wjump-misses-init #           # goto or switch skips over a variable initialziation
+override CFLAGS += -Wmissing-prototypes #         # global fn defined w/out prototype (should be static or in .h)
+override CFLAGS += -Wnested-externs #             # mis/weird-use of extern keyword
+override CFLAGS += -Wold-style-definition #       # this garbage: void bar (a) int a; { }
 
 #CFLAGS += -Wunsuffixed-float-constants # # { float f=0.67; if(f==0.67) printf("y"); else printf("n"); } => n
 #                                         ^ doesn't seem to work right? find_north does funny stuff
@@ -155,16 +154,17 @@ CFLAGS += -Wold-style-definition #       # this garbage: void bar (a) int a; { }
 #                                         ^ real noisy
 
 # CXX-only warnings
-CXXFLAGS += -Wctor-dtor-privacy #        # unusable class b/c everything private and no friends
-CXXFLAGS += -Wdelete-non-virtual-dtor #  # catches undefined behavior
-CXXFLAGS += -Wold-style-cast #           # C-style cast in C++ code
-CXXFLAGS += -Woverloaded-virtual #       # subclass shadowing makes parent impl's unavailable
-CXXFLAGS += -Wsign-promo #               # gcc did what spec requires, but probably not what you want
-CXXFLAGS += -Wstrict-null-sentinel #     # seems like a not-very-C++ thing to do? very unsure
-CXXFLAGS += -Wsuggest-final-methods #    # does what it sounds like
-CXXFLAGS += -Wsuggest-final-types #      # does what it sounds like
-CXXFLAGS += -Wsuggest-override #         # overridden virtual func w/out override keyword
-CXXFLAGS += -Wzero-as-null-pointer-constant # use of 0 as NULL
+override CXXFLAGS += -Wctor-dtor-privacy #        # unusable class b/c everything private and no friends
+override CXXFLAGS += -Wdelete-non-virtual-dtor #  # catches undefined behavior
+override CXXFLAGS += -Wold-style-cast #           # C-style cast in C++ code
+override CXXFLAGS += -Woverloaded-virtual #       # subclass shadowing makes parent impl's unavailable
+override CXXFLAGS += -Wsign-promo #               # gcc did what spec requires, but probably not what you want
+override CXXFLAGS += -Wstrict-null-sentinel #     # seems like a not-very-C++ thing to do? very unsure
+override CXXFLAGS += -Wsuggest-final-methods #    # does what it sounds like
+override CXXFLAGS += -Wsuggest-final-types #      # does what it sounds like
+override CXXFLAGS += -Wsuggest-override #         # overridden virtual func w/out override keyword
+override CXXFLAGS += -Wuseless-cast #             # pretty much what ya think here
+override CXXFLAGS += -Wzero-as-null-pointer-constant # use of 0 as NULL
 
 # -Wc++-compat #                         # C/C++ compat issues
 # -Wc++11-compat #                       # C11 compat issues

--- a/userland/Configuration.mk
+++ b/userland/Configuration.mk
@@ -102,8 +102,6 @@ override CPPFLAGS += -Wmultichar #                # use of 'foo' instead of "foo
 override CPPFLAGS += -Wpointer-arith #            # sizeof things not define'd (i.e. sizeof(void))
 override CPPFLAGS += -Wredundant-decls #          # { int i; int i; } (a lint)
 override CPPFLAGS += -Wshadow #                   # int foo(int a) { int a = 1; } inner a shadows outer a
-override CPPFLAGS += -Wsuggest-attribute=const    # does what it sounds like
-override CPPFLAGS += -Wsuggest-attribute=pure     # does what it sounds like
 override CPPFLAGS += -Wtrampolines #              # attempt to generate a trampoline on the NX stack
 override CPPFLAGS += -Wunused-macros #            # macro defined in this file not used
 override CPPFLAGS += -Wunused-parameter #         # function parameter is unused aside from its declaration
@@ -128,6 +126,8 @@ override CPPFLAGS += -Wwrite-strings #            # { char* c = "foo"; c[0] = 'b
 #CPPFLAGS += -Wpedantic                   # strict ISO C/C++
 #CPPFLAGS += -Wsign-conversion            # implicit integer sign conversions, part of -Wconversion
 #CPPFLAGS += -Wstack-protector            # only if -fstack-protector, on by default, warn fn not protect
+#CPPFLAGS += -Wsuggest-attribute=const    # does what it sounds like - removed due to noise
+#CPPFLAGS += -Wsuggest-attribute=pure     # does what it sounds like - removed due to noise
 #CPPFLAGS += -Wswitch-enum #              # switch of enum doesn't explicitly cover all cases
 #                                         ^ annoying in practice, let default: do its job
 #CPPFLAGS += -Wsystem-headers             # warnings from system headers

--- a/userland/Helpers.mk
+++ b/userland/Helpers.mk
@@ -31,8 +31,8 @@ endif
 CC_VERSION_MAJOR := $(shell $(CC) -dumpversion | cut -d '.' -f1)
 ifeq (1,$(shell expr $(CC_VERSION_MAJOR) \>= 6))
   # Opportunistically turn on gcc 6.0+ warnings since we're already version checking:
-  CPPFLAGS += -Wduplicated-cond #          # if (p->q != NULL) { ... } else if (p->q != NULL) { ... }
-  CPPFLAGS += -Wnull-dereference #         # deref of NULL (thought default if -fdelete-null-pointer-checks, in -Os, but no?)
+  override CPPFLAGS += -Wduplicated-cond #  if (p->q != NULL) { ... } else if (p->q != NULL) { ... }
+  override CPPFLAGS += -Wnull-dereference # deref of NULL (thought default if -fdelete-null-pointer-checks, in -Os, but no?)
 else
   ifneq (5,$(CC_VERSION_MAJOR))
     $(error Your compiler is too old. Need gcc version > 5.1)

--- a/userland/TockLibrary.mk
+++ b/userland/TockLibrary.mk
@@ -67,13 +67,13 @@ vpath %.cpp $(VPATH_DIRS)
 # headers in an include/ folder (both in and adjacent to src/) while we're at it
 define LIB_HEADER_INCLUDES
 ifneq ($$(wildcard $(1)/*.h),"")
-  CPPFLAGS += -I$(1)
+  override CPPFLAGS += -I$(1)
 endif
 ifneq ($$(wildcard $(1)/include/*.h),"")
-  CPPFLAGS += -I$(1)/include
+  override CPPFLAGS += -I$(1)/include
 endif
 ifneq ($$(wildcard $(1)/../include/*.h),"")
-  CPPFLAGS += -I$(1)/../include
+  override CPPFLAGS += -I$(1)/../include
 endif
 endef
 # uncomment to print generated rules

--- a/userland/examples/build_all.sh
+++ b/userland/examples/build_all.sh
@@ -10,7 +10,7 @@ normal=$(tput sgr0)
 function opt_rebuild {
 	if [ "$CI" == "true" ]; then
 		echo "${bold}Rebuilding Verbose: $1${normal}"
-		make V=1
+		make CFLAGS=-Werror V=1
 	fi
 }
 
@@ -20,7 +20,7 @@ for mkfile in `find . -maxdepth 3 -name Makefile`; do
 	pushd $dir > /dev/null
 	echo ""
 	echo "Building $dir"
-	make -j $NUM_JOBS || (echo "${bold} ⤤ Failure building $dir${normal}" ; opt_rebuild $dir; exit 1)
+	make CFLAGS=-Werror -j $NUM_JOBS || (echo "${bold} ⤤ Failure building $dir${normal}" ; opt_rebuild $dir; exit 1)
 	popd > /dev/null
 done
 

--- a/userland/examples/lua-hello/Makefile
+++ b/userland/examples/lua-hello/Makefile
@@ -9,7 +9,7 @@ C_SRCS := $(wildcard *.c)
 # External libraries used
 EXTERN_LIBS += $(TOCK_USERLAND_BASE_DIR)/lua53
 
-CFLAGS += -I$(TOCK_USERLAND_BASE_DIR)/lua53/include
+override CFLAGS += -I$(TOCK_USERLAND_BASE_DIR)/lua53/include
 
 STACK_SIZE    = 3072
 KERNEL_HEAP_SIZE    = 512

--- a/userland/examples/rf233/rf233.c
+++ b/userland/examples/rf233/rf233.c
@@ -484,8 +484,13 @@ static void rf_generate_random_seed(void) {
 /*---------------------------------------------------------------------------*/
 // Append header with FCF, sequence number,
 static int rf233_prepare_without_header(const uint8_t *data, unsigned short data_len) {
+  if ((data_len + HEADER_SIZE) > MAX_PACKET_LEN) {
+    PRINTF("RF233: error, data too large (%u) (prepare_without_header)\n", data_len);
+    return RADIO_TX_ERR;
+  }
+
   // append mac header with length 9
-  uint8_t data_with_header[data_len + HEADER_SIZE];
+  uint8_t data_with_header[MAX_PACKET_LEN];
   data_with_header[0] = 0x61;
   data_with_header[1] = 0xAA;
   data_with_header[2] = radio_header.seq & 0xFF;

--- a/userland/examples/rf233/rf233.c
+++ b/userland/examples/rf233/rf233.c
@@ -519,7 +519,13 @@ int rf233_prepare(const void *payload, unsigned short payload_len) {
   // Frame length is number of bytes in MPDU
   uint8_t templen;
   uint8_t radio_status;
-  uint8_t data[130];
+  uint8_t data[1 + MAX_PACKET_LEN + 2]; // Length + Payload + FCS
+
+  PRINTF("RF233: prepare %u\n", payload_len);
+  if(payload_len > MAX_PACKET_LEN) {
+    PRINTF("RF233: error, frame too large to tx\n");
+    return RADIO_TX_ERR;
+  }
 
   /* Add length of the FCS (2 bytes) */
   templen = payload_len + 2;
@@ -538,12 +544,6 @@ int rf233_prepare(const void *payload, unsigned short payload_len) {
   }
   PRINTF("\n");
 #endif  /* DEBUG_PRINTDATA */
-
-  PRINTF("RF233: prepare %u\n", payload_len);
-  if(payload_len > MAX_PACKET_LEN) {
-    PRINTF("RF233: error, frame too large to tx\n");
-    return RADIO_TX_ERR;
-  }
 
   /* check that the FIFO is clear to access */
   radio_status = rf233_status();

--- a/userland/examples/rf233/rf233.c
+++ b/userland/examples/rf233/rf233.c
@@ -70,7 +70,7 @@ int rf233_pending_packet(void);
 #define RF233_COMMAND(c)                  trx_reg_write(RF233_REG_TRX_STATE, c)
 
 /* each frame has a footer consisting of LQI, ED, RX_STATUS added by the radio */
-#define FOOTER_LEN                        3   /* bytes */
+//#define FOOTER_LEN                        3   /* bytes */
 #define MAX_PACKET_LEN                    127 /* bytes, excluding the length (first) byte */
 #define PACKETBUF_SIZE                    128 /* bytes, for even int writes */
 #define HEADER_SIZE                       9 /* bytes */

--- a/userland/examples/tests/hail/main.c
+++ b/userland/examples/tests/hail/main.c
@@ -29,7 +29,6 @@ simple_ble_config_t ble_config = {
 };
 
 // Empty handler for setting BLE addresses
-#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
 void ble_address_set (void) {
   // nop
 }

--- a/userland/examples/tests/mpu_stack_growth/Makefile
+++ b/userland/examples/tests/mpu_stack_growth/Makefile
@@ -7,7 +7,7 @@ TOCK_USERLAND_BASE_DIR = ../../..
 C_SRCS := $(wildcard *.c)
 
 # Include the STACK_SIZE so the test can use it
-CFLAGS += -DSTACK_SIZE=$(STACK_SIZE)
+override CFLAGS += -DSTACK_SIZE=$(STACK_SIZE)
 
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.

--- a/userland/examples/tests/mpu_walk_region/Makefile
+++ b/userland/examples/tests/mpu_walk_region/Makefile
@@ -7,7 +7,7 @@ TOCK_USERLAND_BASE_DIR = ../../..
 C_SRCS := $(wildcard *.c)
 
 # Include the STACK_SIZE so the test can use it
-CFLAGS += -DSTACK_SIZE=$(STACK_SIZE)
+override CFLAGS += -DSTACK_SIZE=$(STACK_SIZE)
 
 # Include userland master makefile. Contains rules and flags for actually
 # building the application.

--- a/userland/examples/tutorials/03_ble_scan/main.c
+++ b/userland/examples/tutorials/03_ble_scan/main.c
@@ -24,7 +24,6 @@ simple_ble_config_t ble_config = {
   .max_conn_interval = MSEC_TO_UNITS(1250, UNIT_1_25_MS)
 };
 
-#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
 void app_error_fault_handler(__attribute__ ((unused)) uint32_t error_code,
                              __attribute__ ((unused)) uint32_t line_num,
                              __attribute__ ((unused)) uint32_t info) {
@@ -33,7 +32,6 @@ void app_error_fault_handler(__attribute__ ((unused)) uint32_t error_code,
   // The application can continue.
 }
 
-#pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
 void ble_address_set (void) {
   // Need to redefine this function so that we do not try to set the address
   // on the main processor.

--- a/userland/libnrfserialization/Makefile
+++ b/userland/libnrfserialization/Makefile
@@ -11,7 +11,7 @@ $(LIBNAME)_SRCS += $(SYSTEM_FILE) $(notdir $(APPLICATION_SRCS))
 ## Rules to create libnrfserialization
 
 # Need libtock headers
-CPPFLAGS += -I$(TOCK_USERLAND_BASE_DIR)/libtock
+override CPPFLAGS += -I$(TOCK_USERLAND_BASE_DIR)/libtock
 
 include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk
 

--- a/userland/libnrfserialization/Makefile.app
+++ b/userland/libnrfserialization/Makefile.app
@@ -1,11 +1,11 @@
 LIBNRFSER_DIR := $(TOCK_USERLAND_BASE_DIR)/libnrfserialization
 
 # So it doesn't think it's on the nRF and try to include nRF code.
-CFLAGS += -D__TOCK__
-CFLAGS += -DSVCALL_AS_NORMAL_FUNCTION
-CFLAGS += -DSOFTDEVICE_s130
+override CFLAGS += -D__TOCK__
+override CFLAGS += -DSVCALL_AS_NORMAL_FUNCTION
+override CFLAGS += -DSOFTDEVICE_s130
 
-CFLAGS += -I$(LIBNRFSER_DIR)/headers
+override CFLAGS += -I$(LIBNRFSER_DIR)/headers
 
 # If environment variable V is non-empty, be verbose
 ifneq ($(V),)

--- a/userland/libtock/crt1.c
+++ b/userland/libtock/crt1.c
@@ -9,6 +9,7 @@ extern unsigned int* _ebss;
 extern int main(void);
 
 // Allow _start to go undeclared
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 
 __attribute__ ((section(".start"), used))

--- a/userland/libtock/sys.c
+++ b/userland/libtock/sys.c
@@ -11,6 +11,7 @@
 // XXX Suppress missing prototype warnings for this file as the headers should
 // be in newlib internals, but first stab at including things didn't quite work
 // and the warnings are just noise
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #pragma GCC diagnostic ignored "-Wstrict-prototypes"
 

--- a/userland/lua53/Makefile
+++ b/userland/lua53/Makefile
@@ -6,6 +6,6 @@ $(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
 # List all C and Assembly files
 $(LIBNAME)_SRCS  := $(wildcard $($(LIBNAME)_DIR)/lua/*.c)
 
-CFLAGS += -DLUA_32BITS -D"luai_makeseed()"=0
+override CFLAGS += -DLUA_32BITS -D"luai_makeseed()"=0
 
 include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk


### PR DESCRIPTION
This patch series does two things

1. It cleans up all the warnings currently in Tock userland C
2. It turns on `-Werror` _only_ for `build_all`

The idea of 2 being that we shouldn't let code with warnings into master but it shouldn't interfere with development