### PR TITLE
Create a nonvolatile storage interface.

### DIFF
--- a/capsules/README.md
+++ b/capsules/README.md
@@ -90,6 +90,8 @@ simultaneously) support for generic sensor interfaces.
 - **[Asynchronous GPIO](src/gpio_async.rs)**: GPIO pins accessed by split-phase
   calls.
 - **[9DOF](src/ninedof.rs)**: 9DOF sensors (acceleration, magnetometer, gyroscope).
+- **[Nonvolatile Storage](src/nonvolatile_storage.rs)**: Persistent storage for
+  userspace.
 
 
 ### Virtualized Hardware Resources

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -1,14 +1,48 @@
 //! Driver for the FM25CL FRAM chip.
 //!
 //! http://www.cypress.com/part/fm25cl64b-dg
+//!
+//! From the FM25CL website:
+//!
+//! > The FM25CL64B is a 64-Kbit nonvolatile memory employing an advanced
+//! > ferroelectric process. A ferroelectric random access memory or F-RAM is
+//! > nonvolatile and performs reads and writes similar to a RAM. It provides
+//! > reliable data retention for 151 years while eliminating the complexities,
+//! > overhead, and system level reliability problems caused by serial flash,
+//! > EEPROM, and other nonvolatile memories.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! // Create a SPI device for this chip.
+//! let fm25cl_spi = static_init!(
+//!     capsules::virtual_spi::VirtualSpiMasterDevice<'static, usart::USART>,
+//!     capsules::virtual_spi::VirtualSpiMasterDevice::new(mux_spi, Some(&sam4l::gpio::PA[25])));
+//! // Setup the actual FM25CL driver.
+//! let fm25cl = static_init!(
+//!     capsules::fm25cl::FM25CL<'static,
+//!     capsules::virtual_spi::VirtualSpiMasterDevice<'static, usart::USART>>,
+//!     capsules::fm25cl::FM25CL::new(fm25cl_spi,
+//!         &mut capsules::fm25cl::TXBUFFER, &mut capsules::fm25cl::RXBUFFER));
+//! fm25cl_spi.set_client(fm25cl);
+//! ```
+//!
+//! This capsule provides two interfaces:
+//! - `hil::nonvolatile_storage::NonvolatileStorage`
+//! - `FM25CLCustom`
+//!
+//! The first is the generic interface for nonvolatile storage. This allows
+//! this driver to work with capsules like the `nonvolatile_storage_driver`
+//! that provide virtualization and a userspace interface. The second is a
+//! custom interface that exposes other chip-specific functions.
 
 use core::cell::Cell;
 use core::cmp;
-use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
+use kernel::ReturnCode;
 
-use kernel::common::take_cell::{MapCell, TakeCell};
+use kernel::common::take_cell::TakeCell;
 use kernel::hil;
-
 
 
 pub static mut TXBUFFER: [u8; 512] = [0; 512];
@@ -44,6 +78,9 @@ enum State {
     ReadMemory,
 }
 
+pub trait FM25CLCustom {
+    fn read_status(&self) -> ReturnCode;
+}
 
 pub trait FM25CLClient {
     fn status(&self, status: u8);
@@ -56,7 +93,8 @@ pub struct FM25CL<'a, S: hil::spi::SpiMasterDevice + 'a> {
     state: Cell<State>,
     txbuffer: TakeCell<'static, [u8]>,
     rxbuffer: TakeCell<'static, [u8]>,
-    client: Cell<Option<&'static FM25CLClient>>,
+    client: Cell<Option<&'static hil::nonvolatile_storage::NonvolatileStorageClient>>,
+    client_custom: Cell<Option<&'static FM25CLClient>>,
     client_buffer: TakeCell<'static, [u8]>, // Store buffer and state for passing back to client
     client_write_address: Cell<u16>,
     client_write_len: Cell<u16>,
@@ -74,6 +112,7 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CL<'a, S> {
             txbuffer: TakeCell::new(txbuffer),
             rxbuffer: TakeCell::new(rxbuffer),
             client: Cell::new(None),
+            client_custom: Cell::new(None),
             client_buffer: TakeCell::empty(),
             client_write_address: Cell::new(0),
             client_write_len: Cell::new(0),
@@ -81,7 +120,7 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CL<'a, S> {
     }
 
     pub fn set_client<C: FM25CLClient>(&self, client: &'static C) {
-        self.client.set(Some(client));
+        self.client_custom.set(Some(client));
     }
 
     /// Setup SPI for this chip
@@ -89,22 +128,6 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CL<'a, S> {
         self.spi.configure(hil::spi::ClockPolarity::IdleLow,
                            hil::spi::ClockPhase::SampleLeading,
                            SPI_SPEED);
-    }
-
-    pub fn read_status(&self) -> ReturnCode {
-        self.configure_spi();
-
-        self.txbuffer.take().map_or(ReturnCode::ERESERVE, |txbuffer| {
-            self.rxbuffer.take().map_or(ReturnCode::ERESERVE, move |rxbuffer| {
-                txbuffer[0] = Opcodes::ReadStatusRegister as u8;
-
-                // Use 4 bytes instead of the required 2 because that works better
-                // with DMA for some reason.
-                self.spi.read_write_bytes(txbuffer, Some(rxbuffer), 4);
-                self.state.set(State::ReadStatus);
-                ReturnCode::SUCCESS
-            })
-        })
     }
 
     pub fn write(&self, address: u16, buffer: &'static mut [u8], len: u16) -> ReturnCode {
@@ -166,7 +189,7 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> hil::spi::SpiMasterClient for FM25CL
                     // Also replace this buffer
                     self.rxbuffer.replace(read_buffer);
 
-                    self.client.get().map(|client| { client.status(status); });
+                    self.client_custom.get().map(|client| client.status(status));
                 });
             }
             State::WriteEnable => {
@@ -190,13 +213,15 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> hil::spi::SpiMasterClient for FM25CL
             State::WriteMemory => {
                 self.state.set(State::Idle);
 
+                let write_len = cmp::min(write_buffer.len(), self.client_write_len.get() as usize);
+
                 // Replace these buffers
                 self.txbuffer.replace(write_buffer);
                 read_buffer.map(|read_buffer| { self.rxbuffer.replace(read_buffer); });
 
                 // Call done with the write() buffer
                 self.client_buffer.take().map(move |buffer| {
-                    self.client.get().map(move |client| { client.done(buffer); });
+                    self.client.get().map(move |client| client.write_done(buffer, write_len));
                 });
             }
             State::ReadMemory => {
@@ -215,7 +240,9 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> hil::spi::SpiMasterClient for FM25CL
 
                         self.rxbuffer.replace(read_buffer);
 
-                        self.client.get().map(move |client| { client.read(buffer, read_len); });
+                        self.client.get().map(move |client| {
+                            client.read_done(buffer, read_len - 3)
+                        });
                     });
                 });
             }
@@ -224,151 +251,39 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> hil::spi::SpiMasterClient for FM25CL
     }
 }
 
-/// Holds buffers and whatnot that the application has passed us.
-struct App {
-    callback: Option<Callback>,
-    read_buffer: Option<AppSlice<Shared, u8>>,
-    write_buffer: Option<AppSlice<Shared, u8>>,
-}
+// Implement the custom interface that exposes chip-specific commands.
+impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CLCustom for FM25CL<'a, S> {
+    fn read_status(&self) -> ReturnCode {
+        self.configure_spi();
 
-impl Default for App {
-    fn default() -> App {
-        App {
-            callback: None,
-            read_buffer: None,
-            write_buffer: None,
-        }
-    }
-}
+        self.txbuffer.take().map_or(ReturnCode::ERESERVE, |txbuffer| {
+            self.rxbuffer.take().map_or(ReturnCode::ERESERVE, move |rxbuffer| {
+                txbuffer[0] = Opcodes::ReadStatusRegister as u8;
 
-/// Default implementation of the FM25CL driver that provides a Driver
-/// interface for providing access to applications.
-pub struct FM25CLDriver<'a, S: hil::spi::SpiMasterDevice + 'a> {
-    fm25cl: &'a FM25CL<'a, S>,
-    app: MapCell<App>,
-    kernel_read: TakeCell<'static, [u8]>,
-    kernel_write: TakeCell<'static, [u8]>,
-}
-
-impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CLDriver<'a, S> {
-    pub fn new(fm25: &'a FM25CL<S>,
-               write_buf: &'static mut [u8],
-               read_buf: &'static mut [u8])
-               -> FM25CLDriver<'a, S> {
-        FM25CLDriver {
-            fm25cl: fm25,
-            app: MapCell::new(App::default()),
-            kernel_read: TakeCell::new(read_buf),
-            kernel_write: TakeCell::new(write_buf),
-        }
-    }
-}
-
-impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CLClient for FM25CLDriver<'a, S> {
-    fn status(&self, status: u8) {
-        self.app.map(|app| { app.callback.map(|mut cb| { cb.schedule(0, status as usize, 0); }); });
-    }
-
-    fn read(&self, data: &'static mut [u8], len: usize) {
-        self.app.map(|app| {
-            let mut read_len: usize = 0;
-
-            app.read_buffer.as_mut().map(move |read_buffer| {
-                read_len = cmp::min(read_buffer.len(), len);
-
-                let d = &mut read_buffer.as_mut()[0..(read_len as usize)];
-                for (i, c) in data[0..read_len].iter().enumerate() {
-                    d[i] = *c;
-                }
-
-                self.kernel_read.replace(data);
-            });
-
-            app.callback.map(|mut cb| { cb.schedule(1, read_len, 0); });
-        });
-    }
-
-    fn done(&self, buffer: &'static mut [u8]) {
-        self.kernel_write.replace(buffer);
-
-        self.app
-            .map(|app| { app.callback.map(|mut cb| { cb.schedule(2, 0, 0); }); });
-    }
-}
-
-impl<'a, S: hil::spi::SpiMasterDevice + 'a> Driver for FM25CLDriver<'a, S> {
-    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
-        match allow_num {
-            // Pass read buffer in from application
-            0 => {
-                self.app.map(|app| app.read_buffer = Some(slice));
+                // Use 4 bytes instead of the required 2 because that works better
+                // with DMA for some reason.
+                self.spi.read_write_bytes(txbuffer, Some(rxbuffer), 4);
+                self.state.set(State::ReadStatus);
                 ReturnCode::SUCCESS
-            }
-            // Pass write buffer in from application
-            1 => {
-                self.app.map(|app| app.write_buffer = Some(slice));
-                ReturnCode::SUCCESS
-            }
-            _ => ReturnCode::ENOSUPPORT,
-        }
+            })
+        })
+    }
+}
+
+/// Implement the generic `NonvolatileStorage` interface common to chips that
+/// provide nonvolatile memory.
+impl<'a, S: hil::spi::SpiMasterDevice + 'a> hil::nonvolatile_storage::NonvolatileStorage
+    for
+    FM25CL<'a, S> {
+    fn set_client(&self, client: &'static hil::nonvolatile_storage::NonvolatileStorageClient) {
+        self.client.set(Some(client));
     }
 
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
-        match subscribe_num {
-            0 => {
-                self.app.map(|app| app.callback = Some(callback));
-                ReturnCode::SUCCESS
-            }
-
-            // default
-            _ => ReturnCode::ENOSUPPORT,
-        }
+    fn read(&self, buffer: &'static mut [u8], address: usize, length: usize) -> ReturnCode {
+        self.read(address as u16, buffer, length as u16)
     }
 
-    fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
-        match command_num {
-            0 /* check if present */ => ReturnCode::SUCCESS,
-
-            // get status
-            1 => self.fm25cl.read_status(),
-
-            // read
-            2 => {
-                let address = (data & 0xFFFF) as u16;
-                let len = (data >> 16) & 0xFFFF;
-
-                self.kernel_read.take().map_or(ReturnCode::ERESERVE, |kernel_read| {
-                    let read_len = cmp::min(len, kernel_read.len());
-
-                    self.fm25cl.read(address, kernel_read, read_len as u16)
-                })
-            }
-
-            // write
-            3 => {
-                let address = (data & 0xFFFF) as u16;
-                let len = ((data >> 16) & 0xFFFF) as usize;
-
-                self.app.map_or(ReturnCode::ERESERVE, |app| {
-                    app.write_buffer.as_mut().map_or(ReturnCode::ERESERVE, |write_buffer| {
-                        self.kernel_write.take().map_or(ReturnCode::ERESERVE, |kernel_write| {
-                            // Check bounds for write length
-                            let buf_len = cmp::min(write_buffer.len(), kernel_write.len());
-                            let write_len = cmp::min(buf_len, len);
-
-                            let d = &mut write_buffer.as_mut()[0..write_len];
-                            for (i, c) in kernel_write[0..write_len].iter_mut().enumerate() {
-                                *c = d[i];
-                            }
-
-                            self.fm25cl.write(address, kernel_write, write_len as u16)
-                        })
-                    })
-                })
-            }
-
-            // default
-            _ => ReturnCode::ENOSUPPORT,
-        }
+    fn write(&self, buffer: &'static mut [u8], address: usize, length: usize) -> ReturnCode {
+        self.write(address as u16, buffer, length as u16)
     }
 }

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -39,3 +39,4 @@ pub mod mcp23008;
 pub mod gpio_async;
 pub mod max17205;
 pub mod pca9544a;
+pub mod nonvolatile_storage_driver;

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -1,0 +1,550 @@
+//! This provides kernel and userspace access to nonvolatile memory.
+//!
+//! This is an initial implementation that does not provide safety for
+//! individual userland applications. Each application has full access to
+//! the entire memory space that has been provided to userland. Future revisions
+//! should update this to limit applications to only their allocated regions.
+//!
+//! However, the kernel accessible memory does not have to be the same range
+//! as the userspace accessible address space. The kernel memory can overlap
+//! if desired, or can be a completely separate range.
+//!
+//! Here is a diagram of the expected stack with this capsule:
+//! Boxes are components and between the boxes are the traits that are the
+//! interfaces between components. This capsule provides both a kernel and
+//! userspace interface.
+//!
+//! +--------------------------------------------+     +--------------+
+//! |                                            |     |              |
+//! |                  kernel                    |     |  userspace   |
+//! |                                            |     |              |
+//! +--------------------------------------------+     +--------------+
+//!  hil::nonvolatile_storage::NonvolatileStorage       kernel::Driver
+//! +-----------------------------------------------------------------+
+//! |                                                                 |
+//! | capsules::nonvolatile_storage_driver::NonvolatileStorage (this) |
+//! |                                                                 |
+//! +-----------------------------------------------------------------+
+//!            hil::nonvolatile_storage::NonvolatileStorage
+//! +-----------------------------------------------------------------+
+//! |                                                                 |
+//! |               Physical nonvolatile storage driver               |
+//! |                                                                 |
+//! +-----------------------------------------------------------------+
+//!
+//! Example instantiation:
+//! ```rust
+//! let nonvolatile_storage = static_init!(
+//!     capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
+//!     capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
+//!         fm25cl,                      // The underlying storage driver.
+//!         kernel::Container::create(), // Storage for app-specific state.
+//!         3000,                        // The byte start address for the userspace
+//!                                      // accessible memory region.
+//!         2000,                        // The length of the userspace region.
+//!         0,                           // The byte start address of the region
+//!                                      // that is accessible by the kernel.
+//!         3000,                        // The length of the kernel region.
+//!         &mut capsules::nonvolatile_storage_driver::BUFFER));
+//! hil::nonvolatile_storage::NonvolatileStorage::set_client(fm25cl, nonvolatile_storage);
+//! ```
+
+use core::cell::Cell;
+use core::cmp;
+use kernel::{AppId, AppSlice, Callback, Container, Driver, ReturnCode, Shared};
+use kernel::common::take_cell::TakeCell;
+use kernel::hil;
+use kernel::process::Error;
+
+pub static mut BUFFER: [u8; 512] = [0; 512];
+
+#[derive(Clone,Copy,PartialEq)]
+pub enum NonvolatileCommand {
+    UserspaceRead,
+    UserspaceWrite,
+    KernelRead,
+    KernelWrite,
+}
+
+#[derive(Clone,Copy)]
+pub enum NonvolatileUser {
+    App { app_id: AppId },
+    Kernel,
+}
+
+pub struct App {
+    callback_read: Option<Callback>,
+    callback_write: Option<Callback>,
+    pending_command: bool,
+    command: NonvolatileCommand,
+    offset: usize,
+    length: usize,
+    buffer_read: Option<AppSlice<Shared, u8>>,
+    buffer_write: Option<AppSlice<Shared, u8>>,
+}
+
+impl Default for App {
+    fn default() -> App {
+        App {
+            callback_read: None,
+            callback_write: None,
+            pending_command: false,
+            command: NonvolatileCommand::UserspaceRead,
+            offset: 0,
+            length: 0,
+            buffer_read: None,
+            buffer_write: None,
+        }
+    }
+}
+
+pub struct NonvolatileStorage<'a> {
+    // The underlying physical storage device.
+    driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
+    // Per-app state.
+    apps: Container<App>,
+
+    // Internal buffer for copying appslices into.
+    buffer: TakeCell<'static, [u8]>,
+    // What issued the currently executing call. This can be an app or the kernel.
+    current_user: Cell<Option<NonvolatileUser>>,
+
+    // The first byte that is accessible from userspace.
+    userspace_start_address: usize,
+    // How many bytes allocated to userspace.
+    userspace_length: usize,
+    // The first byte that is accessible from the kernel.
+    kernel_start_address: usize,
+    // How many bytes allocated to kernel.
+    kernel_length: usize,
+
+    // Optional client for the kernel. Only needed if the kernel intends to use
+    // this nonvolatile storage.
+    kernel_client: Cell<Option<&'static hil::nonvolatile_storage::NonvolatileStorageClient>>,
+    // Whether the kernel is waiting for a read/write.
+    kernel_pending_command: Cell<bool>,
+    // Whether the kernel wanted a read/write.
+    kernel_command: Cell<NonvolatileCommand>,
+    // Holder for the buffer passed from the kernel in case we need to wait.
+    kernel_buffer: TakeCell<'static, [u8]>,
+    // How many bytes to read/write from the kernel buffer.
+    kernel_readwrite_length: Cell<usize>,
+    // Where to read/write from the kernel request.
+    kernel_readwrite_address: Cell<usize>,
+}
+
+impl<'a> NonvolatileStorage<'a> {
+    pub fn new(driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
+               container: Container<App>,
+               userspace_start_address: usize,
+               userspace_length: usize,
+               kernel_start_address: usize,
+               kernel_length: usize,
+               buffer: &'static mut [u8])
+               -> NonvolatileStorage<'a> {
+        NonvolatileStorage {
+            driver: driver,
+            apps: container,
+            buffer: TakeCell::new(buffer),
+            current_user: Cell::new(None),
+            userspace_start_address: userspace_start_address,
+            userspace_length: userspace_length,
+            kernel_start_address: kernel_start_address,
+            kernel_length: kernel_length,
+            kernel_client: Cell::new(None),
+            kernel_pending_command: Cell::new(false),
+            kernel_command: Cell::new(NonvolatileCommand::KernelRead),
+            kernel_buffer: TakeCell::empty(),
+            kernel_readwrite_length: Cell::new(0),
+            kernel_readwrite_address: Cell::new(0),
+        }
+    }
+
+    // Check so see if we are doing something. If not, go ahead and do this
+    // command. If so, this is queued and will be run when the pending
+    // command completes.
+    fn enqueue_command(&self,
+                       command: NonvolatileCommand,
+                       offset: usize,
+                       length: usize,
+                       app_id: Option<AppId>)
+                       -> ReturnCode {
+
+        // Do bounds check.
+        match command {
+            NonvolatileCommand::UserspaceRead |
+            NonvolatileCommand::UserspaceWrite => {
+                // Userspace sees memory that starts at address 0 even if it
+                // is offset in the physical memory.
+                if offset >= self.userspace_length || length > self.userspace_length ||
+                   offset + length > self.userspace_length {
+                    return ReturnCode::EINVAL;
+                }
+            }
+            NonvolatileCommand::KernelRead |
+            NonvolatileCommand::KernelWrite => {
+                // Because the kernel uses the NonvolatileStorage interface,
+                // its calls are absolute addresses.
+                if offset < self.kernel_start_address ||
+                   offset >= self.kernel_start_address + self.kernel_length ||
+                   length > self.kernel_length ||
+                   offset + length > self.kernel_start_address + self.kernel_length {
+                    return ReturnCode::EINVAL;
+                }
+            }
+        }
+
+        // Do very different actions if this is a call from userspace
+        // or from the kernel.
+        match command {
+            NonvolatileCommand::UserspaceRead |
+            NonvolatileCommand::UserspaceWrite => {
+                app_id.map_or(ReturnCode::FAIL, |appid| {
+                    self.apps
+                        .enter(appid, |app, _| {
+                            // Get the length of the correct allowed buffer.
+                            let allow_buf_len = match command {
+                                NonvolatileCommand::UserspaceRead => {
+                                    app.buffer_read.as_ref().map_or(0, |appbuf| appbuf.len())
+                                }
+                                NonvolatileCommand::UserspaceWrite => {
+                                    app.buffer_write.as_ref().map_or(0, |appbuf| appbuf.len())
+                                }
+                                _ => 0,
+                            };
+
+                            // Check that it exists.
+                            if allow_buf_len == 0 || self.buffer.is_none() {
+                                return ReturnCode::ERESERVE;
+                            }
+
+                            // Shorten the length if the application gave us nowhere to
+                            // put it.
+                            let active_len = cmp::min(length, allow_buf_len);
+
+                            // First need to determine if we can execute this or must
+                            // queue it.
+                            if self.current_user.get().is_none() {
+                                // No app is currently using the underlying storage.
+                                // Mark this app as active, and then execute the command.
+                                self.current_user.set(Some(NonvolatileUser::App { app_id: appid }));
+
+                                // Need to copy bytes if this is a write!
+                                if command == NonvolatileCommand::UserspaceWrite {
+                                    app.buffer_write.as_mut().map(|app_buffer| {
+                                        self.buffer.map(|kernel_buffer| {
+                                        // Check that the internal buffer and the buffer that was
+                                        // allowed are long enough.
+                                        let write_len = cmp::min(active_len, kernel_buffer.len());
+
+                                        let d = &mut app_buffer.as_mut()[0..write_len];
+                                        for (i, c) in kernel_buffer[0..write_len].iter_mut()
+                                                                                 .enumerate() {
+                                            *c = d[i];
+                                        }
+                                    });
+                                    });
+                                }
+
+                                self.userspace_call_driver(command, offset, active_len)
+                            } else {
+                                // Some app is using the storage, we must wait.
+                                if app.pending_command == true {
+                                    // No more room in the queue, nowhere to store this
+                                    // request.
+                                    ReturnCode::ENOMEM
+                                } else {
+                                    // We can store this, so lets do it.
+                                    app.pending_command = true;
+                                    app.command = command;
+                                    app.offset = offset;
+                                    app.length = active_len;
+                                    ReturnCode::SUCCESS
+                                }
+                            }
+                        })
+                        .unwrap_or_else(|err| match err {
+                            Error::OutOfMemory => ReturnCode::ENOMEM,
+                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                            Error::NoSuchApp => ReturnCode::EINVAL,
+                        })
+                })
+            }
+            NonvolatileCommand::KernelRead |
+            NonvolatileCommand::KernelWrite => {
+
+                self.kernel_buffer.take().map_or(ReturnCode::ENOMEM, |kernel_buffer| {
+                    let active_len = cmp::min(length, kernel_buffer.len());
+
+                    // Check if there is something going on.
+                    if self.current_user.get().is_none() {
+                        // Nothing is using this, lets go!
+                        self.current_user.set(Some(NonvolatileUser::Kernel));
+
+                        match command {
+                            NonvolatileCommand::KernelRead => {
+                                self.driver.read(kernel_buffer, offset, active_len)
+                            }
+                            NonvolatileCommand::KernelWrite => {
+                                self.driver.write(kernel_buffer, offset, active_len)
+                            }
+                            _ => ReturnCode::FAIL,
+                        }
+
+                    } else {
+                        if self.kernel_pending_command.get() == true {
+                            ReturnCode::ENOMEM
+                        } else {
+                            self.kernel_pending_command.set(true);
+                            self.kernel_command.set(command);
+                            self.kernel_readwrite_length.set(active_len);
+                            self.kernel_readwrite_address.set(offset);
+                            self.kernel_buffer.replace(kernel_buffer);
+                            ReturnCode::SUCCESS
+                        }
+                    }
+                })
+            }
+        }
+
+    }
+
+    fn userspace_call_driver(&self,
+                             command: NonvolatileCommand,
+                             offset: usize,
+                             length: usize)
+                             -> ReturnCode {
+
+        // Calculate where we want to actually read from in the physical
+        // storage.
+        let physical_address = offset + self.userspace_start_address;
+
+        self.buffer.take().map_or(ReturnCode::ERESERVE, |buffer| {
+            // Check that the internal buffer and the buffer that was
+            // allowed are long enough.
+            let active_len = cmp::min(length, buffer.len());
+
+            // self.current_app.set(Some(appid));
+            match command {
+                NonvolatileCommand::UserspaceRead => {
+                    self.driver.read(buffer, physical_address, active_len)
+                }
+                NonvolatileCommand::UserspaceWrite => {
+                    self.driver.write(buffer, physical_address, active_len)
+                }
+                _ => ReturnCode::FAIL,
+            }
+        })
+    }
+
+    fn check_queue(&self) {
+        // Check if there are any pending events.
+        if self.kernel_pending_command.get() {
+            self.kernel_buffer.take().map(|kernel_buffer| {
+                self.kernel_pending_command.set(false);
+                self.current_user.set(Some(NonvolatileUser::Kernel));
+
+                match self.kernel_command.get() {
+                    NonvolatileCommand::KernelRead => {
+                        self.driver.read(kernel_buffer,
+                                         self.kernel_readwrite_address.get(),
+                                         self.kernel_readwrite_length.get())
+                    }
+                    NonvolatileCommand::KernelWrite => {
+                        self.driver.write(kernel_buffer,
+                                          self.kernel_readwrite_address.get(),
+                                          self.kernel_readwrite_length.get())
+                    }
+                    _ => ReturnCode::FAIL,
+                }
+            });
+        } else {
+            // If the kernel is not requesting anything, check all of the apps.
+            for cntr in self.apps.iter() {
+                let started_command = cntr.enter(|app, _| if app.pending_command {
+                    app.pending_command = false;
+                    self.current_user.set(Some(NonvolatileUser::App { app_id: app.appid() }));
+                    self.userspace_call_driver(app.command, app.offset, app.length) ==
+                    ReturnCode::SUCCESS
+                } else {
+                    false
+                });
+                if started_command {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// This is the callback client for the underlying physical storage driver.
+impl<'a> hil::nonvolatile_storage::NonvolatileStorageClient for NonvolatileStorage<'a> {
+    fn read_done(&self, buffer: &'static mut [u8], length: usize) {
+        // Switch on which user of this capsule generated this callback.
+        self.current_user.get().map(|user| {
+            self.current_user.set(None);
+            match user {
+                NonvolatileUser::Kernel => {
+                    self.kernel_client
+                        .get()
+                        .map(move |client| { client.read_done(buffer, length); });
+                }
+                NonvolatileUser::App { app_id } => {
+                    let _ = self.apps.enter(app_id, move |app, _| {
+                        // Need to copy in the contents of the buffer
+                        app.buffer_read.as_mut().map(|app_buffer| {
+                            let read_len = cmp::min(app_buffer.len(), length);
+
+                            let d = &mut app_buffer.as_mut()[0..(read_len as usize)];
+                            for (i, c) in buffer[0..read_len].iter().enumerate() {
+                                d[i] = *c;
+                            }
+                        });
+
+                        // Replace the buffer we used to do this read.
+                        self.buffer.replace(buffer);
+
+                        // And then signal the app.
+                        app.callback_read.map(|mut cb| cb.schedule(length, 0, 0));
+                    });
+                }
+            }
+        });
+
+        self.check_queue();
+    }
+
+    fn write_done(&self, buffer: &'static mut [u8], length: usize) {
+        // Switch on which user of this capsule generated this callback.
+        self.current_user.get().map(|user| {
+            self.current_user.set(None);
+            match user {
+                NonvolatileUser::Kernel => {
+                    self.kernel_client
+                        .get()
+                        .map(move |client| { client.write_done(buffer, length); });
+                }
+                NonvolatileUser::App { app_id } => {
+                    let _ = self.apps.enter(app_id, move |app, _| {
+                        // Replace the buffer we used to do this write.
+                        self.buffer.replace(buffer);
+
+                        // And then signal the app.
+                        app.callback_write.map(|mut cb| cb.schedule(length, 0, 0));
+                    });
+                }
+            }
+        });
+
+        self.check_queue();
+    }
+}
+
+/// Provide an interface for the kernel.
+impl<'a> hil::nonvolatile_storage::NonvolatileStorage for NonvolatileStorage<'a> {
+    fn set_client(&self, client: &'static hil::nonvolatile_storage::NonvolatileStorageClient) {
+        self.kernel_client.set(Some(client));
+    }
+
+    fn read(&self, buffer: &'static mut [u8], address: usize, length: usize) -> ReturnCode {
+        self.kernel_buffer.replace(buffer);
+        self.enqueue_command(NonvolatileCommand::KernelRead, address, length, None)
+    }
+
+    fn write(&self, buffer: &'static mut [u8], address: usize, length: usize) -> ReturnCode {
+        self.kernel_buffer.replace(buffer);
+        self.enqueue_command(NonvolatileCommand::KernelWrite, address, length, None)
+    }
+}
+
+/// Provide an interface for userland.
+impl<'a> Driver for NonvolatileStorage<'a> {
+    /// Setup shared buffers.
+    ///
+    /// ### `allow_num`
+    ///
+    /// - `0`: Setup a buffer to read from the nonvolatile storage into.
+    /// - `1`: Setup a buffer to write bytes to the nonvolatile storage.
+    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+        self.apps
+            .enter(appid, |app, _| {
+                match allow_num {
+                    0 => app.buffer_read = Some(slice),
+                    1 => app.buffer_write = Some(slice),
+                    _ => return ReturnCode::ENOSUPPORT,
+                }
+                ReturnCode::SUCCESS
+            })
+            .unwrap_or_else(|err| match err {
+                Error::OutOfMemory => ReturnCode::ENOMEM,
+                Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                Error::NoSuchApp => ReturnCode::EINVAL,
+            })
+    }
+
+    /// Setup callbacks.
+    ///
+    /// ### `subscribe_num`
+    ///
+    /// - `0`: Setup a read done callback.
+    /// - `1`: Setup a write done callback.
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+        self.apps
+            .enter(callback.app_id(), |app, _| {
+                match subscribe_num {
+                    0 => app.callback_read = Some(callback),
+                    1 => app.callback_write = Some(callback),
+                    _ => return ReturnCode::ENOSUPPORT,
+                }
+                ReturnCode::SUCCESS
+            })
+            .unwrap_or_else(|err| match err {
+                Error::OutOfMemory => ReturnCode::ENOMEM,
+                Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                Error::NoSuchApp => ReturnCode::EINVAL,
+            })
+    }
+
+    /// Command interface.
+    ///
+    /// Commands are selected by the lowest 8 bits of the first argument.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Return SUCCESS if this driver is included on the platform.
+    /// - `1`: Return the number of bytes available to userspace.
+    /// - `2`: Start a read from the nonvolatile storage.
+    /// - `3`: Start a write to the nonvolatile_storage.
+    fn command(&self, arg0: usize, arg1: usize, appid: AppId) -> ReturnCode {
+        let command_num = arg0 & 0xFF;
+
+        match command_num {
+            0 => /* This driver exists. */ ReturnCode::SUCCESS,
+
+            // How many bytes are accessible from userspace.
+            1 => ReturnCode::SuccessWithValue { value: self.userspace_length },
+
+            // Issue a read
+            2 => {
+                let length = (arg0 >> 8) & 0xFFFFFF;
+                let offset = arg1;
+                self.enqueue_command(NonvolatileCommand::UserspaceRead,
+                                     offset,
+                                     length,
+                                     Some(appid))
+            }
+
+            // Issue a write
+            3 => {
+                let length = (arg0 >> 8) & 0xFFFFFF;
+                let offset = arg1;
+                self.enqueue_command(NonvolatileCommand::UserspaceWrite,
+                                     offset,
+                                     length,
+                                     Some(appid))
+            }
+
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -239,6 +239,7 @@ functionality that is handled by the kernel. `command`, `subscribe`, and
 | 22            | LPS25HB          | Pressure sensor                            |
 | 25            | SPI Slave        | Raw SPI slave interface                    |
 | 26            | DAC              | Digital to analog converter                |
+| 27            | Nonvolatile Storage | Generic interface for persistent storage |
 | 33            | BLE              | Bluetooth low energy communication         |
 | 154           | Radio            | 15.4 radio interface                       |
 | 255           | IPC              | Inter-process communication                |

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -17,6 +17,7 @@ pub mod symmetric_encryption;
 pub mod ninedof;
 pub mod gpio_async;
 pub mod dac;
+pub mod nonvolatile_storage;
 
 /// Shared interface for configuring components.
 pub trait Controller {

--- a/kernel/src/hil/nonvolatile_storage.rs
+++ b/kernel/src/hil/nonvolatile_storage.rs
@@ -1,0 +1,32 @@
+//! Generic interface for nonvolatile memory.
+
+use returncode::ReturnCode;
+
+/// Simple interface for reading and writing nonvolatile memory. It is expected
+/// that drivers for nonvolatile memory would implement this trait.
+pub trait NonvolatileStorage {
+    fn set_client(&self, client: &'static NonvolatileStorageClient);
+
+    /// Read `length` bytes starting at address `address` in to the provided
+    /// buffer. The buffer must be at least `length` bytes long. The address
+    /// must be in the address space of the physical storage.
+    fn read(&self, buffer: &'static mut [u8], address: usize, length: usize) -> ReturnCode;
+
+    /// Write `length` bytes starting at address `address` from the provided
+    /// buffer. The buffer must be at least `length` bytes long. This address
+    /// must be in the address space of the physical storage.
+    fn write(&self, buffer: &'static mut [u8], address: usize, length: usize) -> ReturnCode;
+}
+
+/// Client interface for nonvolatile storage.
+pub trait NonvolatileStorageClient {
+    /// `read_done` is called when the implementor is finished reading in to the
+    /// buffer. The callback returns the buffer and the number of bytes that
+    /// were actually read.
+    fn read_done(&self, buffer: &'static mut [u8], length: usize);
+
+    /// `write_done` is called when the implementor is finished writing from the
+    /// buffer. The callback returns the buffer and the number of bytes that
+    /// were actually written.
+    fn write_done(&self, buffer: &'static mut [u8], length: usize);
+}

--- a/userland/examples/tests/nonvolatile_storage/Makefile
+++ b/userland/examples/tests/nonvolatile_storage/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/nonvolatile_storage/main.c
+++ b/userland/examples/tests/nonvolatile_storage/main.c
@@ -1,0 +1,84 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include <internal/nonvolatile_storage.h>
+
+uint8_t readbuf[256];
+uint8_t writebuf[256];
+
+bool done = false;
+
+static void read_done(int length,
+                      __attribute__ ((unused)) int arg1,
+                      __attribute__ ((unused)) int arg2,
+                      __attribute__ ((unused)) void* ud) {
+  printf("Finished read! %i\n", length);
+  done = true;
+}
+
+static void write_done(int length,
+                       __attribute__ ((unused)) int arg1,
+                       __attribute__ ((unused)) int arg2,
+                       __attribute__ ((unused)) void* ud) {
+  printf("Finished write! %i\n", length);
+  done = true;
+}
+
+int main (void) {
+  int ret;
+
+  printf("[Nonvolatile Storage] Test App\n");
+
+  ret = nonvolatile_storage_internal_read_buffer(readbuf, 256);
+  if (ret != 0) printf("ERROR setting read buffer\n");
+
+  ret = nonvolatile_storage_internal_write_buffer(writebuf, 256);
+  if (ret != 0) printf("ERROR setting write buffer\n");
+
+  // Setup callbacks
+  ret = nonvolatile_storage_internal_read_done_subscribe(read_done, NULL);
+  if (ret != 0) printf("ERROR setting read done callback\n");
+
+  ret = nonvolatile_storage_internal_write_done_subscribe(write_done, NULL);
+  if (ret != 0) printf("ERROR setting write done callback\n");
+
+  int num_bytes = nonvolatile_storage_internal_get_number_bytes();
+  printf("Have %i bytes of nonvolatile storage\n", num_bytes);
+
+  writebuf[0] = 5;
+  writebuf[1] = 10;
+  writebuf[2] = 20;
+  writebuf[3] = 200;
+  writebuf[4] = 123;
+  writebuf[5] = 88;
+
+  done = false;
+  ret  = nonvolatile_storage_internal_write(0, 6);
+  if (ret != 0) printf("ERROR calling write\n");
+  yield_for(&done);
+
+  writebuf[0] = 33;
+  writebuf[1] = 3;
+  writebuf[2] = 66;
+  writebuf[3] = 6;
+  writebuf[4] = 99;
+  writebuf[5] = 9;
+  writebuf[6] = 100;
+  writebuf[7] = 101;
+
+  done = false;
+  ret  = nonvolatile_storage_internal_write(6, 8);
+  if (ret != 0) printf("ERROR calling write\n");
+  yield_for(&done);
+
+  done = false;
+  ret  = nonvolatile_storage_internal_read(0, 14);
+  if (ret != 0) printf("ERROR calling read\n");
+  yield_for(&done);
+
+  for (int i = 0; i < 14; i++) {
+    printf("got[%i]: %i\n", i, readbuf[i]);
+  }
+
+  return 0;
+}

--- a/userland/libtock/internal/nonvolatile_storage.h
+++ b/userland/libtock/internal/nonvolatile_storage.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "tock.h"
+
+#define DRIVER_NUM_NONVOLATILE_STORAGE 27
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int nonvolatile_storage_internal_read_done_subscribe(subscribe_cb cb, void *userdata);
+int nonvolatile_storage_internal_write_done_subscribe(subscribe_cb cb, void *userdata);
+
+int nonvolatile_storage_internal_read_buffer(uint8_t* buffer, uint32_t len);
+int nonvolatile_storage_internal_write_buffer(uint8_t* buffer, uint32_t len);
+
+int nonvolatile_storage_internal_get_number_bytes(void);
+int nonvolatile_storage_internal_read(uint32_t offset, uint32_t length);
+int nonvolatile_storage_internal_write(uint32_t offset, uint32_t length);
+
+#ifdef __cplusplus
+}
+#endif

--- a/userland/libtock/internal/nonvolatile_storage_internal.c
+++ b/userland/libtock/internal/nonvolatile_storage_internal.c
@@ -1,0 +1,31 @@
+#include "internal/nonvolatile_storage.h"
+
+int nonvolatile_storage_internal_read_done_subscribe(subscribe_cb cb, void *userdata) {
+  return subscribe(DRIVER_NUM_NONVOLATILE_STORAGE, 0, cb, userdata);
+}
+
+int nonvolatile_storage_internal_write_done_subscribe(subscribe_cb cb, void *userdata) {
+  return subscribe(DRIVER_NUM_NONVOLATILE_STORAGE, 1, cb, userdata);
+}
+
+int nonvolatile_storage_internal_read_buffer(uint8_t* buffer, uint32_t len) {
+  return allow(DRIVER_NUM_NONVOLATILE_STORAGE, 0, (void*) buffer, len);
+}
+
+int nonvolatile_storage_internal_write_buffer(uint8_t* buffer, uint32_t len) {
+  return allow(DRIVER_NUM_NONVOLATILE_STORAGE, 1, (void*) buffer, len);
+}
+
+int nonvolatile_storage_internal_get_number_bytes(void) {
+  return command(DRIVER_NUM_NONVOLATILE_STORAGE, 1, 0);
+}
+
+int nonvolatile_storage_internal_read(uint32_t offset, uint32_t length) {
+  uint32_t arg0 = (length << 8) | 2;
+  return command(DRIVER_NUM_NONVOLATILE_STORAGE, (int) arg0, (int) offset);
+}
+
+int nonvolatile_storage_internal_write(uint32_t offset, uint32_t length) {
+  uint32_t arg0 = (length << 8) | 3;
+  return command(DRIVER_NUM_NONVOLATILE_STORAGE, (int) arg0, (int) offset);
+}


### PR DESCRIPTION
This adds a nonvolatile storage interface that virtualizes the underlying physical storage and provides both a userspace interface and a kernel interface. It updates the FM25CL FRAM driver to use this interface as well.

### Why?

1. It allows for a board to restrict which address space of nonvolatile memory (like an FRAM chip) that userspace can access. This allows the kernel to safely share the same nonvolatile storage that userspace uses.

2. It virtualizes access to the storage so that multiple apps can use it.

2. It provides a generic interface for nonvolatile storage so that we have one userspace API/driver and not one for each chip.

### What does it not do?

1. It doesn't segment nonvolatile storage between apps. Therefore, any app can read and write all of the userspace accessible nonvolatile storage. This is obviously undesirable, but solving that is much more complicated. We decided that a reasonable first step was to at least provide a virtualization layer and allow the kernel to reserve some address space for itself.

2. It doesn't help apps write their own flash region.

### Notes

Blocked for now as I want to do a little more cleaning up and testing. Wanted to get it as a PR so I didn't lose track of it and for comments.