### PR TITLE
Add Virtual Flash

### DIFF
--- a/capsules/Cargo.lock
+++ b/capsules/Cargo.lock
@@ -3,18 +3,9 @@ name = "capsules"
 version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
- "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kernel"
 version = "0.1.0"
-dependencies = [
- "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rust-libcore"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/capsules/README.md
+++ b/capsules/README.md
@@ -99,6 +99,7 @@ simultaneously) support for generic sensor interfaces.
 These allow for multiple users of shared hardware resources in the kernel.
 
 - **[Virtual Alarm](src/virtual_alarm.rs)**: Shared alarm resource.
+- **[Virtual Flash](src/virtual_flash.rs)**: Shared flash resource.
 - **[Virtual I2C](src/virtual_i2c.rs)**: Shared I2C and fixed addresses.
 - **[Virtual SPI](src/virtual_spi.rs)**: Shared SPI and fixed chip select pins.
 

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -18,6 +18,7 @@ pub mod sdcard;
 pub mod si7021;
 pub mod spi;
 pub mod virtual_alarm;
+pub mod virtual_flash;
 pub mod virtual_i2c;
 pub mod virtual_spi;
 pub mod adc;

--- a/capsules/src/nonvolatile_to_pages.rs
+++ b/capsules/src/nonvolatile_to_pages.rs
@@ -27,7 +27,7 @@
 //!     capsules::nonvolatile_to_pages::NonvolatileToPages::new(
 //!         &mut sam4l::flashcalw::FLASH_CONTROLLER,
 //!         &mut PAGEBUFFER));
-//! hil::flash::Flash::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, nv_to_page);
+//! hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, nv_to_page);
 //! ```
 
 use core::cell::Cell;

--- a/capsules/src/virtual_flash.rs
+++ b/capsules/src/virtual_flash.rs
@@ -1,0 +1,197 @@
+//! Virtualize writing flash.
+//!
+//! `MuxFlash` provides shared access to a flash interface from multiple clients
+//! in the kernel. For instance, a board may wish to expose the internal MCU
+//! flash for multiple uses, like allowing userland apps to write their own
+//! flash space, and to provide a "scratch space" as the end of flash for all
+//! apps to use. Each of these requires a capsule to support the operation, and
+//! must use a `FlashUser` instance to contain the per-user state for the
+//! virtualization.
+//!
+//! Usage
+//! -----
+//!
+//! ```
+//! // Create the mux.
+//! let mux_flash = static_init!(
+//!     capsules::virtual_flash::MuxFlash<'static, sam4l::flashcalw::FLASHCALW>,
+//!     capsules::virtual_flash::MuxFlash::new(&sam4l::flashcalw::FLASH_CONTROLLER));
+//! hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, mux_flash);
+//!
+//! // Everything that then uses the virtualized flash must use one of these.
+//! let virtual_flash = static_init!(
+//!     capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
+//!     capsules::virtual_flash::FlashUser::new(mux_flash));
+//! ```
+
+
+use core::cell::Cell;
+use kernel::ReturnCode;
+use kernel::common::{List, ListLink, ListNode};
+use kernel::common::take_cell::TakeCell;
+use kernel::hil;
+
+/// Handle keeping a list of active users of flash hardware and serialize their
+/// requests. After each completed request the list is checked to see if there
+/// is another flash user with an outstanding read, write, or erase request.
+pub struct MuxFlash<'a, F: hil::flash::Flash + 'static> {
+    flash: &'a F,
+    users: List<'a, FlashUser<'a, F>>,
+    inflight: Cell<Option<&'a FlashUser<'a, F>>>,
+}
+
+impl<'a, F: hil::flash::Flash + 'a> hil::flash::Client<F> for MuxFlash<'a, F> {
+    fn read_complete(&self, pagebuffer: &'static mut F::Page, error: hil::flash::Error) {
+        self.inflight.get().map(move |user| {
+            self.inflight.set(None);
+            user.read_complete(pagebuffer, error);
+        });
+        self.do_next_op();
+    }
+
+    fn write_complete(&self, pagebuffer: &'static mut F::Page, error: hil::flash::Error) {
+        self.inflight.get().map(move |user| {
+            self.inflight.set(None);
+            user.write_complete(pagebuffer, error);
+        });
+        self.do_next_op();
+    }
+
+    fn erase_complete(&self, error: hil::flash::Error) {
+        self.inflight.get().map(move |user| {
+            self.inflight.set(None);
+            user.erase_complete(error);
+        });
+        self.do_next_op();
+    }
+}
+
+impl<'a, F: hil::flash::Flash + 'a> MuxFlash<'a, F> {
+    pub const fn new(flash: &'a F) -> MuxFlash<'a, F> {
+        MuxFlash {
+            flash: flash,
+            users: List::new(),
+            inflight: Cell::new(None),
+        }
+    }
+
+    /// Scan the list of users and find the first user that has a pending
+    /// request, then issue that request to the flash hardware.
+    fn do_next_op(&self) {
+        if self.inflight.get().is_none() {
+            let mnode = self.users.iter().find(|node| node.operation.get() != Op::Idle);
+            mnode.map(|node| {
+                node.buffer.take().map_or_else(|| {
+                    // Don't need a buffer for erase.
+                    match node.operation.get() {
+                        Op::Erase(page_number) => {
+                            self.flash.erase_page(page_number);
+                        }
+                        _ => {}
+                    };
+                },
+                                               |buf| {
+                    match node.operation.get() {
+                        Op::Write(page_number) => {
+                            self.flash.write_page(page_number, buf);
+                        }
+                        Op::Read(page_number) => {
+                            self.flash.read_page(page_number, buf);
+                        }
+                        Op::Erase(page_number) => {
+                            self.flash.erase_page(page_number);
+                        }
+                        Op::Idle => {} // Can't get here...
+                    }
+                });
+                node.operation.set(Op::Idle);
+                self.inflight.set(Some(node));
+            });
+        }
+    }
+}
+
+#[derive(Copy, Clone,PartialEq)]
+enum Op {
+    Idle,
+    Write(usize),
+    Read(usize),
+    Erase(usize),
+}
+
+/// Keep state for each flash user. All uses of the virtualized flash interface
+/// need to create one of these to be a user of the flash. The `new()` function
+/// handles most of the work, a user only has to pass in a reference to the
+/// MuxFlash object.
+pub struct FlashUser<'a, F: hil::flash::Flash + 'static> {
+    mux: &'a MuxFlash<'a, F>,
+    buffer: TakeCell<'static, F::Page>,
+    operation: Cell<Op>,
+    next: ListLink<'a, FlashUser<'a, F>>,
+    client: Cell<Option<&'a hil::flash::Client<FlashUser<'a, F>>>>,
+}
+
+impl<'a, F: hil::flash::Flash + 'a> FlashUser<'a, F> {
+    pub const fn new(mux: &'a MuxFlash<'a, F>) -> FlashUser<'a, F> {
+        FlashUser {
+            mux: mux,
+            buffer: TakeCell::empty(),
+            operation: Cell::new(Op::Idle),
+            next: ListLink::empty(),
+            client: Cell::new(None),
+        }
+    }
+}
+
+impl<'a, F: hil::flash::Flash + 'a, C: hil::flash::Client<Self>> hil::flash::HasClient<'a, C>
+    for
+    FlashUser<'a, F> {
+    fn set_client(&'a self, client: &'a C) {
+        self.mux.users.push_head(self);
+        self.client.set(Some(client));
+    }
+}
+
+impl<'a, F: hil::flash::Flash + 'a> hil::flash::Client<F> for FlashUser<'a, F> {
+    fn read_complete(&self, pagebuffer: &'static mut F::Page, error: hil::flash::Error) {
+        self.client.get().map(move |client| { client.read_complete(pagebuffer, error); });
+    }
+
+    fn write_complete(&self, pagebuffer: &'static mut F::Page, error: hil::flash::Error) {
+        self.client.get().map(move |client| { client.write_complete(pagebuffer, error); });
+    }
+
+    fn erase_complete(&self, error: hil::flash::Error) {
+        self.client.get().map(move |client| { client.erase_complete(error); });
+    }
+}
+
+impl<'a, F: hil::flash::Flash + 'a> ListNode<'a, FlashUser<'a, F>> for FlashUser<'a, F> {
+    fn next(&'a self) -> &'a ListLink<'a, FlashUser<'a, F>> {
+        &self.next
+    }
+}
+
+impl<'a, F: hil::flash::Flash + 'a> hil::flash::Flash for FlashUser<'a, F> {
+    type Page = F::Page;
+
+    fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {
+        self.buffer.replace(buf);
+        self.operation.set(Op::Read(page_number));
+        self.mux.do_next_op();
+        ReturnCode::SUCCESS
+    }
+
+    fn write_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {
+        self.buffer.replace(buf);
+        self.operation.set(Op::Write(page_number));
+        self.mux.do_next_op();
+        ReturnCode::SUCCESS
+    }
+
+    fn erase_page(&self, page_number: usize) -> ReturnCode {
+        self.operation.set(Op::Erase(page_number));
+        self.mux.do_next_op();
+        ReturnCode::SUCCESS
+    }
+}

--- a/chips/sam4l/src/flashcalw.rs
+++ b/chips/sam4l/src/flashcalw.rs
@@ -905,12 +905,14 @@ impl FLASHCALW {
     }
 }
 
-impl hil::flash::Flash for FLASHCALW {
-    type Page = Sam4lPage;
-
-    fn set_client(&self, client: &'static hil::flash::Client<Self>) {
+impl<C: hil::flash::Client<Self>> hil::flash::HasClient<'static, C> for FLASHCALW {
+    fn set_client(&self, client: &'static C) {
         self.client.set(Some(client));
     }
+}
+
+impl hil::flash::Flash for FLASHCALW {
+    type Page = Sam4lPage;
 
     fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {
         self.read_range(page_number * (PAGE_SIZE as usize), buf.len(), buf)

--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -43,10 +43,14 @@
 //! Then a basic implementation of this trait should look like:
 //!
 //! ```rust
+//!
+//! impl hil::flash::HasClient for NewChipStruct {
+//!     fn set_client(&'a self, client: &'a C) { }
+//! }
+//!
 //! impl hil::flash::Flash for NewChipStruct {
 //!     type Page = NewChipPage;
 //!
-//!     fn set_client(&self, client: &'static hil::flash::Client<Self>) { }
 //!     fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode { }
 //!     fn write_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode { }
 //!     fn erase_page(&self, page_number: usize) -> ReturnCode { }
@@ -89,14 +93,16 @@ pub enum Error {
     FlashError,
 }
 
+pub trait HasClient<'a, C> {
+    /// Set the client for this flash peripheral. The client will be called
+    /// when operations complete.
+    fn set_client(&'a self, client: &'a C);
+}
+
 /// A page of writable persistent flash memory.
 pub trait Flash {
     /// Type of a single flash page for the given implementation.
     type Page: AsMut<[u8]>;
-
-    /// Set the client for this flash peripheral. The client will be called
-    /// when operations complete.
-    fn set_client(&self, client: &'static Client<Self>);
 
     /// Read a page of flash into the buffer.
     fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode;


### PR DESCRIPTION
This adds the `virtual_flash.rs` capsule which mirrors our other virtualized HW capsules. It is needed for any platforms which want to have multiple capsules use underlying flash HW.