### PR TITLE
Disable i2cslave Perhiperal for Master Transfer

### DIFF
--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -736,11 +736,9 @@ impl hil::i2c::I2CMaster for I2CHw {
         unsafe {
             pm::enable_clock(self.master_clock);
         }
-
-        // If exists, disable slave clock
-        self.slave_clock.map(|slave_clock| unsafe {
-            pm::disable_clock(slave_clock);
-        });
+        
+        //disable the i2c slave peripheral
+        hil::i2c::I2CSlave::disable(self);
 
         let regs: &mut TWIMRegisters = unsafe { mem::transmute(self.registers) };
 

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -736,7 +736,7 @@ impl hil::i2c::I2CMaster for I2CHw {
         unsafe {
             pm::enable_clock(self.master_clock);
         }
-        
+
         //disable the i2c slave peripheral
         hil::i2c::I2CSlave::disable(self);
 


### PR DESCRIPTION
You can't just disable the clock - it causes the I2C to hang.

Instead call the proper I2CSlave disable function which also disables the clocks.

Tested and working on a signpost initialization procedure.