### PR TITLE
BLE advertisement support 31 byte payload and added scanning

### DIFF
--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -272,7 +272,7 @@ pub unsafe fn reset_handler() {
          &mut nrf51::ble_advertising_driver::BUF,
          ble_radio_virtual_alarm),
         256/8);
-    //nrf51::radio::RADIO.set_client(ble_radio);
+    nrf51::radio::RADIO.set_client(ble_radio);
     ble_radio_virtual_alarm.set_client(ble_radio);
 
     // Start all of the clocks. Low power operation will require a better

--- a/chips/nrf51/src/ble_advertising_driver.rs
+++ b/chips/nrf51/src/ble_advertising_driver.rs
@@ -235,7 +235,6 @@ impl<'a, A: kernel::hil::time::Alarm + 'a> kernel::hil::time::Client for BLE<'a,
     }
 }
 
-// FIXME: Temporary callback function *stolen* from the radio HIL
 impl<'a, A: kernel::hil::time::Alarm + 'a> RxClient for BLE<'a, A> {
     fn receive(&self, buf: &'static mut [u8], len: u8, result: ReturnCode) {
         for cntr in self.app.iter() {

--- a/chips/nrf51/src/ble_advertising_driver.rs
+++ b/chips/nrf51/src/ble_advertising_driver.rs
@@ -4,7 +4,7 @@
 //! in order to send periodic BLE advertisements without blocking
 //! the kernel
 //!
-//! The advertisment interval is configured from the user application. The allowed range
+//! The advertisement interval is configured from the user application. The allowed range
 //! is between 20 ms and 10240 ms, lower or higher values will be set to these values.
 //! Advertisements are sent on channels 37, 38 and 39 with a very shortly time between each
 //! transmission.
@@ -34,19 +34,26 @@
 //! ----------------------------------------------------------------------------------
 //!
 //! ---SUBSCRIBE SYSTEM CALL----------------------------------------------------------
-//!  NOT NEEDED NOT FOR PURE ADVERTISEMENTS
+//!  The 'subscribe' system call supports two arguments `subscribe_num' and 'callback'.
+//! 'subscribe' is used to specify the specific operation, currently:
+//!     * 0: provides a callback user-space when a device scanning for advertisements
+//!          and the callback is used to invoke user-space processes.
 //!
+//! The possible return codes from the 'allow' system call indicate the following:
+//!        * ENOMEM:    Not sufficient amount memory
+//!        * EINVAL:    Invalid operation
 //! ------------------------------------------------------------------------------
 //!
 //! ---COMMAND SYSTEM CALL------------------------------------------------------------
 //! The `command` system call supports two arguments `cmd` and 'sub_cmd'.
 //! 'cmd' is used to specify the specific operation, currently
 //! the following cmd's are supported:
-//!     * 0: start advertisment
-//!     * 1: stop advertisment
+//!     * 0: start advertisement
+//!     * 1: stop advertisement
 //!     * 2: configure tx power
 //!     * 3: configure advertise interval
 //!     * 4: clear the advertisement payload
+//!     * 5: start scanning
 //!
 //! The possible return codes from the 'command' system call indicate the following:
 //!     * SUCCESS:      The command was successful
@@ -56,17 +63,17 @@
 //!
 //! Author: Niklas Adolfsson <niklasadolfsson1@gmail.com>
 //! Author: Fredrik Nilsson <frednils@student.chalmers.se>
-//! Date: June 2, 2017
+//! Date: June 22, 2017
 
 
 use core::cell::Cell;
-use kernel::{AppId, Driver, AppSlice, Shared, Container};
-use kernel::common::take_cell::TakeCell;
-use kernel::hil;
+use kernel;
 use kernel::hil::time::Frequency;
 use kernel::process::Error;
 use kernel::returncode::ReturnCode;
 use radio;
+
+
 pub static mut BUF: [u8; 32] = [0; 32];
 
 
@@ -94,34 +101,44 @@ pub const BLE_HS_ADV_TYPE_SVC_DATA_UUID128: usize = 0x21;
 pub const BLE_HS_ADV_TYPE_URI: usize = 0x24;
 pub const BLE_HS_ADV_TYPE_MFG_DATA: usize = 0xff;
 
+// Advertising Modes
+// FIXME: Only BLE_GAP_CONN_MODE_NON supported
+pub const BLE_GAP_CONN_MODE_NON: usize = 0x00;
+pub const BLE_GAP_CONN_MODE_DIR: usize = 0x01;
+pub const BLE_GAP_CONN_MODE_UND: usize = 0x02;
+pub const BLE_GAP_SCAN_MODE_NON: usize = 0x03;
+pub const BLE_GAP_SCAN_MODE_DIR: usize = 0x04;
+pub const BLE_GAP_SCAN_MODE_UND: usize = 0x05;
 
 #[derive(Default)]
 pub struct App {
-    app_write: Option<AppSlice<Shared, u8>>,
+    app_write: Option<kernel::AppSlice<kernel::Shared, u8>>,
+    app_read: Option<kernel::AppSlice<kernel::Shared, u8>>,
+    scan_callback: Option<kernel::Callback>,
 }
 
-pub struct BLE<'a, A: hil::time::Alarm + 'a> {
+pub struct BLE<'a, A: kernel::hil::time::Alarm + 'a> {
     radio: &'a radio::Radio,
     busy: Cell<bool>,
-    app: Container<App>,
-    kernel_tx: TakeCell<'static, [u8]>,
+    app: kernel::Container<App>,
+    kernel_tx: kernel::common::take_cell::TakeCell<'static, [u8]>,
     alarm: &'a A,
     advertisement_interval: Cell<u32>,
     is_advertising: Cell<bool>,
     offset: Cell<usize>,
 }
 
-impl<'a, A: hil::time::Alarm + 'a> BLE<'a, A> {
+impl<'a, A: kernel::hil::time::Alarm + 'a> BLE<'a, A> {
     pub fn new(radio: &'a radio::Radio,
-               container: Container<App>,
-               buf: &'static mut [u8],
+               container: kernel::Container<App>,
+               tx_buf: &'static mut [u8],
                alarm: &'a A)
                -> BLE<'a, A> {
         BLE {
             radio: radio,
             busy: Cell::new(false),
             app: container,
-            kernel_tx: TakeCell::new(buf),
+            kernel_tx: kernel::common::take_cell::TakeCell::new(tx_buf),
             alarm: alarm,
             advertisement_interval: Cell::new(150 * <A::Frequency>::frequency() / 1000),
             is_advertising: Cell::new(false),
@@ -142,10 +159,10 @@ impl<'a, A: hil::time::Alarm + 'a> BLE<'a, A> {
                     .map(|slice| {
                         let len = slice.len();
                         // Each AD TYP consists of TYPE (1 byte), LENGTH (1 byte) and
-                        // PAYLOAD (0 - 30 bytes)
+                        // PAYLOAD (0 - 31 bytes)
                         // This is why we add 2 to start the payload at the correct position.
                         let i = self.offset.get() + len + 2;
-                        if i < 31 {
+                        if i <= 31 {
                             self.kernel_tx
                                 .take()
                                 .map(|data| {
@@ -154,7 +171,7 @@ impl<'a, A: hil::time::Alarm + 'a> BLE<'a, A> {
                                         *out = *inp;
                                     }
                                     let tmp = self.radio
-                                        .set_adv_data(ad_type, data, len, self.offset.get() + 9);
+                                        .set_adv_data(ad_type, data, len, self.offset.get() + 8);
                                     self.kernel_tx.replace(tmp);
                                     self.offset.set(i);
                                 });
@@ -196,29 +213,51 @@ impl<'a, A: hil::time::Alarm + 'a> BLE<'a, A> {
     }
 }
 
-impl<'a, A: hil::time::Alarm + 'a> hil::time::Client for BLE<'a, A> {
+impl<'a, A: kernel::hil::time::Alarm + 'a> kernel::hil::time::Client for BLE<'a, A> {
     // this method is called once the virtual timer has been expired
     // used to periodically send BLE advertisements without blocking the kernel
     fn fired(&self) {
-        self.radio.start_adv();
-        self.configure_periodic_alarm();
+        if self.busy.get() {
+            if self.is_advertising.get() {
+                self.radio.start_adv_tx();
+            } else {
+                self.radio.start_adv_rx();
+            }
+            self.configure_periodic_alarm();
+        }
+    }
+}
+
+// FIXME: Temporary callback function *stolen* from the radio HIL
+impl<'a, A: kernel::hil::time::Alarm + 'a> kernel::hil::radio::RxClient for BLE<'a, A> {
+    fn receive(&self, buf: &'static mut [u8], len: u8, result: ReturnCode) {
+        for cntr in self.app.iter() {
+            cntr.enter(|app, _| {
+                if app.app_read.is_some() {
+                    let dest = app.app_read.as_mut().unwrap();
+                    let d = &mut dest.as_mut();
+                    // write to buffer in userland
+                    for (i, c) in buf[0..len as usize].iter().enumerate() {
+                        d[i] = *c;
+                    }
+                }
+                app.scan_callback
+                    .map(|mut cb| { cb.schedule(usize::from(result), 0, 0); });
+            });
+        }
     }
 }
 
 // Implementation of SYSCALL interface
-impl<'a, A: hil::time::Alarm + 'a> Driver for BLE<'a, A> {
-    fn command(&self, command_num: usize, data: usize, _: AppId) -> ReturnCode {
+impl<'a, A: kernel::hil::time::Alarm + 'a> kernel::Driver for BLE<'a, A> {
+    fn command(&self, command_num: usize, data: usize, _: kernel::AppId) -> ReturnCode {
         match (command_num, self.busy.get()) {
             // START BLE
             (0, false) => {
-                if self.busy.get() == false {
-                    self.busy.set(true);
-                    self.is_advertising.set(true);
-                    self.configure_periodic_alarm();
-                    ReturnCode::SUCCESS
-                } else {
-                    ReturnCode::FAIL
-                }
+                self.busy.set(true);
+                self.is_advertising.set(true);
+                self.configure_periodic_alarm();
+                ReturnCode::SUCCESS
             }
             //Stop ADV_BLE
             (1, _) => {
@@ -238,17 +277,29 @@ impl<'a, A: hil::time::Alarm + 'a> Driver for BLE<'a, A> {
                 }
                 ReturnCode::SUCCESS
             }
+            // Clear payload
             (4, false) => {
                 self.offset.set(0);
                 self.radio.clear_adv_data();
                 ReturnCode::SUCCESS
             }
+            // Passive scanning mode
+            (5, false) => {
+                self.busy.set(true);
+                self.configure_periodic_alarm();
+                ReturnCode::SUCCESS
+            }
+
             (_, true) => ReturnCode::EBUSY,
             (_, _) => ReturnCode::ENOSUPPORT,
         }
     }
 
-    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(&self,
+             appid: kernel::AppId,
+             allow_num: usize,
+             slice: kernel::AppSlice<kernel::Shared, u8>)
+             -> ReturnCode {
         match (allow_num, self.busy.get()) {
             // See this as a giant case switch or if else statements
             (BLE_HS_ADV_TYPE_FLAGS, false) |
@@ -289,6 +340,7 @@ impl<'a, A: hil::time::Alarm + 'a> Driver for BLE<'a, A> {
                     ret
                 }
             }
+            // Set advertisement address
             (0x30, false) => {
                 let ret = self.app
                     .enter(appid, |app, _| {
@@ -306,9 +358,42 @@ impl<'a, A: hil::time::Alarm + 'a> Driver for BLE<'a, A> {
                     ret
                 }
             }
+            // Passive scanning
+            (0x31, false) => {
+                self.app
+                    .enter(appid, |app, _| {
+                        app.app_read = Some(slice);
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or_else(|err| match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    })
+            }
             (_, true) => ReturnCode::EBUSY,
 
             (_, _) => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+
+    fn subscribe(&self, subscribe_num: usize, callback: kernel::Callback) -> ReturnCode {
+        match subscribe_num {
+            // Callback for scanning
+            0 => {
+                self.app
+                    .enter(callback.app_id(), |app, _| {
+                        app.scan_callback = Some(callback);
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or_else(|err| match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    })
+            }
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/chips/nrf51/src/ble_advertising_driver.rs
+++ b/chips/nrf51/src/ble_advertising_driver.rs
@@ -110,6 +110,13 @@ pub const BLE_GAP_SCAN_MODE_NON: usize = 0x03;
 pub const BLE_GAP_SCAN_MODE_DIR: usize = 0x04;
 pub const BLE_GAP_SCAN_MODE_UND: usize = 0x05;
 
+
+// Temporary trait for BLE
+pub trait RxClient {
+    fn receive(&self, buf: &'static mut [u8], len: u8, result: ReturnCode);
+}
+
+
 #[derive(Default)]
 pub struct App {
     app_write: Option<kernel::AppSlice<kernel::Shared, u8>>,
@@ -229,7 +236,7 @@ impl<'a, A: kernel::hil::time::Alarm + 'a> kernel::hil::time::Client for BLE<'a,
 }
 
 // FIXME: Temporary callback function *stolen* from the radio HIL
-impl<'a, A: kernel::hil::time::Alarm + 'a> kernel::hil::radio::RxClient for BLE<'a, A> {
+impl<'a, A: kernel::hil::time::Alarm + 'a> RxClient for BLE<'a, A> {
     fn receive(&self, buf: &'static mut [u8], len: u8, result: ReturnCode) {
         for cntr in self.app.iter() {
             cntr.enter(|app, _| {

--- a/chips/nrf51/src/radio.rs
+++ b/chips/nrf51/src/radio.rs
@@ -1,14 +1,14 @@
 //! Radio/BLE Driver for nrf51dk
 //!
 //! Sending BLE advertisement packets
-//! Possible payload is 30 bytes
+//! Possible payload is 31 bytes
 //!
 //! Currently all fields in PAYLOAD array are configurable from user-space
 //! except the PDU_TYPE.
 //!
 //! Author: Niklas Adolfsson <niklasadolfsson1@gmail.com>
 //! Author: Fredrik Nilsson <frednils@student.chalmers.se>
-//! Date: June 6, 2017
+//! Date: June 22, 2017
 
 use chip;
 use core::cell::Cell;
@@ -36,6 +36,8 @@ pub const PACKET_LENGTH_FIELD_SIZE: u32 = 0;
 pub const PACKET_PAYLOAD_MAXSIZE: u32 = 64;
 pub const PACKET_BASE_ADDRESS_LENGTH: u32 = 4;
 pub const PACKET_STATIC_LENGTH: u32 = 64;
+pub const NRF_LFLEN_LEN_1BYTE: u32 = 8;
+pub const NRF_S0_LEN_1BYTE: u32 = 1;
 
 
 // internal Radio State
@@ -53,86 +55,64 @@ pub const RADIO_STATE_TXDISABLE: u32 = 12;
 // constants for readability purposes
 pub const PAYLOAD_HDR_PDU: usize = 0;
 pub const PAYLOAD_HDR_LEN: usize = 1;
-pub const PAYLOAD_ADDR_START: usize = 3;
-pub const PAYLOAD_ADDR_END: usize = 8;
-pub const PAYLOAD_DATA_START: usize = 9;
+pub const PAYLOAD_ADDR_START: usize = 2;
+pub const PAYLOAD_ADDR_END: usize = 7;
+pub const PAYLOAD_DATA_START: usize = 8;
 pub const PAYLOAD_LENGTH: usize = 39;
 
-// FROM LEFT
-// ADVTYPE      ;;      4 bits
-// RFU          ;;      2 bits
-// TxAdd        ;;      1 bit
-// RxAdd        ;;      1 bit
-// Length       ;;       6 bits
-// RFU          ;;      2 bits
-// AdvD         ;;      6 bytes
-// AdvData      ;;      31 bytes
 
-// Header (2 bytes) || Address (6 bytes) || Payload 31 bytes
-static mut PAYLOAD: [u8; 39] = [// ADV_IND, public addr  [HEADER]
-                                0x02,
-                                0x00,
-                                // Padding   FIXME: Remove get payload of 31 bytes
-                                0x00,
-                                // Address          [ADV ADDRESS]
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                // [LEN, AD-TYPE, LEN-1 bytes of data ...]
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00,
-                                0x00]; //[DATA]
+// Header (2 bytes) which consist of:
+//
+// Byte #1
+// PDU Type (4 bits) - see below for info
+// RFU (2 bits)      - don't care
+// TXAdd (1 bit)     - don't used yet (use public or private addr)
+// RXAdd (1 bit)     - don't care (not used for beacons)
+//
+// Byte #2
+// Length of the total packet
+
+// PDU TYPES
+// 0x00 - ADV_IND
+// 0x01 - ADV_DIRECT_IND
+// 0x02 - ADV_NONCONN_IND
+// 0x03 - SCAN_REQ
+// 0x04 - SCAN_RSP
+// 0x05 - CONNECT_REQ
+// 0x06 - ADV_SCAN_IND
+
+//  Advertising Type   Connectable  Scannable   Directed    GAP Name
+//  ADV_IND            Yes           Yes         No          Connectable Undirected Advertising
+//  ADV_DIRECT_IND     Yes           No          Yes         Connectable Directed Advertising
+//  ADV_NONCONN_IND    Yes           No          No          Non-connectible Undirected Advertising
+//  ADV_SCAN_IND       Yes           Yes         No          Scannable Undirected Advertising
+
+static mut PAYLOAD: [u8; 39] = [0x00; 39];
 
 pub struct Radio {
     regs: *const peripheral_registers::RADIO_REGS,
     txpower: Cell<usize>,
+    client: Cell<Option<&'static kernel::hil::radio::RxClient>>,
 }
 
 pub static mut RADIO: Radio = Radio::new();
-
 
 impl Radio {
     pub const fn new() -> Radio {
         Radio {
             regs: peripheral_registers::RADIO_BASE as *const peripheral_registers::RADIO_REGS,
             txpower: Cell::new(0),
+            client: Cell::new(None),
         }
     }
 
-    fn init_radio_ble(&self) {
+    // Used configure to radio to send BLE advertisements
+    pub fn start_adv_tx(&self) {
         let regs = unsafe { &*self.regs };
 
         self.radio_on();
+
+        self.set_payload_header_pdu(0x02);
 
         // TX Power acc. to twpower variable in the struct
         self.set_txpower();
@@ -158,7 +138,7 @@ impl Radio {
         self.set_crc_config();
 
         // Buffer configuration
-        self.set_tx_buffer();
+        self.set_buffer();
 
         self.enable_interrupts();
         self.enable_nvic();
@@ -167,6 +147,42 @@ impl Radio {
         regs.TXEN.set(1);
     }
 
+    // Used configure to radio to listen for BLE advertisements
+    // FIXME: alot of boiler plate
+    pub fn start_adv_rx(&self) {
+        let regs = unsafe { &*self.regs };
+
+        self.radio_on();
+
+        // BLE MODE
+        self.set_channel_rate(0x03);
+
+        self.set_channel_freq(37);
+        self.set_data_white_iv(37);
+
+        // Set PREFIX | BASE Address
+        regs.PREFIX0.set(0x0000008e);
+        regs.BASE0.set(0x89bed600);
+
+        self.set_tx_address(0x00);
+        self.set_rx_address(0x01);
+        // regs.RXMATCH.set(0x00);
+
+        // Set Packet Config
+        self.set_packet_config(0x00);
+
+        // CRC Config
+        self.set_crc_config();
+
+        // Buffer configuration
+        self.set_buffer();
+
+        self.enable_interrupts();
+        self.enable_nvic();
+
+        regs.READY.set(0);
+        regs.RXEN.set(1);
+    }
     fn set_crc_config(&self) {
         let regs = unsafe { &*self.regs };
         // CRC Config
@@ -182,33 +198,22 @@ impl Radio {
     fn set_packet_config(&self, _: u32) {
         let regs = unsafe { &*self.regs };
 
-        // This initialization have to do with the header in the PDU it is 2 bytes
-        // ADVTYPE      ;;      4 bits
-        // RFU          ;;      2 bits
-        // TxAdd        ;;      1 bit
-        // RxAdd        ;;      1 bit
-        // Length       ;;      6 bits
-        // RFU          ;;      2 bits
-
-        regs.PCNF0
-            .set(// set S0 to 1 byte
-                 (1 << RADIO_PCNF0_S0LEN_POS) |
-                     // set S1 to 2 bits
-                     (2 << RADIO_PCNF0_S1LEN_POS) |
-                     // set length to 6 bits
-                     (6 << RADIO_PCNF0_LFLEN_POS));
+        // sets the header of PDU TYPE to 1 byte
+        // sets the header length to 1 byte
+        regs.PCNF0.set((NRF_S0_LEN_1BYTE << RADIO_PCNF0_S0LEN_POS) |
+                       (NRF_LFLEN_LEN_1BYTE << RADIO_PCNF0_LFLEN_POS));
 
 
         regs.PCNF1
             .set((RADIO_PCNF1_WHITEEN_ENABLED << RADIO_PCNF1_WHITEEN_POS) |
-                // set little-endian
-                (0 << RADIO_PCNF1_ENDIAN_POS) |
-                // Set BASE + PREFIX address to 4 bytes
-                (3 << RADIO_PCNF1_BALEN_POS) |
-                // don't extend packet length
-                (0 << RADIO_PCNF1_STATLEN_POS) |
-                // max payload size 37
-                (37 << RADIO_PCNF1_MAXLEN_POS));
+                 // set little-endian
+                 (0 << RADIO_PCNF1_ENDIAN_POS) |
+                 // Set BASE + PREFIX address to 4 bytes
+                 (3 << RADIO_PCNF1_BALEN_POS) |
+                 // don't extend packet length
+                 (0 << RADIO_PCNF1_STATLEN_POS) |
+                 // max payload size 37
+                 (37 << RADIO_PCNF1_MAXLEN_POS));
     }
 
     // TODO set from capsules?!
@@ -267,15 +272,11 @@ impl Radio {
         regs.TXPOWER.set(self.txpower.get() as u32);
     }
 
-    fn set_tx_buffer(&self) {
+    fn set_buffer(&self) {
         let regs = unsafe { &*self.regs };
         unsafe {
             regs.PACKETPTR.set((&PAYLOAD as *const u8) as u32);
         }
-    }
-
-    fn set_rx_buffer(&self) {
-        unimplemented!();
     }
 
     #[inline(never)]
@@ -287,11 +288,6 @@ impl Radio {
         nvic::clear_pending(peripheral_interrupts::NvicIdx::RADIO);
 
         if regs.READY.get() == 1 {
-            if regs.STATE.get() <= 4 {
-                self.set_rx_buffer();
-            } else {
-                self.set_tx_buffer();
-            }
             regs.READY.set(0);
             regs.END.set(0);
             regs.START.set(1);
@@ -341,6 +337,20 @@ impl Radio {
                         }
                     }
                 }
+                RADIO_STATE_RXRU |
+                RADIO_STATE_RXIDLE |
+                RADIO_STATE_RXDISABLE |
+                RADIO_STATE_RX => {
+                    if regs.CRCSTATUS.get() == 1 {
+                        unsafe {
+                            self.client.get().map(|client| {
+                                client.receive(&mut PAYLOAD,
+                                               39,
+                                               kernel::returncode::ReturnCode::SUCCESS)
+                            });
+                        }
+                    }
+                }
                 _ => (),
             }
         }
@@ -372,10 +382,7 @@ impl Radio {
 
     pub fn reset_payload(&self) {}
 
-    // these are used by ble_advertising_driver and are therefore public
-
     // FIXME: Support for other PDU types than ADV_NONCONN_IND
-    // NOT USED ATM
     pub fn set_payload_header_pdu(&self, pdu: u8) {
         unsafe {
             PAYLOAD[PAYLOAD_HDR_PDU] = pdu;
@@ -388,7 +395,7 @@ impl Radio {
         }
     }
 
-    // pre-condition addr buffer is 6 bytes ensured by the capsule
+    // pre-condition address buffer is 6 bytes ensured by the capsule
     pub fn set_advertisement_address(&self, addr: &'static mut [u8]) -> &'static mut [u8] {
         for (i, c) in addr.as_ref()[0..6].iter().enumerate() {
             unsafe {
@@ -396,10 +403,6 @@ impl Radio {
             }
         }
         addr
-    }
-
-    pub fn start_adv(&self) {
-        self.init_radio_ble();
     }
 
     // configures new data in the payload
@@ -410,9 +413,6 @@ impl Radio {
                         offset: usize)
                         -> &'static mut [u8] {
 
-        if offset == PAYLOAD_DATA_START {
-            self.clear_adv_data();
-        }
         // set ad type length and type
         unsafe {
             PAYLOAD[offset] = (len + 1) as u8;
@@ -424,9 +424,8 @@ impl Radio {
                 PAYLOAD[i + offset + 2] = *c;
             }
         }
-        unsafe {
-            PAYLOAD[1] = (offset - 1 + len) as u8;
-        }
+
+        self.set_payload_header_len((offset + len) as u8);
         data
     }
 
@@ -454,6 +453,10 @@ impl Radio {
             }
             _ => kernel::ReturnCode::ENOSUPPORT,
         }
+    }
+
+    pub fn set_client<C: kernel::hil::radio::RxClient>(&self, client: &'static C) {
+        self.client.set(Some(client));
     }
 }
 

--- a/chips/nrf51/src/radio.rs
+++ b/chips/nrf51/src/radio.rs
@@ -10,13 +10,13 @@
 //! Author: Fredrik Nilsson <frednils@student.chalmers.se>
 //! Date: June 22, 2017
 
+use ble_advertising_driver;
 use chip;
 use core::cell::Cell;
 use kernel;
 use nvic;
 use peripheral_interrupts;
 use peripheral_registers;
-use ble_advertising_driver;
 
 // nrf51 specific constants
 pub const PACKET0_S1_SIZE: u32 = 0;

--- a/chips/nrf51/src/radio.rs
+++ b/chips/nrf51/src/radio.rs
@@ -16,7 +16,7 @@ use kernel;
 use nvic;
 use peripheral_interrupts;
 use peripheral_registers;
-
+use ble_advertising_driver;
 
 // nrf51 specific constants
 pub const PACKET0_S1_SIZE: u32 = 0;
@@ -92,7 +92,7 @@ static mut PAYLOAD: [u8; 39] = [0x00; 39];
 pub struct Radio {
     regs: *const peripheral_registers::RADIO_REGS,
     txpower: Cell<usize>,
-    client: Cell<Option<&'static kernel::hil::radio::RxClient>>,
+    client: Cell<Option<&'static ble_advertising_driver::RxClient>>,
 }
 
 pub static mut RADIO: Radio = Radio::new();
@@ -455,7 +455,7 @@ impl Radio {
         }
     }
 
-    pub fn set_client<C: kernel::hil::radio::RxClient>(&self, client: &'static C) {
+    pub fn set_client<C: ble_advertising_driver::RxClient>(&self, client: &'static C) {
         self.client.set(Some(client));
     }
 }

--- a/chips/nrf51/src/radio.rs
+++ b/chips/nrf51/src/radio.rs
@@ -66,7 +66,7 @@ pub const PAYLOAD_LENGTH: usize = 39;
 // Byte #1
 // PDU Type (4 bits) - see below for info
 // RFU (2 bits)      - don't care
-// TXAdd (1 bit)     - don't used yet (use public or private address)
+// TXAdd (1 bit)     - don't used yet (use public or private addr)
 // RXAdd (1 bit)     - don't care (not used for beacons)
 //
 // Byte #2
@@ -163,7 +163,7 @@ impl Radio {
         match self.freq.get() {
             37 => self.freq.set(38),
             38 => self.freq.set(39),
-            _ => self.freq.set(37), 
+            _ => self.freq.set(37),
         }
 
         self.set_channel_freq(self.freq.get());
@@ -274,8 +274,8 @@ impl Radio {
         regs.POWER.set(0);
     }
 
-    // pre-condition validated before arriving here
-    // argue where the put the return code
+    // pre-condition validated before arrving here
+    // argue where the put the returncode
     fn set_txpower(&self) {
         let regs = unsafe { &*self.regs };
         regs.TXPOWER.set(self.txpower.get() as u32);

--- a/userland/examples/ble_adv/main.c
+++ b/userland/examples/ble_adv/main.c
@@ -14,17 +14,21 @@
 int main(void)
 {
   printf("\r\nBLE ADVERTISEMENT DEMO APP\r\n");
+  int err;
+
   unsigned char name[] = "TockOS";
-  unsigned char data[] = "1337";
+  unsigned char data[] = "HEJSAHHEJSANNANSANANA";
   unsigned char addr[] = {0x1, 0x2, 0x3, 0x4, 0x5, 0x6};
 
-  int err;
-  err = ble_adv_set_txpower(0);
+  BLE_Gap_Mode_t mode  = CONN_NON;
+  BLE_TX_Power_t power = ODBM;
+
+  err = ble_adv_set_txpower(power);
   if (err < 0) {
     printf("ble_adv_set_txpower error %d\r\n", err);
   }
 
-  err = ble_adv_set_interval(150);
+  err = ble_adv_set_interval(10);
   if ( err < 0) {
     printf("ble_adv_set_interval error %d\r\n", err);
   }
@@ -35,17 +39,17 @@ int main(void)
   }
 
   // name and data are strings, remove \0 by subtracting 1
-  err = ble_adv_data(BLE_HS_ADV_TYPE_COMP_NAME, sizeof(name) - 1, name);
+  err = ble_adv_data(BLE_HS_ADV_TYPE_COMP_NAME, name, sizeof(name) - 1);
   if (err < 0) {
     printf("ble_adv_data error %d\r\n", err);
   }
 
-  err = ble_adv_data(BLE_HS_ADV_TYPE_MFG_DATA, sizeof(data) - 1, data);
+  err = ble_adv_data(BLE_HS_ADV_TYPE_MFG_DATA, data, sizeof(data) - 1);
   if (err < 0) {
     printf("ble_adv_data error %d\r\n", err);
   }
 
-  err = ble_adv_start();
+  err = ble_adv_start(mode);
   if (err < 0) {
     printf("ble_adv_start error %d\r\n", err);
   }

--- a/userland/examples/ble_scan/Makefile
+++ b/userland/examples/ble_scan/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/ble_scan/main.c
+++ b/userland/examples/ble_scan/main.c
@@ -11,7 +11,7 @@
 
 bool isDetected(void);
 bool listFull(void);
-bool validAdType(int);
+bool validAdType(unsigned char);
 void printList(void);
 
 #define BUF_SIZE 39
@@ -23,17 +23,17 @@ struct Vector {
 };
 
 // global variables
-unsigned char scan[BUF_SIZE]     = {0};
-unsigned char *data[MAX_DEVICES] = {0};
+unsigned char scan[BUF_SIZE]     = { 0 };
+unsigned char* data[MAX_DEVICES] = { 0 };
 int last = 0;
-struct Vector scan_list = {.data = &data[0], .size = 0};
+struct Vector scan_list = {.data = (unsigned char (*)[BUF_SIZE])data, .size = 0 };
 
 static void callback(__attribute__((unused)) int unused0,
-                     __attribute__((unused)) int unused1,
-                     __attribute__((unused)) int unused2,
-                     __attribute__((unused)) void* ud) {
+                     __attribute__((unused)) int unused1, __attribute__((unused)) int unused2,
+                     __attribute__((unused)) void* ud)
+{
 
-  if (!listFull() && validAdType(scan[0]) && !isDetected()) {
+  if (!listFull() && validAdType(scan[8]) && !isDetected()) {
     memcpy(scan_list.data[scan_list.size], scan, BUF_SIZE);
     scan_list.size += 1;
   }
@@ -47,7 +47,7 @@ int main(void)
 {
   int err;
 
-  printf("BLE Scanner\r\n");
+  printf("\rBLE Scanner\r\n\n");
 
   // using the pre-configured adv interval
   err = ble_adv_scan(scan, BUF_SIZE, callback);
@@ -58,7 +58,8 @@ int main(void)
   return 0;
 }
 
-bool isDetected(void) {
+bool isDetected(void)
+{
   for (int i = 0; i < scan_list.size; i++) {
     if (memcmp(scan_list.data[i], scan, BUF_SIZE) == 0) {
       return true;
@@ -67,19 +68,24 @@ bool isDetected(void) {
   return false;
 }
 
-void printList(void) {
-  printf("--------SCANNING--------------------------------------------\r\n");
+void printList(void)
+{
+  printf("--------DETECTED DEVICES--------------------------------------------\r\n");
   for (int i = 0; i < scan_list.size; i++) {
-    printf("DEVICE #%d\r\n", i);
-    for (int j = 0; j < BUF_SIZE; j++) {
+    printf("DEVICE ADDRESS: %02x %02x %02x %02x %02x %02x %02x %02x\r\n",
+           scan_list.data[i][7], scan_list.data[i][6], scan_list.data[i][5],
+           scan_list.data[i][4], scan_list.data[i][3], scan_list.data[i][2],
+           scan_list.data[i][1], scan_list.data[i][0]);
+    printf("DATA: ");
+    for (int j = 8; j < BUF_SIZE; j++) {
       printf("%02x ", scan_list.data[i][j]);
     }
-    printf("\r\n");
+    printf("\r\n\n");
   }
-  printf("----------END------------------------------------------------\r\n\n");
+  printf("---------------------------------------------------------------------\r\n\n");
 }
 
-bool validAdType(int type) {
+bool validAdType(unsigned char type) {
   return type <= 0x06;
 }
 

--- a/userland/examples/ble_scan/main.c
+++ b/userland/examples/ble_scan/main.c
@@ -18,12 +18,12 @@ void printList(void);
 #define MAX_DEVICES 50
 
 struct Vector {
-   unsigned char (*data)[BUF_SIZE];
-   int size;
+  unsigned char (*data)[BUF_SIZE];
+  int size;
 };
 
 // global variables
-unsigned char scan[BUF_SIZE] = {0};
+unsigned char scan[BUF_SIZE]     = {0};
 unsigned char *data[MAX_DEVICES] = {0};
 int last = 0;
 struct Vector scan_list = {.data = &data[0], .size = 0};
@@ -33,14 +33,14 @@ static void callback(__attribute__((unused)) int unused0,
                      __attribute__((unused)) int unused2,
                      __attribute__((unused)) void* ud) {
 
-    if(!listFull() && validAdType(scan[0]) && !isDetected()) {
-        memcpy(scan_list.data[scan_list.size], scan, BUF_SIZE);
-        scan_list.size += 1;
-    }
-    if (last != scan_list.size) {
-        printList();
-        last = scan_list.size;
-    }
+  if (!listFull() && validAdType(scan[0]) && !isDetected()) {
+    memcpy(scan_list.data[scan_list.size], scan, BUF_SIZE);
+    scan_list.size += 1;
+  }
+  if (last != scan_list.size) {
+    printList();
+    last = scan_list.size;
+  }
 }
 
 int main(void)
@@ -59,30 +59,30 @@ int main(void)
 }
 
 bool isDetected(void) {
-    for(int i = 0; i < scan_list.size; i++) {
-        if(memcmp(scan_list.data[i], scan, BUF_SIZE) == 0) {
-            return true;
-        }
+  for (int i = 0; i < scan_list.size; i++) {
+    if (memcmp(scan_list.data[i], scan, BUF_SIZE) == 0) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 void printList(void) {
-        printf("--------SCANNING--------------------------------------------\r\n");
-        for(int i = 0; i < scan_list.size; i++)  {
-            printf("DEVICE #%d\r\n", i);
-            for(int j = 0; j < BUF_SIZE; j++) {
-                printf("%02x ", scan_list.data[i][j]);
-            }
-            printf("\r\n");
-        }
-        printf("----------END------------------------------------------------\r\n\n");
+  printf("--------SCANNING--------------------------------------------\r\n");
+  for (int i = 0; i < scan_list.size; i++) {
+    printf("DEVICE #%d\r\n", i);
+    for (int j = 0; j < BUF_SIZE; j++) {
+      printf("%02x ", scan_list.data[i][j]);
+    }
+    printf("\r\n");
+  }
+  printf("----------END------------------------------------------------\r\n\n");
 }
 
 bool validAdType(int type) {
-    return type <= 0x06;
+  return type <= 0x06;
 }
 
 bool listFull(void) {
-    return scan_list.size >= MAX_DEVICES;
+  return scan_list.size >= MAX_DEVICES;
 }

--- a/userland/examples/ble_scan/main.c
+++ b/userland/examples/ble_scan/main.c
@@ -9,17 +9,38 @@
  * Active scanner for BLE advertisements
  */
 
+bool isDetected(void);
+bool listFull(void);
+bool validAdType(int);
+void printList(void);
+
 #define BUF_SIZE 39
-unsigned char scan[BUF_SIZE] = { 0 };
+#define MAX_DEVICES 50
+
+struct Vector {
+   unsigned char (*data)[BUF_SIZE];
+   int size;
+};
+
+// global variables
+unsigned char scan[BUF_SIZE] = {0};
+unsigned char *data[MAX_DEVICES] = {0};
+int last = 0;
+struct Vector scan_list = {.data = &data[0], .size = 0};
 
 static void callback(__attribute__((unused)) int unused0,
-                     __attribute__((unused)) int unused1, __attribute__((unused)) int unused2,
-                     __attribute__((unused)) void* ud)
-{
-  for (int i = 0; i < BUF_SIZE; i++) {
-    printf("%02x ", scan[i]);
-  }
-  printf("\r\n");
+                     __attribute__((unused)) int unused1,
+                     __attribute__((unused)) int unused2,
+                     __attribute__((unused)) void* ud) {
+
+    if(!listFull() && validAdType(scan[0]) && !isDetected()) {
+        memcpy(scan_list.data[scan_list.size], scan, BUF_SIZE);
+        scan_list.size += 1;
+    }
+    if (last != scan_list.size) {
+        printList();
+        last = scan_list.size;
+    }
 }
 
 int main(void)
@@ -35,4 +56,33 @@ int main(void)
   }
 
   return 0;
+}
+
+bool isDetected(void) {
+    for(int i = 0; i < scan_list.size; i++) {
+        if(memcmp(scan_list.data[i], scan, BUF_SIZE) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void printList(void) {
+        printf("--------SCANNING--------------------------------------------\r\n");
+        for(int i = 0; i < scan_list.size; i++)  {
+            printf("DEVICE #%d\r\n", i);
+            for(int j = 0; j < BUF_SIZE; j++) {
+                printf("%02x ", scan_list.data[i][j]);
+            }
+            printf("\r\n");
+        }
+        printf("----------END------------------------------------------------\r\n\n");
+}
+
+bool validAdType(int type) {
+    return type <= 0x06;
+}
+
+bool listFull(void) {
+    return scan_list.size >= MAX_DEVICES;
 }

--- a/userland/examples/ble_scan/main.c
+++ b/userland/examples/ble_scan/main.c
@@ -1,0 +1,38 @@
+#include <ble.h>
+#include <led.h>
+#include <stdio.h>
+#include <string.h>
+#include <timer.h>
+
+/*
+ * BLE Demo Application
+ * Active scanner for BLE advertisements
+ */
+
+#define BUF_SIZE 39
+unsigned char scan[BUF_SIZE] = { 0 };
+
+static void callback(__attribute__((unused)) int unused0,
+                     __attribute__((unused)) int unused1, __attribute__((unused)) int unused2,
+                     __attribute__((unused)) void* ud)
+{
+  for (int i = 0; i < BUF_SIZE; i++) {
+    printf("%02x ", scan[i]);
+  }
+  printf("\r\n");
+}
+
+int main(void)
+{
+  int err;
+
+  printf("BLE Scanner\r\n");
+
+  // using the pre-configured adv interval
+  err = ble_adv_scan(scan, BUF_SIZE, callback);
+  if (err < 0) {
+    printf("ble_adv_start error %d\r\n", err);
+  }
+
+  return 0;
+}

--- a/userland/libtock/ble.c
+++ b/userland/libtock/ble.c
@@ -2,24 +2,36 @@
 #include <stdio.h>
 #include <string.h>
 
-int ble_adv_set_txpower(TX_Power_t power) {
-  return command(DRIVER_RADIO, CFG_TX_POWER, power);
+int ble_adv_set_txpower(BLE_TX_Power_t power) {
+  return command(DRIVER_RADIO, BLE_CFG_TX_POWER, power);
 }
 
 int ble_adv_set_interval(uint16_t interval) {
-  return command(DRIVER_RADIO, CFG_ADV_INTERVAL, interval);
+  return command(DRIVER_RADIO, BLE_CFG_ADV_INTERVAL, interval);
 }
 
-int ble_adv_data(uint8_t type, uint8_t len, const unsigned char *data) {
+int ble_adv_data(uint8_t type, const unsigned char *data, uint8_t len) {
   return allow(DRIVER_RADIO, type, (void*)data, len);
 }
 
 int ble_adv_clear_data(void){
-  return command(DRIVER_RADIO,BLE_ADV_CLEAR_DATA, 1);
+  return command(DRIVER_RADIO, BLE_ADV_CLEAR_DATA, 1);
 }
 
-int ble_adv_start(void){
-  return command(DRIVER_RADIO, BLE_ADV_START, 1);
+int ble_adv_start(BLE_Gap_Mode_t mode) {
+  return command(DRIVER_RADIO, BLE_ADV_START, mode);
+}
+
+int ble_adv_scan(const unsigned char *data, uint8_t len, subscribe_cb callback) {
+  int err;
+
+  err = subscribe(DRIVER_RADIO, BLE_SCAN_CALLBACK, callback, NULL);
+  if (err < SUCCESS) return err;
+
+  err = allow(DRIVER_RADIO, BLE_CFG_SCAN_BUF, (void*)data, len);
+  if (err < SUCCESS) return err;
+
+  return command(DRIVER_RADIO, BLE_SCAN, 1);
 }
 
 int ble_adv_stop(void) {

--- a/userland/libtock/ble.c
+++ b/userland/libtock/ble.c
@@ -26,10 +26,10 @@ int ble_adv_scan(const unsigned char *data, uint8_t len, subscribe_cb callback) 
   int err;
 
   err = subscribe(DRIVER_RADIO, BLE_SCAN_CALLBACK, callback, NULL);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = allow(DRIVER_RADIO, BLE_CFG_SCAN_BUF, (void*)data, len);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   return command(DRIVER_RADIO, BLE_SCAN, 1);
 }


### PR DESCRIPTION
Hi,
The major fixes with this PR are:
- Support payload size of 31 bytes instead of 30
- Support passive scanning of advertisements
- Added a sample application for scanning
- Added more inline comments

There are two controversial things in this PR which comes to mind:
- I'm using the radio HIL for callbacks to user-space
- I'm using the same buffer for both scanning and broadcasting (BLE_NONCONN_IND) because these never occur at the same time in current implementation!

Hopefully I managed to rebase properly this time.

--
Niklas A