### PR TITLE
userland: fix return of _sbrk

### DIFF
--- a/userland/libtock/sys.c
+++ b/userland/libtock/sys.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -76,6 +77,12 @@ int _kill(pid_t pid, int sig)
 
 caddr_t _sbrk(int incr)
 {
-  return memop(1, incr);
+  void* ret;
+  ret = memop(1, incr);
+  if ( ((int) ret) == TOCK_ENOMEM) {
+    errno = ENOMEM;
+    return (caddr_t) -1;
+  }
+  return ret;
 }
 


### PR DESCRIPTION
_sbrk semantics are to return -1 in case of error or a pointer.

TOCK_ENOMEM is not -1, so newlib treated it as a pointer. A quick readover of
the `malloc_extend_top` implementation in newlib (which is what actually calls
_sbrk [well, _sbrk_r which calls _sbrk]) shows that it checks against -1, then
checks that the new pointer is greater than the old pointer (which a modest
negative number certainly would be), then bumps the internal "top" of allocated
memory to the new pointer and rolls merrily on. This explains the behavior we
were seeing where it seems that allocations never failed, rather the MPU would
eventually trip when we ran off the top of the heap