### PR TITLE
style: pin to one version of uncrustify

### DIFF
--- a/doc/Userland.md
+++ b/doc/Userland.md
@@ -257,7 +257,7 @@ and pin definitions for platforms.
 ## Style & Format
 
 We try to keep a consistent style in mainline userland code. For C/C++, we use
-[uncrustify](https://github.com/uncrustify/uncrustify) (>= v0.59). High level:
+[uncrustify](https://github.com/uncrustify/uncrustify). High level:
 
   - Two space character indents
   - Braces on the same line

--- a/userland/tools/uncrustify/.gitignore
+++ b/userland/tools/uncrustify/.gitignore
@@ -1,0 +1,1 @@
+uncrustify-*

--- a/userland/tools/uncrustify/uncrustify.cfg
+++ b/userland/tools/uncrustify/uncrustify.cfg
@@ -25,6 +25,8 @@ nl_start_of_file                = remove
 nl_assign_brace                 = remove
 nl_fcall_brace                  = remove
 nl_enum_brace                   = remove
+nl_enum_class                   = remove
+nl_enum_class_identifier        = remove
 nl_struct_brace                 = remove
 nl_union_brace                  = remove
 nl_if_brace                     = remove
@@ -34,14 +36,10 @@ nl_else_brace                   = remove
 nl_else_if                      = remove
 nl_for_brace                    = remove
 nl_max                          = 4
+nl_max_blank_in_func            = 2
 nl_after_multiline_comment      = true
 code_width                      = 120
 align_assign_span               = 1
 align_assign_thresh             = 8
 mod_paren_on_return             = remove
 mod_sort_include                = true
-
-# Not in 0.59
-# nl_enum_class                   = remove
-# nl_enum_class_identifier        = remove
-# nl_max_blank_in_func            = 2


### PR DESCRIPTION
I suppose it's not the most surprising that different versions would
format things differently. Like rustfmt, just pin to a specific version
and install it automatically on demand

Towards #432.