### PR TITLE
list_boards.sh: hush a bash warning when not using -1

### DIFF
--- a/tools/list_boards.sh
+++ b/tools/list_boards.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # http://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+oneline=0
 while getopts "h?1" opt; do
     case "$opt" in
     h|\?)


### PR DESCRIPTION
Without this, running "make list-boards" gets me an error like:

 ./tools/list_boards.sh: line 19: [: -eq: unary operator expected