### PR TITLE
userland: remove unused load_info section from .ld

### DIFF
--- a/userland/userland_generic.ld
+++ b/userland/userland_generic.ld
@@ -20,12 +20,6 @@ MEMORY {
 }
 
 SECTIONS {
-/* Load information, used by runtime to load app */
-    .load_info :
-    {
-        KEEP(*(.load_info))
-    } > FLASH =0xFF
-
 /* Text section, Code! */
     .text :
     {


### PR DESCRIPTION
As far as I can tell this is not used.