### PR TITLE
Adds a `prepare_for_sleep` method to the Chip trait with implementation for SAM4L

### DIFF
--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -12,6 +12,7 @@ use i2c;
 use kernel::Chip;
 use kernel::common::{RingBuffer, Queue};
 use nvic;
+use pm;
 use spi;
 use trng;
 use usart;
@@ -151,5 +152,17 @@ impl Chip for Sam4l {
 
     fn systick(&self) -> &cortexm4::systick::SysTick {
         self.systick
+    }
+
+    fn prepare_for_sleep(&self) {
+        if pm::deep_sleep_ready() {
+            unsafe {
+                cortexm4::scb::set_sleepdeep();
+            }
+        } else {
+            unsafe {
+                cortexm4::scb::unset_sleepdeep();
+            }
+        }
     }
 }

--- a/chips/sam4l/src/gpio.rs
+++ b/chips/sam4l/src/gpio.rs
@@ -4,6 +4,7 @@ use self::Pin::*;
 use core::cell::Cell;
 use core::mem;
 use core::ops::{Index, IndexMut};
+use core::sync::atomic::{AtomicUsize, Ordering};
 use kernel::common::VolatileCell;
 use kernel::hil;
 use nvic;
@@ -78,6 +79,18 @@ pub enum PeripheralFunction {
 
 const BASE_ADDRESS: usize = 0x400E1000;
 const SIZE: usize = 0x200;
+
+/// Reference count for the number of GPIO interrupts currently active.
+///
+/// This is used to determine if it's possible for the SAM4L to go into
+/// WAIT/RETENTION mode, since those modes will not be woken up by GPIO
+/// interrupts.
+///
+/// This is an `AtomicUsize` because it has to be a `Sync` type to live in a
+/// global---Rust has no way of knowing we're not going to use it across
+/// threads. Use `Ordering::Relaxed` when reading/writing the value to get LLVM
+/// to just use plain loads and stores instead of atomic operations.
+pub static INTERRUPT_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// Name of the GPIO pin on the SAM4L.
 ///
@@ -394,17 +407,23 @@ impl GPIOPin {
     pub fn enable_interrupt(&self) {
         unsafe {
             let port: &mut Registers = mem::transmute(self.port);
-            nvic::enable(self.nvic);
-            port.ier.set.set(self.pin_mask);
+            if port.ier.val.get() & self.pin_mask == 0 {
+                INTERRUPT_COUNT.fetch_add(1, Ordering::Relaxed);
+                nvic::enable(self.nvic);
+                port.ier.set.set(self.pin_mask);
+            }
         }
     }
 
     pub fn disable_interrupt(&self) {
         let port: &mut Registers = unsafe { mem::transmute(self.port) };
-        port.ier.clear.set(self.pin_mask);
-        if port.ier.val.get() == 0 {
-            unsafe {
-                nvic::disable(self.nvic);
+        if port.ier.val.get() & self.pin_mask != 0 {
+            INTERRUPT_COUNT.fetch_sub(1, Ordering::Relaxed);
+            port.ier.clear.set(self.pin_mask);
+            if port.ier.val.get() == 0 {
+                unsafe {
+                    nvic::disable(self.nvic);
+                }
             }
         }
     }

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -494,6 +494,22 @@ pub unsafe fn get_system_frequency() -> u32 {
     SYSTEM_FREQUENCY.get()
 }
 
+/// Utility macro to modify clock mask registers
+/// 
+/// It takes one of two forms:
+///
+///     mask_clock!(CLOCK: pm_register | value)
+///
+/// which performs a logical-or on the existing register value, or
+///
+///     mask_clock!(CLOCK: pm_register & value)
+///
+/// which performs a logical-and.
+///
+/// CLOCK is one of HSB, PBA, PBB, PBC or PBD
+///
+/// pm_register is one of hsbmask, pbamask, pbbmask, pbcmask or pbdmask.
+///
 macro_rules! mask_clock {
     ($module:ident: $field:ident | $mask:expr) => ({
         unlock(concat_idents!($module, _MASK_OFFSET));

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -60,6 +60,7 @@ pub fn main<P: Platform, C: Chip>(platform: &P,
             }
 
             support::atomic(|| if !chip.has_pending_interrupts() && process::processes_blocked() {
+                chip.prepare_for_sleep();
                 support::wfi();
             })
         };

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -17,4 +17,5 @@ pub trait Chip {
     fn has_pending_interrupts(&self) -> bool;
     fn mpu(&self) -> &Self::MPU;
     fn systick(&self) -> &Self::SysTick;
+    fn prepare_for_sleep(&self) {}
 }


### PR DESCRIPTION
Ref #470 

The `prepare_for_sleep` is where chips will determine which sleep state to go into and prepare for it.

On the SAM4L, The basic strategy is to look at the power manager's clock mask register's and compare them against a set of known clock masks that would let us go into deep sleep without preventing any active
peripherals from working.