### PR TITLE
Upgrade Rust nightly

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -3,7 +3,7 @@
 MAKEFLAGS += -r
 MAKEFLAGS += -R
 
-export RUSTUP_TOOLCHAIN ?= nightly-2017-05-24
+export RUSTUP_TOOLCHAIN ?= nightly-2017-06-19
 
 TOOLCHAIN ?= arm-none-eabi
 
@@ -32,7 +32,7 @@ endif
 export TOCK_KERNEL_VERSION := $(shell git describe --always || echo notgit)
 
 # Check that rustc is the right nightly - warn not error if wrong, sometimes useful to test others
-RUSTC_VERSION_STRING := rustc 1.19.0-nightly (5b13bff52 2017-05-23)
+RUSTC_VERSION_STRING := rustc 1.19.0-nightly (10d7cb44c 2017-06-18)
 ifneq ($(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VERSION_STRING))
   DUMMY := $(shell rustup install $(RUSTUP_TOOLCHAIN))
   ifneq ($(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VERSION_STRING))

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -118,17 +118,6 @@ pub struct Platform {
 
 
 impl kernel::Platform for Platform {
-    // TODO: Why is this not inlined, you might ask? Well... we seem to be
-    // hitting some sort of LLVM codegen issue (maybe a bug in LLVM, maybe a bug
-    // in Tock), where certain compilation variants of the below match
-    // statement, when inlined, result in totally unexpected assembly that
-    // results in trying to jump to an instruction that doesn't exist. It _only_
-    // appears in thumbv6, only when the 17-valued branch below is not commented
-    // out, only with optimization level 2 or higher, and only when inlined. So
-    // for now, we're not inlining it until we resolve the issue. So far it's
-    // been raised as an issue on the Rust project:
-    // https://github.com/rust-lang/rust/issues/42248
-    #[inline(never)]
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
         where F: FnOnce(Option<&kernel::Driver>) -> R
     {


### PR DESCRIPTION
Rust nightly 06-19-17 included LLVM upstream fixes that address an issue
we were running into on Cortex-M0 targets.

https://github.com/rust-lang/rust/issues/42248