### PR TITLE
build: trigger rustup component during install

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -41,6 +41,7 @@ ifneq ($(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VE
     $(warning You may experience unexpected compilation warnings or errors)
     $(warning To fix, install `rustup` from https://rustup.rs/, then run: `rustup install $(RUSTUP_TOOLCHAIN)`)
   endif
+  $(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustup component add rust-src)
 endif
 
 # Check that xargo is installed
@@ -88,7 +89,6 @@ target/$(TARGET)/release/$(PLATFORM).elf: target/$(TARGET)/release/$(PLATFORM)
 
 .PHONY: target/$(TARGET)/release/$(PLATFORM)
 target/$(TARGET)/release/$(PLATFORM):
-	$(Q)rustup component add rust-src
 	$(Q)RUSTFLAGS=$(RUSTFLAGS_FOR_XARGO_LINKING) $(XARGO) build --target=$(TARGET) $(VERBOSE) --release
 	$(Q)$(SIZE) $@
 
@@ -117,7 +117,6 @@ target/$(TARGET)/debug/$(PLATFORM).bin: target/$(TARGET)/debug/$(PLATFORM).elf
 # binary. This makes checking for Rust errors much faster.
 .PHONY: check
 check:
-	$(Q)rustup component add rust-src
 	$(Q)RUSTFLAGS=$(RUSTFLAGS_FOR_XARGO_LINKING) $(XARGO) check --target=$(TARGET) $(VERBOSE) --release
 
 .PHONY: clean


### PR DESCRIPTION
This command only needs to be run once, placing it with the install of
the new toolchain means we don't have to remember to put it everywhere
that we possibly invoke rust, plus it gets rid of the `info: already
up to date` message that was printing with every build

Fixes #436.