### PR TITLE
gpio: configure(None) correct behavior. Fixes #464

### DIFF
--- a/chips/sam4l/src/gpio.rs
+++ b/chips/sam4l/src/gpio.rs
@@ -448,7 +448,11 @@ impl hil::Controller for GPIOPin {
     type Config = Option<PeripheralFunction>;
 
 
-    fn configure(&self, config: Option<PeripheralFunction>) {
+    fn configure(&self, config: Self::Config) {
+        // Unassign the pin from its current peripheral function.
+        self.enable();
+
+        // If config is Some, select the desired peripheral.
         config.map(|c| { self.select_peripheral(c); });
     }
 }

--- a/chips/sam4l/src/gpio.rs
+++ b/chips/sam4l/src/gpio.rs
@@ -449,11 +449,10 @@ impl hil::Controller for GPIOPin {
 
 
     fn configure(&self, config: Self::Config) {
-        // Unassign the pin from its current peripheral function.
-        self.enable();
-
-        // If config is Some, select the desired peripheral.
-        config.map(|c| { self.select_peripheral(c); });
+        match config {
+            Some(c) => self.select_peripheral(c),
+            None => self.enable()
+        }
     }
 }
 

--- a/chips/sam4l/src/gpio.rs
+++ b/chips/sam4l/src/gpio.rs
@@ -451,7 +451,7 @@ impl hil::Controller for GPIOPin {
     fn configure(&self, config: Self::Config) {
         match config {
             Some(c) => self.select_peripheral(c),
-            None => self.enable()
+            None => self.enable(),
         }
     }
 }


### PR DESCRIPTION
By enabling the GPIO before potentially assigning it to a peripheral, we ensure that calling `configure(None)` will put the pin into GPIO mode, rather than leaving it in the current peripheral mode.