### PR TITLE
Change system clock interface

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -185,7 +185,8 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
-    sam4l::pm::PM.specify_external_oscillator(sam4l::pm::OscClock::Frequency16MHz, sam4l::pm::OscStartupMode::FastStart);
+    sam4l::pm::PM.specify_external_oscillator(sam4l::pm::OscClock::Frequency16MHz,
+                                              sam4l::pm::OscStartupMode::FastStart);
     sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz);
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -185,8 +185,8 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
-    sam4l::pm::setup_system_clock(sam4l::pm::SystemClockSource::ExternalOscillatorPll,
-                                  48000000);
+    sam4l::pm::PM.specify_external_oscillator(sam4l::pm::OscClock::Frequency16MHz, sam4l::pm::OscStartupMode::FastStart);
+    sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz);
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -185,9 +185,10 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
-    sam4l::pm::PM.specify_external_oscillator(sam4l::pm::OscClock::Frequency16MHz,
-                                              sam4l::pm::OscStartupMode::FastStart);
-    sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz);
+    sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {
+        frequency: sam4l::pm::OscillatorFrequency::Frequency16MHz,
+        startup_mode: sam4l::pm::OscillatorStartup::FastStart,
+    });
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -167,8 +167,8 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
-    sam4l::pm::setup_system_clock(sam4l::pm::SystemClockSource::ExternalOscillatorPll,
-                                  48000000);
+    sam4l::pm::PM.specify_external_oscillator(sam4l::pm::OscClock::Frequency16MHz, sam4l::pm::OscStartupMode::FastStart);
+    sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz);
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -167,7 +167,8 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
-    sam4l::pm::PM.specify_external_oscillator(sam4l::pm::OscClock::Frequency16MHz, sam4l::pm::OscStartupMode::FastStart);
+    sam4l::pm::PM.specify_external_oscillator(sam4l::pm::OscClock::Frequency16MHz,
+                                              sam4l::pm::OscStartupMode::FastStart);
     sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz);
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -167,9 +167,10 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
-    sam4l::pm::PM.specify_external_oscillator(sam4l::pm::OscClock::Frequency16MHz,
-                                              sam4l::pm::OscStartupMode::FastStart);
-    sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz);
+    sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {
+        frequency: sam4l::pm::OscillatorFrequency::Frequency16MHz,
+        startup_mode: sam4l::pm::OscillatorStartup::FastStart,
+    });
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);

--- a/boards/imixv1/src/main.rs
+++ b/boards/imixv1/src/main.rs
@@ -162,7 +162,7 @@ unsafe fn set_pin_primary_functions() {
 pub unsafe fn reset_handler() {
     sam4l::init();
 
-    sam4l::pm::setup_system_clock(sam4l::pm::SystemClockSource::DfllRc32k, 48000000);
+    sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::DfllRc32kAt48MHz);
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);

--- a/chips/sam4l/src/bscif.rs
+++ b/chips/sam4l/src/bscif.rs
@@ -1,0 +1,67 @@
+//! Implementation of the Backup System Control Interface (BSCIF) peripheral.
+
+use kernel::common::VolatileCell;
+
+#[repr(C, packed)]
+struct BscifRegisters {
+    ier: VolatileCell<u32>,
+    idr: VolatileCell<u32>,
+    imr: VolatileCell<u32>,
+    isr: VolatileCell<u32>,
+    icr: VolatileCell<u32>,
+    pclksr: VolatileCell<u32>,
+    unlock: VolatileCell<u32>,
+    cscr: VolatileCell<u32>,
+    oscctrl32: VolatileCell<u32>,
+    rc32kcr: VolatileCell<u32>,
+    rc32ktune: VolatileCell<u32>,
+    bod33ctrl: VolatileCell<u32>,
+    bod33level: VolatileCell<u32>,
+    bod33sampling: VolatileCell<u32>,
+    bod18ctrl: VolatileCell<u32>,
+    bot18level: VolatileCell<u32>,
+    bod18sampling: VolatileCell<u32>,
+    vregcr: VolatileCell<u32>,
+    _reserved1: [VolatileCell<u32>; 4],
+    rc1mcr: VolatileCell<u32>,
+    _reserved2: VolatileCell<u32>,
+    bgctrl: VolatileCell<u32>,
+    bgsr: VolatileCell<u32>,
+    _reserved3: [VolatileCell<u32>; 4],
+    br0: VolatileCell<u32>,
+    br1: VolatileCell<u32>,
+    br2: VolatileCell<u32>,
+    br3: VolatileCell<u32>,
+    _reserved4: [VolatileCell<u32>; 215],
+    brifbversion: VolatileCell<u32>,
+    bgrefifbversion: VolatileCell<u32>,
+    vregifgversion: VolatileCell<u32>,
+    bodifcversion: VolatileCell<u32>,
+    rc32kifbversion: VolatileCell<u32>,
+    osc32ifaversion: VolatileCell<u32>,
+    version: VolatileCell<u32>,
+}
+
+const BSCIF_BASE: usize = 0x400F0400;
+static mut BSCIF: *mut BscifRegisters = BSCIF_BASE as *mut BscifRegisters;
+
+/// Setup the internal 32kHz RC oscillator.
+pub unsafe fn enable_rc32k() {
+    let bscif_rc32kcr = (*BSCIF).rc32kcr.get();
+    // Unlock the BSCIF::RC32KCR register
+    (*BSCIF).unlock.set(0xAA000024);
+    // Write the BSCIF::RC32KCR register.
+    // Enable the generic clock source, the temperature compensation, and the
+    // 32k output.
+    (*BSCIF).rc32kcr.set(bscif_rc32kcr | (1 << 2) | (1 << 1) | (1 << 0));
+    // Wait for it to be ready, although it feels like this won't do anything
+    while (*BSCIF).rc32kcr.get() & (1 << 0) == 0 {}
+
+    // Load magic calibration value for the 32KHz RC oscillator
+    //
+    // Unlock the BSCIF::RC32KTUNE register
+    (*BSCIF).unlock.set(0xAA000028);
+    // Write the BSCIF::RC32KTUNE register
+    (*BSCIF).rc32ktune.set(0x001d0015);
+}
+

--- a/chips/sam4l/src/bscif.rs
+++ b/chips/sam4l/src/bscif.rs
@@ -64,4 +64,3 @@ pub unsafe fn enable_rc32k() {
     // Write the BSCIF::RC32KTUNE register
     (*BSCIF).rc32ktune.set(0x001d0015);
 }
-

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -196,7 +196,7 @@ impl I2CHw {
     /// in the CWGR register to make the bus run at a particular I2C speed.
     fn set_bus_speed(&self) {
         // Set I2C waveform timing parameters based on ASF code
-        let system_frequency = unsafe { pm::get_system_frequency() };
+        let system_frequency = pm::get_system_frequency();
         let mut exp = 0;
         let mut f_prescaled = system_frequency / 400000 / 2;
         while (f_prescaled > 0xff) && (exp <= 0x7) {

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -18,6 +18,7 @@ mod helpers;
 pub mod chip;
 pub mod ast;
 pub mod bpm;
+pub mod bscif;
 pub mod dma;
 pub mod i2c;
 pub mod spi;

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -1,13 +1,13 @@
 //! Implementation of the power manager (PM) peripheral.
 
-use core::cell::Cell;
-use core::sync::atomic::Ordering;
-use kernel::common::VolatileCell;
 
 use bpm;
 use bscif;
+use core::cell::Cell;
+use core::sync::atomic::Ordering;
 use flashcalw;
 use gpio;
+use kernel::common::VolatileCell;
 use scif;
 
 #[repr(C, packed)]
@@ -205,7 +205,9 @@ impl PowerManager {
         }
     }
 
-    pub unsafe fn specify_external_oscillator(&self, oscillator_clock: OscClock, startup_mode: OscStartupMode) {
+    pub unsafe fn specify_external_oscillator(&self,
+                                              oscillator_clock: OscClock,
+                                              startup_mode: OscStartupMode) {
         match oscillator_clock {
             OscClock::Frequency16MHz => self.oscillator_frequency.set(16000000),
         };
@@ -235,7 +237,6 @@ impl PowerManager {
             }
         }
     }
-
 }
 
 unsafe fn unlock(register_offset: u32) {
@@ -310,9 +311,7 @@ unsafe fn configure_external_oscillator_pll(startup_mode: OscStartupMode) {
 }
 
 pub fn get_system_frequency() -> u32 {
-    unsafe {
-        PM.system_frequency.get()
-    }
+    unsafe { PM.system_frequency.get() }
 }
 
 /// Utility macro to modify clock mask registers

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -1,9 +1,14 @@
-//! Implementation of the power manager peripheral.
+//! Implementation of the power manager (PM) peripheral.
+
+use core::cell::Cell;
+use core::sync::atomic::Ordering;
+use kernel::common::VolatileCell;
 
 use bpm;
-use core::sync::atomic::Ordering;
+use bscif;
+use flashcalw;
 use gpio;
-use kernel::common::VolatileCell;
+use scif;
 
 #[repr(C, packed)]
 struct PmRegisters {
@@ -45,122 +50,6 @@ struct PmRegisters {
     _reserved9: [VolatileCell<u32>; 152],
     config: VolatileCell<u32>, // 0x200
     version: VolatileCell<u32>,
-}
-
-#[repr(C, packed)]
-struct BscifRegisters {
-    ier: VolatileCell<u32>,
-    idr: VolatileCell<u32>,
-    imr: VolatileCell<u32>,
-    isr: VolatileCell<u32>,
-    icr: VolatileCell<u32>,
-    pclksr: VolatileCell<u32>,
-    unlock: VolatileCell<u32>,
-    cscr: VolatileCell<u32>,
-    oscctrl32: VolatileCell<u32>,
-    rc32kcr: VolatileCell<u32>,
-    rc32ktune: VolatileCell<u32>,
-    bod33ctrl: VolatileCell<u32>,
-    bod33level: VolatileCell<u32>,
-    bod33sampling: VolatileCell<u32>,
-    bod18ctrl: VolatileCell<u32>,
-    bot18level: VolatileCell<u32>,
-    bod18sampling: VolatileCell<u32>,
-    vregcr: VolatileCell<u32>,
-    _reserved1: [VolatileCell<u32>; 4],
-    rc1mcr: VolatileCell<u32>,
-    _reserved2: VolatileCell<u32>,
-    bgctrl: VolatileCell<u32>,
-    bgsr: VolatileCell<u32>,
-    _reserved3: [VolatileCell<u32>; 4],
-    br0: VolatileCell<u32>,
-    br1: VolatileCell<u32>,
-    br2: VolatileCell<u32>,
-    br3: VolatileCell<u32>,
-    _reserved4: [VolatileCell<u32>; 215],
-    brifbversion: VolatileCell<u32>,
-    bgrefifbversion: VolatileCell<u32>,
-    vregifgversion: VolatileCell<u32>,
-    bodifcversion: VolatileCell<u32>,
-    rc32kifbversion: VolatileCell<u32>,
-    osc32ifaversion: VolatileCell<u32>,
-    version: VolatileCell<u32>,
-}
-
-#[repr(C, packed)]
-struct ScifRegisters {
-    ier: VolatileCell<u32>,
-    idr: VolatileCell<u32>,
-    imr: VolatileCell<u32>,
-    isr: VolatileCell<u32>,
-    icr: VolatileCell<u32>,
-    pclksr: VolatileCell<u32>,
-    unlock: VolatileCell<u32>,
-    cscr: VolatileCell<u32>,
-    oscctrl0: VolatileCell<u32>,
-    pll0: VolatileCell<u32>,
-    dfll0conf: VolatileCell<u32>,
-    dfll0val: VolatileCell<u32>,
-    dfll0mul: VolatileCell<u32>,
-    dfll0step: VolatileCell<u32>,
-    dfll0ssg: VolatileCell<u32>,
-    dfll0ratio: VolatileCell<u32>,
-    dfll0sync: VolatileCell<u32>,
-    rccr: VolatileCell<u32>,
-    rcfastcfg: VolatileCell<u32>,
-    rcfastsr: VolatileCell<u32>,
-    rc80mcr: VolatileCell<u32>,
-    _reserved1: [VolatileCell<u32>; 4],
-    hrpcr: VolatileCell<u32>,
-    fpcr: VolatileCell<u32>,
-    fpmul: VolatileCell<u32>,
-    fpdiv: VolatileCell<u32>,
-    gcctrl0: VolatileCell<u32>,
-    gcctrl1: VolatileCell<u32>,
-    gcctrl2: VolatileCell<u32>,
-    gcctrl3: VolatileCell<u32>,
-    gcctrl4: VolatileCell<u32>,
-    gcctrl5: VolatileCell<u32>,
-    gcctrl6: VolatileCell<u32>,
-    gcctrl7: VolatileCell<u32>,
-    gcctrl8: VolatileCell<u32>,
-    gcctrl9: VolatileCell<u32>,
-    gcctrl10: VolatileCell<u32>,
-    gcctrl11: VolatileCell<u32>,
-    _reserved2: [VolatileCell<u32>; 205],
-    rcfastversion: VolatileCell<u32>,
-    gclkprescversion: VolatileCell<u32>,
-    pllifaversion: VolatileCell<u32>,
-    oscifaversion: VolatileCell<u32>,
-    dfllifbversion: VolatileCell<u32>,
-    rcoscifaversion: VolatileCell<u32>,
-    _reserved3: VolatileCell<u32>,
-    rc80mversion: VolatileCell<u32>,
-    gclkversion: VolatileCell<u32>,
-    version: VolatileCell<u32>,
-}
-
-#[repr(C, packed)]
-struct FlashcalwRegisters {
-    fcr: VolatileCell<u32>,
-    fcmd: VolatileCell<u32>,
-    fsr: VolatileCell<u32>,
-    fpr: VolatileCell<u32>,
-    fvr: VolatileCell<u32>,
-    fgpfrhi: VolatileCell<u32>,
-    fgpfrlo: VolatileCell<u32>,
-    _reserved1: [VolatileCell<u32>; 251],
-    ctrl: VolatileCell<u32>,
-    sr: VolatileCell<u32>,
-    _reserved2: [VolatileCell<u32>; 4],
-    maint0: VolatileCell<u32>,
-    maint1: VolatileCell<u32>,
-    mcfg: VolatileCell<u32>,
-    men: VolatileCell<u32>,
-    mctrl: VolatileCell<u32>,
-    msr: VolatileCell<u32>,
-    _reserved3: [VolatileCell<u32>; 49],
-    pvr: VolatileCell<u32>,
 }
 
 pub enum MainClock {
@@ -259,21 +148,37 @@ pub enum SystemClockSource {
     /// Use the internal digital frequency locked loop (DFLL) sourced from
     /// the internal RC32K clock. Note this typically requires calibration
     /// of the RC32K to have a consistent clock.
-    DfllRc32k,
+    DfllRc32kAt48MHz,
 
     /// Use an external crystal oscillator as the direct source for the
     /// system clock.
-    ExternalOscillator,
+    ExternalOscillatorAt16MHz,
 
     /// Use an external crystal oscillator as the input to the internal
     /// PLL for the system clock. This expects a 16 MHz crystal.
-    ExternalOscillatorPll,
+    PllExternalOscillatorAt48MHz,
+}
+
+/// Which frequency range does your external oscillator fall in? Configuration
+/// needs to change based on this.
+pub enum OscClock {
+    /// 16 MHz external oscillator
+    Frequency16MHz,
+}
+
+/// Configuration for the startup time of the external oscillator. In practice
+/// we have found that some boards work with a short startup time, while others
+/// need a slow start in order to properly wake from sleep.
+#[derive(Copy,Clone,Debug)]
+pub enum OscStartupMode {
+    /// Use a fast startup. ~0.5 ms in practice.
+    FastStart,
+
+    /// Use a slow startup. ~8.9 ms in practice.
+    SlowStart,
 }
 
 const PM_BASE: usize = 0x400E0000;
-const BSCIF_BASE: usize = 0x400F0400;
-const SCIF_BASE: usize = 0x400E0800;
-const FLASHCALW_BASE: usize = 0x400A0000;
 
 const HSB_MASK_OFFSET: u32 = 0x24;
 const PBA_MASK_OFFSET: u32 = 0x28;
@@ -281,221 +186,133 @@ const PBB_MASK_OFFSET: u32 = 0x2C;
 const PBC_MASK_OFFSET: u32 = 0x30;
 const PBD_MASK_OFFSET: u32 = 0x34;
 
-static mut PM: *mut PmRegisters = PM_BASE as *mut PmRegisters;
-static mut BSCIF: *mut BscifRegisters = BSCIF_BASE as *mut BscifRegisters;
-static mut SCIF: *mut ScifRegisters = SCIF_BASE as *mut ScifRegisters;
-static mut FLASHCALW: *mut FlashcalwRegisters = FLASHCALW_BASE as *mut FlashcalwRegisters;
+static mut PM_REGS: *mut PmRegisters = PM_BASE as *mut PmRegisters;
+pub static mut PM: PowerManager = PowerManager::new();
 
-static mut SYSTEM_FREQUENCY: VolatileCell<u32> = VolatileCell::new(0);
+pub struct PowerManager {
+    system_frequency: Cell<u32>,
+    oscillator_frequency: Cell<u32>,
+    oscillator_startup: Cell<OscStartupMode>,
+}
+
+impl PowerManager {
+    const fn new() -> PowerManager {
+        // initialize with default values
+        PowerManager {
+            system_frequency: Cell::new(0),
+            oscillator_frequency: Cell::new(0),
+            oscillator_startup: Cell::new(OscStartupMode::FastStart),
+        }
+    }
+
+    pub unsafe fn specify_external_oscillator(&self, oscillator_clock: OscClock, startup_mode: OscStartupMode) {
+        match oscillator_clock {
+            OscClock::Frequency16MHz => self.oscillator_frequency.set(16000000),
+        };
+
+        self.oscillator_startup.set(startup_mode);
+    }
+
+    pub unsafe fn setup_system_clock(&self, clock_source: SystemClockSource) {
+
+        // For now, always go to PS2 as it enables all core speeds
+        bpm::set_power_scaling(bpm::PowerScaling::PS2);
+
+        match clock_source {
+            SystemClockSource::DfllRc32kAt48MHz => {
+                configure_48mhz_dfll();
+                self.system_frequency.set(48000000);
+            }
+
+            SystemClockSource::ExternalOscillatorAt16MHz => {
+                configure_external_oscillator(self.oscillator_startup.get());
+                self.system_frequency.set(16000000);
+            }
+
+            SystemClockSource::PllExternalOscillatorAt48MHz => {
+                configure_external_oscillator_pll(self.oscillator_startup.get());
+                self.system_frequency.set(48000000);
+            }
+        }
+    }
+
+}
 
 unsafe fn unlock(register_offset: u32) {
-    (*PM).unlock.set(0xAA000000 | register_offset);
+    (*PM_REGS).unlock.set(0xAA000000 | register_offset);
 }
 
 unsafe fn select_main_clock(clock: MainClock) {
     unlock(0);
-    (*PM).mcctrl.set(clock as u32);
-}
-
-/// Enable HCACHE
-unsafe fn enable_cache() {
-    enable_clock(Clock::HSB(HSBClock::FLASHCALWP));
-    enable_clock(Clock::PBB(PBBClock::HRAMC1));
-    // Enable cache
-    (*FLASHCALW).ctrl.set(0x01);
-
-    // Wait for the cache controller to be enabled.
-    while (*FLASHCALW).sr.get() & (1 << 0) == 0 {}
-}
-
-/// Configure high-speed flash mode. This is taken from the ASF code
-unsafe fn enable_high_speed_flash() {
-    // Since we are running at a fast speed we have to set a clock delay
-    // for flash, as well as enable fast flash mode.
-    let flashcalw_fcr = (*FLASHCALW).fcr.get();
-    (*FLASHCALW).fcr.set(flashcalw_fcr | (1 << 6));
-
-    // Enable high speed mode for flash
-    let flashcalw_fcmd = (*FLASHCALW).fcmd.get();
-    let flashcalw_fcmd_new1 = flashcalw_fcmd & (!(0x3F << 0));
-    let flashcalw_fcmd_new2 = flashcalw_fcmd_new1 | (0xA5 << 24) | (0x10 << 0);
-    (*FLASHCALW).fcmd.set(flashcalw_fcmd_new2);
-
-    // And wait for the flash to be ready
-    while (*FLASHCALW).fsr.get() & (1 << 0) == 0 {}
-}
-
-/// Setup the internal 32kHz RC oscillator.
-unsafe fn enable_rc32k() {
-    let bscif_rc32kcr = (*BSCIF).rc32kcr.get();
-    // Unlock the BSCIF::RC32KCR register
-    (*BSCIF).unlock.set(0xAA000024);
-    // Write the BSCIF::RC32KCR register.
-    // Enable the generic clock source, the temperature compensation, and the
-    // 32k output.
-    (*BSCIF).rc32kcr.set(bscif_rc32kcr | (1 << 2) | (1 << 1) | (1 << 0));
-    // Wait for it to be ready, although it feels like this won't do anything
-    while (*BSCIF).rc32kcr.get() & (1 << 0) == 0 {}
-
-    // Load magic calibration value for the 32KHz RC oscillator
-    //
-    // Unlock the BSCIF::RC32KTUNE register
-    (*BSCIF).unlock.set(0xAA000028);
-    // Write the BSCIF::RC32KTUNE register
-    (*BSCIF).rc32ktune.set(0x001d0015);
+    (*PM_REGS).mcctrl.set(clock as u32);
 }
 
 /// Configure the system clock to use the DFLL with the RC32K as the source.
 /// Run at 48 MHz.
 unsafe fn configure_48mhz_dfll() {
     // Enable HCACHE
-    enable_cache();
+    flashcalw::FLASH_CONTROLLER.enable_cache();
 
-    // Check to see if the DFLL is already setup.
-    //
-    if (((*SCIF).dfll0conf.get() & 0x03) == 0) || (((*SCIF).pclksr.get() & (1 << 2)) == 0) {
-
-        // Enable the GENCLK_SRC_RC32K
-        enable_rc32k();
-
-        // Next init closed loop mode.
-        //
-        // Must do a SCIF sync before reading the SCIF register
-        (*SCIF).dfll0sync.set(0x01);
-        // Wait for it to be ready
-        while (*SCIF).pclksr.get() & (1 << 3) == 0 {}
-
-        // Read the current DFLL settings
-        let scif_dfll0conf = (*SCIF).dfll0conf.get();
-        // Set the new values
-        //                                        enable     closed loop
-        let scif_dfll0conf_new1 = scif_dfll0conf | (1 << 0) | (1 << 1);
-        let scif_dfll0conf_new2 = scif_dfll0conf_new1 & (!(3 << 16));
-        // frequency range 2
-        let scif_dfll0conf_new3 = scif_dfll0conf_new2 | (2 << 16);
-        // Enable the general clock. Yeah getting this fields is complicated.
-        //                 enable     RC32K       no divider
-        let scif_gcctrl0 = (1 << 0) | (13 << 8) | (0 << 1) | (0 << 16);
-        (*SCIF).gcctrl0.set(scif_gcctrl0);
-
-        // Setup DFLL. Must wait after every operation for the ready bit to go high.
-        // First, enable dfll apparently
-        // unlock dfll0conf
-        (*SCIF).unlock.set(0xAA000028);
-        // enable
-        (*SCIF).dfll0conf.set(0x01);
-        while (*SCIF).pclksr.get() & (1 << 3) == 0 {}
-        // Set step values
-        // unlock
-        (*SCIF).unlock.set(0xAA000034);
-        // 4, 4
-        (*SCIF).dfll0step.set((4 << 0) | (4 << 16));
-        while (*SCIF).pclksr.get() & (1 << 3) == 0 {}
-        // Set multiply value
-        // unlock
-        (*SCIF).unlock.set(0xAA000030);
-        // 1464 = 48000000 / 32768
-        (*SCIF).dfll0mul.set(1464);
-        while (*SCIF).pclksr.get() & (1 << 3) == 0 {}
-        // Set SSG value
-        // unlock
-        (*SCIF).unlock.set(0xAA000038);
-        // just set to zero to disable
-        (*SCIF).dfll0ssg.set(0);
-        while (*SCIF).pclksr.get() & (1 << 3) == 0 {}
-        // Set actual configuration
-        // unlock
-        (*SCIF).unlock.set(0xAA000028);
-        // we already prepared this value
-        (*SCIF).dfll0conf.set(scif_dfll0conf_new3);
-
-        // Now wait for it to be ready (DFLL0LOCKF)
-        while (*SCIF).pclksr.get() & (1 << 2) == 0 {}
-    }
+    // start the dfll
+    scif::setup_dfll_rc32k_48mhz();
 
     // Since we are running at a fast speed we have to set a clock delay
     // for flash, as well as enable fast flash mode.
-    enable_high_speed_flash();
+    flashcalw::FLASH_CONTROLLER.enable_high_speed_flash();
 
     // Choose the main clock
     select_main_clock(MainClock::DFLL);
 }
 
 /// Configure the system clock to use the 16 MHz external crystal directly
-unsafe fn configure_external_oscillator() {
+unsafe fn configure_external_oscillator(startup_mode: OscStartupMode) {
     // Use the cache
-    enable_cache();
+    flashcalw::FLASH_CONTROLLER.enable_cache();
 
     // Need the 32k RC oscillator for things like BPM module and AST.
-    enable_rc32k();
+    bscif::enable_rc32k();
 
-    // Enable the OSC0
-    (*SCIF).unlock.set(0xAA000020);
-    // enable, 557 us startup time, gain level 4 (sortof), is crystal.
-    (*SCIF).oscctrl0.set((1 << 16) | (1 << 8) | (4 << 1) | (1 << 0));
-    // Wait for oscillator to be ready
-    while (*SCIF).pclksr.get() & (1 << 0) == 0 {}
+    // start the external oscillator
+    match startup_mode {
+        OscStartupMode::FastStart => scif::setup_osc_16mhz_fast_startup(),
+        OscStartupMode::SlowStart => scif::setup_osc_16mhz_slow_startup(),
+    };
 
     // Go to high speed flash mode
-    enable_high_speed_flash();
+    flashcalw::FLASH_CONTROLLER.enable_high_speed_flash();
 
     // Set the main clock to be the external oscillator
     select_main_clock(MainClock::OSC0);
 }
 
 /// Configure the system clock to use the PLL with the 16 MHz external crystal
-unsafe fn configure_external_oscillator_pll() {
+unsafe fn configure_external_oscillator_pll(startup_mode: OscStartupMode) {
     // Use the cache
-    enable_cache();
+    flashcalw::FLASH_CONTROLLER.enable_cache();
 
     // Need the 32k RC oscillator for things like BPM module and AST.
-    enable_rc32k();
+    bscif::enable_rc32k();
 
-    // Enable the OSC0
-    (*SCIF).unlock.set(0xAA000020);
-    // enable, 557 us startup time, gain level 4 (sortof), is crystal.
-    (*SCIF).oscctrl0.set((1 << 16) | (1 << 8) | (4 << 1) | (1 << 0));
-    // Wait for oscillator to be ready
-    while (*SCIF).pclksr.get() & (1 << 0) == 0 {}
+    // start the external oscillator
+    match startup_mode {
+        OscStartupMode::FastStart => scif::setup_osc_16mhz_fast_startup(),
+        OscStartupMode::SlowStart => scif::setup_osc_16mhz_slow_startup(),
+    };
 
     // Setup the PLL
-    // Enable the PLL0 register
-    (*SCIF).unlock.set(0xAA000024);
-    // Maximum startup time, multiply by 5, divide=1, divide output by 2, enable.
-    (*SCIF).pll0.set((0x3F << 24) | (5 << 16) | (1 << 8) | (1 << 4) | (1 << 0));
-    // Wait for the PLL to be ready
-    while (*SCIF).pclksr.get() & (1 << 6) == 0 {}
+    scif::setup_pll_osc_48mhz();
 
     // Go to high speed flash mode
-    enable_high_speed_flash();
+    flashcalw::FLASH_CONTROLLER.enable_high_speed_flash();
 
     // Set the main clock to be the PLL
     select_main_clock(MainClock::PLL);
 }
 
-pub unsafe fn setup_system_clock(clock_source: SystemClockSource, frequency: u32) {
-    SYSTEM_FREQUENCY.set(frequency);
-
-    // For now, always go to PS2 as it enables all core speeds
-    bpm::set_power_scaling(bpm::PowerScaling::PS2);
-
-    match clock_source {
-        SystemClockSource::DfllRc32k => {
-            configure_48mhz_dfll();
-        }
-
-        SystemClockSource::ExternalOscillator => {
-            configure_external_oscillator();
-        }
-
-        SystemClockSource::ExternalOscillatorPll => {
-            configure_external_oscillator_pll();
-        }
+pub fn get_system_frequency() -> u32 {
+    unsafe {
+        PM.system_frequency.get()
     }
-}
-
-pub unsafe fn get_system_frequency() -> u32 {
-    SYSTEM_FREQUENCY.get()
 }
 
 /// Utility macro to modify clock mask registers
@@ -517,14 +334,14 @@ pub unsafe fn get_system_frequency() -> u32 {
 macro_rules! mask_clock {
     ($module:ident: $field:ident | $mask:expr) => ({
         unlock(concat_idents!($module, _MASK_OFFSET));
-        let val = (*PM).$field.get() | ($mask);
-        (*PM).$field.set(val);
+        let val = (*PM_REGS).$field.get() | ($mask);
+        (*PM_REGS).$field.set(val);
     });
 
     ($module:ident: $field:ident & $mask:expr) => ({
         unlock(concat_idents!($module, _MASK_OFFSET));
-        let val = (*PM).$field.get() & ($mask);
-        (*PM).$field.set(val);
+        let val = (*PM_REGS).$field.get() & ($mask);
+        (*PM_REGS).$field.set(val);
     });
 }
 
@@ -568,9 +385,9 @@ const DEEP_SLEEP_PBBMASK: u32 = 0x3;
 /// through the INTERRUPT_COUNT variable.
 pub fn deep_sleep_ready() -> bool {
     unsafe {
-        (*PM).hsbmask.get() & !(DEEP_SLEEP_HSBMASK) == 0 &&
-        (*PM).pbamask.get() & !(DEEP_SLEEP_PBAMASK) == 0 &&
-        (*PM).pbbmask.get() & !(DEEP_SLEEP_PBBMASK) == 0 &&
+        (*PM_REGS).hsbmask.get() & !(DEEP_SLEEP_HSBMASK) == 0 &&
+        (*PM_REGS).pbamask.get() & !(DEEP_SLEEP_PBAMASK) == 0 &&
+        (*PM_REGS).pbbmask.get() & !(DEEP_SLEEP_PBBMASK) == 0 &&
         gpio::INTERRUPT_COUNT.load(Ordering::Relaxed) == 0
     }
 }

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -241,7 +241,7 @@ impl Spi {
     pub fn set_baud_rate(&self, rate: u32) -> u32 {
         // Main clock frequency
         let mut real_rate = rate;
-        let clock = unsafe { pm::get_system_frequency() };
+        let clock = pm::get_system_frequency();
 
         if real_rate < 188235 {
             real_rate = 188235;

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -352,7 +352,7 @@ impl USART {
     fn set_baud_rate(&self, baud_rate: u32) {
         let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
 
-        let system_frequency = unsafe { pm::get_system_frequency() };
+        let system_frequency = pm::get_system_frequency();
 
         // The clock divisor is calculated differently in UART and SPI modes.
         let cd = match self.usart_mode.get() {
@@ -781,14 +781,14 @@ impl hil::spi::SpiMaster for USART {
         self.set_baud_rate(rate);
 
         // Calculate what rate will actually be
-        let system_frequency = unsafe { pm::get_system_frequency() };
+        let system_frequency = pm::get_system_frequency();
         let cd = system_frequency / rate;
         system_frequency / cd
     }
 
     fn get_rate(&self) -> u32 {
         let regs: &mut USARTRegisters = unsafe { mem::transmute(self.registers) };
-        let system_frequency = unsafe { pm::get_system_frequency() };
+        let system_frequency = pm::get_system_frequency();
         let cd = regs.brgr.get() & 0xFFFF;
         system_frequency / cd
     }


### PR DESCRIPTION
Adds a `specify_external_oscillator` function, to be called from `main.rs`, which sets both the frequency of the oscillator and whether it starts up quickly or slowly.

This should fix sleeping on Signpost boards (for now) which need a slower startup (for uncertain reasons) or else they do not wake up from sleep. However, since Hail sleeps just fine as is, we don't want to impose the startup penalty on it, and this PR allows Hail (and other hardware) to stay with the faster startup timing.

Also, since I was in there, this PR pulls apart PM and separates functionality into various modules based on the peripheral they correspond to.

Tested on a Hail in all supported system clock modes.

Fixes #300 