### PR TITLE
Create a generic and default load_processes() function

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -35,43 +35,20 @@ mod test_take_map_cell;
 static mut SPI_READ_BUF: [u8; 64] = [0; 64];
 static mut SPI_WRITE_BUF: [u8; 64] = [0; 64];
 
-unsafe fn load_processes() -> &'static mut [Option<kernel::Process<'static>>] {
-    extern "C" {
-        /// Beginning of the ROM region containing app images.
-        static _sapps: u8;
-    }
+// State for loading and holding applications.
 
-    const NUM_PROCS: usize = 4;
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 4;
 
-    // how should the kernel respond when a process faults
-    const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultResponse::Panic;
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultResponse::Panic;
 
-    #[link_section = ".app_memory"]
-    static mut APP_MEMORY: [u8; 49152] = [0; 49152];
+#[link_section = ".app_memory"]
+static mut APP_MEMORY: [u8; 49152] = [0; 49152];
 
-    static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None, None, None];
+// Actual memory for holding the active process structures.
+static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None, None, None];
 
-    let mut apps_in_flash_ptr = &_sapps as *const u8;
-    let mut app_memory_ptr = APP_MEMORY.as_mut_ptr();
-    let mut app_memory_size = APP_MEMORY.len();
-    for i in 0..NUM_PROCS {
-        let (process, flash_offset, memory_offset) = kernel::Process::create(apps_in_flash_ptr,
-                                                                             app_memory_ptr,
-                                                                             app_memory_size,
-                                                                             FAULT_RESPONSE);
-
-        if process.is_none() {
-            break;
-        }
-
-        PROCESSES[i] = process;
-        apps_in_flash_ptr = apps_in_flash_ptr.offset(flash_offset as isize);
-        app_memory_ptr = app_memory_ptr.offset(memory_offset as isize);
-        app_memory_size -= memory_offset;
-    }
-
-    &mut PROCESSES
-}
 
 struct Hail {
     console: &'static Console<'static, usart::USART>,
@@ -419,5 +396,13 @@ pub unsafe fn reset_handler() {
     // test_take_map_cell::test_take_map_cell();
 
     // debug!("Initialization complete. Entering main loop");
-    kernel::main(&hail, &mut chip, load_processes(), &hail.ipc);
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+    }
+    kernel::process::load_processes(&_sapps as *const u8,
+                                    &mut APP_MEMORY,
+                                    &mut PROCESSES,
+                                    FAULT_RESPONSE);
+    kernel::main(&hail, &mut chip, &mut PROCESSES, &hail.ipc);
 }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -33,6 +33,18 @@ mod spi_dummy;
 #[allow(dead_code)]
 mod power;
 
+// State for loading apps.
+
+const NUM_PROCS: usize = 2;
+
+// how should the kernel respond when a process faults
+const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultResponse::Panic;
+
+#[link_section = ".app_memory"]
+static mut APP_MEMORY: [u8; 16384] = [0; 16384];
+
+static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None];
+
 struct Imix {
     console: &'static capsules::console::Console<'static, sam4l::usart::USART>,
     gpio: &'static capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
@@ -412,43 +424,13 @@ pub unsafe fn reset_handler() {
     rf233.start();
 
     debug!("Initialization complete. Entering main loop");
-    kernel::main(&imix, &mut chip, load_processes(), &imix.ipc);
-}
-
-unsafe fn load_processes() -> &'static mut [Option<kernel::Process<'static>>] {
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
     }
-
-    const NUM_PROCS: usize = 2;
-
-    // how should the kernel respond when a process faults
-    const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultResponse::Panic;
-
-    #[link_section = ".app_memory"]
-    static mut APP_MEMORY: [u8; 16384] = [0; 16384];
-
-    static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None];
-
-    let mut apps_in_flash_ptr = &_sapps as *const u8;
-    let mut app_memory_ptr = APP_MEMORY.as_mut_ptr();
-    let mut app_memory_size = APP_MEMORY.len();
-    for i in 0..NUM_PROCS {
-        let (process, flash_offset, memory_offset) = kernel::Process::create(apps_in_flash_ptr,
-                                                                             app_memory_ptr,
-                                                                             app_memory_size,
-                                                                             FAULT_RESPONSE);
-
-        if process.is_none() {
-            break;
-        }
-
-        PROCESSES[i] = process;
-        apps_in_flash_ptr = apps_in_flash_ptr.offset(flash_offset as isize);
-        app_memory_ptr = app_memory_ptr.offset(memory_offset as isize);
-        app_memory_size -= memory_offset;
-    }
-
-    &mut PROCESSES
+    kernel::process::load_processes(&_sapps as *const u8,
+                                    &mut APP_MEMORY,
+                                    &mut PROCESSES,
+                                    FAULT_RESPONSE);
+    kernel::main(&imix, &mut chip, &mut PROCESSES, &imix.ipc);
 }

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -67,43 +67,20 @@ const BUTTON2_PIN: usize = 18;
 const BUTTON3_PIN: usize = 19;
 const BUTTON4_PIN: usize = 20;
 
-unsafe fn load_process() -> &'static mut [Option<kernel::Process<'static>>] {
-    extern "C" {
-        /// Beginning of the ROM region containing app images.
-        static _sapps: u8;
-    }
 
-    const NUM_PROCS: usize = 1;
+// State for loading and holding applications.
 
-    // how should the kernel respond when a process faults
-    const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultResponse::Panic;
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultResponse::Panic;
 
-    #[link_section = ".app_memory"]
-    static mut APP_MEMORY: [u8; 8192] = [0; 8192];
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 1;
 
-    static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None];
+#[link_section = ".app_memory"]
+static mut APP_MEMORY: [u8; 8192] = [0; 8192];
 
-    let mut apps_in_flash_ptr = &_sapps as *const u8;
-    let mut app_memory_ptr = APP_MEMORY.as_mut_ptr();
-    let mut app_memory_size = APP_MEMORY.len();
-    for i in 0..NUM_PROCS {
-        let (process, flash_offset, memory_offset) = kernel::Process::create(apps_in_flash_ptr,
-                                                                             app_memory_ptr,
-                                                                             app_memory_size,
-                                                                             FAULT_RESPONSE);
+static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None];
 
-        if process.is_none() {
-            break;
-        }
-
-        PROCESSES[i] = process;
-        apps_in_flash_ptr = apps_in_flash_ptr.offset(flash_offset as isize);
-        app_memory_ptr = app_memory_ptr.offset(memory_offset as isize);
-        app_memory_size -= memory_offset;
-    }
-
-    &mut PROCESSES
-}
 
 pub struct Platform {
     gpio: &'static capsules::gpio::GPIO<'static, nrf51::gpio::GPIOPin>,
@@ -305,9 +282,16 @@ pub unsafe fn reset_handler() {
     chip.systick().enable(true);
 
     debug!("Initialization complete. Entering main loop");
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+    }
+    kernel::process::load_processes(&_sapps as *const u8,
+                                    &mut APP_MEMORY,
+                                    &mut PROCESSES,
+                                    FAULT_RESPONSE);
     kernel::main(&platform,
                  &mut chip,
-                 load_process(),
+                 &mut PROCESSES,
                  &kernel::ipc::IPC::new());
-
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -39,6 +39,40 @@ extern "C" {
 
 pub static mut PROCS: &'static mut [Option<Process<'static>>] = &mut [];
 
+/// Helper function to load processes from flash into an array of active
+/// processes. This is the default template for loading processes, but a board
+/// is able to create its own `load_processes()` function and use that instead.
+///
+/// Processes are found in flash starting from the given address and iterating
+/// through Tock Binary Format headers. Processes are given memory out of the
+/// `app_memory` buffer until either the memory is exhausted or the allocated
+/// number of processes are created, with process structures placed in the
+/// provided array. How process faults are handled by the kernel is also
+/// selected.
+pub unsafe fn load_processes(start_of_flash: *const u8,
+                             app_memory: &mut [u8],
+                             procs: &mut [Option<Process<'static>>],
+                             fault_response: FaultResponse) {
+    let mut apps_in_flash_ptr = start_of_flash;
+    let mut app_memory_ptr = app_memory.as_mut_ptr();
+    let mut app_memory_size = app_memory.len();
+    for i in 0..procs.len() {
+        let (process, flash_offset, memory_offset) = Process::create(apps_in_flash_ptr,
+                                                                     app_memory_ptr,
+                                                                     app_memory_size,
+                                                                     fault_response);
+
+        if process.is_none() {
+            break;
+        }
+
+        procs[i] = process;
+        apps_in_flash_ptr = apps_in_flash_ptr.offset(flash_offset as isize);
+        app_memory_ptr = app_memory_ptr.offset(memory_offset as isize);
+        app_memory_size -= memory_offset;
+    }
+}
+
 pub fn schedule(callback: FunctionCall, appid: AppId) -> bool {
     let procs = unsafe { &mut PROCS };
     let idx = appid.idx();

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -63,10 +63,17 @@ pub unsafe fn load_processes(start_of_flash: *const u8,
                                                                      fault_response);
 
         if process.is_none() {
-            break;
+            // We did not get a valid process, but we may have gotten a disabled
+            // process or padding. Therefore we want to skip this chunk of flash
+            // and see if there is a valid app there. However, if we cannot
+            // advance the flash pointer, then we are done.
+            if flash_offset == 0 && memory_offset == 0 {
+                break;
+            }
+        } else {
+            procs[i] = process;
         }
 
-        procs[i] = process;
         apps_in_flash_ptr = apps_in_flash_ptr.offset(flash_offset as isize);
         app_memory_ptr = app_memory_ptr.offset(memory_offset as isize);
         app_memory_size -= memory_offset;


### PR DESCRIPTION
Historically the `load_process()` function has been in the board's main.rs file. This has lead to some duplicated code. This PR adds a generic version to process.rs that platforms can use if they wish.

It also updates the imix and hail boards to use the generic version.