### PR TITLE
Avoid requiring an explicit size in static_init

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(asm,const_fn,lang_items,compiler_builtins_lib)]
+#![feature(asm,const_fn,drop_types_in_const,lang_items,compiler_builtins_lib)]
 
 extern crate capsules;
 extern crate cortexm4;

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(asm,const_fn,lang_items,compiler_builtins_lib)]
+#![feature(asm,const_fn,drop_types_in_const,lang_items,compiler_builtins_lib)]
 
 extern crate capsules;
 extern crate compiler_builtins;

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -35,7 +35,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(lang_items,compiler_builtins_lib)]
+#![feature(lang_items,drop_types_in_const,compiler_builtins_lib)]
 
 extern crate cortexm0;
 extern crate capsules;
@@ -156,8 +156,7 @@ pub unsafe fn reset_handler() {
         (&nrf51::gpio::PORT[LED2_PIN], capsules::led::ActivationMode::ActiveLow), // 22
         (&nrf51::gpio::PORT[LED3_PIN], capsules::led::ActivationMode::ActiveLow), // 23
         (&nrf51::gpio::PORT[LED4_PIN], capsules::led::ActivationMode::ActiveLow), // 24
-        ],
-        256/8);
+        ], 256/8);
     let led = static_init!(
         capsules::led::LED<'static, nrf51::gpio::GPIOPin>,
         capsules::led::LED::new(led_pins),


### PR DESCRIPTION
Sacrifices up to a word of memory in order to avoid requiring the caller
to explicitly pass in the size of the type. When we finally get
`size_of` or other intrinsics at compile-time, we'll be able to get rid
of that overhead as well.

For backwards compatibility accepts an optional size argument which is
simply ignored.