### PR TITLE
app flash: allow apps to write their own flash

### DIFF
--- a/capsules/README.md
+++ b/capsules/README.md
@@ -77,6 +77,8 @@ These capsules provide a `Driver` interface for common MCU peripherals.
 
 These provide common and better abstractions for userspace.
 
+- **[App Flash](src/app_flash_driver.rs)**: Allow applications to write their
+  own flash.
 - **[Button](src/button.rs)**: Detect button presses.
 - **[Console](src/console.rs)**: UART console support.
 - **[LED](src/led.rs)**: Turn on and off LEDs.

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -1,0 +1,236 @@
+//! This allows multiple apps to write their own flash region.
+//!
+//! All write requests from userland are checked to ensure that they are only
+//! trying to write their own flash space, and not the TBF header either.
+//!
+//! This driver can handle non page aligned writes.
+//!
+//! Userland apps should allocate buffers in flash when they are compiled to
+//! ensure that there is room to write to. This should be accomplished by
+//! declaring `const` buffers.
+//!
+//! Usage
+//! -----
+//!
+//! ```
+//! pub static mut APP_FLASH_BUFFER: [u8; 512] = [0; 512];
+//! let app_flash = static_init!(
+//!     capsules::app_flash_driver::AppFlash<'static>,
+//!     capsules::app_flash_driver::AppFlash::new(nv_to_page,
+//!         kernel::Container::create(), &mut APP_FLASH_BUFFER));
+//! ```
+
+use core::cell::Cell;
+use core::cmp;
+use kernel::{AppId, AppSlice, Callback, Container, Driver, ReturnCode, Shared};
+use kernel::common::take_cell::TakeCell;
+use kernel::hil;
+use kernel::process::Error;
+
+pub struct App {
+    callback: Option<Callback>,
+    buffer: Option<AppSlice<Shared, u8>>,
+    pending_command: bool,
+    flash_address: usize,
+}
+
+impl Default for App {
+    fn default() -> App {
+        App {
+            callback: None,
+            buffer: None,
+            pending_command: false,
+            flash_address: 0,
+        }
+    }
+}
+
+pub struct AppFlash<'a> {
+    driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
+    apps: Container<App>,
+    current_app: Cell<Option<AppId>>,
+    buffer: TakeCell<'static, [u8]>,
+}
+
+impl<'a> AppFlash<'a> {
+    pub fn new(driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
+               container: Container<App>,
+               buffer: &'static mut [u8])
+               -> AppFlash<'a> {
+        AppFlash {
+            driver: driver,
+            apps: container,
+            current_app: Cell::new(None),
+            buffer: TakeCell::new(buffer),
+        }
+    }
+
+    // Check to see if we are doing something. If not, go ahead and do this
+    // command. If so, this is queued and will be run when the pending command
+    // completes.
+    fn enqueue_write(&self, flash_address: usize, appid: AppId) -> ReturnCode {
+        self.apps
+            .enter(appid, |app, _| {
+
+                // Check that this is a valid range in the app's flash.
+                let flash_length = app.buffer.as_mut().map_or(0, |app_buffer| app_buffer.len());
+                let (app_flash_start, app_flash_end) = appid.get_editable_flash_range();
+                if flash_address < app_flash_start || flash_address >= app_flash_end ||
+                   flash_address + flash_length >= app_flash_end {
+                    return ReturnCode::EINVAL;
+                }
+
+                if self.current_app.get().is_none() {
+                    self.current_app.set(Some(appid));
+
+                    app.buffer.as_mut().map_or(ReturnCode::ERESERVE, |app_buffer| {
+                        // Copy contents to internal buffer and write it.
+                        self.buffer.take().map_or(ReturnCode::ERESERVE, |buffer| {
+                            let length = cmp::min(buffer.len(), app_buffer.len());
+                            let d = &mut app_buffer.as_mut()[0..length];
+                            for (i, c) in buffer.as_mut()[0..length].iter_mut().enumerate() {
+                                *c = d[i];
+                            }
+
+                            self.driver.write(buffer, flash_address, length)
+                        })
+                    })
+
+                } else {
+                    // Queue this request for later.
+                    if app.pending_command == true {
+                        ReturnCode::ENOMEM
+                    } else {
+                        app.pending_command = true;
+                        app.flash_address = flash_address;
+                        ReturnCode::SUCCESS
+                    }
+                }
+            })
+            .unwrap_or_else(|err| match err {
+                Error::OutOfMemory => ReturnCode::ENOMEM,
+                Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                Error::NoSuchApp => ReturnCode::EINVAL,
+            })
+    }
+}
+
+impl<'a> hil::nonvolatile_storage::NonvolatileStorageClient for AppFlash<'a> {
+    fn read_done(&self, _buffer: &'static mut [u8], _length: usize) {}
+
+    fn write_done(&self, buffer: &'static mut [u8], _length: usize) {
+        // Put our write buffer back.
+        self.buffer.replace(buffer);
+
+        // Notify the current application that the command finished.
+        self.current_app.get().map(|appid| {
+            self.current_app.set(None);
+            let _ =
+                self.apps.enter(appid,
+                                |app, _| { app.callback.map(|mut cb| { cb.schedule(0, 0, 0); }); });
+        });
+
+        // Check if there are any pending events.
+        for cntr in self.apps.iter() {
+            let started_command = cntr.enter(|app, _| {
+                if app.pending_command {
+                    app.pending_command = false;
+                    self.current_app.set(Some(app.appid()));
+                    let flash_address = app.flash_address;
+
+                    app.buffer.as_mut().map_or(false, |app_buffer| {
+                        self.buffer.take().map_or(false, |buffer| {
+
+                            if app_buffer.len() != 512 {
+                                false
+                            } else {
+                                // Copy contents to internal buffer and write it.
+                                let length = cmp::min(buffer.len(), app_buffer.len());
+                                let d = &mut app_buffer.as_mut()[0..length];
+                                for (i, c) in buffer.as_mut()[0..length].iter_mut().enumerate() {
+                                    *c = d[i];
+                                }
+
+                                self.driver.write(buffer, flash_address, length) ==
+                                ReturnCode::SUCCESS
+                            }
+                        })
+                    })
+                } else {
+                    false
+                }
+            });
+            if started_command {
+                break;
+            }
+        }
+    }
+}
+
+impl<'a> Driver for AppFlash<'a> {
+    /// Setup buffer to write from.
+    ///
+    /// ### `allow_num`
+    ///
+    /// - `0`: Set write buffer. This entire buffer will be written to flash.
+    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+        match allow_num {
+            0 => {
+                self.apps
+                    .enter(appid, |app, _| {
+                        app.buffer = Some(slice);
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or_else(|err| match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    })
+            }
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Setup callbacks.
+    ///
+    /// ### `subscribe_num`
+    ///
+    /// - `0`: Set a write_done callback.
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+        match subscribe_num {
+            0 => {
+                self.apps
+                    .enter(callback.app_id(), |app, _| {
+                        app.callback = Some(callback);
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or_else(|err| match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    })
+            }
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// App flash control.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Driver check.
+    /// - `1`: Write the memory from the `allow` buffer to the address in flash.
+    fn command(&self, command_num: usize, arg1: usize, appid: AppId) -> ReturnCode {
+        match command_num {
+            0 => /* This driver exists. */ ReturnCode::SUCCESS,
+
+            // Write to flash from the allowed buffer.
+            1 => {
+                let flash_address = arg1;
+                self.enqueue_write(flash_address, appid)
+            }
+
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -42,3 +42,4 @@ pub mod max17205;
 pub mod pca9544a;
 pub mod nonvolatile_to_pages;
 pub mod nonvolatile_storage_driver;
+pub mod app_flash_driver;

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -240,6 +240,7 @@ functionality that is handled by the kernel. `command`, `subscribe`, and
 | 25            | SPI Slave        | Raw SPI slave interface                    |
 | 26            | DAC              | Digital to analog converter                |
 | 27            | Nonvolatile Storage | Generic interface for persistent storage |
+| 30            | App Flash        | Allow apps to write their own flash        |
 | 33            | BLE              | Bluetooth low energy communication         |
 | 154           | Radio            | 15.4 radio interface                       |
 | 255           | IPC              | Inter-process communication                |

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -33,6 +33,10 @@ impl AppId {
     pub fn idx(&self) -> usize {
         self.idx
     }
+
+    pub fn get_editable_flash_range(&self) -> (usize, usize) {
+        process::get_editable_flash_range(self.idx)
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/userland/examples/tests/app_state/Makefile
+++ b/userland/examples/tests/app_state/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/app_state/main.c
+++ b/userland/examples/tests/app_state/main.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+
+#include <app_state.h>
+#include <tock.h>
+
+#define MAGIC 0xcafe
+
+struct demo_app_state_t {
+  uint32_t magic;
+  uint32_t count;
+};
+
+// This macro sets up all of the state required to create a persistent data
+// structure. It will automatically be registered with the library and setup
+// a structure as if this line of code was here instead:
+//
+//   struct demo_app_state_t app_state;
+//
+// To get the initial structure from flash the app should call
+// `app_state_load_sync()`. It can the write the struct like any normal
+// variable. When the app wishes to "checkpoint" the state and write it back to
+// the persistent flash, it should call `app_state_save_sync()`.
+APP_STATE_DECLARE(struct demo_app_state_t, app_state);
+
+int main(void) {
+  int ret;
+
+  ret = app_state_load_sync();
+  if (ret < 0) {
+    printf("Error loading application state: %s\n", tock_strerror(ret));
+    return ret;
+  }
+
+  if (app_state.magic != MAGIC) {
+    printf("Application has never saved state before\n");
+    app_state.magic = MAGIC;
+    app_state.count = 1;
+  } else {
+    char plural[2] = {'s', 0};
+    if (app_state.count == 1) {
+      *plural = 0;
+    }
+    printf("This application has run %lu time%s before\n", app_state.count, plural);
+    app_state.count += 1;
+  }
+
+  ret = app_state_save_sync();
+  if (ret != 0) {
+    printf("ERROR saving application state: %s\n", tock_strerror(ret));
+    return ret;
+  }
+  printf("State saved successfully. Done.\n");
+
+  return 0;
+}

--- a/userland/libtock/app_state.c
+++ b/userland/libtock/app_state.c
@@ -1,0 +1,71 @@
+#include <string.h>
+
+#include "app_state.h"
+#include "tock.h"
+
+// Internal callback for synchronous interfaces
+static void app_state_sync_cb(__attribute__ ((unused)) int callback_type,
+                              __attribute__ ((unused)) int value,
+                              __attribute__ ((unused)) int unused,
+                              void* ud) {
+  *((bool*) ud) = true;
+}
+
+
+static bool _app_state_inited = false;
+static int app_state_init(void) {
+  int err;
+  err = allow(DRIVER_NUM_APP_FLASH, 0, _app_state_ram_pointer, _app_state_size);
+  if (err < 0) return err;
+
+  // Check that we have a region to use for this.
+  int number_regions = tock_app_number_writeable_flash_regions();
+  if (number_regions == 0) return TOCK_ENOMEM;
+
+  // Get the pointer to flash which we need to ask the kernel where it is.
+  _app_state_flash_pointer = tock_app_writeable_flash_region_begins_at(0);
+
+  _app_state_inited = true;
+  return 0;
+}
+
+
+int app_state_load_sync(void) {
+  if (!_app_state_inited) {
+    int err;
+    err = app_state_init();
+    if (err < 0) return err;
+  }
+
+  memcpy(_app_state_ram_pointer, _app_state_flash_pointer, _app_state_size);
+  return 0;
+}
+
+int app_state_save(subscribe_cb callback, void* callback_args) {
+  int err;
+
+  if (!_app_state_inited) {
+    err = app_state_init();
+    if (err < 0) return err;
+  }
+
+  err = subscribe(DRIVER_NUM_APP_FLASH, 0, callback, callback_args);
+  if (err < 0) return err;
+
+  return command(DRIVER_NUM_APP_FLASH, 1, (uint32_t) _app_state_flash_pointer);
+}
+
+
+static bool save_sync_flag;
+int app_state_save_sync(void) {
+  int err;
+  save_sync_flag = false;
+
+  err = app_state_save(app_state_sync_cb, (void*) &save_sync_flag);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&save_sync_flag);
+
+  return 0;
+}

--- a/userland/libtock/app_state.h
+++ b/userland/libtock/app_state.h
@@ -1,0 +1,84 @@
+#pragma once
+
+// Utility for allowing apps to read and write a region of flash. This interface
+// is designed for apps to specify a special region of flash that stores
+// persistent data, and not as a general purpose flash reading and writing tool.
+//
+// The expected use looks something like:
+//
+//   struct valuable_data {
+//     uint32_t magic;
+//     uint32_t my_value1;
+//     uint32_t my_value2;
+//   }
+//
+//   // Setup the struct that has the app state.
+//   APP_STATE_DECLARE(struct valuable_data, my_data);
+//
+//   int main() {
+//     int ret;
+//
+//     // Get the initial copy of the data in flash.
+//     ret = app_state_load_sync();
+//     if (ret != 0) prinrf("ERROR(%i): Could not read the flash region.\n", ret);
+//
+//     // Check that the magic value is as expected.
+//     if (data_in_ram.magic != MAGIC) {
+//       // do some initialization
+//     }
+//
+//     // do other computation
+//
+//     // Save changed valuable data.
+//     ret = app_state_save_sync();
+//     if (ret != 0) prinrf("ERROR(%i): Could not write back to flash.\n", ret);
+//   }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "tock.h"
+
+#define DRIVER_NUM_APP_FLASH 30
+
+
+// Declare an application state structure
+//
+// This macro does a little extra bookkeeping, however it should look
+// much like a simple declaration in practice:
+//
+//     APP_STATE_DECLARE(struct my_state_t, memory_copy);
+//
+// Which you can read as the equivalent of:
+//
+//     struct my_state_t memory_copy;
+//
+// The variable `memory_copy` is available as regular C structure, however
+// users must explicitly `load` and `save` application state as appropriate
+#define APP_STATE_DECLARE(_type, _identifier)                         \
+  __attribute__((section(".app_state")))                              \
+  _type _app_state_flash;                                             \
+  _type _identifier;                                                  \
+  void* _app_state_flash_pointer = NULL;                              \
+  void* _app_state_ram_pointer = &_identifier;                        \
+  size_t _app_state_size = sizeof(_type);
+
+extern void* _app_state_flash_pointer;
+extern void* _app_state_ram_pointer;
+extern size_t _app_state_size;
+
+// Load application state from persistent storage
+__attribute__ ((warn_unused_result))
+int app_state_load_sync(void);
+
+// Save application state to persistent storage
+__attribute__ ((warn_unused_result))
+int app_state_save(subscribe_cb callback, void* callback_args);
+__attribute__ ((warn_unused_result))
+int app_state_save_sync(void);
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/userland/libtock/app_state.h
+++ b/userland/libtock/app_state.h
@@ -55,7 +55,8 @@ extern "C" {
 //     struct my_state_t memory_copy;
 //
 // The variable `memory_copy` is available as regular C structure, however
-// users must explicitly `load` and `save` application state as appropriate
+// users must explicitly `load` and `save` application state as appropriate.
+// Note that each process may only use APP_STATE_DECLARE once.
 #define APP_STATE_DECLARE(_type, _identifier)                         \
   __attribute__((section(".app_state")))                              \
   _type _app_state_flash;                                             \

--- a/userland/userland_generic.ld
+++ b/userland/userland_generic.ld
@@ -31,6 +31,12 @@ SECTIONS {
         _etext = .;
     } > FLASH =0xFF
 
+/* App state section. Used for persistent app data. */
+    .app_state :
+    {
+        KEEP (*(.app_state))
+    } > FLASH =0xFF
+
 /* ARM Exception support
  *
  * This contains compiler-generated support for unwinding the stack,


### PR DESCRIPTION
Provides userspace with a mechanism to write their own flash space.

### Help

I need some way to ensure that an app is only trying to write its own space (and not the TBF header). Also, I think this doesn't work if the MPU is enabled, even if an app is writing its own space.