### PR TITLE
RF233: correct offsets and lengths so 1 byte of payload isn't dropped

### DIFF
--- a/kernel/src/hil/radio.rs
+++ b/kernel/src/hil/radio.rs
@@ -13,7 +13,7 @@ pub trait TxClient {
 }
 
 pub trait RxClient {
-    fn receive(&self, buf: &'static mut [u8], len: u8, result: ReturnCode);
+    fn receive(&self, buf: &'static mut [u8], frame_len: u8, result: ReturnCode);
 }
 
 pub trait ConfigClient {
@@ -24,10 +24,33 @@ pub trait PowerClient {
     fn changed(&self, on: bool);
 }
 
-pub const HEADER_SIZE: u8 = 10;
-pub const MAX_PACKET_SIZE: u8 = 128;
-pub const MAX_BUF_SIZE: usize = 129; // +1 for opcode
-pub const MIN_PACKET_SIZE: u8 = HEADER_SIZE + 2; // +2 for CRC
+/// These constants are used for interacting with the SPI buffer, which contains
+/// a 1-byte SPI command, a 1-byte PHY header, and then the 802.15.4 frame. In
+/// theory, the number of extra bytes in front of the frame can depend on the
+/// particular method used to communicate with the radio, but we leave this as a
+/// constant in this generic trait for now.
+///
+/// Furthermore, the minimum MHR size assumes that
+/// - The source PAN ID is omitted
+/// - There is no auxiliary security header
+/// - There are no IEs
+///
+/// +---------+-----+-----+-------------+-----+
+/// | SPI com | PHR | MHR | MAC payload | MFR |
+/// +---------+-----+-----+-------------+-----+
+/// \______ Static buffer rx/txed to SPI _____/
+///                 \__ PSDU / frame length __/
+/// \___ 2 bytes ___/
+
+pub const MIN_MHR_SIZE: usize = 9;
+pub const MFR_SIZE: usize = 2;
+pub const MAX_MTU: usize = 127;
+pub const MIN_FRAME_SIZE: usize = MIN_MHR_SIZE + MFR_SIZE;
+pub const MAX_FRAME_SIZE: usize = MAX_MTU;
+
+pub const PSDU_OFFSET: usize = 2;
+pub const MAX_BUF_SIZE: usize = PSDU_OFFSET + MAX_MTU;
+pub const MIN_PAYLOAD_OFFSET: usize = PSDU_OFFSET + MIN_MHR_SIZE;
 
 pub trait Radio: RadioConfig + RadioData {}
 
@@ -70,15 +93,16 @@ pub trait RadioConfig {
 pub trait RadioData {
     fn payload_offset(&self, long_src: bool, long_dest: bool) -> u8;
     fn header_size(&self, long_src: bool, long_dest: bool) -> u8;
-    fn packet_header_size(&self, packet: &'static [u8]) -> u8;
-    fn packet_get_src(&self, packet: &'static [u8]) -> u16;
-    fn packet_get_dest(&self, packet: &'static [u8]) -> u16;
-    fn packet_get_src_long(&self, packet: &'static [u8]) -> [u8; 8];
-    fn packet_get_dest_long(&self, packet: &'static [u8]) -> [u8; 8];
-    fn packet_get_length(&self, packet: &'static [u8]) -> u8;
-    fn packet_get_pan(&self, packet: &'static [u8]) -> u16;
-    fn packet_has_src_long(&self, packet: &'static [u8]) -> bool;
-    fn packet_has_dest_long(&self, packet: &'static [u8]) -> bool;
+    fn packet_payload_offset(&self, spi_buf: &[u8]) -> u8;
+    fn packet_header_size(&self, spi_buf: &[u8]) -> u8;
+    fn packet_get_src(&self, spi_buf: &[u8]) -> u16;
+    fn packet_get_dest(&self, spi_buf: &[u8]) -> u16;
+    fn packet_get_src_long(&self, spi_buf: &[u8]) -> [u8; 8];
+    fn packet_get_dest_long(&self, spi_buf: &[u8]) -> [u8; 8];
+    fn packet_get_length(&self, spi_buf: &[u8]) -> u8;
+    fn packet_get_pan(&self, spi_buf: &[u8]) -> u16;
+    fn packet_has_src_long(&self, spi_buf: &[u8]) -> bool;
+    fn packet_has_dest_long(&self, spi_buf: &[u8]) -> bool;
 
     fn set_transmit_client(&self, client: &'static TxClient);
     fn set_receive_client(&self, client: &'static RxClient, receive_buffer: &'static mut [u8]);
@@ -86,14 +110,14 @@ pub trait RadioData {
 
     fn transmit(&self,
                 dest: u16,
-                tx_data: &'static mut [u8],
-                tx_len: u8,
+                spi_buf: &'static mut [u8],
+                payload_len: u8,
                 source_long: bool)
                 -> ReturnCode;
     fn transmit_long(&self,
                      dest: [u8; 8],
-                     tx_data: &'static mut [u8],
-                     tx_len: u8,
+                     spi_buf: &'static mut [u8],
+                     payload_len: u8,
                      source_long: bool)
                      -> ReturnCode;
 }

--- a/userland/examples/radio_ack/main.c
+++ b/userland/examples/radio_ack/main.c
@@ -10,8 +10,8 @@ char packet_rx[BUF_SIZE];
 char packet_tx[BUF_SIZE];
 bool toggle = true;
 
-static void callback(__attribute__ ((unused)) int unused0,
-                     __attribute__ ((unused)) int unused1,
+static void callback(__attribute__ ((unused)) int err,
+                     __attribute__ ((unused)) int payload_length,
                      __attribute__ ((unused)) int unused2,
                      __attribute__ ((unused)) void* ud) {
   led_toggle(0);
@@ -23,11 +23,13 @@ int main(void) {
   char counter = 0;
   // printf("Starting 802.15.4 packet reception app.\n");
   for (i = 0; i < BUF_SIZE; i++) {
-    packet_rx[i] = packet_tx[i] = i;
+    packet_tx[i] = i;
+    packet_rx[i] = 0;
   }
   radio_set_addr(0x802);
   radio_set_pan(0xABCD);
   radio_commit();
+  radio_init();
   radio_receive_callback(callback, packet_rx, BUF_SIZE);
   while (1) {
     int err = radio_send(0x0802, packet_tx, BUF_SIZE);

--- a/userland/examples/radio_rx/main.c
+++ b/userland/examples/radio_rx/main.c
@@ -10,8 +10,8 @@ char packet_rx[BUF_SIZE];
 char packet_tx[BUF_SIZE];
 bool toggle = true;
 
-static void callback(__attribute__ ((unused)) int unused0,
-                     __attribute__ ((unused)) int unused1,
+static void callback(__attribute__ ((unused)) int err,
+                     __attribute__ ((unused)) int payload_length,
                      __attribute__ ((unused)) int unused2,
                      __attribute__ ((unused)) void* ud) {
   led_toggle(0);
@@ -22,11 +22,13 @@ int main(void) {
   int i;
   // printf("Starting 802.15.4 packet reception app.\n");
   for (i = 0; i < BUF_SIZE; i++) {
-    packet_rx[i] = packet_tx[i] = i;
+    packet_rx[i] = 0;
+    packet_tx[i] = i;
   }
   radio_set_addr(0x802);
   radio_set_pan(0xABCD);
   radio_commit();
+  radio_init();
   radio_receive_callback(callback, packet_rx, BUF_SIZE);
   while (1) {
     delay_ms(4000);

--- a/userland/examples/radio_rxtx/main.c
+++ b/userland/examples/radio_rxtx/main.c
@@ -17,6 +17,7 @@ int main(void) {
   radio_set_addr(0x802);
   radio_set_pan(0xABCD);
   radio_commit();
+  radio_init();
   while (1) {
     if (radio_receive(packet, BUF_SIZE) >= 0) {
       radio_send(0xFFFF, packet, BUF_SIZE);

--- a/userland/examples/radio_tx/main.c
+++ b/userland/examples/radio_tx/main.c
@@ -16,10 +16,9 @@ int main(void) {
     packet[i] = i;
   }
   gpio_enable_output(0);
-  radio_init();
   radio_set_addr(0x1540);
-  radio_init();
   radio_set_pan(0xABCD);
+  radio_commit();
   radio_init();
   while (1) {
     led_toggle(0);

--- a/userland/libtock/radio.c
+++ b/userland/libtock/radio.c
@@ -30,6 +30,8 @@ int radio_init(void) {
   return 0;
 } // Do nothing for now
 
+int rx_result = 0;
+int rx_payload_len = 0;
 int tx_acked = 0;
 
 static void cb_tx(__attribute__ ((unused)) int len,
@@ -40,10 +42,12 @@ static void cb_tx(__attribute__ ((unused)) int len,
   *((bool*)ud) = true;
 }
 
-static void cb_rx(__attribute__ ((unused)) int unused0,
-                  __attribute__ ((unused)) int unused1,
+static void cb_rx(int result,
+                  int payload_len,
                   __attribute__ ((unused)) int unused2,
                   void* ud) {
+  rx_result = result;
+  rx_payload_len = payload_len;
   *((bool*)ud) = true;
 }
 
@@ -128,7 +132,10 @@ int radio_receive(const char* packet, unsigned char len) {
     return err;
   }
   yield_for(&cond);
-  return (int)packet[1];
+  if (rx_result < 0) {
+    return rx_result;
+  }
+  return rx_payload_len;
 }
 
 int radio_receive_callback(subscribe_cb callback,


### PR DESCRIPTION
Partial fix for #499.
I ended up changing some parts of the `kernel::hil::radio` trait so that length types make sense. Nothing has been done about the missing CRC check, MAC address filtering or faulty MHR parsing.