### PR TITLE
Added coulomb helper function for ltc294x

### DIFF
--- a/userland/libtock/ltc294x.c
+++ b/userland/libtock/ltc294x.c
@@ -237,6 +237,14 @@ int ltc294x_shutdown_sync(void) {
   return 0;
 }
 
+int ltc294x_convert_to_coulomb_uah(int c, int Rsense, uint16_t prescaler, ltc294x_model_e model) {
+    if(model == LTC2941 || model == LTC2942) {
+        return (int)(c*0.085*(50.0/Rsense)*(prescaler/128.0));
+    } else {
+        return (int)(c*0.340*(50.0/Rsense)*(prescaler/4096.0));
+    }
+}
+
 int ltc294x_convert_to_voltage_mv (int v) {
   return 23.6*(v/(float)0xFFFF)*1000;
 }

--- a/userland/libtock/ltc294x.c
+++ b/userland/libtock/ltc294x.c
@@ -238,11 +238,11 @@ int ltc294x_shutdown_sync(void) {
 }
 
 int ltc294x_convert_to_coulomb_uah(int c, int Rsense, uint16_t prescaler, ltc294x_model_e model) {
-    if(model == LTC2941 || model == LTC2942) {
-        return (int)(c*0.085*(50.0/Rsense)*(prescaler/128.0));
-    } else {
-        return (int)(c*0.340*(50.0/Rsense)*(prescaler/4096.0));
-    }
+  if (model == LTC2941 || model == LTC2942) {
+    return (int)(c*0.085*(50.0/Rsense)*(prescaler/128.0));
+  } else {
+    return (int)(c*0.340*(50.0/Rsense)*(prescaler/4096.0));
+  }
 }
 
 int ltc294x_convert_to_voltage_mv (int v) {

--- a/userland/libtock/ltc294x.h
+++ b/userland/libtock/ltc294x.h
@@ -119,6 +119,7 @@ int ltc294x_shutdown_sync(void);
 //
 // Helpers
 //
+int ltc294x_convert_to_coulomb_uah(int c, int Rsense, uint16_t prescaler, ltc294x_model_e model) __attribute__((const));
 int ltc294x_convert_to_voltage_mv(int v) __attribute__((const));
 int ltc294x_convert_to_current_ua(int c, int Rsense) __attribute__((const));
 


### PR DESCRIPTION
Currently we do this conversion in the signpost energy library, but I think it's more appropriate to be encapsulated in the userland driver like the other helper functions.