### PR TITLE
style: treat formatted files as built objects

### DIFF
--- a/userland/AppMakefile.mk
+++ b/userland/AppMakefile.mk
@@ -195,10 +195,29 @@ clean::
 
 
 # Rules for running the C linter
+FORMATTED_FILES := $(patsubst %.c,$(BUILDDIR)/format/%.uncrustify,$(C_SRCS))
+FORMATTED_FILES += $(patsubst %.cc,$(BUILDDIR)/format/%.uncrustify,$(filter %.cc, $(CXX_SRCS)))
+FORMATTED_FILES += $(patsubst %.cpp,$(BUILDDIR)/format/%.uncrustify,$(filter %.cpp, $(CXX_SRCS)))
+FORMATTED_FILES += $(patsubst %.cxx,$(BUILDDIR)/format/%.uncrustify,$(filter %.cxx, $(CXX_SRCS)))
+
+$(BUILDDIR)/format:
+	@mkdir -p $@
 
 .PHONY: fmt format
-fmt format::
-	$(Q)$(UNCRUSTIFY) $(C_SRCS) $(CXX_SRCS)
+fmt format:: $(FORMATTED_FILES)
+
+$(BUILDDIR)/format/%.uncrustify: %.c
+	$(Q)$(UNCRUSTIFY) -f $< -o $@
+	$(Q)cmp -s $< $@ || (if [ "$$CI" == "true" ]; then diff -y $< $@; rm $@; exit 1; else cp $@ $<; fi)
+$(BUILDDIR)/format/%.uncrustify: %.cc
+	$(Q)$(UNCRUSTIFY) -f $< -o $@
+	$(Q)cmp -s $< $@ || (if [ "$$CI" == "true" ]; then diff -y $< $@; rm $@; exit 1; else cp $@ $<; fi)
+$(BUILDDIR)/format/%.uncrustify: %.cpp
+	$(Q)$(UNCRUSTIFY) -f $< -o $@
+	$(Q)cmp -s $< $@ || (if [ "$$CI" == "true" ]; then diff -y $< $@; rm $@; exit 1; else cp $@ $<; fi)
+$(BUILDDIR)/format/%.uncrustify: %.cxx
+	$(Q)$(UNCRUSTIFY) -f $< -o $@
+	$(Q)cmp -s $< $@ || (if [ "$$CI" == "true" ]; then diff -y $< $@; rm $@; exit 1; else cp $@ $<; fi)
 
 
 

--- a/userland/TockLibrary.mk
+++ b/userland/TockLibrary.mk
@@ -160,9 +160,17 @@ $(eval $(call CLEAN_RULE,$($(LIBNAME)_BUILDDIR)))
 
 
 # Rules for running the C linter
-define FORMAT_RULE
+$(LIBNAME)_FORMATTED_FILES := $(patsubst %.c,$($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.c, $($(LIBNAME)_SRCS_FLAT)))
+$(LIBNAME)_FORMATTED_FILES += $(patsubst %.cc,$($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.cc, $($(LIBNAME)_SRCS_FLAT)))
+$(LIBNAME)_FORMATTED_FILES += $(patsubst %.cpp,$($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.cpp, $($(LIBNAME)_SRCS_FLAT)))
+$(LIBNAME)_FORMATTED_FILES += $(patsubst %.cxx,$($(LIBNAME)_BUILDDIR)/format/%.uncrustify,$(filter %.cxx, $($(LIBNAME)_SRCS_FLAT)))
+
+$($(LIBNAME)_BUILDDIR)/format:
+	@mkdir -p $@
+
 .PHONY: fmt format
-fmt format::
-	$(Q)$(UNCRUSTIFY) $(1)
-endef
-$(eval $(call FORMAT_RULE,$($(LIBNAME)_SRCS)))
+fmt format:: $($(LIBNAME)_FORMATTED_FILES)
+
+$($(LIBNAME)_BUILDDIR)/format/%.uncrustify: %.c
+	$(Q)$(UNCRUSTIFY) -f $< -o $@
+	$(Q)cmp -s $< $@ || (if [ "$$CI" == "true" ]; then diff -y $< $@; rm $@; exit 1; else cp $@ $<; fi)

--- a/userland/tools/uncrustify/uncrustify.sh
+++ b/userland/tools/uncrustify/uncrustify.sh
@@ -83,15 +83,4 @@ fi
 set +e
 
 COMMON_FLAGS="-c $SCRIPT_DIR/uncrustify.cfg"
-if [ "$CI" == "true" ]; then
-  uncrustify $COMMON_FLAGS --check "$@"
-  if [ $? -ne 0 ]; then
-    uncrustify $COMMON_FLAGS --if-changed "$@"
-    for f in $(ls *.uncrustify); do
-      diff -y ${f%.*} $f
-    done
-    exit 1
-  fi
-else
-  exec uncrustify $COMMON_FLAGS --no-backup "$@"
-fi
+exec uncrustify $COMMON_FLAGS "$@"


### PR DESCRIPTION
Instead of unconditionally formatting all sources, now create a
%.c[c|pp|xx] -> build/format/%.uncrustify mapping for formatted files.
This allows make to do the right thing on only reformat ("rebuild")
when the source file has actually changed.

Addresses Problem 3 from #432.