### PR TITLE
doc: Updating auto-generated documentation

### DIFF
--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -1,3 +1,5 @@
+//! Shared implementations for ARM Cortex-M4 MCUs.
+
 #![crate_name = "cortexm4"]
 #![crate_type = "rlib"]
 #![feature(asm,const_fn,naked_functions)]

--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -1,3 +1,5 @@
+//! Implementation of the ARM memory protection unit.
+
 use kernel;
 use kernel::common::VolatileCell;
 use kernel::common::math::PowerOfTwo;

--- a/arch/cortex-m4/src/scb.rs
+++ b/arch/cortex-m4/src/scb.rs
@@ -1,4 +1,6 @@
-// Based on: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CIHFDJCA.html
+//! ARM System Control Block
+//!
+//! http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CIHFDJCA.html
 
 use kernel::common::VolatileCell;
 

--- a/arch/cortex-m4/src/systick.rs
+++ b/arch/cortex-m4/src/systick.rs
@@ -1,3 +1,5 @@
+//! ARM SysTick peripheral.
+
 use kernel;
 use kernel::common::VolatileCell;
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -1,3 +1,8 @@
+//! Board file for Hail development platform.
+//!
+//! - https://github.com/helena-project/tock/tree/master/boards/hail
+//! - https://github.com/lab11/hail
+
 #![no_std]
 #![no_main]
 #![feature(asm,const_fn,drop_types_in_const,lang_items,compiler_builtins_lib)]

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -1,5 +1,3 @@
-//! ADC Capsule
-//!
 //! Provides userspace applications with the ability to sample
 //! analog signals.
 

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -1,6 +1,23 @@
-//! Provide capsule driver for controlling buttons on a board.  This allows for much more cross
-//! platform controlling of buttons without having to know which of the GPIO pins exposed across
-//! the syscall interface are buttons.
+//! Provides capsule driver for controlling buttons on a board.
+//!
+//! This allows for much more cross platform controlling of buttons without
+//! having to know which of the GPIO pins exposed across the syscall interface
+//! are buttons.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let button_pins = static_init!(
+//!     [&'static sam4l::gpio::GPIOPin; 1],
+//!     [&sam4l::gpio::PA[16]]);
+//! let button = static_init!(
+//!     capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
+//!     capsules::button::Button::new(button_pins, kernel::Container::create()));
+//! for btn in button_pins.iter() {
+//!     btn.set_client(button);
+//! }
+//! ```
 
 use kernel::{AppId, Container, Callback, Driver, ReturnCode};
 use kernel::hil;

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -1,7 +1,4 @@
-//! Console Capsule
-//!
-//! Console provides userspace with the ability to print text via a serial
-//! interface.
+//! Provides userspace with the ability to print text via a serial interface.
 
 use core::cell::Cell;
 use kernel::{AppId, AppSlice, Container, Callback, Shared, Driver, ReturnCode};

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -1,14 +1,13 @@
-//! CRC driver
-//!
-//! This capsule provides userspace access to a CRC unit.
+//! Provides userspace access to a CRC unit.
 //!
 //! ## Instantiation
 //!
-//! Instatiate the capsule for use as a system call driver with a hardware implementation and a
-//! `Container` for the `App` type, and set the result as a client of the hardware implementation.
-//! For example, using the SAM4L's `CRCU` driver:
+//! Instantiate the capsule for use as a system call driver with a hardware
+//! implementation and a `Container` for the `App` type, and set the result as a
+//! client of the hardware implementation. For example, using the SAM4L's `CRCU`
+//! driver:
 //!
-//! ```
+//! ```rust
 //! let crc = static_init!(
 //!     capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
 //!     capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, kernel::Container::create()));
@@ -18,49 +17,53 @@
 //!
 //! ## CRC Algorithms
 //!
-//! The capsule supports two general purpose CRC algorithms, as well as a few hardware specific
-//! algorithms implemented on the Atmel SAM4L.
+//! The capsule supports two general purpose CRC algorithms, as well as a few
+//! hardware specific algorithms implemented on the Atmel SAM4L.
 //!
-//! In the values used to identify polynomials below, more-significant bits correspond to
-//! higher-order terms, and the most significant bit is omitted because it always equals one.  All
-//! algorithms listed here consume each input byte from most-significant bit to least-significant.
+//! In the values used to identify polynomials below, more-significant bits
+//! correspond to higher-order terms, and the most significant bit is omitted
+//! because it always equals one.  All algorithms listed here consume each input
+//! byte from most-significant bit to least-significant.
 //!
 //! ### CRC-32
 //!
-//! __Polynomial__: 0x04C11DB7
+//! __Polynomial__: `0x04C11DB7`
 //!
-//! This algorithm is used in Ethernet and many other applications. It bit-reverses and then
-//! bit-inverts the output.
+//! This algorithm is used in Ethernet and many other applications. It bit-
+//! reverses and then bit-inverts the output.
 //!
 //! ### CRC-32C
 //!
-//! __Polynomial__: 0x1EDC6F41
+//! __Polynomial__: `0x1EDC6F41`
 //!
-//! Bit-reverses and then bit-inverts the output. It *may* be equivalent to various CRC functions
-//! using the same name.
+//! Bit-reverses and then bit-inverts the output. It *may* be equivalent to
+//! various CRC functions using the same name.
 //!
 //! ### SAM4L-16
 //!
-//! __Polynomial__: 0x1021
+//! __Polynomial__: `0x1021`
 //!
-//! This algorithm does no post-processing on the output value. The sixteen-bit CRC result is
-//! placed in the low-order bits of the returned result value, and the high-order bits will all be
-//! set.  That is, result values will always be of the form `0xFFFFxxxx` for this algorithm.  It
-//! can be performed purely in hardware on the SAM4L.
+//! This algorithm does no post-processing on the output value. The sixteen-bit
+//! CRC result is placed in the low-order bits of the returned result value, and
+//! the high-order bits will all be set.  That is, result values will always be
+//! of the form `0xFFFFxxxx` for this algorithm.  It can be performed purely in
+//! hardware on the SAM4L.
 //!
 //! ### SAM4L-32
 //!
-//! __Polynomial__: 0x04C11DB7
+//! __Polynomial__: `0x04C11DB7`
 //!
-//! This algorithm uses the same polynomial as `CRC-32`, but does no post-processing on the output
-//! value.  It can be perfomed purely in hardware on the SAM4L.
+//! This algorithm uses the same polynomial as `CRC-32`, but does no post-
+//! processing on the output value.  It can be perfomed purely in hardware on
+//! the SAM4L.
 //!
 //! ### SAM4L-32C
 //!
-//! __Polynomial__: 0x1EDC6F41
+//! __Polynomial__: `0x1EDC6F41`
 //!
-//! This algorithm uses the same polynomial as `CRC-32C`, but does no post-processing on the output
-//! value.  It can be performed purely in hardware on the SAM4L.
+//! This algorithm uses the same polynomial as `CRC-32C`, but does no post-
+//! processing on the output value.  It can be performed purely in hardware on
+//! the SAM4L.
 
 use core::cell::Cell;
 use kernel::{AppId, AppSlice, Container, Callback, Driver, ReturnCode, Shared};

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -1,4 +1,6 @@
-//! Driver for the FM25CL FRAM chip (http://www.cypress.com/part/fm25cl64b-dg)
+//! Driver for the FM25CL FRAM chip.
+//!
+//! http://www.cypress.com/part/fm25cl64b-dg
 
 use core::cell::Cell;
 use core::cmp;

--- a/capsules/src/fxos8700cq.rs
+++ b/capsules/src/fxos8700cq.rs
@@ -1,7 +1,23 @@
-//! Driver for the FXOS8700CQ accelerometer
+//! Driver for the FXOS8700CQ accelerometer.
+//!
 //! http://www.nxp.com/assets/documents/data/en/data-sheets/FXOS8700CQ.pdf
+//!
 //! The driver provides x, y, and z acceleration data to a callback function.
-//! To use readings from the sensor in userland, see FXOS8700CQ.h in libtock.
+//! It implements the `hil::ninedof::NineDof` trait.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let fxos8700_i2c = static_init!(I2CDevice, I2CDevice::new(i2c_bus, 0x1e));
+//! let fxos8700 = static_init!(
+//!     capsules::fxos8700cq::Fxos8700cq<'static>,
+//!     capsules::fxos8700cq::Fxos8700cq::new(fxos8700_i2c,
+//!                                           &sam4l::gpio::PA[9], // Interrupt pin
+//!                                           &mut capsules::fxos8700cq::BUF));
+//! fxos8700_i2c.set_client(fxos8700);
+//! sam4l::gpio::PA[9].set_client(fxos8700);
+//! ```
 
 use core::cell::Cell;
 use kernel::ReturnCode;

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -1,8 +1,25 @@
-//! GPIO Capsule
+//! Provides userspace applications with access to GPIO pins.
 //!
-//! Provides a driver for userspace applications to control GPIO pins.
-//! GPIOs are presented through a driver interface with synchronous comands
+//! GPIOs are presented through a driver interface with synchronous commands
 //! and a callback for interrupts.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let gpio_pins = static_init!(
+//!     [&'static sam4l::gpio::GPIOPin; 4],
+//!     [&sam4l::gpio::PB[14],
+//!      &sam4l::gpio::PB[15],
+//!      &sam4l::gpio::PB[11],
+//!      &sam4l::gpio::PB[12]]);
+//! let gpio = static_init!(
+//!     capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
+//!     capsules::gpio::GPIO::new(gpio_pins));
+//! for pin in gpio_pins.iter() {
+//!     pin.set_client(gpio);
+//! }
+//! ```
 
 use core::cell::Cell;
 use kernel::{AppId, Callback, Driver, ReturnCode};

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -1,5 +1,6 @@
-//! Capsule for presenting both an I2C Master and I2C Slave interface to
-//! applications. By calling `listen` this module will wait for I2C messages
+//! Provides both an I2C Master and I2C Slave interface to userspace.
+//!
+//! By calling `listen` this module will wait for I2C messages
 //! send to it by other masters on the I2C bus. If this device wants to
 //! transmit as an I2C master, this module will put the I2C hardware in master
 //! mode, transmit the read/write, then go back to listening (if listening

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -1,4 +1,29 @@
-//! Driver for the ISL29035 digital light sensor
+//! Driver for the ISL29035 digital light sensor.
+//!
+//! http://bit.ly/2rA00cH
+//!
+//! > The ISL29035 is an integrated ambient and infrared light-to-digital
+//! > converter with I2C (SMBus compatible) Interface. Its advanced self-
+//! > calibrated photodiode array emulates human eye response with excellent IR
+//! > rejection. The on-chip ADC is capable of rejecting 50Hz and 60Hz flicker
+//! > caused by artificial light sources. The Lux range select feature allows
+//! > users to program the Lux range for optimized counts/Lux.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let isl29035_i2c = static_init!(I2CDevice, I2CDevice::new(i2c_bus, 0x44));
+//! let isl29035_virtual_alarm = static_init!(
+//!     VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+//!     VirtualMuxAlarm::new(mux_alarm));
+//! let isl29035 = static_init!(
+//!     capsules::isl29035::Isl29035<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
+//!     capsules::isl29035::Isl29035::new(isl29035_i2c, isl29035_virtual_alarm,
+//!                                       &mut capsules::isl29035::BUF));
+//! isl29035_i2c.set_client(isl29035);
+//! isl29035_virtual_alarm.set_client(isl29035);
+//! ```
 
 use core::cell::Cell;
 use kernel::{AppId, Callback, Driver, ReturnCode};

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -1,7 +1,22 @@
-//! Provide capsule driver for controlling LEDs on a board.
-//! This allows for much more cross platform controlling of LEDs
-//! without having to know which of the GPIO pins exposed across
-//! the syscall interface are LEDs.
+//! Provides userspace access to LEDs on a board.
+//!
+//! This allows for much more cross platform controlling of LEDs without having
+//! to know which of the GPIO pins exposed across the syscall interface are
+//! LEDs.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let led_pins = static_init!(
+//!     [(&'static sam4l::gpio::GPIOPin, capsules::led::ActivationMode); 3],
+//!     [(&sam4l::gpio::PA[13], capsules::led::ActivationMode::ActiveLow),   // Red
+//!      (&sam4l::gpio::PA[15], capsules::led::ActivationMode::ActiveLow),   // Green
+//!      (&sam4l::gpio::PA[14], capsules::led::ActivationMode::ActiveLow)]); // Blue
+//! let led = static_init!(
+//!     capsules::led::LED<'static, sam4l::gpio::GPIOPin>,
+//!     capsules::led::LED::new(led_pins));
+//! ```
 
 use kernel::{AppId, Driver, ReturnCode};
 use kernel::hil;

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -1,6 +1,20 @@
-//! ST LPS25HB Pressure Sensor Driver
+//! Driver for the ST LPS25HB pressure sensor.
 //!
 //! http://www.st.com/en/mems-and-sensors/lps25hb.html
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let lps25hb_i2c = static_init!(I2CDevice, I2CDevice::new(i2c_bus, 0x5C));
+//! let lps25hb = static_init!(
+//!     capsules::lps25hb::LPS25HB<'static>,
+//!     capsules::lps25hb::LPS25HB::new(lps25hb_i2c,
+//!         &sam4l::gpio::PA[10],
+//!         &mut capsules::lps25hb::BUFFER));
+//! lps25hb_i2c.set_client(lps25hb);
+//! sam4l::gpio::PA[10].set_client(lps25hb);
+//! ```
 
 use core::cell::Cell;
 use kernel::{AppId, Callback, Driver, ReturnCode};

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -1,18 +1,18 @@
 //! Driver for the LTC294X line of coulomb counters.
 //!
-//! http://www.linear.com/product/LTC2941
-//! http://www.linear.com/product/LTC2942
-//! http://www.linear.com/product/LTC2943
+//! - http://www.linear.com/product/LTC2941
+//! - http://www.linear.com/product/LTC2942
+//! - http://www.linear.com/product/LTC2943
 //!
-//! From the website:
-//!  "The LTC2941 measures battery charge state in battery-supplied handheld PC
-//!  and portable product applications. Its operating range is perfectly suited
-//!  for single-cell Li-Ion batteries. A precision coulomb counter integrates
-//!  current through a sense resistor between the battery’s positive terminal
-//!  and the load or charger. The measured charge is stored in internal
-//!  registers. An SMBus/I2C interface accesses and configures the device."
+//! > The LTC2941 measures battery charge state in battery-supplied handheld PC
+//! > and portable product applications. Its operating range is perfectly suited
+//! > for single-cell Li-Ion batteries. A precision coulomb counter integrates
+//! > current through a sense resistor between the battery’s positive terminal
+//! > and the load or charger. The measured charge is stored in internal
+//! > registers. An SMBus/I2C interface accesses and configures the device.
 //!
-//! ### Capsule Structure
+//! Structure
+//! ---------
 //!
 //! This file implements the LTC294X driver in two objects. First is the
 //! `LTC294X` struct. This implements all of the actual logic for the
@@ -21,7 +21,8 @@
 //! to potentially interface with the LTC294X chip rather than only provide
 //! it to userspace.
 //!
-//! ### Instantiating the LTC294X capsule
+//! Usage
+//! -----
 //!
 //! Here is a sample usage of this capsule in a board's main.rs file:
 //!
@@ -40,24 +41,6 @@
 //!     capsules::ltc294x::LTC294XDriver<'static>,
 //!     capsules::ltc294x::LTC294XDriver::new(ltc294x));
 //! ltc294x.set_client(ltc294x_driver);
-//! ```
-//!
-//! ### System call interface
-//!
-//! ```
-//! Command Number     Description
-//! ------------------------------
-//! 0                  Check if this driver exists
-//! 1                  Read the status of the LTC294X
-//! 2                  Configure the LTC294X
-//! 3                  Reset the accumulated charge to 0
-//! 4                  Set a high threshold for charge usage
-//! 5                  Set a low threshold for charge usage
-//! 6                  Get the current charge usage
-//! 7                  Shutdown the LTC294X
-//! 8                  Get the current voltage (only on 42 and 43)
-//! 9                  Get the current current (only on 43)
-//! 10                 Set the current LTC294X model in this capsule
 //! ```
 
 use core::cell::Cell;
@@ -100,6 +83,7 @@ enum State {
     Done,
 }
 
+/// Which version of the chip we are actually using.
 #[derive(Clone,Copy)]
 pub enum ChipModel {
     LTC2941 = 1,
@@ -107,12 +91,14 @@ pub enum ChipModel {
     LTC2943 = 3,
 }
 
+/// Settings for which interrupt we want.
 pub enum InterruptPinConf {
     Disabled = 0x00,
     ChargeCompleteMode = 0x01,
     AlertMode = 0x02,
 }
 
+/// Threshold options for battery alerts.
 pub enum VBatAlert {
     Off = 0x00,
     Threshold2V8 = 0x01,
@@ -120,6 +106,7 @@ pub enum VBatAlert {
     Threshold3V0 = 0x03,
 }
 
+/// Supported events for the LTC294X.
 pub trait LTC294XClient {
     fn interrupt(&self);
     fn status(&self,
@@ -134,6 +121,7 @@ pub trait LTC294XClient {
     fn done(&self);
 }
 
+/// Implementation of a driver for the LTC294X coulomb counters.
 pub struct LTC294X<'a> {
     i2c: &'a i2c::I2CDevice,
     interrupt_pin: Option<&'a gpio::Pin>,
@@ -452,6 +440,19 @@ impl<'a> LTC294XClient for LTC294XDriver<'a> {
 }
 
 impl<'a> Driver for LTC294XDriver<'a> {
+    /// Setup callbacks.
+    ///
+    /// ### `subscribe_num`
+    ///
+    /// - `0`: Set the callback that that is triggered when events finish and
+    ///   when readings are ready. The first argument represents which callback
+    ///   was triggered.
+    ///   - `0`: Interrupt occurred from the LTC294X.
+    ///   - `1`: Got the status.
+    ///   - `2`: Read the charge used.
+    ///   - `3`: `done()` was called.
+    ///   - `4`: Read the voltage.
+    ///   - `5`: Read the current.
     fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
             0 => {
@@ -464,6 +465,23 @@ impl<'a> Driver for LTC294XDriver<'a> {
         }
     }
 
+    /// Request operations for the LTC294X chip.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Driver check.
+    /// - `1`: Get status of the chip.
+    /// - `2`: Configure settings of the chip.
+    /// - `3`: Reset accumulated charge measurement to zero.
+    /// - `4`: Set the upper threshold for charge.
+    /// - `5`: Set the lower threshold for charge.
+    /// - `6`: Get the current charge accumulated.
+    /// - `7`: Shutdown the chip.
+    /// - `8`: Get the voltage reading. Only supported on the LTC2942 and
+    ///   LTC2943.
+    /// - `9`: Get the current reading. Only supported on the LTC2943.
+    /// - `10`: Set the model of the LTC294X actually being used. `data` is the
+    ///   value of the X.
     fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
         match command_num {
             // Check this driver exists.

--- a/capsules/src/mcp23008.rs
+++ b/capsules/src/mcp23008.rs
@@ -1,16 +1,17 @@
-//! Driver for the Microchip MCP23008 I2C GPIO Extender
+//! Driver for the Microchip MCP23008 I2C GPIO extender.
 //!
 //! http://www.microchip.com/wwwproducts/en/MCP23008
 //!
 //! Paraphrased from the website:
-//! "The MCP23008 device provides 8-bit, general purpose, parallel I/O expansion
-//! for I2C bus applications. The MCP23008 has three address pins and consists
-//! of multiple 8-bit configuration registers for input, output and polarity
-//! selection. The system master can enable the I/Os as either inputs or outputs
-//! by writing the I/O configuration bits. The data for each input or output is
-//! kept in the corresponding Input or Output register. The polarity of the
-//! Input Port register can be inverted with the Polarity Inversion register.
-//! All registers can be read by the system master."
+//!
+//! > The MCP23008 device provides 8-bit, general purpose, parallel I/O
+//! > expansion for I2C bus applications. The MCP23008 has three address pins
+//! > and consists of multiple 8-bit configuration registers for input, output
+//! > and polarity selection. The system master can enable the I/Os as either
+//! > inputs or outputs by writing the I/O configuration bits. The data for each
+//! > input or output is kept in the corresponding Input or Output register. The
+//! > polarity of the Input Port register can be inverted with the Polarity
+//! > Inversion register. All registers can be read by the system master.
 //!
 //! Usage
 //! -----
@@ -19,6 +20,7 @@
 //! trait.
 //!
 //! Example usage:
+//!
 //! ```rust
 //! // Configure the MCP23008. Device address 0x20.
 //! let mcp23008_i2c = static_init!(
@@ -47,6 +49,7 @@
 //!     port.set_client(gpio_async);
 //! }
 //! ```
+//!
 //! Note that if interrupts are not needed, a `None` can be passed in when the
 //! `mcp23008` object is created.
 

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -1,4 +1,16 @@
-//! This allows a 9DOF sensor to be used by multiple apps.
+//! Provides userspace with virtualized access to 9DOF sensors.
+//!
+//! Usage
+//! -----
+//!
+//! You need a device that provides the `hil::ninedof::NineDof` trait.
+//!
+//! ``rust
+//! let ninedof = static_init!(
+//!     capsules::ninedof::NineDof<'static>,
+//!     capsules::ninedof::NineDof::new(fxos8700, kernel::Container::create()));
+//! hil::ninedof::NineDof::set_client(fxos8700, ninedof);
+//! ```
 
 use core::cell::Cell;
 use kernel::{AppId, Callback, Container, Driver};

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -1,8 +1,20 @@
-//! Nrf51822Serialization is the kernel-level driver that provides
-//! the UART API that the nRF51822 serialization library requires.
+//! Provides userspace with the UART API that the nRF51822 serialization library
+//! requires.
 //!
-//! This capsule handles interfacing with the UART driver, and includes
-//! some nuances that keep the Nordic BLE serialization library happy.
+//! This capsule handles interfacing with the UART driver, and includes some
+//! nuances that keep the Nordic BLE serialization library happy.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let nrf_serialization = static_init!(
+//!     Nrf51822Serialization<usart::USART>,
+//!     Nrf51822Serialization::new(&usart::USART3,
+//!                                &mut nrf51822_serialization::WRITE_BUF,
+//!                                &mut nrf51822_serialization::READ_BUF));
+//! hil::uart::UART::set_client(&usart::USART3, nrf_serialization);
+//! ```
 
 use kernel::{AppId, Callback, AppSlice, Driver, ReturnCode, Shared};
 use kernel::common::take_cell::{MapCell, TakeCell};

--- a/capsules/src/radio.rs
+++ b/capsules/src/radio.rs
@@ -1,5 +1,5 @@
-//! The radio capsule provides userspace applications with the ability
-//! to send and receive 802.15.4 packets
+//! Provides userspace applications with the ability
+//! to send and receive 802.15.4 packets.
 
 // System call interface for sending and receiving 802.15.4 packets.
 //

--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -1,24 +1,23 @@
-// I like them sometimes, for formatting -pal
-#![allow(unused_parens)]
-
-///
-/// Capsule for sending 802.15.4 packets with an Atmel RF233.
-///
-/// This implementation is completely non-blocking. This means that
-/// the state machine is somewhat complex, as it must interleave interrupt
-/// handling with requests and radio state management. See the SPI
-/// read_write_done handler for details.
-///
-/// To do items:
-///    - Support TX power control
-///    - Support channel selection
-///    - Support link-layer acknowledgements
-///    - Support power management (turning radio off)
-// Capsule for sending 802.15.4 packets with an Atmel RF233.
+//! Driver for sending 802.15.4 packets with an Atmel RF233.
+//!
+//! This implementation is completely non-blocking. This means that the state
+//! machine is somewhat complex, as it must interleave interrupt handling with
+//! requests and radio state management. See the SPI `read_write_done` handler
+//! for details.
+//!
+//! To do items:
+//!
+//! - Support TX power control
+//! - Support channel selection
+//! - Support link-layer acknowledgements
+//! - Support power management (turning radio off)
 //
 // Author: Philip Levis
 // Date: Jan 12 2017
 //
+
+// I like them sometimes, for formatting -pal
+#![allow(unused_parens)]
 
 use core::cell::Cell;
 use kernel::ReturnCode;

--- a/capsules/src/rf233_const.rs
+++ b/capsules/src/rf233_const.rs
@@ -1,3 +1,5 @@
+//! Support for the RF233 capsule.
+
 #![allow(non_camel_case_types)]
 
 #[derive(PartialEq, Copy, Clone, Debug)]

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -1,10 +1,18 @@
-//! RNG Capsule
-//!
 //! Provides a simple driver for userspace applications to request randomness.
-//! The RNG accepts a user-defined callback and buffer to hold received randomness.
-//! A single command starts the RNG, the callback is called when the requested
-//! amount of randomness is received, or the buffer is filled.
-
+//!
+//! The RNG accepts a user-defined callback and buffer to hold received
+//! randomness. A single command starts the RNG, the callback is called when the
+//! requested amount of randomness is received, or the buffer is filled.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let rng = static_init!(
+//!         capsules::rng::SimpleRng<'static, sam4l::trng::Trng>,
+//!         capsules::rng::SimpleRng::new(&sam4l::trng::TRNG, kernel::Container::create()));
+//! sam4l::trng::TRNG.set_client(rng);
+//! ```
 
 use core::cell::Cell;
 use kernel::{AppId, AppSlice, Container, Callback, Driver, ReturnCode, Shared};

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -1,5 +1,35 @@
-//! Provide capsule driver for accessing an SD Card.
-//! This allows initialization and block reads or writes on top of SPI
+//! Provides driver for accessing an SD Card and a userspace Driver.
+//!
+//! This allows initialization and block reads or writes on top of SPI.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let sdcard_spi = static_init!(
+//!     capsules::virtual_spi::VirtualSpiMasterDevice<'static, usart::USART>,
+//!     capsules::virtual_spi::VirtualSpiMasterDevice::new(mux_spi,
+//!                                                        Some(&sam4l::gpio::PA[13])));
+//! let sdcard_virtual_alarm = static_init!(
+//!     VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+//!     VirtualMuxAlarm::new(mux_alarm));
+//!
+//! let sdcard = static_init!(
+//!     capsules::sdcard::SDCard<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
+//!     capsules::sdcard::SDCard::new(sdcard_spi,
+//!                                   sdcard_virtual_alarm,
+//!                                   Some(&sam4l::gpio::PA[17]),
+//!                                   &mut capsules::sdcard::TXBUFFER,
+//!                                   &mut capsules::sdcard::RXBUFFER));
+//! sdcard_spi.set_client(sdcard);
+//! sdcard_virtual_alarm.set_client(sdcard);
+//! sam4l::gpio::PA[17].set_client(sdcard);
+//!
+//! let sdcard_driver = static_init!(
+//!     capsules::sdcard::SDCardDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
+//!     capsules::sdcard::SDCardDriver::new(sdcard, &mut capsules::sdcard::KERNEL_BUFFER));
+//! sdcard.set_client(sdcard_driver);
+//! ```
 
 // Resources for SD Card API:
 //  * elm-chan.org/docs/mmc/mmc_e.html

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -1,6 +1,37 @@
-//! Silicon Labs SI7021 Temperature/Humidity Sensor
+//! Driver for the Silicon Labs SI7021 temperature/humidity sensor.
 //!
 //! https://www.silabs.com/products/sensors/humidity-sensors/Pages/si7013-20-21.aspx
+//!
+//! > The Si7006/13/20/21/34 devices are Silicon Labs’ latest generation I2C
+//! > relative humidity and temperature sensors. All members of this device
+//! > family combine fully factory-calibrated humidity and temperature sensor
+//! > elements with an analog to digital converter, signal processing and an I2C
+//! > host interface. Patented use of industry-standard low-K polymer
+//! > dielectrics provides excellent accuracy and long term stability, along
+//! > with low drift and low hysteresis. The innovative CMOS design also offers
+//! > the lowest power consumption in the industry for a relative humidity and
+//! > temperature sensor. The Si7013/20/21/34 devices are designed for high-
+//! > accuracy applications, while the Si7006 is targeted toward lower-accuracy
+//! > applications that traditionally have used discrete RH/T sensors.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let si7021_i2c = static_init!(
+//!     capsules::virtual_i2c::I2CDevice,
+//!     capsules::virtual_i2c::I2CDevice::new(i2c_bus, 0x40));
+//! let si7021_virtual_alarm = static_init!(
+//!     VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+//!     VirtualMuxAlarm::new(mux_alarm));
+//! let si7021 = static_init!(
+//!     capsules::si7021::SI7021<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
+//!     capsules::si7021::SI7021::new(si7021_i2c,
+//!         si7021_virtual_alarm,
+//!         &mut capsules::si7021::BUFFER));
+//! si7021_i2c.set_client(si7021);
+//! si7021_virtual_alarm.set_client(si7021);
+//! ```
 
 use core::cell::Cell;
 use kernel::{AppId, Callback, Driver, ReturnCode};

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -1,5 +1,5 @@
-//! The SPI capsule provides userspace applications with the ability
-//! to communicate over the SPI bus.
+//! Provides userspace applications with the ability to communicate over the SPI
+//! bus.
 
 use core::cell::Cell;
 use core::cmp;

--- a/capsules/src/symmetric_encryption.rs
+++ b/capsules/src/symmetric_encryption.rs
@@ -1,65 +1,73 @@
-//! Symmetric Block Cipher Capsule
+//! Provides userspace applications with the ability to encrypt and decrypt
+//! messages.
 //!
-//! Provides a driver for user space applications to encrypt and decrypt messages.
+//! Userspace Interface
+//! -------------------
 //!
-//! The system calls allow, subscribe and command are used to initiate the driver.
-//! The methods set_key_done() and crypt_done() are invoked by chip to send
-//! back the result of the operation and then passed the user application via
-//! the callback from the subscribe call.
+//! The system calls allow, subscribe and command are used to initiate the
+//! driver. The methods `set_key_done()` and `crypt_done()` are invoked by chip
+//! to send back the result of the operation and then passed the user
+//! application via the callback from the subscribe call.
 //!
-//! ---ALLOW SYSTEM CALL ------------------------------------------------------------
-//! The 'allow' system call is used to provide three different buffers and
-//! the following allow_num's are supported:
+//! ### `allow` System Call
 //!
-//!     * 0: A buffer with the key to be used for encryption and decryption.
-//!          Currently it can only configured once.
-//!     * 1: A buffer with data that will be encrypted and/or decrypted
-//!     * 4: A buffer to configure to initial counter when counter mode of
-//!          block cipher is used.
+//! The `allow` system call is used to provide three different buffers and the
+//! following allow_num's are supported:
 //!
-//! The possible return codes from the 'allow' system call indicate the following:
-//!     * SUCCESS: The buffer has successfully been filled
-//!     * ENOSUPPORT: Invalid allow_num
-//!     * ENOMEM: No sufficient memory available
-//!     * EINVAL => Invalid address of the buffer or other error
-//! ------------------------------------------------------------------------------
+//! * 0: A buffer with the key to be used for encryption and decryption.
+//!   Currently it can only configured once.
+//! * 1: A buffer with data that will be encrypted and/or decrypted
+//! * 4: A buffer to configure to initial counter when counter mode of block
+//!   cipher is used.
 //!
-//! ---SUBSCRIBE SYSTEM CALL----------------------------------------------------------
-//! The `subscribe` system call supports the single `subscribe_number`
-//! zero, which is used to provide a callback that will receive the
-//! result of configuring the key, encryption or decryption.
-//! The possible return from the 'subscribe' system call indicates the following:
-//!     * SUCCESS: the callback been successfully been configured
-//!     * ENOSUPPORT: Invalid allow_num
-//!     * ENOMEM: No sufficient memory available
-//!     * EINVAL => Invalid address of the buffer or other error
-//! ------------------------------------------------------------------------------
+//! The possible return codes from the 'allow' system call indicate the
+//! following:
 //!
-//! ---COMMAND SYSTEM CALL------------------------------------------------------------
-//! The `command` system call supports two arguments `cmd` and 'sub_cmd'.
-//! 'cmd' is used to specify the specific operation, currently
-//! the following cmd's are supported:
-//!     * 0: configure the key
-//!     * 2: encryption
-//!     * 3: decryption
+//! * `SUCCESS`: The buffer has successfully been filled.
+//! * `ENOSUPPORT`: Invalid allow_num.
+//! * `ENOMEM`: No sufficient memory available.
+//! * `EINVAL`: Invalid address of the buffer or other error.
 //!
-//! 'sub_cmd' is used to specify the specific algorithm to be used and currently
+//!
+//! ### `subscribe` System Call
+//!
+//! The `subscribe` system call supports the single `subscribe_number` zero,
+//! which is used to provide a callback that will receive the result of
+//! configuring the key, encryption or decryption. The possible return from the
+//! `subscribe` system call indicates the following:
+//!
+//! * `SUCCESS`: the callback been successfully been configured.
+//! * `ENOSUPPORT`: Invalid allow_num.
+//! * `ENOMEM`: No sufficient memory available.
+//! * `EINVAL`: Invalid address of the buffer or other error.
+//!
+//!
+//! ### `command` System Call
+//!
+//! The `command` system call supports two arguments `cmd` and `sub_cmd`. `cmd`
+//! is used to specify the specific operation, currently the following cmd's are
+//! supported:
+//!
+//! * `0`: configure the key
+//! * `2`: encryption
+//! * `3`: decryption
+//!
+//! `sub_cmd` is used to specify the specific algorithm to be used and currently
 //!  the following sub_cmd's are supported:
-//!     * 0: aes128 counter-mode
+//!
+//! * `0`: aes128 counter-mode
 //!
 //! The possible return from the 'command' system call indicates the following:
-//!   * SUCCESS:    The operation has been successful
-//!   * EBUSY:      The driver is busy
-//!   * ESIZE:      Invalid key size currently is must be 16, 24 or 32 bytes
-//!   * ENOSUPPORT: Invalid 'cmd' or 'sub_cmd'
-//!   * EFAIL:      The key is configured or other error
-//! ------------------------------------------------------------------------------
 //!
-//!
-//!
-//! Author: Niklas Adolfsson <niklasadolfsson1@gmail.com>
-//! Author: Fredrik Nilsson <frednils@student.chalmers.se>
-//! Date: March 31, 2017
+//! * `SUCCESS`:    The operation has been successful.
+//! * `EBUSY`:      The driver is busy.
+//! * `ESIZE`:      Invalid key size currently is must be 16, 24 or 32 bytes.
+//! * `ENOSUPPORT`: Invalid `cmd` or `sub_cmd`.
+//! * `EFAIL`:      The key is configured or other error.
+
+// Author: Niklas Adolfsson <niklasadolfsson1@gmail.com>
+// Author: Fredrik Nilsson <frednils@student.chalmers.se>
+// Date: March 31, 2017
 
 use core::cell::Cell;
 use kernel::{AppId, AppSlice, Container, Callback, Driver, ReturnCode, Shared};
@@ -72,7 +80,7 @@ pub static mut KEY: [u8; 16] = [0; 16];
 pub static mut IV: [u8; 16] = [0; 16];
 
 
-// This enum shall keep track of the state of the AESDriver
+/// This enum shall keep track of the state of the AESDriver
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 pub enum CryptoState {

--- a/capsules/src/temp_nrf51dk.rs
+++ b/capsules/src/temp_nrf51dk.rs
@@ -1,8 +1,4 @@
-//! NRF51DK Temperature Sensor Capsule
-//!
-//!
-//! Provides a simple driver for userspace applications to perform temperature measurements
-
+//! Provides userspace with access to the NRF51DK onboard temperature sensor.
 
 use core::cell::Cell;
 use kernel::{AppId, Container, Callback, Driver, ReturnCode};

--- a/capsules/src/timer.rs
+++ b/capsules/src/timer.rs
@@ -1,5 +1,3 @@
-//! Timer Capsule
-//!
 //! Provides userspace applications with a timer API.
 
 use core::cell::Cell;

--- a/capsules/src/tmp006.rs
+++ b/capsules/src/tmp006.rs
@@ -1,6 +1,12 @@
-//! Driver for the TI TMP006 Infrared Thermopile Contactless Temperature Sensor
+//! Driver for the TI TMP006 infrared thermopile contactless temperature sensor.
 //!
 //! http://www.ti.com/product/TMP006
+//!
+//! > The TMP006 and TMP006B are fully integrated MEMs thermopile sensors that
+//! > measure the temperature of an object without having to be in direct
+//! > contact. The thermopile absorbs passive infrared energy from an object at
+//! > wavelengths between 4 um to 16 um within the end-user defined field of
+//! > view.
 
 use core::cell::Cell;
 use kernel::{AppId, Callback, Driver, ReturnCode};

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -1,6 +1,17 @@
-//! Driver for the Taos TSL2561 Light Sensor
+//! Driver for the Taos TSL2561 light sensor.
 //!
 //! http://www.digikey.com/product-detail/en/ams-taos-usa-inc/TSL2561FN/TSL2561-FNCT-ND/3095298
+//!
+//! > The TSL2560 and TSL2561 are light-to-digital converters that transform
+//! > light intensity to a digital signal output capable of direct I2C
+//! > interface. Each device combines one broadband photodiode (visible plus
+//! > infrared) and one infrared-responding photodiodeon a single CMOS
+//! > integrated circuit capable of providing a near-photopic response over an
+//! > effective 20-bit dynamic range (16-bit resolution). Two integrating ADCs
+//! > convert the photodiode currents to a digital output that represents the
+//! > irradiance measured on each channel. This digital output can be input to a
+//! > microprocessor where illuminance (ambient light level) in lux is derived
+//! > using an empirical formula to approximate the human eye response.
 
 use core::cell::Cell;
 use kernel::{AppId, Callback, Driver, ReturnCode};

--- a/capsules/src/virtual_i2c.rs
+++ b/capsules/src/virtual_i2c.rs
@@ -1,8 +1,7 @@
-//! Mux and Virtualize an I2C Master Bus
+//! Virtualize an I2C master bus.
 //!
-//! `MuxI2C` provides shared access to a single I2C Master Bus
-//! for multiple users.
-//! `I2CDevice` provides access to a specific I2C address.
+//! `MuxI2C` provides shared access to a single I2C Master Bus for multiple
+//! users. `I2CDevice` provides access to a specific I2C address.
 
 use core::cell::Cell;
 use kernel::common::{List, ListLink, ListNode};

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -1,4 +1,4 @@
-//! Virtualize a Spi Master bus to enable multiple users of the Spi bus.
+//! Virtualize a SPI master bus to enable multiple users of the SPI bus.
 
 use core::cell::Cell;
 use kernel::ReturnCode;

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -1,19 +1,19 @@
-// adc.rs -- Implementation of SAM4L ADCIFE.
-//
-// This is an implementation of the SAM4L analog to digital converter. It is
-// bare-bones because it provides little flexibility on how samples are taken.
-// Currently, all samples
-//   - are 12 bits
-//   - use the ground pad as the negative reference
-//   - use a VCC/2 positive reference
-//   - are right justified
-//
-// Samples can either be collected individually or continuously at a specified
-// frequency
-//
-// Author: Philip Levis <pal@cs.stanford.edu>, Branden Ghena <brghena@umich.edu>
-// Updated: May 1, 2017
-//
+//! Implementation of the SAM4L ADCIFE.
+//!
+//! This is an implementation of the SAM4L analog to digital converter. It is
+//! bare-bones because it provides little flexibility on how samples are taken.
+//! Currently, all samples:
+//!
+//! - are 12 bits
+//! - use the ground pad as the negative reference
+//! - use a VCC/2 positive reference
+//! - are right justified
+//!
+//! Samples can either be collected individually or continuously at a specified
+//! frequency.
+//!
+//! - Author: Philip Levis <pal@cs.stanford.edu>, Branden Ghena <brghena@umich.edu>
+//! - Updated: May 1, 2017
 
 use core::{cmp, mem, slice};
 use core::cell::Cell;
@@ -62,8 +62,9 @@ enum Channel {
 /// Initialization of an ADC channel.
 impl AdcChannel {
     /// Create a new ADC channel.
-    /// channel - Channel enum representing the channel number and whether it is
-    ///           internal
+    ///
+    /// - `channel`: Channel enum representing the channel number and whether it
+    ///   is internal
     const fn new(channel: Channel) -> AdcChannel {
         AdcChannel {
             chan_num: ((channel as u8) & 0x0F) as u32,
@@ -161,8 +162,8 @@ pub static mut ADC0: Adc = Adc::new(BASE_ADDRESS, dma::DMAPeripheral::ADCIFE_RX)
 impl Adc {
     /// Create a new ADC driver.
     ///
-    /// base_address - pointer to the ADC's memory mapped I/O registers
-    /// rx_dma_peripheral - type used for DMA transactions
+    /// - `base_address`: pointer to the ADC's memory mapped I/O registers
+    /// - `rx_dma_peripheral`: type used for DMA transactions
     const fn new(base_address: *mut AdcRegisters, rx_dma_peripheral: dma::DMAPeripheral) -> Adc {
         Adc {
             // pointer to memory mapped I/O registers
@@ -194,14 +195,14 @@ impl Adc {
 
     /// Sets the client for this driver.
     ///
-    /// client - reference to capsule which handles responses
+    /// - `client`: reference to capsule which handles responses
     pub fn set_client<C: EverythingClient>(&self, client: &'static C) {
         self.client.set(Some(client));
     }
 
     /// Sets the DMA channel for this driver.
     ///
-    /// rx_dma - reference to the DMA channel the ADC should use
+    /// - `rx_dma`: reference to the DMA channel the ADC should use
     pub fn set_dma(&self, rx_dma: &'static dma::DMAChannel) {
         self.rx_dma.set(Some(rx_dma));
     }
@@ -340,7 +341,7 @@ impl hil::adc::Adc for Adc {
     /// Capture a single analog sample, calling the client when complete.
     /// Returns an error if the ADC is already sampling.
     ///
-    /// channel - the ADC channel to sample
+    /// - `channel`: the ADC channel to sample
     fn sample(&self, channel: &Self::Channel) -> ReturnCode {
         let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
 
@@ -388,8 +389,8 @@ impl hil::adc::Adc for Adc {
     /// microseconds (10000 samples per second). To sample faster, use the
     /// sample_highspeed function.
     ///
-    /// channel - the ADC channel to sample
-    /// frequency - the number of samples per second to collect
+    /// - `channel`: the ADC channel to sample
+    /// - `frequency`: the number of samples per second to collect
     fn sample_continuous(&self, channel: &Self::Channel, frequency: u32) -> ReturnCode {
         let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
 
@@ -531,12 +532,12 @@ impl hil::adc::AdcHighSpeed for Adc {
     /// frequency range of the ADC is from 187 kHz to 23 Hz (although its
     /// precision is limited at higher frequencies due to aliasing).
     ///
-    /// channel - the ADC channel to sample
-    /// frequency - frequency to sample at
-    /// buffer1 - first buffer to fill with samples
-    /// length1 - number of samples to collect (up to buffer length)
-    /// buffer2 - second buffer to fill once the first is full
-    /// length2 - number of samples to collect (up to buffer length)
+    /// - `channel`: the ADC channel to sample
+    /// - `frequency`: frequency to sample at
+    /// - `buffer1`: first buffer to fill with samples
+    /// - `length1`: number of samples to collect (up to buffer length)
+    /// - `buffer2`: second buffer to fill once the first is full
+    /// - `length2`: number of samples to collect (up to buffer length)
     fn sample_highspeed(&self,
                         channel: &Self::Channel,
                         frequency: u32,
@@ -629,8 +630,8 @@ impl hil::adc::AdcHighSpeed for Adc {
     /// Provide a new buffer to send on-going buffered continuous samples to.
     /// This is expected to be called after the `samples_ready` callback.
     ///
-    /// buf - buffer to fill with samples
-    /// length - number of samples to collect (up to buffer length)
+    /// - `buf`: buffer to fill with samples
+    /// - `length`: number of samples to collect (up to buffer length)
     fn provide_buffer(&self,
                       buf: &'static mut [u16],
                       length: usize)
@@ -679,7 +680,7 @@ impl hil::adc::AdcHighSpeed for Adc {
 impl dma::DMAClient for Adc {
     /// Handler for DMA transfer completion.
     ///
-    /// pid - the DMA peripheral that is complete
+    /// - `pid`: the DMA peripheral that is complete
     fn xfer_done(&self, pid: dma::DMAPeripheral) {
         // check if this was an RX transfer
         if pid == self.rx_dma_peripheral {

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -1,9 +1,8 @@
-// chips::sam4l::ast -- Implementation of a single hardware timer.
-//
-// Author: Amit Levy <levya@cs.stanford.edu>
-// Author: Philip Levis <pal@cs.stanford.edu>
-// Date: July 16, 2015
-//
+//! Implementation of a single hardware timer.
+//!
+//! - Author: Amit Levy <levya@cs.stanford.edu>
+//! - Author: Philip Levis <pal@cs.stanford.edu>
+//! - Date: July 16, 2015
 
 use core::cell::Cell;
 use kernel::common::VolatileCell;

--- a/chips/sam4l/src/bpm.rs
+++ b/chips/sam4l/src/bpm.rs
@@ -1,3 +1,5 @@
+//! Implementation of the BPM peripheral.
+
 use kernel::common::VolatileCell;
 
 #[repr(C, packed)]

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -1,3 +1,5 @@
+//! Interrupt mapping and DMA channel setup.
+
 use adc;
 use ast;
 use cortexm4;

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -1,12 +1,12 @@
-//! CRCCU implementation for the SAM4L
+//! Implementation of the SAM4L CRCCU.
 //!
 //! See datasheet section "41. Cyclic Redundancy Check Calculation Unit (CRCCU)".
 //!
 //! The SAM4L can compute CRCs using three different polynomials:
 //!
-//!   * 0x04C11DB7 (as used in "CRC-32"; Atmel calls this "CCIT8023")
-//!   * 0x1EDC6F41 (as used in "CRC-32C"; Atmel calls this "CASTAGNOLI")
-//!   * 0x1021     (as used in "CRC-16-CCITT"; Atmel calls this "CCIT16")
+//!   * `0x04C11DB7` (as used in "CRC-32"; Atmel calls this "CCIT8023")
+//!   * `0x1EDC6F41` (as used in "CRC-32C"; Atmel calls this "CASTAGNOLI")
+//!   * `0x1021`     (as used in "CRC-16-CCITT"; Atmel calls this "CCIT16")
 //!
 //! (The integers above give each polynomial from most-significant to least-significant
 //! bit, except that the most significant bit is omitted because it is always 1.)

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -1,3 +1,5 @@
+//! Implementation of the PDCA DMA peripheral.
+
 use core::{cmp, intrinsics, mem};
 use core::cell::Cell;
 use kernel::common::VolatileCell;
@@ -6,7 +8,7 @@ use kernel::common::take_cell::TakeCell;
 use nvic;
 use pm;
 
-/// Memory registers for a DMA channel. Section 16.6.1 of the datasheet
+/// Memory registers for a DMA channel. Section 16.6.1 of the datasheet.
 #[repr(C, packed)]
 #[allow(dead_code)]
 struct DMARegisters {
@@ -26,10 +28,10 @@ struct DMARegisters {
     _unused: [usize; 4],
 }
 
-/// The PDCA's base addresses in memory (Section 7.1 of manual)
+/// The PDCA's base addresses in memory (Section 7.1 of manual).
 const DMA_BASE_ADDR: usize = 0x400A2000;
 
-/// The number of bytes between each memory mapped DMA Channel (Section 16.6.1)
+/// The number of bytes between each memory mapped DMA Channel (Section 16.6.1).
 const DMA_CHANNEL_SIZE: usize = 0x40;
 
 /// Shared counter that Keeps track of how many DMA channels are currently
@@ -38,7 +40,7 @@ static mut NUM_ENABLED: usize = 0;
 
 /// The DMA channel number. Each channel transfers data between memory and a
 /// particular peripheral function (e.g., SPI read or SPI write, but not both
-/// simultaneously). There are 16 available channels (Section 16.7)
+/// simultaneously). There are 16 available channels (Section 16.7).
 #[derive(Copy,Clone)]
 pub enum DMAChannelNum {
     // Relies on the fact that assigns values 0-15 to each constructor in order
@@ -61,8 +63,8 @@ pub enum DMAChannelNum {
 }
 
 
-/// The peripheral function a channel is assigned to (Section 16.7)
-/// *_RX means transfer data from peripheral to memory, *_TX means transfer data
+/// The peripheral function a channel is assigned to (Section 16.7). `*_RX`
+/// means transfer data from peripheral to memory, `*_TX` means transfer data
 /// from memory to peripheral.
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, PartialEq)]

--- a/chips/sam4l/src/gpio.rs
+++ b/chips/sam4l/src/gpio.rs
@@ -1,4 +1,4 @@
-
+//! Implementation of the GPIO controller.
 
 use self::Pin::*;
 use core::cell::Cell;
@@ -81,8 +81,8 @@ const SIZE: usize = 0x200;
 
 /// Name of the GPIO pin on the SAM4L.
 ///
-/// The "Package and Pinout" section[^1] of the SAM4L datasheet shows the mapping
-/// between these names and hardware pins on different chip packages.
+/// The "Package and Pinout" section[^1] of the SAM4L datasheet shows the
+/// mapping between these names and hardware pins on different chip packages.
 ///
 /// [^1]: Section 3.1, pages 10-18
 #[derive(Copy,Clone)]

--- a/chips/sam4l/src/helpers.rs
+++ b/chips/sam4l/src/helpers.rs
@@ -25,6 +25,8 @@ pub fn volatile_bitwise_and<T: BitAnd<Output = T>>(item: &mut T, val: T) {
     transform_volatile(item, |t| t & val);
 }
 
+/// Define a function for an interrupt and enqueue the interrupt on the global
+/// queue.
 #[macro_export]
 macro_rules! interrupt_handler {
     ($name: ident, $nvic: ident $(, $body: expr)*) => {

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -1,4 +1,4 @@
-//! TWIM Driver for the SAM4L
+//! Implementation of the SAM4L TWIMS peripheral.
 //!
 //! The implementation, especially of repeated starts, is quite sensitive to the
 //! ordering of operations (e.g. setup DMA, then set command register, then next
@@ -8,8 +8,6 @@
 //!
 //! The point is that until this changes, and this notice is taken away: IF YOU
 //! CHANGE THIS DRIVER, TEST RIGOROUSLY!!!
-//!
-
 
 use core::cell::Cell;
 use core::mem;

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -1,3 +1,7 @@
+//! Peripheral implementations for the SAM4L MCU.
+//!
+//! http://www.atmel.com/microsite/sam4l/default.aspx
+
 #![crate_name = "sam4l"]
 #![crate_type = "rlib"]
 #![feature(asm,core_intrinsics,concat_idents,const_fn)]

--- a/chips/sam4l/src/nvic.rs
+++ b/chips/sam4l/src/nvic.rs
@@ -1,3 +1,5 @@
+//! Implementation of the SAM4L interrupt controller.
+
 use core::intrinsics;
 use kernel::common::VolatileCell;
 

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -1,3 +1,5 @@
+//! Implementation of the power manager peripheral.
+
 use kernel::common::VolatileCell;
 
 #[repr(C, packed)]

--- a/chips/sam4l/src/scif.rs
+++ b/chips/sam4l/src/scif.rs
@@ -1,12 +1,11 @@
-// scif.rs -- System control interface for SAM4L
-//
-// This file includes support for the SCIF (Chapter 13 of SAML manual),
-// which configures system clocks. Does not currently support all
-// features/functionality: only main oscillator and generic clocks.
-//
-// Author: Philip Levis
-// Date: Aug 2, 2015
-//
+//! Implementation of the system control interface for the SAM4L.
+//!
+//! This file includes support for the SCIF (Chapter 13 of SAML manual), which
+//! configures system clocks. Does not currently support all
+//! features/functionality: only main oscillator and generic clocks.
+//!
+//! - Author: Philip Levis
+//! - Date: Aug 2, 2015
 
 use kernel::common::VolatileCell;
 

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -1,3 +1,11 @@
+//! Implementation of DMA-based SPI master and slave communication for the
+//! SAM4L.
+//!
+//! Driver for the SPI hardware (separate from the USARTS), described in chapter
+//! 26 of the datasheet.
+//!
+//! - Authors: Sam Crow <samcrow@uw.edu>, Philip Levis <pal@cs.stanford.edu>
+
 use core::cell::Cell;
 use core::cmp;
 use core::mem;
@@ -17,13 +25,6 @@ use kernel::hil::spi::SpiSlaveClient;
 use nvic;
 use pm;
 
-/// Implementation of DMA-based SPI master communication for
-/// the Atmel SAM4L CortexM4 microcontroller.
-/// Authors: Sam Crow <samcrow@uw.edu>
-///          Philip Levis <pal@cs.stanford.edu>
-///
-// Driver for the SPI hardware (separate from the USARTS),
-// described in chapter 26 of the datasheet
 /// The registers used to interface with the hardware
 #[repr(C, packed)]
 struct SpiRegisters {
@@ -395,8 +396,8 @@ impl Spi {
     }
 
     /// Asynchronous buffer read/write of SPI.
-    /// returns SUCCESS if operation starts (will receive callback through SpiMasterClient),
-    /// returns EBUSY if the operation does not start.
+    /// returns `SUCCESS` if operation starts (will receive callback through SpiMasterClient),
+    /// returns `EBUSY` if the operation does not start.
     // The write buffer has to be mutable because it's passed back to
     // the caller, and the caller may want to be able write into it.
     fn read_write_bytes(&self,
@@ -497,9 +498,9 @@ impl spi::SpiMaster for Spi {
     /// Asynchronous buffer read/write of SPI.
     /// write_buffer must  be Some; read_buffer may be None;
     /// if read_buffer is Some, then length of read/write is the
-    /// minimum of two buffer lengths; returns SUCCESS if operation
+    /// minimum of two buffer lengths; returns `SUCCESS` if operation
     /// starts (will receive callback through SpiMasterClient), returns
-    /// EBUSY if the operation does not start.
+    /// `EBUSY` if the operation does not start.
     // The write buffer has to be mutable because it's passed back to
     // the caller, and the caller may want to be able write into it.
     fn read_write_bytes(&self,

--- a/chips/sam4l/src/trng.rs
+++ b/chips/sam4l/src/trng.rs
@@ -1,4 +1,4 @@
-//! TRNG driver for the SAM4L
+//! Implementation of the SAM4L TRNG.
 
 use core::cell::Cell;
 use kernel::common::VolatileCell;

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -1,3 +1,7 @@
+//! Implementation of the SAM4L USART peripheral.
+//!
+//! Supports UART and SPI master modes.
+
 use core::cell::Cell;
 use core::cmp;
 use core::mem;

--- a/chips/sam4l/src/wdt.rs
+++ b/chips/sam4l/src/wdt.rs
@@ -1,3 +1,5 @@
+//! Implementation of the SAM4L hardware watchdog timer.
+
 use core::cell::Cell;
 use core::mem;
 use kernel::common::VolatileCell;

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -1,6 +1,9 @@
+//! Data structure for storing a callback to userspace or kernelspace.
+
 use core::nonzero::NonZero;
 use process;
 
+/// Userspace app identifier.
 #[derive(Clone, Copy, Debug)]
 pub struct AppId {
     idx: usize,
@@ -38,6 +41,7 @@ pub enum RustOrRawFnPtr {
     Rust { func: fn(usize, usize, usize, usize), },
 }
 
+/// Wrapper around a function pointer.
 #[derive(Clone, Copy, Debug)]
 pub struct Callback {
     app_id: AppId,

--- a/kernel/src/common/list.rs
+++ b/kernel/src/common/list.rs
@@ -1,3 +1,5 @@
+//! Linked list implementation.
+
 use core::cell::Cell;
 
 pub struct ListLink<'a, T: 'a>(Cell<Option<&'a T>>);

--- a/kernel/src/common/math.rs
+++ b/kernel/src/common/math.rs
@@ -1,3 +1,5 @@
+//! Helper functions for common mathematical operations.
+
 use core::convert::{From, Into};
 use core::intrinsics as int;
 

--- a/kernel/src/common/queue.rs
+++ b/kernel/src/common/queue.rs
@@ -1,3 +1,5 @@
+//! Interface for queue structure.
+
 pub trait Queue<T> {
     fn has_elements(&self) -> bool;
     fn is_full(&self) -> bool;

--- a/kernel/src/common/ring_buffer.rs
+++ b/kernel/src/common/ring_buffer.rs
@@ -1,3 +1,5 @@
+//! Implementation of a ring buffer.
+
 use common::queue;
 use core::ptr::read_volatile;
 

--- a/kernel/src/common/take_cell.rs
+++ b/kernel/src/common/take_cell.rs
@@ -1,3 +1,5 @@
+//! Tock specific `Cell` types for sharing references.
+
 use core::{mem, ptr};
 use core::cell::{Cell, UnsafeCell};
 

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -1,6 +1,10 @@
-/// Allocates a global array of static size, initially set to zero. When this
-/// macro is hit, it will initialize the array to the value given and return a
-/// `&'static mut` reference to it.
+//! Utility macros including `static_init!`.
+
+/// Allocates a global array of static size to initialize data structures.
+///
+/// The global array is initially set to zero. When this macro is hit, it will
+/// initialize the array to the value given and return a `&'static mut`
+/// reference to it.
 ///
 /// Note that you will have to specify the array-size as an argument, but a
 /// wrong size will result in a compile-time error. This argument will be

--- a/kernel/src/common/volatile_cell.rs
+++ b/kernel/src/common/volatile_cell.rs
@@ -1,3 +1,5 @@
+//! Implementation of types for accessing MCU registers.
+
 // Source: https://github.com/hackndev/zinc/tree/master/volatile_cell
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/kernel/src/container.rs
+++ b/kernel/src/container.rs
@@ -1,3 +1,5 @@
+//! Data structure to store a list of userspace applications.
+
 use callback::AppId;
 use core::marker::PhantomData;
 use core::mem::size_of;

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -1,3 +1,16 @@
+//! Provides a `debug!` macro for in-kernel debugging.
+//!
+//! This module uses an internal buffer to write the strings into. If you are
+//! writing and the buffer fills up, you can make the size of `output_buffer`
+//! larger.
+//!
+//! Example
+//! -------
+//!
+//! ```rust
+//! debug!("Yes the code gets here with value {}", i);
+//! ```
+
 use callback::{AppId, Callback};
 use core::cmp::min;
 use core::fmt::{Arguments, Result, Write, write};
@@ -278,6 +291,7 @@ pub fn begin_debug(msg: &str, file_line: &(&'static str, u32)) {
     }
 }
 
+/// In-kernel `printf()` debugging.
 #[macro_export]
 macro_rules! debug {
     () => ({

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -1,4 +1,4 @@
-//! Driver implemented system call interface.
+//! System call interface for userspace applications.
 //!
 //! Drivers implement these interfaces to expose operations to applications.
 //!
@@ -47,7 +47,7 @@ use returncode::ReturnCode;
 /// system calls are assigned to drivers.
 pub trait Driver {
     /// `subscribe` lets an application pass a callback to the driver to be
-    /// called later.
+    /// called later. This returns `ENOSUPPORT` if not used.
     ///
     /// Calls to subscribe should do minimal synchronous work.  Instead, they
     /// should defer most work and returns results to the application via the
@@ -74,7 +74,8 @@ pub trait Driver {
         ReturnCode::ENOSUPPORT
     }
 
-    /// `command` instructs a driver to perform some action synchronously.
+    /// `command` instructs a driver to perform some action synchronously. This
+    /// returns `ENOSUPPORT` if not used.
     ///
     /// The return value should reflect the result of an action. For example,
     /// enabling/disabling a peripheral should return a success or error code.
@@ -94,7 +95,7 @@ pub trait Driver {
     }
 
     /// `allow` lets an application give the driver access to a buffer in the
-    /// application's memory.
+    /// application's memory. This returns `ENOSUPPORT` if not used.
     ///
     /// The buffer is __shared__ between the application and driver, meaning the
     /// driver should not rely on the contents of the buffer to remain

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -1,6 +1,6 @@
-/// Interfaces for analog to digital converter peripherals.
-use returncode::ReturnCode;
+//! Interfaces for analog to digital converter peripherals.
 
+use returncode::ReturnCode;
 
 // *** Interfaces for low-speed, single-sample ADCs ***
 

--- a/kernel/src/hil/crc.rs
+++ b/kernel/src/hil/crc.rs
@@ -1,4 +1,4 @@
-//! Generic interface for CRC computation
+//! Interface for CRC computation.
 
 use returncode::ReturnCode;
 

--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -1,3 +1,5 @@
+//! Interface for flash storage.
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     PageBoundary,

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -1,5 +1,6 @@
-/// Enum for configuring any pull-up or pull-down
-/// resistors on the GPIO pin.
+//! Interface for direct control of GPIO pins.
+
+/// Enum for configuring any pull-up or pull-down resistors on the GPIO pin.
 #[derive(Debug)]
 pub enum InputMode {
     PullUp,
@@ -7,8 +8,7 @@ pub enum InputMode {
     PullNone,
 }
 
-/// Enum for selecting which edge to trigger interrupts
-/// on.
+/// Enum for selecting which edge to trigger interrupts on.
 #[derive(Debug)]
 pub enum InterruptMode {
     RisingEdge,

--- a/kernel/src/hil/gpio_async.rs
+++ b/kernel/src/hil/gpio_async.rs
@@ -1,3 +1,5 @@
+//! Interface for GPIO pins that require split-phase operation to control.
+
 use hil;
 use returncode::ReturnCode;
 

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -1,3 +1,5 @@
+//! Interface for I2C master and slave peripherals.
+
 use core::fmt::{Display, Formatter, Result};
 
 /// The type of error encoutered during an I2C command transmission.

--- a/kernel/src/hil/led.rs
+++ b/kernel/src/hil/led.rs
@@ -1,4 +1,4 @@
-//! led.rs -- Drivers for LEDs that abstract away polarity and pin.
+//! Interface for LEDs that abstract away polarity and pin.
 //!
 //!  Author: Philip Levis <pal@cs.stanford.edu>
 //!  Date: July 31, 2015

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -1,3 +1,5 @@
+//! Public traits for interfaces between Tock components.
+
 pub mod led;
 pub mod time;
 pub mod gpio;
@@ -15,6 +17,7 @@ pub mod symmetric_encryption;
 pub mod ninedof;
 pub mod gpio_async;
 
+/// Shared interface for configuring components.
 pub trait Controller {
     type Config;
 

--- a/kernel/src/hil/ninedof.rs
+++ b/kernel/src/hil/ninedof.rs
@@ -1,3 +1,5 @@
+//! Interface for chips that provide 9DOF functionality.
+//!
 //! This trait file provides a standard interface for chips that implement
 //! some or all of a nine degrees of freedom (accelerometer, magnetometer,
 //! gyroscope) sensor. Any interface functions that a chip cannot implement

--- a/kernel/src/hil/radio.rs
+++ b/kernel/src/hil/radio.rs
@@ -1,11 +1,11 @@
-/// Hardware independent interface for an 802.15.4 radio.
-/// Note that configuration commands are asynchronous and
-/// must be committed with a call to config_commit. For
-/// example, calling set_address will change the source address
-/// of packets but does not change the address stored in hardware
-/// used for address recognition. This must be committed to hardware
-/// with a call to config_commit. Please see the relevant TRD for
-/// more details.
+//! Interface for sending and receiving IEEE 802.15.4 packets.
+//!
+//! Hardware independent interface for an 802.15.4 radio. Note that
+//! configuration commands are asynchronous and must be committed with a call to
+//! config_commit. For example, calling set_address will change the source
+//! address of packets but does not change the address stored in hardware used
+//! for address recognition. This must be committed to hardware with a call to
+//! config_commit. Please see the relevant TRD for more details.
 
 use returncode::ReturnCode;
 pub trait TxClient {
@@ -31,9 +31,10 @@ pub const MIN_PACKET_SIZE: u8 = HEADER_SIZE + 2; // +2 for CRC
 
 pub trait Radio: RadioConfig + RadioData {}
 
+/// Configure the 802.15.4 radio.
 pub trait RadioConfig {
     /// buf must be at least MAX_BUF_SIZE in length, and
-    /// reg_read and reg_write must be 2 bytes
+    /// reg_read and reg_write must be 2 bytes.
     fn initialize(&self,
                   spi_buf: &'static mut [u8],
                   reg_write: &'static mut [u8],

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -1,4 +1,4 @@
-//! Interfaces for accessing a random number generator
+//! Interfaces for accessing a random number generator.
 //!
 //! A random number generator produces a stream of random numbers, either from
 //! hardware or based on an initial seed. The [RNG](trait.RNG.html) trait

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -1,4 +1,4 @@
-//! Traits and parameters for SPI master communication.
+//! Interfaces for SPI master and slave communication.
 
 use core::option::Option;
 

--- a/kernel/src/hil/symmetric_encryption.rs
+++ b/kernel/src/hil/symmetric_encryption.rs
@@ -1,14 +1,15 @@
-//! Interfaces for accessing encryption and decryption of symmetric ciphers
-//! (only AES-128-ctr for suppported nrf51dk "at the moment")
+//! Interfaces for accessing encryption and decryption of symmetric ciphers.
 //!
-//! The interface is supposed to work for hardware supported crypto but
-//! should work for software implemented crypto as well.
+//! Only AES-128-ctr supported at the moment.
+//!
+//! The interface is supposed to work for hardware supported crypto but should
+//! work for software implemented crypto as well.
 //!
 //! State Machine:
-//!  1. init()
-//!  2. set_key()
-//!  3. aes128_crypt_ctr()   - can be used arbitary number of times
 //!
+//! 1. `init()`
+//! 2. `set_key()`
+//! 3. `aes128_crypt_ctr()`: can be used arbitrary number of times.
 
 use returncode::ReturnCode;
 

--- a/kernel/src/hil/temperature.rs
+++ b/kernel/src/hil/temperature.rs
@@ -1,3 +1,5 @@
+//! Interface for sampling a temperature sensor.
+
 use returncode::ReturnCode;
 
 pub trait TemperatureDriver {

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -1,4 +1,4 @@
-//! Hardware agnostic interfaces for counter-like resources
+//! Hardware agnostic interfaces for counter-like resources.
 
 pub trait Time {
     type Frequency: Frequency;

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -1,4 +1,5 @@
-/// UART hardware interface
+//! Interfaces for UART communications.
+
 #[derive(Copy, Clone, Debug)]
 pub enum StopBits {
     One = 0,
@@ -20,7 +21,7 @@ pub struct UARTParams {
     pub hw_flow_control: bool,
 }
 
-/// The type of error encountered during UART transaction
+/// The type of error encountered during UART transaction.
 #[derive(Copy, Clone, PartialEq)]
 pub enum Error {
     /// Parity error during receive
@@ -49,36 +50,36 @@ pub trait UART {
 
     /// Initialize UART
     ///
-    /// # Panics if UARTParams are invalid for the current chip
+    /// Panics if UARTParams are invalid for the current chip.
     fn init(&self, params: UARTParams);
 
-    /// Transmit data
+    /// Transmit data.
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize);
 
-    /// Receive data until buffer is full
+    /// Receive data until buffer is full.
     fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize);
 }
 
 pub trait UARTAdvanced: UART {
-    /// Receive data until `interbyte_timeout` bit periods have passed since the last byte
-    /// or buffer is full. Does not timeout until at least one byte has been
-    /// received
+    /// Receive data until `interbyte_timeout` bit periods have passed since the
+    /// last byte or buffer is full. Does not timeout until at least one byte
+    /// has been received.
     ///
-    /// * `interbyte_timeout` - number of bit periods since last data received
+    /// * `interbyte_timeout`: number of bit periods since last data received.
     fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8);
 
     /// Receive data until `terminator` data byte has been received or buffer
     /// is full
     ///
-    /// * `terminator` - data byte terminating a reception
+    /// * `terminator`: data byte terminating a reception.
     fn receive_until_terminator(&self, rx_buffer: &'static mut [u8], terminator: u8);
 }
 
-/// Implement Client to receive callbacks from UART
+/// Implement Client to receive callbacks from UART.
 pub trait Client {
-    /// UART transmit complete
+    /// UART transmit complete.
     fn transmit_complete(&self, tx_buffer: &'static mut [u8], error: Error);
 
-    /// UART receive complete
+    /// UART receive complete.
     fn receive_complete(&self, rx_buffer: &'static mut [u8], rx_len: usize, error: Error);
 }

--- a/kernel/src/hil/watchdog.rs
+++ b/kernel/src/hil/watchdog.rs
@@ -1,3 +1,5 @@
+//! Interface for a watchdog timer.
+
 pub trait Watchdog {
     /// Enable the watchdog timer. Period is the time in milliseconds
     /// the watchdog will timeout if not serviced.

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -1,4 +1,4 @@
-//! IPC mechanism for Tock.
+//! Inter-process communication mechanism for Tock.
 //!
 //! This is a special syscall driver that allows userspace applications to
 //! share memory.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -36,6 +36,7 @@ pub use platform::systick::SysTick;
 pub use process::{Process, State};
 pub use returncode::ReturnCode;
 
+/// Main loop.
 pub fn main<P: Platform, C: Chip>(platform: &P,
                                   chip: &mut C,
                                   processes: &'static mut [Option<process::Process<'static>>],

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -1,3 +1,5 @@
+//! Data structure for passing application memory to the kernel.
+
 use AppId;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};

--- a/kernel/src/memop.rs
+++ b/kernel/src/memop.rs
@@ -1,4 +1,4 @@
-//! Implementation of the MEMOP family of syscalls
+//! Implementation of the MEMOP family of syscalls.
 
 use process::Process;
 use returncode::ReturnCode;

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -3,10 +3,12 @@ use driver::Driver;
 pub mod mpu;
 pub mod systick;
 
+/// Interface for individual boards.
 pub trait Platform {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R where F: FnOnce(Option<&Driver>) -> R;
 }
 
+/// Interface for individual MCUs.
 pub trait Chip {
     type MPU: mpu::MPU;
     type SysTick: systick::SysTick;

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,3 +1,5 @@
+//! Interface for configuring the Memory Protection Unit.
+
 #[derive(Debug)]
 pub enum AccessPermission {
     //                                 Privileged  Unprivileged

--- a/kernel/src/platform/systick.rs
+++ b/kernel/src/platform/systick.rs
@@ -1,3 +1,6 @@
+//! Interface and default implementation for the system tick timer.
+
+/// Interface for the system tick timer.
 pub trait SysTick {
     /// Sets the timer as close as possible to the given interval in
     /// microseconds.  The clock is 24-bits wide and specific timing is

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1,3 +1,5 @@
+//! Support for creating and running userspace applications.
+
 use callback::AppId;
 use common::{RingBuffer, Queue, VolatileCell};
 

--- a/kernel/src/returncode.rs
+++ b/kernel/src/returncode.rs
@@ -1,5 +1,5 @@
-//! returncode.rs -- Standard return type for invoking operations, returning
-//! success or an error code.
+//! Standard return type for invoking operations, returning success or an error
+//! code.
 //!
 //!  Author: Philip Levis <pal@cs.stanford.edu>
 //!  Date: Dec 22, 2016

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -1,3 +1,5 @@
+//! Tock core scheduler.
+
 use core::nonzero::NonZero;
 use memop;
 use platform::{Chip, Platform};

--- a/kernel/src/support/mod.rs
+++ b/kernel/src/support/mod.rs
@@ -1,8 +1,8 @@
-//! A bare-metal library supplying functions rustc may lower code to
+//! A bare-metal library supplying functions rustc may lower code to.
 //!
 //! This library is not intended for general use, and is superseded by a system
 //! libc if one is available. In a freestanding context, however, common
-//! functions such as memset, memcpy, etc are not implemented. This library
+//! functions such as memset, memcpy, etc. are not implemented. This library
 //! provides an implementation of these functions which are either required by
 //! libcore or called by rustc implicitly.
 //!


### PR DESCRIPTION
Improve comments in source files to make the `make doc` output look better.

- Fixed some markdown issues.
- Added header lines to each file and made them consistent.
- Added some usage examples.