### PR TITLE
Fixes bug in MPU setup with non-empty IPC regions

### DIFF
--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -31,9 +31,9 @@ impl Region {
         }
     }
 
-    pub fn empty() -> Region {
+    pub fn empty(region_num: usize) -> Region {
         Region {
-            base_address: 0,
+            base_address: (region_num as u32) | 1 << 4,
             attributes: 0,
         }
     }
@@ -83,7 +83,7 @@ impl MPU for () {
                      _: ExecutePermission,
                      _: AccessPermission)
                      -> Option<Region> {
-        Some(Region::empty())
+        Some(Region::empty(0))
     }
 
     fn set_mpu(&self, _: Region) {}

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -388,7 +388,7 @@ impl<'a> Process<'a> {
         // Setup IPC MPU regions
         for (i, region) in self.mpu_regions.iter().enumerate() {
             if region.get().0 == ptr::null() {
-                mpu.set_mpu(mpu::Region::empty());
+                mpu.set_mpu(mpu::Region::empty(i + 3));
                 continue;
             }
             match MPU::create_region(i + 3,


### PR DESCRIPTION
When a process has empty IPC regions we were clearing them with an
"empty" `Region`. However, this empty region didn't actually have a
region number, so it was just destroying whichever region had just been
set (usually the grant region, which is extra bad).

This manifested in #395 when a non-empty IPC region was overriden by an empty one, resulting in that region _not_ being exposed to the app, and the app crashing.

This PR fixes the bug by requiring a region number when an "empty" `Region` is created. It's just as non-portable as the rest of the current implementation of MPU regions, but for now it at least fixes the bug.