### PR TITLE
doc: add cmake to getting started

### DIFF
--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -9,7 +9,7 @@ developing Tock.
 1. [Rust](http://www.rust-lang.org/) (install `rustup` so Tock will choose the right version automatically)
 1. [Xargo](http://www.rust-lang.org/) (Rust `cargo` wrapper that installs core library for embedded targets)
 2. [arm-none-eabi toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) (version >= 5.2)
-3. Command line utilities: wget, sed, make
+3. Command line utilities: wget, sed, make, cmake
 
 ### Installing Requirements
 


### PR DESCRIPTION
I just tried to build on my mac and got:

```
~/git/tock $ make
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C boards/hail/
../Makefile.common:62: Required tool `xargo` is out-of-date.
../Makefile.common:63: Running `cargo install cargo-update` and `cargo install-update xargo` in 3 seconds (ctrl-c to cancel)
    Updating registry `https://github.com/rust-lang/crates.io-index`
  Installing cargo-update v1.1.1
   Compiling unicode-xid v0.0.4
   Compiling unicode-width v0.1.4
   Compiling serde v1.0.10
   Compiling embed-resource v1.1.3
   Compiling vec_map v0.8.0
   Compiling libc v0.2.26
   Compiling lazy_static v0.2.8
   Compiling regex-syntax v0.4.1
   Compiling unicode-segmentation v1.1.0
   Compiling semver-parser v0.7.0
   Compiling percent-encoding v1.0.0
   Compiling utf8-ranges v1.0.0
   Compiling strsim v0.6.0
   Compiling ansi_term v0.9.0
   Compiling quote v0.3.15
   Compiling array_tool v0.4.0
   Compiling unicode-normalization v0.1.5
   Compiling matches v0.1.6
   Compiling bitflags v0.9.1
   Compiling gcc v0.3.51
   Compiling json v0.11.8
   Compiling pkg-config v0.3.9
   Compiling void v1.0.2
   Compiling tabwriter v1.0.3
   Compiling synom v0.11.3
   Compiling cargo-update v1.1.1
   Compiling atty v0.2.2
   Compiling rand v0.3.15
   Compiling memchr v1.0.1
   Compiling term_size v0.3.0
   Compiling unicode-bidi v0.3.4
   Compiling semver v0.6.0
   Compiling unreachable v1.0.0
   Compiling syn v0.11.11
   Compiling textwrap v0.6.0
   Compiling aho-corasick v0.6.3
   Compiling thread_local v0.3.4
   Compiling lazysort v0.1.1
   Compiling idna v0.1.4
   Compiling clap v2.25.0
   Compiling libz-sys v1.0.16
   Compiling curl-sys v0.3.14
   Compiling openssl-sys v0.9.14
   Compiling cmake v0.1.24
   Compiling url v1.5.1
   Compiling toml v0.4.2
   Compiling regex v0.2.2
   Compiling libssh2-sys v0.2.6
   Compiling libgit2-sys v0.6.12
error: failed to run custom build command for `libssh2-sys v0.2.6`
process didn't exit successfully: `/var/folders/gm/0yrmvt053jv5m0xrqky_6w3h0000gn/T/cargo-install.xZI5DwFOnWuz/release/build/libssh2-sys-116ee51de26cd777/build-script-build` (exit code: 101)
--- stdout
running: "cmake" "/Users/bradjc/.cargo/registry/src/github.com-1ecc6299db9ec823/libssh2-sys-0.2.6/libssh2" "-DCRYPTO_BACKEND=OpenSSL" "-DOPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include" "-DBUILD_SHARED_LIBS=OFF" "-DENABLE_ZLIB_COMPRESSION=ON" "-DCMAKE_INSTALL_LIBDIR=lib" "-DBUILD_EXAMPLES=OFF" "-DBUILD_TESTING=OFF" "-DCMAKE_INSTALL_PREFIX=/var/folders/gm/0yrmvt053jv5m0xrqky_6w3h0000gn/T/cargo-install.xZI5DwFOnWuz/release/build/libssh2-sys-51d38d70f80c6b08/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_BUILD_TYPE=Release"

--- stderr
fatal: Not a git repository (or any of the parent directories): .git
thread 'main' panicked at '
failed to execute command: No such file or directory (os error 2)
is `cmake` not installed?

build script failed, must exit now', /Users/bradjc/.cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.24/src/lib.rs:593
note: Run with `RUST_BACKTRACE=1` for a backtrace.

warning: build failed, waiting for other jobs to finish...
error: failed to compile `cargo-update v1.1.1`, intermediate artifacts can be found at `/var/folders/gm/0yrmvt053jv5m0xrqky_6w3h0000gn/T/cargo-install.xZI5DwFOnWuz`

Caused by:
  build failed
error: no such subcommand: `install-update`
)
```

Running `brew install cmake` made the error go away.