### PR TITLE
nRF52/buttons

### DIFF
--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -1,3 +1,74 @@
+//! Tock kernel for the Nordic Semiconductor nRF52 development kit (DK), a.k.a. the PCA10040.
+//! It is based on nRF52838 SoC (Cortex M4 core with a BLE transceiver) with many exported
+//! I/O and peripherals.
+//!
+//! nRF52838 has only one port and uses pins 0-31!
+//!
+//! Furthermore, there exist another a preview development kit for nRF52840 but it is not supported
+//! yet because unfortunately the pin configuration differ from nRF52-DK whereas nRF52840 uses two
+//! ports where port 0 has 32 pins and port 1 has 16 pins.
+//!
+//!
+//!   GPIO:
+//!     P0.27 -> (top left header)
+//!     P0.26 -> (top left header)
+//!     P0.02 -> (top left header)
+//!     P0.25 -> (top left header)
+//!     P0.24 -> (top left header)
+//!     P0.23 -> (top left header)
+//!     P0.22 -> (top left header)
+//!     P0.20 -> (top left header)
+//!     P0.19 -> (top left header)
+//!     P0.18 -> (top mid header)
+//!     P0.17 -> (top mid header)
+//!     P0.16 -> (top mid header)
+//!     P0.15 -> (top mid header)
+//!     P0.14 -> (top mid header)
+//!     P0.13 -> (top mid header)
+//!     P0.12 -> (top mid header)
+//!     P0.11 -> (top mid header)
+//!     P0.10 -> (top right header)
+//!     P0.09 -> (top right header)
+//!     P0.08 -> (top right header)
+//!     P0.07 -> (top right header)
+//!     P0.06 -> (top right header)
+//!     P0.05 -> (top right header)
+//!     P0.21 -> (top right header)
+//!     P0.01 -> (top right header)
+//!     P0.00 -> (top right header)
+//!     P0.03 -> (bottom right header)
+//!     P0.04 -> (bottom right header)
+//!     P0.28 -> (bottom right header)
+//!     P0.29 -> (bottom right header)
+//!     P0.30 -> (bottom right header)
+//!     P0.31 -> (bottom right header)
+//!
+//!   LEDs:
+//!     P0.17 -> LED1
+//!     P0.18 -> LED2
+//!     P0.19 -> LED3
+//!     P0.20 -> LED4
+//!
+//!   Buttons:
+//!     P0.13 -> Button1
+//!     P0.14 -> Button2
+//!     P0.15 -> Button3
+//!     P0.16 -> Button4
+//!     P0.21 -> Reset Button
+//!
+//!   UART:
+//!     P0.05 -> RTS
+//!     P0.06 -> TXD
+//!     P0.07 -> CTS
+//!     P0.08 -> RXD
+//!
+//!   NFC:
+//!     P0.09 -> NFC1
+//!     P0.10 -> NFC2
+//!
+//!  Author: Niklas Adolfsson <niklasadolfsson1@gmail.com>
+//!  Date: July 16, 2017
+
 #![no_std]
 #![no_main]
 #![feature(lang_items,drop_types_in_const,compiler_builtins_lib)]
@@ -16,6 +87,13 @@ const LED1_PIN: usize = 17;
 const LED2_PIN: usize = 18;
 const LED3_PIN: usize = 19;
 const LED4_PIN: usize = 20;
+
+// The nRF52 DK buttons (see back of board)
+const BUTTON1_PIN: usize = 13;
+const BUTTON2_PIN: usize = 14;
+const BUTTON3_PIN: usize = 15;
+const BUTTON4_PIN: usize = 16;
+const BUTTON_RST_PIN: usize = 21;
 
 #[macro_use]
 mod io;
@@ -61,6 +139,7 @@ unsafe fn load_process() -> &'static mut [Option<kernel::Process<'static>>] {
 
 pub struct Platform {
     console: &'static capsules::console::Console<'static, nrf52::uart::UART>,
+    button: &'static capsules::button::Button<'static, nrf52::gpio::GPIOPin>,
     gpio: &'static capsules::gpio::GPIO<'static, nrf52::gpio::GPIOPin>,
     led: &'static capsules::led::LED<'static, nrf52::gpio::GPIOPin>,
     timer: &'static capsules::timer::TimerDriver
@@ -78,6 +157,7 @@ impl kernel::Platform for Platform {
             1 => f(Some(self.gpio)),
             3 => f(Some(self.timer)),
             8 => f(Some(self.led)),
+            9 => f(Some(self.button)),
             _ => f(None),
         }
     }
@@ -88,20 +168,51 @@ impl kernel::Platform for Platform {
 pub unsafe fn reset_handler() {
     nrf52::init();
 
+    // make non-volatile memory writable and activate the reset button (pin 21)
+    let nvmc = nrf52::nvmc::NVMC::new();
+    let uicr = nrf52::uicr::UICR::new();
+    nvmc.configure_writeable();
+    while !nvmc.is_ready() {}
+    uicr.set_psel0_reset_pin(BUTTON_RST_PIN);
+    while !nvmc.is_ready() {}
+    uicr.set_psel1_reset_pin(BUTTON_RST_PIN);
+
     // GPIOs
+    // FIXME: Test if it works and remove un-commented code!
     let gpio_pins = static_init!(
-        [&'static nrf52::gpio::GPIOPin; 11],
-        [&nrf52::gpio::PORT[1],  // Bottom left header on DK board
-        &nrf52::gpio::PORT[2],  //   |
-        &nrf52::gpio::PORT[3],  //   V
-        &nrf52::gpio::PORT[4],  //
-        &nrf52::gpio::PORT[5],  //
-        &nrf52::gpio::PORT[6],  // -----
-        &nrf52::gpio::PORT[16], //
-        &nrf52::gpio::PORT[15], //
-        &nrf52::gpio::PORT[14], //
-        &nrf52::gpio::PORT[13], //
-        &nrf52::gpio::PORT[12], //
+        [&'static nrf52::gpio::GPIOPin; 15],
+        [&nrf52::gpio::PORT[3],  // Bottom left header on DK board
+        &nrf52::gpio::PORT[4],   //
+        &nrf52::gpio::PORT[28],  //
+        &nrf52::gpio::PORT[29],  //
+        &nrf52::gpio::PORT[30],  //
+        &nrf52::gpio::PORT[31],  // -----
+        &nrf52::gpio::PORT[10],  // Top right header on DK board
+        &nrf52::gpio::PORT[9],   //
+        &nrf52::gpio::PORT[8],   //
+        &nrf52::gpio::PORT[7],   //
+        &nrf52::gpio::PORT[6],   //
+        &nrf52::gpio::PORT[5],   //
+        &nrf52::gpio::PORT[21],  //
+        &nrf52::gpio::PORT[1],   //
+        &nrf52::gpio::PORT[0],   // -----
+        /*&nrf52::gpio::PORT[18],  // Top mid header on DK board
+        &nrf52::gpio::PORT[17],  //
+        &nrf52::gpio::PORT[16],  //
+        &nrf52::gpio::PORT[15],  //
+        &nrf52::gpio::PORT[14],  //
+        &nrf52::gpio::PORT[13],  //
+        &nrf52::gpio::PORT[12],  //
+        &nrf52::gpio::PORT[11],  // ----
+        &nrf52::gpio::PORT[27],  // Top left header on DK board
+        &nrf52::gpio::PORT[26],  //
+        &nrf52::gpio::PORT[2],  //
+        &nrf52::gpio::PORT[25],  //
+        &nrf52::gpio::PORT[24],  //
+        &nrf52::gpio::PORT[23],  //
+        &nrf52::gpio::PORT[22],  //
+        &nrf52::gpio::PORT[20],  //
+        &nrf52::gpio::PORT[19],  // ----*/
         ],
         4 * 11);
 
@@ -127,6 +238,24 @@ pub unsafe fn reset_handler() {
         capsules::led::LED::new(led_pins),
         64/8);
 
+    let button_pins = static_init!(
+        [&'static nrf52::gpio::GPIOPin; 4],
+        [&nrf52::gpio::PORT[BUTTON1_PIN], // 13
+        &nrf52::gpio::PORT[BUTTON2_PIN],  // 14
+        &nrf52::gpio::PORT[BUTTON3_PIN],  // 15
+        &nrf52::gpio::PORT[BUTTON4_PIN],  // 16
+        ],
+        4 * 4);
+    let button = static_init!(
+        capsules::button::Button<'static, nrf52::gpio::GPIOPin>,
+        capsules::button::Button::new(button_pins, kernel::Container::create()),
+        96/8);
+    for btn in button_pins.iter() {
+        use kernel::hil::gpio::PinCtl;
+        btn.set_input_mode(kernel::hil::gpio::InputMode::PullUp);
+        btn.set_client(button);
+    }
+
     let alarm = &nrf52::rtc::RTC;
     alarm.start();
     let mux_alarm = static_init!(
@@ -147,10 +276,10 @@ pub unsafe fn reset_handler() {
                          12);
     virtual_alarm1.set_client(timer);
 
-    nrf52::uart::UART0.configure(nrf52::pinmux::Pinmux::new(6), /*. tx  */
-                                 nrf52::pinmux::Pinmux::new(8), /* rx  */
-                                 nrf52::pinmux::Pinmux::new(7), /* cts */
-                                 nrf52::pinmux::Pinmux::new(5)); /*. rts */
+    nrf52::uart::UART0.configure(nrf52::pinmux::Pinmux::new(6), // tx
+                                 nrf52::pinmux::Pinmux::new(8), // rx
+                                 nrf52::pinmux::Pinmux::new(7), // cts
+                                 nrf52::pinmux::Pinmux::new(5)); // rts
     let console = static_init!(
         capsules::console::Console<nrf52::uart::UART>,
         capsules::console::Console::new(&nrf52::uart::UART0,
@@ -179,7 +308,9 @@ pub unsafe fn reset_handler() {
     while !nrf52::clock::CLOCK.low_started() {}
     while !nrf52::clock::CLOCK.high_started() {}
 
+
     let platform = Platform {
+        button: button,
         console: console,
         led: led,
         gpio: gpio,
@@ -190,10 +321,10 @@ pub unsafe fn reset_handler() {
     chip.systick().reset();
     chip.systick().enable(true);
 
+
     debug!("Initialization complete. Entering main loop\r");
     kernel::main(&platform,
                  &mut chip,
                  load_process(),
                  &kernel::ipc::IPC::new());
-
 }

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -20,5 +20,7 @@ pub mod gpio;
 pub mod timer;
 pub mod rtc;
 pub mod uart;
+pub mod nvmc;
+pub mod uicr;
 pub mod pinmux;
 pub use chip::NRF52;

--- a/chips/nrf52/src/nvmc.rs
+++ b/chips/nrf52/src/nvmc.rs
@@ -1,0 +1,25 @@
+// Non-Volatile Memory Controller
+// Used in order read and write to internal flash
+// minimal implementation to support activation of the reset button
+
+use peripheral_registers;
+
+pub struct NVMC {
+    regs: *const peripheral_registers::NVMC,
+}
+
+impl NVMC {
+    pub const fn new() -> NVMC {
+        NVMC { regs: peripheral_registers::NVMC_BASE as *mut peripheral_registers::NVMC }
+    }
+
+    pub fn configure_writeable(&self) {
+        let regs = unsafe { &*self.regs };
+        regs.config.set(1);
+    }
+
+    pub fn is_ready(&self) -> bool {
+        let regs = unsafe { &*self.regs };
+        regs.ready.get() == 1
+    }
+}

--- a/chips/nrf52/src/peripheral_registers.rs
+++ b/chips/nrf52/src/peripheral_registers.rs
@@ -121,3 +121,27 @@ pub struct TIMER {
     _reserved6: [VolatileCell<u32>; 11], // 0x514
     pub cc: [VolatileCell<u32>; 4], // 0x540
 }
+pub const UICR_BASE: usize = 0x10001200;
+#[repr(C, packed)]
+pub struct UICR {
+    pub pselreset0: VolatileCell<u32>, // 0x200 - 0x204
+    pub pselreset1: VolatileCell<u32>, // 0x204 - 0x208
+    pub approtect: VolatileCell<u32>, // 0x208 - 0x20c
+    pub nfcpins: VolatileCell<u32>, // 0x20c - 0x210
+}
+
+pub const NVMC_BASE: usize = 0x4001E400;
+#[repr(C, packed)]
+pub struct NVMC {
+    pub ready: VolatileCell<u32>, // 0x400-0x404
+    _reserved1: [VolatileCell<u32>; 64], // 0x404-0x504
+    pub config: VolatileCell<u32>, //0x504-0x508
+    pub erasepage: VolatileCell<u32>, //0x508-0x50c
+    pub erasepcr0: VolatileCell<u32>, // 0x50c-0x510
+    pub eraseuicr: VolatileCell<u32>, // 0x510-0x514
+    _reserved2: [VolatileCell<u32>; 11], // 0x514-0x540
+    pub icachecnf: VolatileCell<u32>, //0x540-0x544
+    _reserved3: [VolatileCell<u32>; 1], //0x544-0x548
+    pub ihit: VolatileCell<u32>, //0x548-0x54c
+    pub imiss: VolatileCell<u32>, //0x54c-0x550
+}

--- a/chips/nrf52/src/uicr.rs
+++ b/chips/nrf52/src/uicr.rs
@@ -1,0 +1,24 @@
+// User information configuration registers
+// minimal implementation to support activation of the reset button
+
+use peripheral_registers;
+
+pub struct UICR {
+    regs: *const peripheral_registers::UICR,
+}
+
+
+impl UICR {
+    pub const fn new() -> UICR {
+        UICR { regs: peripheral_registers::UICR_BASE as *mut peripheral_registers::UICR }
+    }
+
+    pub fn set_psel0_reset_pin(&self, pin: usize) {
+        let regs = unsafe { &*self.regs };
+        regs.pselreset0.set(pin as u32);
+    }
+    pub fn set_psel1_reset_pin(&self, pin: usize) {
+        let regs = unsafe { &*self.regs };
+        regs.pselreset1.set(pin as u32);
+    }
+}


### PR DESCRIPTION
Hi,
I added the following:
- Support for all pushbuttons including the reset button. 
- Added board specific comments
- Moved a couple of comments and added offset intialization in the [chips/uart.rs](https://github.com/niklasad1/tock/blob/nRF52/buttons/chips/nrf52/src/uart.rs)

Furthermore, the reset button was quite tricky because I had to modify non volatile memory in order to change the register that holds the value for the reset button.  

I added two minimal modules in chips [nvmc.rs](https://github.com/niklasad1/tock/blob/nRF52/buttons/chips/nrf52/src/nvmc.rs) and [uicr.rs](https://github.com/niklasad1/tock/blob/nRF52/buttons/chips/nrf52/src/uicr.rs) for this.