### PR TITLE
userland: allow runtime override of TOCK_ARCHS

### DIFF
--- a/userland/Configuration.mk
+++ b/userland/Configuration.mk
@@ -30,7 +30,7 @@ KERNEL_HEAP_SIZE ?= 1024
 PACKAGE_NAME ?= $(notdir $(shell pwd))
 
 # Tock supported architectures
-TOCK_ARCHS := cortex-m0 cortex-m4
+TOCK_ARCHS ?= cortex-m0 cortex-m4
 
 # This could be replaced with an installed version of `elf2tbf`
 ELF2TBF ?= cargo run --manifest-path $(abspath $(TOCK_USERLAND_BASE_DIR))/tools/elf2tbf/Cargo.toml --


### PR DESCRIPTION
This should be a `?=` like everything else, in the interest of allowing
quick command line overrides