### PR TITLE
Fix if/if bug and possibly implement packet_get_length/pan in RF233

### DIFF
--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -1103,8 +1103,14 @@ impl<'a, S: spi::SpiMasterDevice + 'a> radio::RadioData for RF233<'a, S> {
     // have to copy it into a buffer whose byte 0 is the frame read/write
     // command.
     fn payload_offset(&self, long_src: bool, long_dest: bool) -> u8 {
-        let mut len: u8 = 1; // The SPI command at the head of the buffer
-        len += radio::HEADER_SIZE; // Size if both addresses are short
+        // The SPI command at the head of the buffer takes up 1 byte
+        1 + self.header_size(long_src, long_dest)
+    }
+
+    // Returns the total length (in bytes) of the header depending on
+    // whether or not the source and destination addresses are long
+    fn header_size(&self, long_src: bool, long_dest: bool) -> u8 {
+        let mut len: u8 = radio::HEADER_SIZE;
         if long_src {
             len += 6;
         }
@@ -1114,16 +1120,8 @@ impl<'a, S: spi::SpiMasterDevice + 'a> radio::RadioData for RF233<'a, S> {
         len
     }
 
-    fn header_size(&self, long_src: bool, long_dest: bool) -> u8 {
-        let mut len: u8 = radio::HEADER_SIZE;
-        if long_src {
-            len += 6;
-        } else if long_dest {
-            len += 6;
-        }
-        len
-    }
-
+    // Returns the total length (in bytes) of the header in an
+    // existing packet
     fn packet_header_size(&self, packet: &'static [u8]) -> u8 {
         if packet.len() < radio::HEADER_SIZE as usize {
             0
@@ -1264,21 +1262,22 @@ impl<'a, S: spi::SpiMasterDevice + 'a> radio::RadioData for RF233<'a, S> {
         }
     }
 
-    fn packet_get_length(&self, packet: &'static [u8]) -> u16 {
+    fn packet_get_length(&self, packet: &'static [u8]) -> u8 {
         if packet.len() < radio::HEADER_SIZE as usize {
             return 0;
         } else {
-            return 0;
+            // -2 for CRC, +1 for length byte: see prepare_packet()
+            return packet[1] - 2 + 1;
         }
     }
+
     fn packet_get_pan(&self, packet: &'static [u8]) -> u16 {
         if packet.len() < radio::HEADER_SIZE as usize {
             return 0;
         } else {
-            return 0;
+            return (packet[5] as u16) | ((packet[6] as u16) << 8);
         }
     }
-
 
     fn set_transmit_client(&self, client: &'static radio::TxClient) {
         self.tx_client.set(Some(client));

--- a/kernel/src/hil/radio.rs
+++ b/kernel/src/hil/radio.rs
@@ -74,7 +74,7 @@ pub trait RadioData {
     fn packet_get_dest(&self, packet: &'static [u8]) -> u16;
     fn packet_get_src_long(&self, packet: &'static [u8]) -> [u8; 8];
     fn packet_get_dest_long(&self, packet: &'static [u8]) -> [u8; 8];
-    fn packet_get_length(&self, packet: &'static [u8]) -> u16;
+    fn packet_get_length(&self, packet: &'static [u8]) -> u8;
     fn packet_get_pan(&self, packet: &'static [u8]) -> u16;
     fn packet_has_src_long(&self, packet: &'static [u8]) -> bool;
     fn packet_has_dest_long(&self, packet: &'static [u8]) -> bool;


### PR DESCRIPTION
This PR fixes two issues with the RF233 implementation for the imix platform.

1. Previously, the two functions `payload_offset` and `header_size` independently determine the header size of a packet parameterized by whether the source and destination addresses are long. However, the latter used a mutually exclusize `if`-`else if` branch, which is an error. This PR changes `header_size` to use the correct `if`-`if` structure, and makes `payload_offset` rely on `header_size` for this computation to avoid similar bugs in the future.
2. Also, the two functions `packet_get_length` and `packet_get_pan` previously only return `0` regardless, which is not correct (they should be extracting the relevant fields from the provided packet). This PR extracts the fields from the packet header according to how the header is constructed in `prepare_packet`. In `packet_get_length`, I'm not entirely sure that the `- 2 + 1` is right, it's just the opposite of what happens in `prepare_packet`. @phil-levis could you check if that's what we're supposed to do?