### PR TITLE
Imix submodule power configuration

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -175,13 +175,12 @@ pub unsafe fn reset_handler() {
 
     set_pin_primary_functions();
 
-    let power_config = power::ModulePowerConfig {
+    power::configure_submodules(power::SubmoduleConfig {
         rf233: true,
         nrf51422: true,
         sensors: true,
         trng: true,
-    };
-    power::configure_module_power(power_config);
+    });
 
     // # CONSOLE
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -30,6 +30,9 @@ mod i2c_dummy;
 #[allow(dead_code)]
 mod spi_dummy;
 
+#[allow(dead_code)]
+mod power;
+
 struct Imix {
     console: &'static capsules::console::Console<'static, sam4l::usart::USART>,
     gpio: &'static capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
@@ -171,6 +174,14 @@ pub unsafe fn reset_handler() {
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);
 
     set_pin_primary_functions();
+
+    let power_config = power::ModulePowerConfig {
+        rf233: true,
+        nrf51422: true,
+        sensors: true,
+        trng: true
+    };
+    power::configure_module_power(power_config);
 
     // # CONSOLE
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -179,7 +179,7 @@ pub unsafe fn reset_handler() {
         rf233: true,
         nrf51422: true,
         sensors: true,
-        trng: true
+        trng: true,
     };
     power::configure_module_power(power_config);
 

--- a/boards/imix/src/power.rs
+++ b/boards/imix/src/power.rs
@@ -3,9 +3,9 @@ extern crate sam4l;
 
 use kernel::hil::Controller;
 use sam4l::gpio::{PA, PB, PC};
+use sam4l::gpio::GPIOPin;
 use sam4l::gpio::PeripheralFunction;
 use sam4l::gpio::PeripheralFunction::{A, B};
-use sam4l::gpio::GPIOPin;
 
 type DetachablePin = (&'static GPIOPin, Option<PeripheralFunction>);
 
@@ -33,15 +33,16 @@ trait PowerGated {
 
 struct ImixSubmodule {
     gate_pin: &'static GPIOPin,
-    detachable_pins: Option<&'static [DetachablePin]>
+    detachable_pins: Option<&'static [DetachablePin]>,
 }
 
 impl ImixSubmodule {
-    const fn new(detachable_pins: Option<&'static [DetachablePin]>, 
-                 gate_pin: &'static GPIOPin) -> ImixSubmodule {
+    const fn new(detachable_pins: Option<&'static [DetachablePin]>,
+                 gate_pin: &'static GPIOPin)
+                 -> ImixSubmodule {
         ImixSubmodule {
             gate_pin: gate_pin,
-            detachable_pins: detachable_pins
+            detachable_pins: detachable_pins,
         }
     }
 }
@@ -74,15 +75,13 @@ pub struct ModulePowerConfig {
     pub rf233: bool,
     pub nrf51422: bool,
     pub sensors: bool,
-    pub trng: bool
+    pub trng: bool,
 }
 
 pub unsafe fn configure_module_power(enabled_modules: ModulePowerConfig) {
-    let rf233_detachable_pins = static_init!([DetachablePin; 3], 
-                                             [(&PA[08], None), 
-                                              (&PA[09], None),
-                                              (&PA[10], None)]);
-    let rf233 = static_init!(ImixSubmodule, 
+    let rf233_detachable_pins = static_init!([DetachablePin; 3],
+                                             [(&PA[08], None), (&PA[09], None), (&PA[10], None)]);
+    let rf233 = static_init!(ImixSubmodule,
                              ImixSubmodule::new(Some(rf233_detachable_pins), &PC[18]));
 
     let nrf_detachable_pins = static_init!([DetachablePin; 6],
@@ -96,25 +95,23 @@ pub unsafe fn configure_module_power(enabled_modules: ModulePowerConfig) {
     let nrf = static_init!(ImixSubmodule,
                            ImixSubmodule::new(Some(nrf_detachable_pins), &PC[17]));
 
-    let sensors = static_init!(ImixSubmodule,
-                               ImixSubmodule::new(None, &PC[16]));
-    let trng = static_init!(ImixSubmodule,
-                            ImixSubmodule::new(None, &PC[19]));
+    let sensors = static_init!(ImixSubmodule, ImixSubmodule::new(None, &PC[16]));
+    let trng = static_init!(ImixSubmodule, ImixSubmodule::new(None, &PC[19]));
 
     match enabled_modules.rf233 {
-        true  => rf233.on(),
-        false => rf233.off()
+        true => rf233.on(),
+        false => rf233.off(),
     }
     match enabled_modules.nrf51422 {
         true => nrf.on(),
-        false => nrf.off()
+        false => nrf.off(),
     }
     match enabled_modules.sensors {
         true => sensors.on(),
-        false => sensors.off()
+        false => sensors.off(),
     }
     match enabled_modules.trng {
         true => trng.on(),
-        false => trng.off()
+        false => trng.off(),
     }
 }

--- a/boards/imix/src/power.rs
+++ b/boards/imix/src/power.rs
@@ -54,10 +54,12 @@ impl PowerGated for ImixSubmodule {
                 pin.restore(function);
             }
         }
+        self.gate_pin.enable_output();
         self.gate_pin.set();
     }
 
     fn off(&self) {
+        self.gate_pin.enable_output();
         self.gate_pin.clear();
         if self.detachable_pins.is_some() {
             for it in self.detachable_pins.unwrap().iter() {
@@ -81,7 +83,7 @@ pub unsafe fn configure_module_power(enabled_modules: ModulePowerConfig) {
                                               (&PA[09], None),
                                               (&PA[10], None)]);
     let rf233 = static_init!(ImixSubmodule, 
-                             ImixSubmodule::new(Some(rf233_detachable_pins), &PA[18]));
+                             ImixSubmodule::new(Some(rf233_detachable_pins), &PC[18]));
 
     let nrf_detachable_pins = static_init!([DetachablePin; 6],
                                            [(&PB[07], None),

--- a/boards/imix/src/power.rs
+++ b/boards/imix/src/power.rs
@@ -27,7 +27,7 @@ impl Detachable for GPIOPin {
 }
 
 trait PowerGated {
-    fn power(&self, setting: bool);
+    fn power(&self, state: bool);
 }
 
 struct ImixSubmodule {
@@ -47,9 +47,9 @@ impl ImixSubmodule {
 }
 
 impl PowerGated for ImixSubmodule {
-    fn power(&self, setting: bool) {
+    fn power(&self, state: bool) {
         self.gate_pin.enable_output();
-        match setting {
+        match state {
             true => {
                 if self.detachable_pins.is_some() {
                     for it in self.detachable_pins.unwrap().iter() {

--- a/boards/imix/src/power.rs
+++ b/boards/imix/src/power.rs
@@ -58,7 +58,7 @@ impl PowerGated for ImixSubmodule {
                     }
                 }
                 self.gate_pin.set();
-            },
+            }
             false => {
                 self.gate_pin.clear();
                 if self.detachable_pins.is_some() {
@@ -67,7 +67,7 @@ impl PowerGated for ImixSubmodule {
                         pin.detach();
                     }
                 }
-            },
+            }
         }
     }
 }

--- a/boards/imix/src/power.rs
+++ b/boards/imix/src/power.rs
@@ -1,0 +1,118 @@
+extern crate kernel;
+extern crate sam4l;
+
+use kernel::hil::Controller;
+use sam4l::gpio::{PA, PB, PC};
+use sam4l::gpio::PeripheralFunction;
+use sam4l::gpio::PeripheralFunction::{A, B};
+use sam4l::gpio::GPIOPin;
+
+type DetachablePin = (&'static GPIOPin, Option<PeripheralFunction>);
+
+trait Detachable {
+    fn detach(&self);
+    fn restore(&self, function: Option<PeripheralFunction>);
+}
+
+impl Detachable for GPIOPin {
+    fn detach(&self) {
+        self.configure(None);
+        self.enable_output();
+        self.clear();
+    }
+
+    fn restore(&self, function: Option<PeripheralFunction>) {
+        self.configure(function);
+    }
+}
+
+trait PowerGated {
+    fn on(&self);
+    fn off(&self);
+}
+
+struct ImixSubmodule {
+    gate_pin: &'static GPIOPin,
+    detachable_pins: Option<&'static [DetachablePin]>
+}
+
+impl ImixSubmodule {
+    const fn new(detachable_pins: Option<&'static [DetachablePin]>, 
+                 gate_pin: &'static GPIOPin) -> ImixSubmodule {
+        ImixSubmodule {
+            gate_pin: gate_pin,
+            detachable_pins: detachable_pins
+        }
+    }
+}
+
+impl PowerGated for ImixSubmodule {
+    fn on(&self) {
+        if self.detachable_pins.is_some() {
+            for it in self.detachable_pins.unwrap().iter() {
+                let &(pin, function) = it;
+                pin.restore(function);
+            }
+        }
+        self.gate_pin.set();
+    }
+
+    fn off(&self) {
+        self.gate_pin.clear();
+        if self.detachable_pins.is_some() {
+            for it in self.detachable_pins.unwrap().iter() {
+                let &(pin, _) = it;
+                pin.detach();
+            }
+        }
+    }
+}
+
+pub struct ModulePowerConfig {
+    pub rf233: bool,
+    pub nrf51422: bool,
+    pub sensors: bool,
+    pub trng: bool
+}
+
+pub unsafe fn configure_module_power(enabled_modules: ModulePowerConfig) {
+    let rf233_detachable_pins = static_init!([DetachablePin; 3], 
+                                             [(&PA[08], None), 
+                                              (&PA[09], None),
+                                              (&PA[10], None)]);
+    let rf233 = static_init!(ImixSubmodule, 
+                             ImixSubmodule::new(Some(rf233_detachable_pins), &PA[18]));
+
+    let nrf_detachable_pins = static_init!([DetachablePin; 6],
+                                           [(&PB[07], None),
+                                            (&PA[17], None),
+                                            (&PA[18], Some(A)),
+                                            (&PC[07], Some(B)),
+                                            (&PC[08], Some(B)),
+                                            (&PC[09], None)]);
+
+    let nrf = static_init!(ImixSubmodule,
+                           ImixSubmodule::new(Some(nrf_detachable_pins), &PC[17]));
+
+    let sensors = static_init!(ImixSubmodule,
+                               ImixSubmodule::new(None, &PC[16]));
+    let trng = static_init!(ImixSubmodule,
+                            ImixSubmodule::new(None, &PC[19]));
+
+    match enabled_modules.rf233 {
+        true  => rf233.on(),
+        false => rf233.off()
+    }
+    match enabled_modules.nrf51422 {
+        true => nrf.on(),
+        false => nrf.off()
+    }
+    match enabled_modules.sensors {
+        true => sensors.on(),
+        false => sensors.off()
+    }
+    match enabled_modules.trng {
+        true => trng.on(),
+        false => trng.off()
+    }
+}


### PR DESCRIPTION
On imix, there are several pins which need to be 'detached' whenever we switch the power off for a particular submodule. In this case, by 'detached', I mean configured as a GPIO and pulled down, but pin detachment itself is more abstract than that. When the submodule is turned back on, all of these pins need to be restored to their original functions. When testing the power consumption of each submodule, I need to do quite a few of these detachments/restorations in addition to enabling/disabling the power gate for the module, so I wrote a general purpose API that makes this process much easier.

This functionality has other potential uses for the Signpost platform. I put together a rough first pass at an API that could satisfy both my testing needs and the Signpost application, and am making a PR for the opportunity to discuss and make changes.