### PR TITLE
userland: prepend `TOCK_` to error names

### DIFF
--- a/userland/examples/radio_tx/main.c
+++ b/userland/examples/radio_tx/main.c
@@ -24,7 +24,7 @@ int main(void) {
   while (1) {
     led_toggle(0);
     int err = radio_send(0x0802, packet, BUF_SIZE);
-    if (err != SUCCESS) {
+    if (err != TOCK_SUCCESS) {
       gpio_toggle(0);
     }
     delay_ms(250);

--- a/userland/examples/tests/adc_continuous/main.c
+++ b/userland/examples/tests/adc_continuous/main.c
@@ -43,7 +43,7 @@ static void continuous_sample_cb(uint8_t channel,
 
     // stop single sampling
     int err = adc_stop_sampling();
-    if (err < SUCCESS) {
+    if (err < TOCK_SUCCESS) {
       printf("Failed to stop sampling: %d\n", err);
       return;
     }
@@ -52,7 +52,7 @@ static void continuous_sample_cb(uint8_t channel,
     printf("Beginning buffered sampling on channel %d at %d Hz\n",
            ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY);
     err = adc_continuous_buffered_sample(ADC_CHANNEL, ADC_HIGHSPEED_FREQUENCY);
-    if (err < SUCCESS) {
+    if (err < TOCK_SUCCESS) {
       printf("continuous buffered sample error: %d\n", err);
       return;
     }
@@ -90,7 +90,7 @@ static void continuous_buffered_sample_cb(uint8_t channel,
 
     // stop single sampling
     int err = adc_stop_sampling();
-    if (err < SUCCESS) {
+    if (err < TOCK_SUCCESS) {
       printf("Failed to stop sampling: %d\n", err);
       return;
     }
@@ -99,7 +99,7 @@ static void continuous_buffered_sample_cb(uint8_t channel,
     printf("Beginning continuous sampling on channel %d at %d Hz\n",
            ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
     err = adc_continuous_sample(ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
-    if (err < SUCCESS) {
+    if (err < TOCK_SUCCESS) {
       printf("continuous sample error: %d\n", err);
       return;
     }
@@ -119,19 +119,19 @@ int main(void) {
 
   // set ADC callbacks
   err = adc_set_continuous_sample_callback(continuous_sample_cb, NULL);
-  if (err < SUCCESS) {
+  if (err < TOCK_SUCCESS) {
     printf("set continuous sample callback error: %d\n", err);
     return -1;
   }
   err = adc_set_continuous_buffered_sample_callback(continuous_buffered_sample_cb, NULL);
-  if (err < SUCCESS) {
+  if (err < TOCK_SUCCESS) {
     printf("set continuous buffered sample callback error: %d\n", err);
     return -1;
   }
 
   // set main buffer for ADC samples
   err = adc_set_buffer(sample_buffer1, BUF_SIZE);
-  if (err < SUCCESS) {
+  if (err < TOCK_SUCCESS) {
     printf("set buffer error: %d\n", err);
     return -1;
   }
@@ -139,7 +139,7 @@ int main(void) {
   // set secondary buffer for ADC samples. In continuous mode, the ADC will
   // automatically switch between the two each callback
   err = adc_set_double_buffer(sample_buffer2, BUF_SIZE);
-  if (err < SUCCESS) {
+  if (err < TOCK_SUCCESS) {
     printf("set double buffer error: %d\n", err);
     return -1;
   }
@@ -148,7 +148,7 @@ int main(void) {
   printf("Beginning continuous sampling on channel %d at %d Hz\n",
          ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
   err = adc_continuous_sample(ADC_CHANNEL, ADC_LOWSPEED_FREQUENCY);
-  if (err < SUCCESS) {
+  if (err < TOCK_SUCCESS) {
     printf("continuous sample error: %d\n", err);
     return -1;
   }

--- a/userland/examples/tests/crc/main.c
+++ b/userland/examples/tests/crc/main.c
@@ -52,13 +52,13 @@ int main(void) {
       struct test_case *t = &test_cases[test_index];
 
       uint32_t result;
-      if ((r = crc_compute(t->input, strlen(t->input), t->alg, &result)) != SUCCESS) {
+      if ((r = crc_compute(t->input, strlen(t->input), t->alg, &result)) != TOCK_SUCCESS) {
         printf("CRC compute failed: %d\n", r);
         exit(1);
       }
 
       printf("[%8lx] Case %2d: ", procid, test_index);
-      if (r == SUCCESS) {
+      if (r == TOCK_SUCCESS) {
         printf("result=%08lx ", result);
         if (result == t->output)
           printf("(OK)");

--- a/userland/libtock/adc.c
+++ b/userland/libtock/adc.c
@@ -52,33 +52,33 @@ static void adc_cb(int callback_type,
 
   switch (callback_type) {
     case SingleSample:
-      result->error   = SUCCESS;
+      result->error   = TOCK_SUCCESS;
       result->channel = arg1;
       result->sample  = arg2;
       break;
 
     case ContinuousSample:
-      result->error   = SUCCESS;
+      result->error   = TOCK_SUCCESS;
       result->channel = arg1;
       result->sample  = arg2;
       break;
 
     case SingleBuffer:
-      result->error   = SUCCESS;
+      result->error   = TOCK_SUCCESS;
       result->channel = (arg1 & 0xFF);
       result->length  = ((arg1 >> 8) & 0xFFFFFF);
       result->buffer  = (uint16_t*)arg2;
       break;
 
     case ContinuousBuffer:
-      result->error   = SUCCESS;
+      result->error   = TOCK_SUCCESS;
       result->channel = (arg1 & 0xFF);
       result->length  = ((arg1 >> 8) & 0xFFFFFF);
       result->buffer  = (uint16_t*)arg2;
       break;
 
     default:
-      result->error = FAIL;
+      result->error = TOCK_FAIL;
       break;
   }
 
@@ -234,13 +234,13 @@ int adc_sample_sync(uint8_t channel, uint16_t* sample) {
   int err;
   adc_data_t result = {0};
   result.fired = false;
-  result.error = SUCCESS;
+  result.error = TOCK_SUCCESS;
 
   err = adc_set_callback(adc_cb, (void*) &result);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = adc_single_sample(channel);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   // wait for callback
   yield_for(&result.fired);
@@ -255,23 +255,23 @@ int adc_sample_buffer_sync(uint8_t channel, uint32_t frequency, uint16_t* buffer
   int err;
   adc_data_t result = {0};
   result.fired = false;
-  result.error = SUCCESS;
+  result.error = TOCK_SUCCESS;
 
   err = adc_set_callback(adc_cb, (void*) &result);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = adc_set_buffer(buffer, length);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = adc_buffered_sample(channel, frequency);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   // wait for callback
   yield_for(&result.fired);
 
   // copy over result
   if (result.buffer != buffer) {
-    return FAIL;
+    return TOCK_FAIL;
   }
 
   return result.error;

--- a/userland/libtock/aes.c
+++ b/userland/libtock/aes.c
@@ -64,13 +64,13 @@ int aes128_encrypt_ctr(unsigned const char* buf, unsigned char buf_len,
   int err;
 
   err = aes128_set_callback(callback, NULL);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = aes128_set_data(buf, buf_len);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = aes128_set_ctr(ctr, ctr_len);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   return aes128_encrypt_start();
 }
@@ -83,13 +83,13 @@ int aes128_decrypt_ctr(const unsigned char* buf, unsigned char buf_len,
   int err;
 
   err = aes128_set_callback(callback, NULL);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = aes128_set_data(buf, buf_len);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = aes128_set_ctr(ctr, ctr_len);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   return aes128_decrypt_start();
 }
@@ -105,7 +105,7 @@ int aes128_set_key_sync(const unsigned char* key, unsigned char len) {
   int err;
 
   err = allow(AES_DRIVER, AES_KEY, (void*)key, len);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   return command(AES_DRIVER, AES_KEY, 0);
 }
@@ -117,19 +117,19 @@ int aes128_encrypt_ctr_sync(unsigned const char* buf, unsigned char buf_len,
                             unsigned const char* ctr, unsigned char ctr_len) {
 
   int err;
-  aes_data_t result = { .fired = false, .error = SUCCESS };
+  aes_data_t result = { .fired = false, .error = TOCK_SUCCESS };
 
   err = aes128_set_callback(aes_cb, &result);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = aes128_set_data(buf, buf_len);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = aes128_set_ctr(ctr, ctr_len);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = aes128_encrypt_start();
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   yield_for(&result.fired);
 
@@ -143,19 +143,19 @@ int aes128_decrypt_ctr_sync(const unsigned char* buf, unsigned char buf_len,
                             const unsigned char* ctr, unsigned char ctr_len) {
 
   int err;
-  aes_data_t result = { .fired = false, .error = SUCCESS };
+  aes_data_t result = { .fired = false, .error = TOCK_SUCCESS };
 
   err = aes128_set_callback(aes_cb, &result);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = aes128_set_data(buf, buf_len);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = aes128_set_ctr(ctr, ctr_len);
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   err = aes128_decrypt_start();
-  if (err < SUCCESS) return err;
+  if (err < TOCK_SUCCESS) return err;
 
   yield_for(&result.fired);
 

--- a/userland/libtock/alarm_timer.c
+++ b/userland/libtock/alarm_timer.c
@@ -36,7 +36,7 @@ static int heap_insert(alarm_t* alarm) {
     alarm_heap.data = (alarm_t**)realloc(alarm_heap.data,
                                          new_capacity * sizeof(alarm_t*));
     if (alarm_heap.data == NULL) {
-      return ENOMEM;
+      return TOCK_ENOMEM;
     }
     alarm_heap.capacity = new_capacity;
   }

--- a/userland/libtock/console.c
+++ b/userland/libtock/console.c
@@ -35,16 +35,16 @@ static void putstr_cb(int _x __attribute__ ((unused)),
 }
 
 int putnstr(const char *str, size_t len) {
-  int ret = SUCCESS;
+  int ret = TOCK_SUCCESS;
 
   putstr_data_t* data = (putstr_data_t*)malloc(sizeof(putstr_data_t));
-  if (data == NULL) return ENOMEM;
+  if (data == NULL) return TOCK_ENOMEM;
 
   data->len    = len;
   data->called = false;
   data->buf    = (char*)malloc(len * sizeof(char));
   if (data->buf == NULL) {
-    ret = ENOMEM;
+    ret = TOCK_ENOMEM;
     goto putnstr_fail_buf_alloc;
   }
   strncpy(data->buf, str, len);

--- a/userland/libtock/crc.c
+++ b/userland/libtock/crc.c
@@ -44,7 +44,7 @@ int crc_compute(const void *buf, size_t buflen, enum crc_alg alg, uint32_t *resu
   crc_request(alg);
   yield_for(&d.fired);
 
-  if (d.status == SUCCESS)
+  if (d.status == TOCK_SUCCESS)
     *result = d.result;
 
   return d.status;

--- a/userland/libtock/radio.c
+++ b/userland/libtock/radio.c
@@ -76,9 +76,9 @@ int radio_send(unsigned short addr, const char* packet, unsigned char len) {
   } else {
     yield_for(&cond);
     if (tx_acked) {
-      return SUCCESS;
+      return TOCK_SUCCESS;
     } else {
-      return ENOACK;
+      return TOCK_ENOACK;
     }
   }
 }
@@ -101,15 +101,15 @@ int radio_set_power(char power) {
 int radio_commit(void) {
   bool cond = false;
   int err   = subscribe(SYS_RADIO, EVT_CFG, cb_config, &cond);
-  if (err != SUCCESS) {
+  if (err != TOCK_SUCCESS) {
     return err;
   }
   err = command(SYS_RADIO, COM_COMMIT, 0);
-  if (err != SUCCESS) {
+  if (err != TOCK_SUCCESS) {
     return err;
   }
   yield_for(&cond);
-  return SUCCESS;
+  return TOCK_SUCCESS;
 }
 
 // Valid channels are 10-26
@@ -146,5 +146,5 @@ int radio_receive_callback(subscribe_cb callback,
 }
 
 int radio_ready(void) {
-  return command(SYS_RADIO, COM_READY, 0) == SUCCESS;
+  return command(SYS_RADIO, COM_READY, 0) == TOCK_SUCCESS;
 }

--- a/userland/libtock/sdcard.c
+++ b/userland/libtock/sdcard.c
@@ -40,24 +40,24 @@ static void sdcard_cb (int callback_type, int arg1, int arg2, void* callback_arg
   switch (callback_type) {
     case 0:
       // card_detection_changed
-      result->error = EUNINSTALLED;
+      result->error = TOCK_EUNINSTALLED;
       break;
 
     case 1:
       // init_done
       result->block_size = arg1;
       result->size_in_kB = arg2;
-      result->error      = SUCCESS;
+      result->error      = TOCK_SUCCESS;
       break;
 
     case 2:
       // read_done
-      result->error = SUCCESS;
+      result->error = TOCK_SUCCESS;
       break;
 
     case 3:
       // write_done
-      result->error = SUCCESS;
+      result->error = TOCK_SUCCESS;
       break;
 
     case 4:
@@ -93,7 +93,7 @@ int sdcard_initialize_sync (uint32_t* block_size, uint32_t* size_in_kB) {
   int err;
   sdcard_data_t result;
   result.fired = false;
-  result.error = SUCCESS;
+  result.error = TOCK_SUCCESS;
 
   err = sdcard_set_callback(sdcard_cb, (void*) &result);
   if (err < 0) return err;
@@ -123,7 +123,7 @@ int sdcard_read_block_sync (uint32_t sector) {
   int err;
   sdcard_data_t result;
   result.fired = false;
-  result.error = SUCCESS;
+  result.error = TOCK_SUCCESS;
 
   err = sdcard_set_callback(sdcard_cb, (void*) &result);
   if (err < 0) return err;
@@ -145,7 +145,7 @@ int sdcard_write_block_sync (uint32_t sector) {
   int err;
   sdcard_data_t result;
   result.fired = false;
-  result.error = SUCCESS;
+  result.error = TOCK_SUCCESS;
 
   err = sdcard_set_callback(sdcard_cb, (void*) &result);
   if (err < 0) return err;

--- a/userland/libtock/tock.h
+++ b/userland/libtock/tock.h
@@ -40,20 +40,20 @@ void* tock_app_grant_begins_at(void);
 // Checks to see if the given driver number exists on this platform.
 bool driver_exists(uint32_t driver);
 
-#define SUCCESS   0
-#define FAIL     -1
-#define EBUSY    -2
-#define EALREADY -3
-#define EOFF     -4
-#define ERESERVE -5
-#define EINVAL   -6
-#define ESIZE    -7
-#define ECANCEL  -8
-#define ENOMEM   -9
-#define ENOSUPPORT -10
-#define ENODEVICE  -11
-#define EUNINSTALLED -12
-#define ENOACK -13
+#define TOCK_SUCCESS       0
+#define TOCK_FAIL         -1
+#define TOCK_EBUSY        -2
+#define TOCK_EALREADY     -3
+#define TOCK_EOFF         -4
+#define TOCK_ERESERVE     -5
+#define TOCK_EINVAL       -6
+#define TOCK_ESIZE        -7
+#define TOCK_ECANCEL      -8
+#define TOCK_ENOMEM       -9
+#define TOCK_ENOSUPPORT   -10
+#define TOCK_ENODEVICE    -11
+#define TOCK_EUNINSTALLED -12
+#define TOCK_ENOACK       -13
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This allows `tock.h` to be compatible with `errno.h`.

Fixes #353