### PR TITLE
style: add format for libraries too

### DIFF
--- a/userland/AppMakefile.mk
+++ b/userland/AppMakefile.mk
@@ -191,7 +191,7 @@ clean::
 # Rules for running the C linter
 
 .PHONY: fmt format
-fmt format:
+fmt format::
 	$(Q)$(UNCRUSTIFY) $(C_SRCS) $(CXX_SRCS)
 
 

--- a/userland/TockLibrary.mk
+++ b/userland/TockLibrary.mk
@@ -155,3 +155,12 @@ clean::
 	rm -Rf $(1)
 endef
 $(eval $(call CLEAN_RULE,$($(LIBNAME)_BUILDDIR)))
+
+
+# Rules for running the C linter
+define FORMAT_RULE
+.PHONY: fmt format
+fmt format::
+	$(Q)$(UNCRUSTIFY) $(1)
+endef
+$(eval $(call FORMAT_RULE,$($(LIBNAME)_SRCS)))

--- a/userland/examples/format_all.sh
+++ b/userland/examples/format_all.sh
@@ -12,6 +12,9 @@ function opt_rebuild {
 	fi
 }
 
+echo ""
+echo "${bold}Formatting examples${normal}"
+
 for mkfile in `find . -maxdepth 3 -name Makefile`; do
 	dir=`dirname $mkfile`
 	if [ $dir == "." ]; then continue; fi
@@ -20,10 +23,10 @@ for mkfile in `find . -maxdepth 3 -name Makefile`; do
 
 	pushd $dir > /dev/null
 	echo ""
-	echo "Building $dir"
+	echo "Fromatting $dir"
 	make format || (echo "${bold} ⤤ Failure formatting $dir${normal}" ; opt_rebuild $dir; exit 1)
 	popd > /dev/null
 done
 
 echo ""
-echo "${bold}All Built.${normal}"
+echo "${bold}All formatted.${normal}"

--- a/userland/libtock/adc.c
+++ b/userland/libtock/adc.c
@@ -52,29 +52,29 @@ static void adc_cb(int callback_type,
 
   switch (callback_type) {
     case SingleSample:
-      result->error = SUCCESS;
+      result->error   = SUCCESS;
       result->channel = arg1;
-      result->sample = arg2;
+      result->sample  = arg2;
       break;
 
     case ContinuousSample:
-      result->error = SUCCESS;
+      result->error   = SUCCESS;
       result->channel = arg1;
-      result->sample = arg2;
+      result->sample  = arg2;
       break;
 
     case SingleBuffer:
-      result->error = SUCCESS;
+      result->error   = SUCCESS;
       result->channel = (arg1 & 0xFF);
-      result->length = ((arg1 >> 8) & 0xFFFFFF);
-      result->buffer = (uint16_t*)arg2;
+      result->length  = ((arg1 >> 8) & 0xFFFFFF);
+      result->buffer  = (uint16_t*)arg2;
       break;
 
     case ContinuousBuffer:
-      result->error = SUCCESS;
+      result->error   = SUCCESS;
       result->channel = (arg1 & 0xFF);
-      result->length = ((arg1 >> 8) & 0xFFFFFF);
-      result->buffer = (uint16_t*)arg2;
+      result->length  = ((arg1 >> 8) & 0xFFFFFF);
+      result->buffer  = (uint16_t*)arg2;
       break;
 
     default:
@@ -87,10 +87,10 @@ static void adc_cb(int callback_type,
 
 // function pointers used for wrapping adc callbacks with the `adc_routing_cb`
 // below
-static void(*single_sample_callback)(uint8_t, uint16_t, void*) = NULL;
-static void(*continuous_sample_callback)(uint8_t, uint16_t, void*) = NULL;
-static void(*buffered_sample_callback)(uint8_t, uint32_t, uint16_t*, void*) = NULL;
-static void(*continuous_buffered_sample_callback)(uint8_t, uint32_t, uint16_t*, void*) = NULL;
+static void (*single_sample_callback)(uint8_t, uint16_t, void*) = NULL;
+static void (*continuous_sample_callback)(uint8_t, uint16_t, void*) = NULL;
+static void (*buffered_sample_callback)(uint8_t, uint32_t, uint16_t*, void*) = NULL;
+static void (*continuous_buffered_sample_callback)(uint8_t, uint32_t, uint16_t*, void*) = NULL;
 
 // Internal callback for routing to operation-specific callbacks
 //
@@ -111,9 +111,9 @@ static void(*continuous_buffered_sample_callback)(uint8_t, uint32_t, uint16_t*, 
 //             number of samples collected in upper 24 bits
 //      arg2 - pointer to buffer filled with samples
 static void adc_routing_cb(int callback_type,
-                   int arg1,
-                   int arg2,
-                   void* callback_args) {
+                           int arg1,
+                           int arg2,
+                           void* callback_args) {
 
   switch (callback_type) {
     case SingleSample:
@@ -134,8 +134,8 @@ static void adc_routing_cb(int callback_type,
 
     case SingleBuffer:
       if (buffered_sample_callback) {
-        uint8_t channel = (uint8_t)(arg1 & 0xFF);
-        uint32_t length = ((arg1 >> 8) & 0xFFFFFF);
+        uint8_t channel  = (uint8_t)(arg1 & 0xFF);
+        uint32_t length  = ((arg1 >> 8) & 0xFFFFFF);
         uint16_t* buffer = (uint16_t*)arg2;
         buffered_sample_callback(channel, length, buffer, callback_args);
       }
@@ -143,8 +143,8 @@ static void adc_routing_cb(int callback_type,
 
     case ContinuousBuffer:
       if (continuous_buffered_sample_callback) {
-        uint8_t channel = (uint8_t)(arg1 & 0xFF);
-        uint32_t length = ((arg1 >> 8) & 0xFFFFFF);
+        uint8_t channel  = (uint8_t)(arg1 & 0xFF);
+        uint32_t length  = ((arg1 >> 8) & 0xFFFFFF);
         uint16_t* buffer = (uint16_t*)arg2;
         continuous_buffered_sample_callback(channel, length, buffer, callback_args);
       }
@@ -161,16 +161,16 @@ int adc_set_callback(subscribe_cb callback, void* callback_args) {
 
 int adc_set_buffer(uint16_t* buffer, uint32_t len) {
   // we "allow" byte arrays, so this is actually twice as long
-  return allow(DRIVER_NUM_ADC, 0, (void*)buffer, len*2);
+  return allow(DRIVER_NUM_ADC, 0, (void*)buffer, len * 2);
 }
 
 int adc_set_double_buffer(uint16_t* buffer, uint32_t len) {
   // we "allow" byte arrays, so this is actually twice as long
-  return allow(DRIVER_NUM_ADC, 1, (void*)buffer, len*2);
+  return allow(DRIVER_NUM_ADC, 1, (void*)buffer, len * 2);
 }
 
 bool adc_is_present(void) {
-  return (command(DRIVER_NUM_ADC, 0, 0) >= 0);
+  return command(DRIVER_NUM_ADC, 0, 0) >= 0;
 }
 
 int adc_channel_count(void) {
@@ -203,25 +203,25 @@ int adc_stop_sampling(void) {
 
 // ***** Callback Wrappers *****
 
-int adc_set_single_sample_callback(void(*callback)(uint8_t, uint16_t, void*),
+int adc_set_single_sample_callback(void (*callback)(uint8_t, uint16_t, void*),
                                    void* callback_args) {
   single_sample_callback = callback;
   return adc_set_callback(adc_routing_cb, callback_args);
 }
 
-int adc_set_continuous_sample_callback(void(*callback)(uint8_t, uint16_t, void*),
+int adc_set_continuous_sample_callback(void (*callback)(uint8_t, uint16_t, void*),
                                        void* callback_args) {
   continuous_sample_callback = callback;
   return adc_set_callback(adc_routing_cb, callback_args);
 }
 
-int adc_set_buffered_sample_callback(void(*callback)(uint8_t, uint32_t, uint16_t*, void*),
+int adc_set_buffered_sample_callback(void (*callback)(uint8_t, uint32_t, uint16_t*, void*),
                                      void* callback_args) {
   buffered_sample_callback = callback;
   return adc_set_callback(adc_routing_cb, callback_args);
 }
 
-int adc_set_continuous_buffered_sample_callback(void(*callback)(uint8_t, uint32_t, uint16_t*, void*),
+int adc_set_continuous_buffered_sample_callback(void (*callback)(uint8_t, uint32_t, uint16_t*, void*),
                                                 void* callback_args){
   continuous_buffered_sample_callback = callback;
   return adc_set_callback(adc_routing_cb, callback_args);

--- a/userland/libtock/aes.c
+++ b/userland/libtock/aes.c
@@ -17,9 +17,9 @@ typedef struct {
 // callback_args - user data passed into the set_callback function
 //
 static void aes_cb(int callback_type,
-    __attribute__ ((unused)) int unused1,
-    __attribute__ ((unused)) int unused2,
-    void *callback_args) {
+                   __attribute__ ((unused)) int unused1,
+                   __attribute__ ((unused)) int unused2,
+                   void *callback_args) {
 
   aes_data_t *result = (aes_data_t*)callback_args;
   result->fired = true;
@@ -56,11 +56,11 @@ int aes128_decrypt_start(void) {
   return command(AES_DRIVER, AES_DEC, 0);
 }
 
-// Function to encrypt by aes128 counter-mode with a given payload and 
+// Function to encrypt by aes128 counter-mode with a given payload and
 // initial counter asynchronously
-int aes128_encrypt_ctr(unsigned const char* buf, unsigned char buf_len, 
-    unsigned const char* ctr, unsigned char ctr_len, subscribe_cb callback) {
-  
+int aes128_encrypt_ctr(unsigned const char* buf, unsigned char buf_len,
+                       unsigned const char* ctr, unsigned char ctr_len, subscribe_cb callback) {
+
   int err;
 
   err = aes128_set_callback(callback, NULL);
@@ -69,17 +69,17 @@ int aes128_encrypt_ctr(unsigned const char* buf, unsigned char buf_len,
   err = aes128_set_data(buf, buf_len);
   if (err < SUCCESS) return err;
 
-  err = aes128_set_ctr(ctr, ctr_len); 
+  err = aes128_set_ctr(ctr, ctr_len);
   if (err < SUCCESS) return err;
 
   return aes128_encrypt_start();
 }
 
-// Function to decrypt by aes128 counter-mode with a given payload and 
+// Function to decrypt by aes128 counter-mode with a given payload and
 // initial counter asynchronously
-int aes128_decrypt_ctr(const unsigned char* buf, unsigned char buf_len, 
-    const unsigned char* ctr, unsigned char ctr_len, subscribe_cb callback) {
-  
+int aes128_decrypt_ctr(const unsigned char* buf, unsigned char buf_len,
+                       const unsigned char* ctr, unsigned char ctr_len, subscribe_cb callback) {
+
   int err;
 
   err = aes128_set_callback(callback, NULL);
@@ -88,7 +88,7 @@ int aes128_decrypt_ctr(const unsigned char* buf, unsigned char buf_len,
   err = aes128_set_data(buf, buf_len);
   if (err < SUCCESS) return err;
 
-  err = aes128_set_ctr(ctr, ctr_len); 
+  err = aes128_set_ctr(ctr, ctr_len);
   if (err < SUCCESS) return err;
 
   return aes128_decrypt_start();
@@ -101,7 +101,7 @@ int aes128_decrypt_ctr(const unsigned char* buf, unsigned char buf_len,
 // kernel. No need to for a callback for this since it is synchronous in
 // the kernel as well.
 int aes128_set_key_sync(const unsigned char* key, unsigned char len) {
-  
+
   int err;
 
   err = allow(AES_DRIVER, AES_KEY, (void*)key, len);
@@ -111,11 +111,11 @@ int aes128_set_key_sync(const unsigned char* key, unsigned char len) {
 }
 
 
-// Function to encrypt by aes128 counter-mode with a given payload and 
+// Function to encrypt by aes128 counter-mode with a given payload and
 // initial counter synchronously
-int aes128_encrypt_ctr_sync(unsigned const char* buf, unsigned char buf_len, 
-    unsigned const char* ctr, unsigned char ctr_len) {
-  
+int aes128_encrypt_ctr_sync(unsigned const char* buf, unsigned char buf_len,
+                            unsigned const char* ctr, unsigned char ctr_len) {
+
   int err;
   aes_data_t result = { .fired = false, .error = SUCCESS };
 
@@ -125,7 +125,7 @@ int aes128_encrypt_ctr_sync(unsigned const char* buf, unsigned char buf_len,
   err = aes128_set_data(buf, buf_len);
   if (err < SUCCESS) return err;
 
-  err = aes128_set_ctr(ctr, ctr_len); 
+  err = aes128_set_ctr(ctr, ctr_len);
   if (err < SUCCESS) return err;
 
   err = aes128_encrypt_start();
@@ -137,11 +137,11 @@ int aes128_encrypt_ctr_sync(unsigned const char* buf, unsigned char buf_len,
 }
 
 
-// Function to decrypt by aes128 counter-mode with a given payload and 
+// Function to decrypt by aes128 counter-mode with a given payload and
 // initial counter synchronously
-int aes128_decrypt_ctr_sync(const unsigned char* buf, unsigned char buf_len, 
-    const unsigned char* ctr, unsigned char ctr_len) {
-  
+int aes128_decrypt_ctr_sync(const unsigned char* buf, unsigned char buf_len,
+                            const unsigned char* ctr, unsigned char ctr_len) {
+
   int err;
   aes_data_t result = { .fired = false, .error = SUCCESS };
 
@@ -151,13 +151,13 @@ int aes128_decrypt_ctr_sync(const unsigned char* buf, unsigned char buf_len,
   err = aes128_set_data(buf, buf_len);
   if (err < SUCCESS) return err;
 
-  err = aes128_set_ctr(ctr, ctr_len); 
+  err = aes128_set_ctr(ctr, ctr_len);
   if (err < SUCCESS) return err;
 
   err = aes128_decrypt_start();
   if (err < SUCCESS) return err;
 
   yield_for(&result.fired);
-  
+
   return result.error;
 }

--- a/userland/libtock/aes.h
+++ b/userland/libtock/aes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/ble.h
+++ b/userland/libtock/ble.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #define DRIVER_RADIO      33
 

--- a/userland/libtock/button.c
+++ b/userland/libtock/button.c
@@ -5,15 +5,15 @@ int button_subscribe(subscribe_cb callback, void *ud) {
 }
 
 int button_count(void) {
-  return command(DRIVER_NUM_BUTTON, 0, 0);  
+  return command(DRIVER_NUM_BUTTON, 0, 0);
 }
 
 int button_enable_interrupt(int pin_num) {
-  return command(DRIVER_NUM_BUTTON, 1, pin_num);  
+  return command(DRIVER_NUM_BUTTON, 1, pin_num);
 }
 
 int button_disable_interrupt(int pin_num) {
-  return command(DRIVER_NUM_BUTTON, 2, pin_num);  
+  return command(DRIVER_NUM_BUTTON, 2, pin_num);
 }
 
 int button_read(int pin_num) {

--- a/userland/libtock/button.h
+++ b/userland/libtock/button.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/console.c
+++ b/userland/libtock/console.c
@@ -14,14 +14,13 @@ typedef struct putstr_data {
 static putstr_data_t *putstr_head = NULL;
 static putstr_data_t *putstr_tail = NULL;
 
-static void putstr_cb(
-                int _x __attribute__ ((unused)),
-                int _y __attribute__ ((unused)),
-                int _z __attribute__ ((unused)),
-                void* ud __attribute__ ((unused))) {
+static void putstr_cb(int _x __attribute__ ((unused)),
+                      int _y __attribute__ ((unused)),
+                      int _z __attribute__ ((unused)),
+                      void* ud __attribute__ ((unused))) {
   putstr_data_t* data = putstr_head;
   data->called = true;
-  putstr_head = data->next;
+  putstr_head  = data->next;
 
   if (putstr_head == NULL) {
     putstr_tail = NULL;
@@ -41,9 +40,9 @@ int putnstr(const char *str, size_t len) {
   putstr_data_t* data = (putstr_data_t*)malloc(sizeof(putstr_data_t));
   if (data == NULL) return ENOMEM;
 
-  data->len = len;
+  data->len    = len;
   data->called = false;
-  data->buf = (char*)malloc(len * sizeof(char));
+  data->buf    = (char*)malloc(len * sizeof(char));
   if (data->buf == NULL) {
     ret = ENOMEM;
     goto putnstr_fail_buf_alloc;
@@ -59,7 +58,7 @@ int putnstr(const char *str, size_t len) {
     putstr_tail = data;
   } else {
     putstr_tail->next = data;
-    putstr_tail = data;
+    putstr_tail       = data;
   }
 
   yield_for(&data->called);

--- a/userland/libtock/crc.c
+++ b/userland/libtock/crc.c
@@ -30,7 +30,7 @@ static void callback(int status, int v1, __attribute__((unused)) int v2, void *d
 {
   struct data *d = data;
 
-  d->fired = true;
+  d->fired  = true;
   d->status = status;
   d->result = v1;
 }

--- a/userland/libtock/crc.h
+++ b/userland/libtock/crc.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/crt1.c
+++ b/userland/libtock/crt1.c
@@ -15,11 +15,10 @@ extern int main(void);
 __attribute__ ((section(".start"), used))
 __attribute__ ((weak))
 __attribute__ ((noreturn))
-void _start(
-    void* mem_start __attribute__((unused)),
-    void* app_heap_break __attribute__((unused)),
-    void* kernel_memory_break __attribute__((unused))) {
+void _start(void* mem_start __attribute__((unused)),
+            void* app_heap_break __attribute__((unused)),
+            void* kernel_memory_break __attribute__((unused))) {
   main();
-  while(1) { yield(); }
+  while (1) { yield(); }
 }
 

--- a/userland/libtock/gpio.c
+++ b/userland/libtock/gpio.c
@@ -26,7 +26,7 @@ int gpio_read(GPIO_Pin_t pin) {
 }
 
 int gpio_enable_interrupt(GPIO_Pin_t pin, GPIO_InputMode_t pin_config,
-    GPIO_InterruptMode_t irq_config) {
+                          GPIO_InterruptMode_t irq_config) {
   uint32_t data = ((irq_config & 0xFF) << 16) | ((pin_config & 0xFF) << 8) | (pin & 0xFF);
   return command(GPIO_DRIVER_NUM, 7, data);
 }

--- a/userland/libtock/gpio.h
+++ b/userland/libtock/gpio.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/gpio_async.c
+++ b/userland/libtock/gpio_async.c
@@ -1,8 +1,8 @@
-#include "tock.h"
 #include "gpio_async.h"
+#include "tock.h"
 
-#define CONCAT_PORT_PIN(port, pin) (((pin & 0xFF)<<8) | (port & 0xFF))
-#define CONCAT_PORT_PIN_DATA(port, pin, data) (((data & 0xFFFF)<<16) | ((pin & 0xFF)<<8) | (port & 0xFF))
+#define CONCAT_PORT_PIN(port, pin) (((pin & 0xFF) << 8) | (port & 0xFF))
+#define CONCAT_PORT_PIN_DATA(port, pin, data) (((data & 0xFFFF) << 16) | ((pin & 0xFF) << 8) | (port & 0xFF))
 
 
 struct gpio_async_data {
@@ -20,8 +20,8 @@ static void gpio_async_cb(__attribute__ ((unused)) int callback_type,
                           void* ud) {
   struct gpio_async_data* myresult = (struct gpio_async_data*) ud;
   myresult->callback_type = callback_type;
-  myresult->value = value;
-  myresult->fired = true;
+  myresult->value         = value;
+  myresult->fired         = true;
 }
 
 
@@ -71,7 +71,6 @@ int gpio_async_interrupt_callback(subscribe_cb callback, void* callback_args) {
 
 
 
-
 int gpio_async_make_output_sync(uint32_t port, uint8_t pin) {
   int err;
   result.fired = false;
@@ -91,7 +90,6 @@ int gpio_async_make_output_sync(uint32_t port, uint8_t pin) {
 int gpio_async_set_sync(uint32_t port, uint8_t pin) {
   int err;
   result.fired = false;
-
 
   err = gpio_async_set_callback(gpio_async_cb, (void*) &result);
   if (err < 0) return err;

--- a/userland/libtock/gpio_async.h
+++ b/userland/libtock/gpio_async.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "tock.h"
 #include "gpio.h"
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/i2c_master_slave.c
+++ b/userland/libtock/i2c_master_slave.c
@@ -1,5 +1,5 @@
-#include "tock.h"
 #include "i2c_master_slave.h"
+#include "tock.h"
 
 struct i2c_master_slave_data {
   bool fired;
@@ -16,8 +16,8 @@ static void i2c_master_slave_cb(int callback_type,
                                 void* ud) {
   struct i2c_master_slave_data* data = (struct i2c_master_slave_data*) ud;
   data->callback_type = callback_type;
-  data->length = length;
-  data->fired = true;
+  data->length        = length;
+  data->fired         = true;
 }
 
 

--- a/userland/libtock/ipc.h
+++ b/userland/libtock/ipc.h
@@ -2,7 +2,8 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <tock.h>
+
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/isl29035.c
+++ b/userland/libtock/isl29035.c
@@ -7,11 +7,11 @@ struct isl_data {
 
 // internal callback for faking synchronous reads
 static void isl29035_cb(int intensity,
-                           __attribute__ ((unused)) int unused1,
-                           __attribute__ ((unused)) int unused2, void* ud) {
+                        __attribute__ ((unused)) int unused1,
+                        __attribute__ ((unused)) int unused2, void* ud) {
   struct isl_data* result = (struct isl_data*)ud;
   result->intensity = intensity;
-  result->fired = true;
+  result->fired     = true;
 }
 
 int isl29035_read_light_intensity(void) {

--- a/userland/libtock/isl29035.h
+++ b/userland/libtock/isl29035.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/led.c
+++ b/userland/libtock/led.c
@@ -1,18 +1,18 @@
-#include "tock.h"
 #include "led.h"
+#include "tock.h"
 
 int led_on(int led_num) {
-	return command(DRIVER_NUM_LEDS, 1, led_num);
+  return command(DRIVER_NUM_LEDS, 1, led_num);
 }
 
 int led_off(int led_num) {
-	return command(DRIVER_NUM_LEDS, 2, led_num);
+  return command(DRIVER_NUM_LEDS, 2, led_num);
 }
 
 int led_toggle(int led_num) {
-	return command(DRIVER_NUM_LEDS, 3, led_num);
+  return command(DRIVER_NUM_LEDS, 3, led_num);
 }
 
 int led_count(void) {
-	return command(DRIVER_NUM_LEDS, 0, 0);
+  return command(DRIVER_NUM_LEDS, 0, 0);
 }

--- a/userland/libtock/lps25hb.c
+++ b/userland/libtock/lps25hb.c
@@ -1,5 +1,5 @@
-#include "tock.h"
 #include "lps25hb.h"
+#include "tock.h"
 
 struct lps25hb_data {
   bool fired;
@@ -19,25 +19,25 @@ static void lps25hb_cb(int value,
 }
 
 int lps25hb_set_callback (subscribe_cb callback, void* callback_args) {
-    return subscribe(DRIVER_NUM_LPS25HB, 0, callback, callback_args);
+  return subscribe(DRIVER_NUM_LPS25HB, 0, callback, callback_args);
 }
 
 int lps25hb_get_pressure (void) {
-    return command(DRIVER_NUM_LPS25HB, 1, 0);
+  return command(DRIVER_NUM_LPS25HB, 1, 0);
 }
 
 int lps25hb_get_pressure_sync (void) {
-    int err;
-    result.fired = false;
+  int err;
+  result.fired = false;
 
-    err = lps25hb_set_callback(lps25hb_cb, (void*) &result);
-    if (err < 0) return err;
+  err = lps25hb_set_callback(lps25hb_cb, (void*) &result);
+  if (err < 0) return err;
 
-    err = lps25hb_get_pressure();
-    if (err < 0) return err;
+  err = lps25hb_get_pressure();
+  if (err < 0) return err;
 
-    // Wait for the callback.
-    yield_for(&result.fired);
+  // Wait for the callback.
+  yield_for(&result.fired);
 
-    return result.value;
+  return result.value;
 }

--- a/userland/libtock/ltc294x.c
+++ b/userland/libtock/ltc294x.c
@@ -1,5 +1,5 @@
-#include "tock.h"
 #include "ltc294x.h"
+#include "tock.h"
 
 
 struct ltc294x_data {
@@ -16,7 +16,7 @@ static void ltc294x_cb(__attribute__ ((unused)) int callback_type,
                        void* ud) {
   struct ltc294x_data* data = (struct ltc294x_data*) ud;
   data->charge = value;
-  data->fired = true;
+  data->fired  = true;
 }
 
 int ltc294x_set_callback (subscribe_cb callback, void* callback_args) {
@@ -34,14 +34,14 @@ int ltc294x_configure(ltc294x_model_e model,
   uint8_t M = 0;
   if (model == LTC2941 || model == LTC2942) {
     // ltc2941/2 expects log_2 of prescaler value
-    for(int i = 0; i < 8; i++) {
-      if ((1<<i) & prescaler) {
+    for (int i = 0; i < 8; i++) {
+      if ((1 << i) & prescaler) {
         M = i;
       }
     }
   } else if (model == LTC2943) {
     // See Table 3 in the datasheet.
-    switch(prescaler) {
+    switch (prescaler) {
       case 1:    M = 0; break;
       case 4:    M = 1; break;
       case 16:   M = 2; break;
@@ -239,16 +239,16 @@ int ltc294x_shutdown_sync(void) {
 
 int ltc294x_convert_to_coulomb_uah(int c, int Rsense, uint16_t prescaler, ltc294x_model_e model) {
   if (model == LTC2941 || model == LTC2942) {
-    return (int)(c*0.085*(50.0/Rsense)*(prescaler/128.0));
+    return (int)(c * 0.085 * (50.0 / Rsense) * (prescaler / 128.0));
   } else {
-    return (int)(c*0.340*(50.0/Rsense)*(prescaler/4096.0));
+    return (int)(c * 0.340 * (50.0 / Rsense) * (prescaler / 4096.0));
   }
 }
 
 int ltc294x_convert_to_voltage_mv (int v) {
-  return 23.6*(v/(float)0xFFFF)*1000;
+  return 23.6 * (v / (float)0xFFFF) * 1000;
 }
 
 int ltc294x_convert_to_current_ua (int c, int Rsense) {
-  return (int)((60.0/Rsense)*((c-0x7FFF)/(float)0x7FFF)*1000000.0);
+  return (int)((60.0 / Rsense) * ((c - 0x7FFF) / (float)0x7FFF) * 1000000.0);
 }

--- a/userland/libtock/ltc294x.h
+++ b/userland/libtock/ltc294x.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <stdint.h>
+
+#include "tock.h"
+
 #define DRIVER_NUM_LTC294X 18
 
 #ifdef __cplusplus

--- a/userland/libtock/ninedof.c
+++ b/userland/libtock/ninedof.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 
-#include "ninedof.h"
 #include "math.h"
+#include "ninedof.h"
 
 struct ninedof_data {
   int x;
@@ -15,9 +15,9 @@ static struct ninedof_data res = { .fired = false };
 // internal callback for faking synchronous reads
 static void ninedof_cb(int x, int y, int z, void* ud) {
   struct ninedof_data* result = (struct ninedof_data*) ud;
-  result->x = x;
-  result->y = y;
-  result->z = z;
+  result->x     = x;
+  result->y     = y;
+  result->z     = z;
   result->fired = true;
 }
 
@@ -53,41 +53,41 @@ int ninedof_start_magnetometer_reading(void) {
 }
 
 int ninedof_read_acceleration_sync(int* x, int* y, int* z) {
-    int err;
-    res.fired = false;
+  int err;
+  res.fired = false;
 
-    err = ninedof_subscribe(ninedof_cb, (void*) &res);
-    if (err < 0) return err;
+  err = ninedof_subscribe(ninedof_cb, (void*) &res);
+  if (err < 0) return err;
 
-    err = ninedof_start_accel_reading();
-    if (err < 0) return err;
+  err = ninedof_start_accel_reading();
+  if (err < 0) return err;
 
-    // Wait for the callback.
-    yield_for(&res.fired);
+  // Wait for the callback.
+  yield_for(&res.fired);
 
-    *x = res.x;
-    *y = res.y;
-    *z = res.z;
+  *x = res.x;
+  *y = res.y;
+  *z = res.z;
 
-    return 0;
+  return 0;
 }
 
 int ninedof_read_magenetometer_sync(int* x, int* y, int* z) {
-    int err;
-    res.fired = false;
+  int err;
+  res.fired = false;
 
-    err = ninedof_subscribe(ninedof_cb, (void*) &res);
-    if (err < 0) return err;
+  err = ninedof_subscribe(ninedof_cb, (void*) &res);
+  if (err < 0) return err;
 
-    err = ninedof_start_magnetometer_reading();
-    if (err < 0) return err;
+  err = ninedof_start_magnetometer_reading();
+  if (err < 0) return err;
 
-    // Wait for the callback.
-    yield_for(&res.fired);
+  // Wait for the callback.
+  yield_for(&res.fired);
 
-    *x = res.x;
-    *y = res.y;
-    *z = res.z;
+  *x = res.x;
+  *y = res.y;
+  *z = res.z;
 
-    return 0;
+  return 0;
 }

--- a/userland/libtock/ninedof.h
+++ b/userland/libtock/ninedof.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/radio.c
+++ b/userland/libtock/radio.c
@@ -1,5 +1,5 @@
-#include "radio.h"
 #include "gpio.h"
+#include "radio.h"
 /*
  * Userland library for sending and receiving 802.15.4 packets.
  *
@@ -13,16 +13,16 @@ const int SYS_RADIO = 154;
 const int BUF_RX = 0;
 const int BUF_TX = 1;
 
-const int COM_ADDR = 1;
-const int COM_PAN = 2;
-const int COM_CHAN = 3;
-const int COM_POWER = 4;
-const int COM_TX = 5;
-const int COM_READY = 6;
+const int COM_ADDR   = 1;
+const int COM_PAN    = 2;
+const int COM_CHAN   = 3;
+const int COM_POWER  = 4;
+const int COM_TX     = 5;
+const int COM_READY  = 6;
 const int COM_COMMIT = 7;
 
-const int EVT_TX = 0;
-const int EVT_RX = 1;
+const int EVT_TX  = 0;
+const int EVT_RX  = 1;
 const int EVT_CFG = 2;
 
 int radio_init(void) {
@@ -32,25 +32,25 @@ int radio_init(void) {
 
 int tx_acked = 0;
 
-static void cb_tx( __attribute__ ((unused)) int len,
-                int acked,
-                __attribute__ ((unused)) int unused2,
-                void* ud) {
-  tx_acked = acked;
+static void cb_tx(__attribute__ ((unused)) int len,
+                  int acked,
+                  __attribute__ ((unused)) int unused2,
+                  void* ud) {
+  tx_acked     = acked;
   *((bool*)ud) = true;
 }
 
-static void cb_rx( __attribute__ ((unused)) int unused0,
-                __attribute__ ((unused)) int unused1,
-                __attribute__ ((unused)) int unused2,
-                void* ud) {
+static void cb_rx(__attribute__ ((unused)) int unused0,
+                  __attribute__ ((unused)) int unused1,
+                  __attribute__ ((unused)) int unused2,
+                  void* ud) {
   *((bool*)ud) = true;
 }
 
-static void cb_config( __attribute__ ((unused)) int unused0,
-                       __attribute__ ((unused)) int unused1,
-                       __attribute__ ((unused)) int unused2,
-                       void* ud) {
+static void cb_config(__attribute__ ((unused)) int unused0,
+                      __attribute__ ((unused)) int unused1,
+                      __attribute__ ((unused)) int unused2,
+                      void* ud) {
   *((bool*)ud) = true;
 }
 
@@ -58,7 +58,7 @@ static void cb_config( __attribute__ ((unused)) int unused0,
 // be copied into a packet buffer with header space within the kernel.
 int radio_send(unsigned short addr, const char* packet, unsigned char len) {
   bool cond = false;
-  int err = allow(SYS_RADIO, BUF_TX, (void*)packet, len);
+  int err   = allow(SYS_RADIO, BUF_TX, (void*)packet, len);
   if (err < 0) {
     return err;
   }
@@ -70,7 +70,7 @@ int radio_send(unsigned short addr, const char* packet, unsigned char len) {
   // the 32-bit argument.
   unsigned int param = addr;
   param |= (len << 16);
-  err = command(SYS_RADIO, COM_TX, param);
+  err    = command(SYS_RADIO, COM_TX, param);
   if (err != 0) {
     return err;
   } else {
@@ -100,7 +100,7 @@ int radio_set_power(char power) {
 
 int radio_commit(void) {
   bool cond = false;
-  int err = subscribe(SYS_RADIO, EVT_CFG, cb_config, &cond);
+  int err   = subscribe(SYS_RADIO, EVT_CFG, cb_config, &cond);
   if (err != SUCCESS) {
     return err;
   }
@@ -119,7 +119,7 @@ int radio_set_channel(unsigned char channel) {
 
 int radio_receive(const char* packet, unsigned char len) {
   bool cond = false;
-  int err = allow(SYS_RADIO, BUF_RX, (void*)packet, len);
+  int err   = allow(SYS_RADIO, BUF_RX, (void*)packet, len);
   if (err < 0) {
     return err;
   }

--- a/userland/libtock/radio.h
+++ b/userland/libtock/radio.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/rng.c
+++ b/userland/libtock/rng.c
@@ -1,5 +1,5 @@
-#include <tock.h>
 #include <rng.h>
+#include <tock.h>
 
 struct rng_data {
   bool fired;
@@ -14,7 +14,7 @@ static void rng_cb(__attribute__ ((unused)) int callback_type,
                    __attribute__ ((unused)) int val2,
                    void* ud) {
   struct rng_data* data = (struct rng_data*) ud;
-  data->fired = true;
+  data->fired    = true;
   data->received = received;
 }
 

--- a/userland/libtock/sdcard.c
+++ b/userland/libtock/sdcard.c
@@ -1,7 +1,7 @@
 // SD card interface
 
-#include "tock.h"
 #include "sdcard.h"
+#include "tock.h"
 
 // used for creating synchronous versions of functions
 //
@@ -47,7 +47,7 @@ static void sdcard_cb (int callback_type, int arg1, int arg2, void* callback_arg
       // init_done
       result->block_size = arg1;
       result->size_in_kB = arg2;
-      result->error = SUCCESS;
+      result->error      = SUCCESS;
       break;
 
     case 2:

--- a/userland/libtock/si7021.c
+++ b/userland/libtock/si7021.c
@@ -1,5 +1,5 @@
-#include "tock.h"
 #include "si7021.h"
+#include "tock.h"
 
 struct data {
   bool fired;
@@ -15,34 +15,34 @@ static void cb(int temp,
                __attribute__ ((unused)) int unused,
                void* ud) {
   struct data* data = (struct data*) ud;
-  data->temp = temp;
-  data->humi = humidity;
+  data->temp  = temp;
+  data->humi  = humidity;
   data->fired = true;
 }
 
 int si7021_set_callback (subscribe_cb callback, void* callback_args) {
-    return subscribe(DRIVER_NUM_SI7021, 0, callback, callback_args);
+  return subscribe(DRIVER_NUM_SI7021, 0, callback, callback_args);
 }
 
 int si7021_get_temperature_humidity (void) {
-    return command(DRIVER_NUM_SI7021, 1, 0);
+  return command(DRIVER_NUM_SI7021, 1, 0);
 }
 
 int si7021_get_temperature_humidity_sync (int* temperature, unsigned* humidity) {
-    int err;
-    result.fired = false;
+  int err;
+  result.fired = false;
 
-    err = si7021_set_callback(cb, (void*) &result);
-    if (err < 0) return err;
+  err = si7021_set_callback(cb, (void*) &result);
+  if (err < 0) return err;
 
-    err = si7021_get_temperature_humidity();
-    if (err < 0) return err;
+  err = si7021_get_temperature_humidity();
+  if (err < 0) return err;
 
-    // Wait for the callback.
-    yield_for(&result.fired);
+  // Wait for the callback.
+  yield_for(&result.fired);
 
-    *temperature = result.temp;
-    *humidity = result.humi;
+  *temperature = result.temp;
+  *humidity    = result.humi;
 
-    return 0;
+  return 0;
 }

--- a/userland/libtock/spi.c
+++ b/userland/libtock/spi.c
@@ -1,17 +1,39 @@
 #include "spi.h"
 
-__attribute__((const)) int spi_init(void) {return 0;}
-int spi_set_chip_select(unsigned char cs) {return command(4, 3, cs);}
-int spi_get_chip_select(void)             {return command(4, 4, 0);}
-int spi_set_rate(int rate)                {return command(4, 5, rate);}
-int spi_get_rate(void)                    {return command(4, 6, 0);}
-int spi_set_phase(bool phase)             {return command(4, 7, (unsigned char)phase);}
-int spi_get_phase(void)                   {return command(4, 8, 0);}
-int spi_set_polarity(bool pol)            {return command(4, 9, (unsigned char)pol);}
-int spi_get_polarity(void)                {return command(4, 10, 0);}
-int spi_hold_low(void)                    {return command(4, 11, 0);}
-int spi_release_low(void)                 {return command(4, 12, 0);}
-
+__attribute__((const))
+int spi_init(void) {
+  return 0;
+}
+int spi_set_chip_select(unsigned char cs) {
+  return command(4, 3, cs);
+}
+int spi_get_chip_select(void) {
+  return command(4, 4, 0);
+}
+int spi_set_rate(int rate) {
+  return command(4, 5, rate);
+}
+int spi_get_rate(void) {
+  return command(4, 6, 0);
+}
+int spi_set_phase(bool phase) {
+  return command(4, 7, (unsigned char)phase);
+}
+int spi_get_phase(void) {
+  return command(4, 8, 0);
+}
+int spi_set_polarity(bool pol) {
+  return command(4, 9, (unsigned char)pol);
+}
+int spi_get_polarity(void) {
+  return command(4, 10, 0);
+}
+int spi_hold_low(void) {
+  return command(4, 11, 0);
+}
+int spi_release_low(void) {
+  return command(4, 12, 0);
+}
 int spi_write_byte(unsigned char byte) {
   return command(4, 1, byte);
 }
@@ -25,10 +47,10 @@ int spi_read_buf(const char* str, size_t len) {
   return allow(4, 0, buf, len);
 }
 
-static void spi_cb( __attribute__ ((unused)) int unused0,
-                    __attribute__ ((unused)) int unused1,
-                    __attribute__ ((unused)) int unused2,
-                    __attribute__ ((unused)) void* ud) {
+static void spi_cb(__attribute__ ((unused)) int unused0,
+                   __attribute__ ((unused)) int unused1,
+                   __attribute__ ((unused)) int unused2,
+                   __attribute__ ((unused)) void* ud) {
   *((bool*)ud) = true;
 }
 
@@ -54,7 +76,7 @@ int spi_write(const char* str,
 
 int spi_read_write(const char* write,
                    char* read,
-                   size_t  len,
+                   size_t len,
                    subscribe_cb cb, bool* cond) {
 
   int err = allow(4, 0, (void*)read, len);
@@ -65,7 +87,7 @@ int spi_read_write(const char* write,
 }
 
 int spi_write_sync(const char* write,
-                   size_t  len) {
+                   size_t len) {
   bool cond = false;
   spi_write(write, len, spi_cb, &cond);
   yield_for(&cond);
@@ -74,9 +96,9 @@ int spi_write_sync(const char* write,
 
 int spi_read_write_sync(const char* write,
                         char* read,
-                        size_t  len) {
+                        size_t len) {
   bool cond = false;
-  int err = spi_read_write(write, read, len, spi_cb, &cond);
+  int err   = spi_read_write(write, read, len, spi_cb, &cond);
   if (err < 0) {
     return err;
   }

--- a/userland/libtock/spi.h
+++ b/userland/libtock/spi.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/spi_slave.c
+++ b/userland/libtock/spi_slave.c
@@ -2,11 +2,21 @@
 
 #define SPI_SLAVE 25
 
-int spi_slave_get_chip_select(void)             {return command(SPI_SLAVE, 2, 0);}
-int spi_slave_set_phase(bool phase)             {return command(SPI_SLAVE, 3, (unsigned char)phase);}
-int spi_slave_get_phase(void)                   {return command(SPI_SLAVE, 4, 0);}
-int spi_slave_set_polarity(bool pol)            {return command(SPI_SLAVE, 5, (unsigned char)pol);}
-int spi_slave_get_polarity(void)                {return command(SPI_SLAVE, 6, 0);}
+int spi_slave_get_chip_select(void) {
+  return command(SPI_SLAVE, 2, 0);
+}
+int spi_slave_set_phase(bool phase) {
+  return command(SPI_SLAVE, 3, (unsigned char)phase);
+}
+int spi_slave_get_phase(void) {
+  return command(SPI_SLAVE, 4, 0);
+}
+int spi_slave_set_polarity(bool pol) {
+  return command(SPI_SLAVE, 5, (unsigned char)pol);
+}
+int spi_slave_get_polarity(void) {
+  return command(SPI_SLAVE, 6, 0);
+}
 
 /* This registers a callback for when the slave is selected. */
 int spi_slave_chip_selected(subscribe_cb cb, bool* cond) {
@@ -22,16 +32,16 @@ int spi_slave_read_buf(const char* str, size_t len) {
   return allow(SPI_SLAVE, 0, buf, len);
 }
 
-static void spi_slave_cb( __attribute__ ((unused)) int unused0,
-                    __attribute__ ((unused)) int unused1,
-                    __attribute__ ((unused)) int unused2,
-                    __attribute__ ((unused)) void* ud) {
+static void spi_slave_cb(__attribute__ ((unused)) int unused0,
+                         __attribute__ ((unused)) int unused1,
+                         __attribute__ ((unused)) int unused2,
+                         __attribute__ ((unused)) void* ud) {
   *((bool*)ud) = true;
 }
 
 int spi_slave_write(const char* str,
-              size_t len,
-              subscribe_cb cb, bool* cond) {
+                    size_t len,
+                    subscribe_cb cb, bool* cond) {
   int err;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
@@ -50,9 +60,9 @@ int spi_slave_write(const char* str,
 }
 
 int spi_slave_read_write(const char* write,
-                   char* read,
-                   size_t  len,
-                   subscribe_cb cb, bool* cond) {
+                         char* read,
+                         size_t len,
+                         subscribe_cb cb, bool* cond) {
 
   int err = allow(SPI_SLAVE, 0, (void*)read, len);
   if (err < 0) {
@@ -62,7 +72,7 @@ int spi_slave_read_write(const char* write,
 }
 
 int spi_slave_write_sync(const char* write,
-                   size_t  len) {
+                         size_t len) {
   bool cond = false;
   spi_slave_write(write, len, spi_slave_cb, &cond);
   yield_for(&cond);
@@ -70,10 +80,10 @@ int spi_slave_write_sync(const char* write,
 }
 
 int spi_slave_read_write_sync(const char* write,
-                        char* read,
-                        size_t  len) {
+                              char* read,
+                              size_t len) {
   bool cond = false;
-  int err = spi_slave_read_write(write, read, len, spi_slave_cb, &cond);
+  int err   = spi_slave_read_write(write, read, len, spi_slave_cb, &cond);
   if (err < 0) {
     return err;
   }

--- a/userland/libtock/spi_slave.h
+++ b/userland/libtock/spi_slave.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/sys.c
+++ b/userland/libtock/sys.c
@@ -18,9 +18,9 @@
 // XXX Also suppress attribute suggestions as these are stubs
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=const"
 
-//------------------------------
+// ------------------------------
 // LIBC SUPPORT STUBS
-//------------------------------
+// ------------------------------
 
 void* __dso_handle = 0;
 
@@ -30,11 +30,10 @@ int _unlink(const char *pathname) {
 
 int _isatty(int fd)
 {
-    if (fd == 0)
-    {
-        return 1;
-    }
-    return 0;
+  if (fd == 0) {
+    return 1;
+  }
+  return 0;
 }
 int _open(const char* path, int flags, ...)
 {
@@ -42,29 +41,29 @@ int _open(const char* path, int flags, ...)
 }
 int _write(int fd, const void *buf, uint32_t count)
 {
-    putnstr((const char*)buf, count);
-    return count;
+  putnstr((const char*)buf, count);
+  return count;
 }
 int _close(int fd)
 {
-    return -1;
+  return -1;
 }
 int _fstat(int fd, struct stat *st)
 {
-    st->st_mode = S_IFCHR;
-    return 0;
+  st->st_mode = S_IFCHR;
+  return 0;
 }
 int _lseek(int fd, uint32_t offset, int whence)
 {
-    return 0;
+  return 0;
 }
 int _read(int fd, void *buf, uint32_t count)
 {
-    return 0; //k_read(fd, (uint8_t*) buf, count);
+  return 0;   // k_read(fd, (uint8_t*) buf, count);
 }
 void _exit(int __status)
 {
-  while(666) {}
+  while (666) {}
 }
 int _getpid(void)
 {

--- a/userland/libtock/timer.h
+++ b/userland/libtock/timer.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "tock.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <tock.h>
 
 /*
  * Sets the callback for timers

--- a/userland/libtock/tmp006.c
+++ b/userland/libtock/tmp006.c
@@ -3,66 +3,65 @@
 static bool readtemp;
 
 // internal callback for faking synchronous reads
-static void tmp006_cb(
-                int temp_value,
-                int error_code,
-                int unused __attribute__ ((unused)),
-                void* callback_args) {
-    readtemp = true;
+static void tmp006_cb(int temp_value,
+                      int error_code,
+                      int unused __attribute__ ((unused)),
+                      void* callback_args) {
+  readtemp = true;
 
-    // return data to user
-    int32_t* callback_vals = (int32_t*)callback_args;
-    callback_vals[0] = temp_value;
-    callback_vals[1] = error_code;
+  // return data to user
+  int32_t* callback_vals = (int32_t*)callback_args;
+  callback_vals[0] = temp_value;
+  callback_vals[1] = error_code;
 }
 
 // enable TMP006, take a single reading, disable TMP006, return value to user
 int tmp006_read_sync(int16_t* temp_reading) {
-    // store temperature value and error code
-    int32_t callback_vals[2] = {0};
+  // store temperature value and error code
+  int32_t callback_vals[2] = {0};
 
-    // request a single sample
-    uint32_t err_code = subscribe(DRIVER_NUM_TMP006, 0, tmp006_cb, callback_vals);
-    if (err_code != ERR_NONE) {
-        return err_code;
-    }
+  // request a single sample
+  uint32_t err_code = subscribe(DRIVER_NUM_TMP006, 0, tmp006_cb, callback_vals);
+  if (err_code != ERR_NONE) {
+    return err_code;
+  }
 
-    // wait for result
-    readtemp = false;
-    yield_for(&readtemp);
+  // wait for result
+  readtemp = false;
+  yield_for(&readtemp);
 
-    // write value for user
-    *temp_reading = (int16_t)callback_vals[0];
+  // write value for user
+  *temp_reading = (int16_t)callback_vals[0];
 
-    // return error code to user
-    return callback_vals[1];
+  // return error code to user
+  return callback_vals[1];
 }
 
 // enable TMP006, take a single reading, disable TMP006, callback with value
 int tmp006_read_async(subscribe_cb callback, void* callback_args) {
 
-    // subscribe to a single temp value callback
-    //  also enables the temperature sensor for the duration of one sample
-    return subscribe(DRIVER_NUM_TMP006, 0, callback, callback_args);
+  // subscribe to a single temp value callback
+  //  also enables the temperature sensor for the duration of one sample
+  return subscribe(DRIVER_NUM_TMP006, 0, callback, callback_args);
 }
 
 // enable TMP006, configure periodic sampling with interrupts, callback with value on interrupt
 int tmp006_start_sampling(uint8_t period, subscribe_cb callback, void* callback_args) {
-    // set period for periodic temp readings
-    uint32_t err_code = command(DRIVER_NUM_TMP006, 1, period);
-    if (err_code != ERR_NONE) {
-        return err_code;
-    }
+  // set period for periodic temp readings
+  uint32_t err_code = command(DRIVER_NUM_TMP006, 1, period);
+  if (err_code != ERR_NONE) {
+    return err_code;
+  }
 
-    // subscribe to periodic temp value callbacks
-    //  also enables the temperature sensor
-    return subscribe(DRIVER_NUM_TMP006, 1, callback, callback_args);
+  // subscribe to periodic temp value callbacks
+  //  also enables the temperature sensor
+  return subscribe(DRIVER_NUM_TMP006, 1, callback, callback_args);
 }
 
 // disable TMP006
 int tmp006_stop_sampling(void) {
-    // unsubscribe from periodic temp value callbacks
-    //  also disables the temperature sensor
-    return command(DRIVER_NUM_TMP006, 2, 0);
+  // unsubscribe from periodic temp value callbacks
+  //  also disables the temperature sensor
+  return command(DRIVER_NUM_TMP006, 2, 0);
 }
 

--- a/userland/libtock/tmp006.h
+++ b/userland/libtock/tmp006.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tock.h>
+#include "tock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userland/libtock/tock.c
+++ b/userland/libtock/tock.c
@@ -1,11 +1,12 @@
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <stdbool.h>
+
 #include "tock.h"
 
 void yield_for(bool *cond) {
-  while(!*cond) {
+  while (!*cond) {
     yield();
   }
 }
@@ -34,69 +35,69 @@ void yield(void) {
   //   and SP (and r9 in PCS variants that designate r9 as v6)
   // As our compilation flags mark r9 as the PIC base register, it does not need
   // to be saved. Thus we must clobber r0-3, r12, and LR
-  asm volatile(
-      "svc 0       \n"
-      :
-      :
-      : "memory", "r0", "r1", "r2", "r3", "r12", "lr"
-      );
+  asm volatile (
+    "svc 0       \n"
+    :
+    :
+    : "memory", "r0", "r1", "r2", "r3", "r12", "lr"
+    );
 }
 
 int subscribe(uint32_t driver, uint32_t subscribe,
               subscribe_cb cb, void* userdata) {
-  register uint32_t r0 asm("r0") = driver;
-  register uint32_t r1 asm("r1") = subscribe;
-  register void*    r2 asm("r2") = cb;
-  register void*    r3 asm("r3") = userdata;
+  register uint32_t r0 asm ("r0") = driver;
+  register uint32_t r1 asm ("r1") = subscribe;
+  register void*    r2 asm ("r2") = cb;
+  register void*    r3 asm ("r3") = userdata;
   register int ret asm ("r0");
-  asm volatile(
-      "svc 1"
-      : "=r" (ret)
-      : "r" (r0), "r" (r1), "r" (r2), "r" (r3)
-      : "memory");
+  asm volatile (
+    "svc 1"
+    : "=r" (ret)
+    : "r" (r0), "r" (r1), "r" (r2), "r" (r3)
+    : "memory");
   return ret;
 }
 
 
 int command(uint32_t driver, uint32_t command, int data) {
-  register uint32_t r0 asm("r0") = driver;
-  register uint32_t r1 asm("r1") = command;
-  register uint32_t r2 asm("r2") = data;
+  register uint32_t r0 asm ("r0") = driver;
+  register uint32_t r1 asm ("r1") = command;
+  register uint32_t r2 asm ("r2") = data;
   register int ret asm ("r0");
-  asm volatile(
-      "svc 2"
-      : "=r" (ret)
-      : "r" (r0), "r" (r1), "r" (r2)
-      : "memory"
-      );
+  asm volatile (
+    "svc 2"
+    : "=r" (ret)
+    : "r" (r0), "r" (r1), "r" (r2)
+    : "memory"
+    );
   return ret;
 }
 
 int allow(uint32_t driver, uint32_t allow, void* ptr, size_t size) {
-  register uint32_t r0 asm("r0") = driver;
-  register uint32_t r1 asm("r1") = allow;
-  register void*    r2 asm("r2") = ptr;
-  register size_t   r3 asm("r3") = size;
+  register uint32_t r0 asm ("r0") = driver;
+  register uint32_t r1 asm ("r1") = allow;
+  register void*    r2 asm ("r2") = ptr;
+  register size_t r3 asm ("r3")   = size;
   register int ret asm ("r0");
-  asm volatile(
-      "svc 3"
-      : "=r" (ret)
-      : "r" (r0), "r" (r1), "r" (r2), "r" (r3)
-      : "memory"
-      );
+  asm volatile (
+    "svc 3"
+    : "=r" (ret)
+    : "r" (r0), "r" (r1), "r" (r2), "r" (r3)
+    : "memory"
+    );
   return ret;
 }
 
 void* memop(uint32_t op_type, int arg1) {
-  register uint32_t r0 asm("r0") = op_type;
-  register int      r1 asm("r1") = arg1;
-  register void*   ret asm("r0");
-  asm volatile(
-      "svc 4"
-      : "=r" (ret)
-      : "r" (r0), "r" (r1)
-      : "memory"
-      );
+  register uint32_t r0 asm ("r0") = op_type;
+  register int r1 asm ("r1")      = arg1;
+  register void*   ret asm ("r0");
+  asm volatile (
+    "svc 4"
+    : "=r" (ret)
+    : "r" (r0), "r" (r1)
+    : "memory"
+    );
   return ret;
 }
 
@@ -106,21 +107,21 @@ bool driver_exists(uint32_t driver) {
 }
 
 void* tock_app_memory_begins_at(void) {
-	return memop(2, 0);
+  return memop(2, 0);
 }
 
 void* tock_app_memory_ends_at(void) {
-	return memop(3, 0);
+  return memop(3, 0);
 }
 
 void* tock_app_flash_begins_at(void) {
-	return memop(4, 0);
+  return memop(4, 0);
 }
 
 void* tock_app_flash_ends_at(void) {
-	return memop(5, 0);
+  return memop(5, 0);
 }
 
 void* tock_app_grant_begins_at(void) {
-	return memop(6, 0);
+  return memop(6, 0);
 }

--- a/userland/libtock/tsl2561.c
+++ b/userland/libtock/tsl2561.c
@@ -19,25 +19,25 @@ static void tsl2561_cb(__attribute__ ((unused)) int callback_type,
 }
 
 int tsl2561_set_callback (subscribe_cb callback, void* callback_args) {
-    return subscribe(DRIVER_NUM_TSL2561, 0, callback, callback_args);
+  return subscribe(DRIVER_NUM_TSL2561, 0, callback, callback_args);
 }
 
 int tsl2561_get_lux (void) {
-    return command(DRIVER_NUM_TSL2561, 1, 0);
+  return command(DRIVER_NUM_TSL2561, 1, 0);
 }
 
 int tsl2561_get_lux_sync (void) {
-    int err;
-    result.fired = false;
+  int err;
+  result.fired = false;
 
-    err = tsl2561_set_callback(tsl2561_cb, (void*) &result);
-    if (err < 0) return err;
+  err = tsl2561_set_callback(tsl2561_cb, (void*) &result);
+  if (err < 0) return err;
 
-    err = tsl2561_get_lux();
-    if (err < 0) return err;
+  err = tsl2561_get_lux();
+  if (err < 0) return err;
 
-    // Wait for the callback.
-    yield_for(&result.fired);
+  // Wait for the callback.
+  yield_for(&result.fired);
 
-    return result.value;
+  return result.value;
 }


### PR DESCRIPTION
The way this is done right now has the slightly unfortunate effect
that `format_all` will reformat libtock for every application (for
the same reason that it "rebuilds" libtock (only it's already built)
when doing a `build_all`). This isn't a problem per se, it's just a
little slow.

I'll add that ergnomic nit to #432, but I think it's more valuable
to get consistent formatting in while I noodle over that problem