### PR TITLE
Correct the binary path in the imix v2.0 Makefile

### DIFF
--- a/boards/imix/Makefile
+++ b/boards/imix/Makefile
@@ -18,16 +18,16 @@ endif
 TOCKLOADER_JTAG_FLAGS = --jtag --board imix --arch cortex-m4 --jtag-device ATSAM4LC8C
 
 .PHONY: program
-program: target/sam4l/release/$(PLATFORM).bin
+program: target/$(TARGET)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $<
 
 # upload kernel over JTAG
 .PHONY: flash
-flash: target/sam4l/release/$(PLATFORM).bin
+flash: target/$(TARGET)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<
 
 .PHONY: flash-debug
-flash-debug: target/sam4l/debug/$(PLATFORM).bin
+flash-debug: target/$(TARGET)/debug/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<
 
 # Command to flash the bootloader. Flashes the bootloader onto the SAM4L.

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -197,10 +197,11 @@ $ make examples/blink
 
 ### Optional Requirements
 
-For some boards, currently `Hail`, you will need `tockloader`. `tockloader`
-also has features that are generally useful to all Tock boards, such as easy to
-manage serial connections, and the ability to list, add, replace, and remove
-applications over JTAG (or USB if a bootloader is installed).
+For some boards, currently `Hail` and `imix` (but not `imixv1`), you will need
+`tockloader`. `tockloader` also has features that are generally useful to all
+Tock boards, such as easy to manage serial connections, and the ability to
+list, add, replace, and remove applications over JTAG (or USB if a bootloader
+is installed).
 
 1. [tockloader](https://github.com/helena-project/tockloader) (version 0.6.1)
 


### PR DESCRIPTION
I was able to `make` but not `make flash` using the updated `imix` v2.0 code in `master`. Comparing with `boards/hail/Makefile`, it seems that the target path was just slightly off. With this change I am able to flash with no issues.

Also, could someone clarify which tockloader version we are supposed to be using? I just did `pip3 install tockloader --user` as per the tockloader repo's suggestions, but the getting started doc specifies a particular version.

- Fixes the imixv2 Makefile to point to the right target, otherwise it expects the binary to be in `target/sam4l/release` and is not able to flash.
- Updates the getting started documentation to reflect the fact that flashing imix v2.0 now requires tockloader.