### PR TITLE
Enforce checking of return values for syscalls

### DIFF
--- a/userland/examples/build_all.sh
+++ b/userland/examples/build_all.sh
@@ -17,6 +17,9 @@ function opt_rebuild {
 for mkfile in `find . -maxdepth 3 -name Makefile`; do
 	dir=`dirname $mkfile`
 	if [ $dir == "." ]; then continue; fi
+	# Skip directories with leading _'s, useful for leaving test apps around
+	if [[ $(basename $dir) == _* ]]; then continue; fi
+
 	pushd $dir > /dev/null
 	echo ""
 	echo "Building $dir"

--- a/userland/libtock/console.h
+++ b/userland/libtock/console.h
@@ -6,9 +6,9 @@
 extern "C" {
 #endif
 
-void putstr(const char* str);
-void putnstr(const char* str, size_t len);
-void putnstr_async(const char* str, size_t len, subscribe_cb cb, void* userdata);
+int putstr(const char* str);
+int putnstr(const char* str, size_t len);
+int putnstr_async(const char* str, size_t len, subscribe_cb cb, void* userdata);
 
 #ifdef __cplusplus
 }

--- a/userland/libtock/nrf51_serialization.c
+++ b/userland/libtock/nrf51_serialization.c
@@ -1,24 +1,28 @@
 #include "nrf51_serialization.h"
 
-void nrf51_serialization_subscribe (subscribe_cb cb) {
+int nrf51_serialization_subscribe (subscribe_cb cb) {
   // get some callback love
-  subscribe(5, 0, cb, NULL);
+  return subscribe(5, 0, cb, NULL);
 }
 
-void nrf51_serialization_setup_rx_buffer (char* rx, int rx_len) {
+int nrf51_serialization_setup_rx_buffer (char* rx, int rx_len) {
   // Pass the RX buffer for the UART module to use.
-  allow(5, 0, rx, rx_len);
+  return allow(5, 0, rx, rx_len);
 }
 
-void nrf51_serialization_write (char* tx, int tx_len) {
+int nrf51_serialization_write (char* tx, int tx_len) {
+  int ret;
+
   // Pass in the TX buffer.
-  allow(5, 1, tx, tx_len);
+  ret = allow(5, 1, tx, tx_len);
+  if (ret < 0) return ret;
 
   // Do the write!!!!!
-  command(5, 1, 0);
+  ret = command(5, 1, 0);
+  return ret;
 }
 
-void nrf51_wakeup (void) {
-  command(5, 9001, 0);
+int nrf51_wakeup (void) {
+  return command(5, 9001, 0);
 }
 

--- a/userland/libtock/nrf51_serialization.h
+++ b/userland/libtock/nrf51_serialization.h
@@ -8,16 +8,16 @@ extern "C" {
 
 // Give the BLE Serialization / UART layer a callback to call when
 // a packet is received and when a TX is finished.
-void nrf51_serialization_subscribe (subscribe_cb cb);
+int nrf51_serialization_subscribe (subscribe_cb cb);
 
 // Pass a buffer for the driver to write received UART bytes to.
-void nrf51_serialization_setup_rx_buffer (char* rx, int rx_len);
+int nrf51_serialization_setup_rx_buffer (char* rx, int rx_len);
 
 // Write a packet to the BLE Serialization connectivity processor.
-void nrf51_serialization_write (char* tx, int tx_len);
+int nrf51_serialization_write (char* tx, int tx_len);
 
 // Generate an event to wake the app from a yield
-void nrf51_wakeup (void);
+int nrf51_wakeup (void);
 
 #ifdef __cplusplus
 }

--- a/userland/libtock/nrf51_serialization.h
+++ b/userland/libtock/nrf51_serialization.h
@@ -8,15 +8,19 @@ extern "C" {
 
 // Give the BLE Serialization / UART layer a callback to call when
 // a packet is received and when a TX is finished.
+__attribute__ ((warn_unused_result))
 int nrf51_serialization_subscribe (subscribe_cb cb);
 
 // Pass a buffer for the driver to write received UART bytes to.
+__attribute__ ((warn_unused_result))
 int nrf51_serialization_setup_rx_buffer (char* rx, int rx_len);
 
 // Write a packet to the BLE Serialization connectivity processor.
+__attribute__ ((warn_unused_result))
 int nrf51_serialization_write (char* tx, int tx_len);
 
 // Generate an event to wake the app from a yield
+__attribute__ ((warn_unused_result))
 int nrf51_wakeup (void);
 
 #ifdef __cplusplus

--- a/userland/libtock/tock.h
+++ b/userland/libtock/tock.h
@@ -12,9 +12,15 @@ typedef void (subscribe_cb)(int, int, int,void*);
 
 void yield(void);
 void yield_for(bool*);
+
+__attribute__ ((warn_unused_result))
 int command(uint32_t driver, uint32_t command, int data);
+
+__attribute__ ((warn_unused_result))
 int subscribe(uint32_t driver, uint32_t subscribe,
               subscribe_cb cb, void* userdata);
+
+__attribute__ ((warn_unused_result))
 int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size);
 
 // op_type can be:


### PR DESCRIPTION
This should at least allow users from #414 to identify when the attempt to write a string fails