### PR TITLE
Uses Correct Order of Operations to Prevent Internal Timer Overflow

### DIFF
--- a/userland/libtock/alarm_timer.c
+++ b/userland/libtock/alarm_timer.c
@@ -128,7 +128,7 @@ uint32_t alarm_read(void) {
 // Timer implementation
 
 void timer_in(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t *timer) {
-  uint32_t interval   = ms * alarm_internal_frequency() / 1000;
+  uint32_t interval   = (uint32_t)(ms * (alarm_internal_frequency() / 1000.0));
   uint32_t now        = alarm_read();
   uint32_t expiration = now + interval;
   alarm_at(expiration, cb, ud, &timer->alarm);
@@ -148,7 +148,7 @@ static void repeating_cb( uint32_t now,
 }
 
 void timer_every(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t* repeating) {
-  uint32_t interval = ms * alarm_internal_frequency() / 1000;
+  uint32_t interval = (uint32_t)(ms * (alarm_internal_frequency() / 1000.0));
 
   repeating->interval = interval;
   repeating->cb       = cb;

--- a/userland/libtock/alarm_timer.c
+++ b/userland/libtock/alarm_timer.c
@@ -128,7 +128,8 @@ uint32_t alarm_read(void) {
 // Timer implementation
 
 void timer_in(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t *timer) {
-  uint32_t interval   = (uint32_t)(ms * (alarm_internal_frequency() / 1000.0));
+  uint32_t frequency  = alarm_internal_frequency();
+  uint32_t interval   = (ms/1000) * frequency + (ms % 1000) * (frequency / 1000);
   uint32_t now        = alarm_read();
   uint32_t expiration = now + interval;
   alarm_at(expiration, cb, ud, &timer->alarm);
@@ -148,7 +149,8 @@ static void repeating_cb( uint32_t now,
 }
 
 void timer_every(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t* repeating) {
-  uint32_t interval = (uint32_t)(ms * (alarm_internal_frequency() / 1000.0));
+  uint32_t frequency  = alarm_internal_frequency();
+  uint32_t interval   = (ms/1000) * frequency + (ms % 1000) * (frequency / 1000);
 
   repeating->interval = interval;
   repeating->cb       = cb;


### PR DESCRIPTION
Also implicitly casts the division to a float in case alarm_internal_frequency() returns a non-divisable number, then casts the result back to uint32_t.

This has been tested in a Signpost app and seems to be working properly with the changes.