### PR TITLE
doc/Getting_Started.md rustc version

### DIFF
--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -15,7 +15,7 @@ developing Tock.
 
 #### Rust (nightly)
 
-We are using `rustc 1.19.0-nightly (5b13bff52 2017-05-23)`. We recommend
+We are using `rustc 1.19.0-nightly (04145943a 2017-06-19)`. We recommend
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 


### PR DESCRIPTION
➜  tock git:(doc_fixes) ✗ rustc -V                     
rustc 1.19.0-nightly (04145943a 2017-06-19)

I also want to change 
__(Linux): sudo pip3 install tockloader==0.6.1__ to __pip3 install tockloader == 0.6.1 --user__
but I leave it for now.