### PR TITLE
SAM4L Low Power: Manage USART clocks

### DIFF
--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -20,7 +20,6 @@ impl Write for Writer {
                 parity: uart::Parity::None,
                 hw_flow_control: false,
             });
-            uart.reset();
             uart.enable_tx();
 
         }

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -20,7 +20,6 @@ impl Write for Writer {
                 parity: uart::Parity::None,
                 hw_flow_control: false,
             });
-            uart.reset();
             uart.enable_tx();
 
         }

--- a/boards/imixv1/src/io.rs
+++ b/boards/imixv1/src/io.rs
@@ -20,7 +20,6 @@ impl Write for Writer {
                 parity: uart::Parity::None,
                 hw_flow_control: false,
             });
-            uart.reset();
             uart.enable_tx();
 
         }

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -392,6 +392,15 @@ macro_rules! mask_clock {
     });
 }
 
+/// Utility macro to get value of clock register. Used to check if a specific
+/// clock is enabled or not. See above description of `make_clock!`.
+macro_rules! get_clock {
+    ($module:ident: $field:ident & $mask:expr) => ({
+        unlock(concat_idents!($module, _MASK_OFFSET));
+        ((*PM_REGS).$field.get() & ($mask)) != 0
+    });
+}
+
 // Clock masks that allow us to go into deep sleep without disabling any active
 // peripherals.
 
@@ -456,5 +465,15 @@ pub unsafe fn disable_clock(clock: Clock) {
         Clock::PBB(v) => mask_clock!(PBB: pbbmask & !(1 << (v as u32))),
         Clock::PBC(v) => mask_clock!(PBC: pbcmask & !(1 << (v as u32))),
         Clock::PBD(v) => mask_clock!(PBD: pbdmask & !(1 << (v as u32))),
+    }
+}
+
+pub unsafe fn is_clock_enabled(clock: Clock) -> bool {
+    match clock {
+        Clock::HSB(v) => get_clock!(HSB: hsbmask & (1 << (v as u32))),
+        Clock::PBA(v) => get_clock!(PBA: pbamask & (1 << (v as u32))),
+        Clock::PBB(v) => get_clock!(PBB: pbbmask & (1 << (v as u32))),
+        Clock::PBC(v) => get_clock!(PBC: pbcmask & (1 << (v as u32))),
+        Clock::PBD(v) => get_clock!(PBD: pbdmask & (1 << (v as u32))),
     }
 }

--- a/userland/examples/tests/hello_loop/Makefile
+++ b/userland/examples/tests/hello_loop/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/hello_loop/README.md
+++ b/userland/examples/tests/hello_loop/README.md
@@ -1,0 +1,7 @@
+# Hello Loop Test App
+
+Periodically prints "Hello\n" to the console. This is meant to help test
+low-power operation when using the USART. On the SAM4L, with a board configured
+to be able to enter deep sleep, power consumption should drop to microamps (in
+WAIT mode) for a large majority of the time while the app continues to operate
+normally.

--- a/userland/examples/tests/hello_loop/main.c
+++ b/userland/examples/tests/hello_loop/main.c
@@ -1,0 +1,13 @@
+/* vim: set sw=2 expandtab tw=80: */
+
+#include <stdio.h>
+
+#include <console.h>
+#include <timer.h>
+
+int main(void) {
+  while (1) {
+    printf("Hello\n");
+    delay_ms(1000);
+  }
+}


### PR DESCRIPTION
Ref: #470

A step towards automatic low power on the SAM4L.

This change only leaves the USART clock enabled when the USART is currently transmitting or recieving. 

In order to properly deal with transmission through the DMA (which may complete while there are still bytes in the TX buffer), the change adds a check for the TX_EMPTY interrupt.

Merging this change will allow platforms that only use the USART to run applications in deep sleep mode when possible that use the USART. For example, the following simple application will go into deep sleep for all but a few microseconds every five seconds:

```c
int main() {
  while(1) {
    printf("Hello\n");
    delay_ms(5000);
  }
}
```

Note, however, that for this to work as expected, other peripherals (which do not yet implement proper clock management) would need to be disabled.