### PR TITLE
userland: warnings on use of certain functions

### DIFF
--- a/userland/Configuration.mk
+++ b/userland/Configuration.mk
@@ -59,6 +59,10 @@ override CPPFLAGS += \
 	    -mpic-register=r9\
 	    -mno-pic-data-is-text-relative
 
+# This allows Tock to add additional warnings for functions that frequently cause problems.
+# See the included header for more details.
+override CPPFLAGS += -include $(TOCK_USERLAND_BASE_DIR)/support/warning_header.h
+
 # Flags for creating application Object files
 OBJDUMP_FLAGS += --disassemble-all --source --disassembler-options=force-thumb -C --section-headers
 

--- a/userland/examples/security_app/main.c
+++ b/userland/examples/security_app/main.c
@@ -61,7 +61,7 @@ int main(void) {
     led_toggle(0);
 
     printf("\tPIR:\t\t%d\n\tReed Switch:\t%d\n\n",
-        sensor_data.pir, sensor_data.reed_switch);
+           sensor_data.pir, sensor_data.reed_switch);
   }
 
   return 0;

--- a/userland/examples/security_app/main.c
+++ b/userland/examples/security_app/main.c
@@ -42,8 +42,8 @@ static void gpio_cb (int pin_num,
 //  * Accelerometer (movement)
 //  and makes that available over RF communication
 int main(void) {
-  putstr("*********************\n");
-  putstr("Security Application\n");
+  printf("*********************\n");
+  printf("Security Application\n");
 
   // configure pins
   gpio_interrupt_callback(gpio_cb, NULL);
@@ -60,12 +60,8 @@ int main(void) {
     yield();
     led_toggle(0);
 
-    {
-      char buf[64];
-      sprintf(buf, "\tPIR:\t\t%d\n\tReed Switch:\t%d\n\n",
-              sensor_data.pir, sensor_data.reed_switch);
-      putstr(buf);
-    }
+    printf("\tPIR:\t\t%d\n\tReed Switch:\t%d\n\n",
+        sensor_data.pir, sensor_data.reed_switch);
   }
 
   return 0;

--- a/userland/examples/tests/gpio/main.c
+++ b/userland/examples/tests/gpio/main.c
@@ -21,7 +21,7 @@ static void timer_cb (__attribute__ ((unused)) int arg0,
 // GPIO output example
 // **************************************************
 static void gpio_output(void) {
-  putstr("Periodically blinking LED\n");
+  printf("Periodically blinking LED\n");
 
   // Start repeating timer
   tock_timer_t timer;
@@ -37,8 +37,8 @@ static void gpio_output(void) {
 // GPIO input example
 // **************************************************
 static void gpio_input(void) {
-  putstr("Periodically reading value of the GPIO 0 pin\n");
-  putstr("Jump pin high to test (defaults to low)\n");
+  printf("Periodically reading value of the GPIO 0 pin\n");
+  printf("Jump pin high to test (defaults to low)\n");
 
   // set LED pin as input and start repeating timer
   // pin is configured with a pull-down resistor, so it should read 0 as default
@@ -63,8 +63,8 @@ static void gpio_cb (__attribute__ ((unused)) int pin_num,
                      __attribute__ ((unused)) void* userdata) {}
 
 static void gpio_interrupt(void) {
-  putstr("Print GPIO 0 pin reading whenever its value changes\n");
-  putstr("Jump pin high to test\n");
+  printf("Print GPIO 0 pin reading whenever its value changes\n");
+  printf("Jump pin high to test\n");
 
   // set callback for GPIO interrupts
   gpio_interrupt_callback(gpio_cb, NULL);
@@ -74,14 +74,14 @@ static void gpio_interrupt(void) {
 
   while (1) {
     yield();
-    putstr("\tGPIO Interrupt!\n");
+    printf("\tGPIO Interrupt!\n");
   }
 }
 
 
 int main(void) {
-  putstr("*********************\n");
-  putstr("GPIO Test Application\n");
+  printf("*********************\n");
+  printf("GPIO Test Application\n");
 
   // Set mode to which test you want
   uint8_t mode = 0;

--- a/userland/examples/tests/si7021/main.c
+++ b/userland/examples/tests/si7021/main.c
@@ -10,7 +10,7 @@
 #include <tock.h>
 
 int main (void) {
-  putstr("[SI7021] Test App\n");
+  printf("[SI7021] Test App\n");
 
   // Start a measurement
   int temp;

--- a/userland/libtock/alarm_timer.c
+++ b/userland/libtock/alarm_timer.c
@@ -129,7 +129,7 @@ uint32_t alarm_read(void) {
 
 void timer_in(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t *timer) {
   uint32_t frequency  = alarm_internal_frequency();
-  uint32_t interval   = (ms/1000) * frequency + (ms % 1000) * (frequency / 1000);
+  uint32_t interval   = (ms / 1000) * frequency + (ms % 1000) * (frequency / 1000);
   uint32_t now        = alarm_read();
   uint32_t expiration = now + interval;
   alarm_at(expiration, cb, ud, &timer->alarm);
@@ -149,8 +149,8 @@ static void repeating_cb( uint32_t now,
 }
 
 void timer_every(uint32_t ms, subscribe_cb cb, void* ud, tock_timer_t* repeating) {
-  uint32_t frequency  = alarm_internal_frequency();
-  uint32_t interval   = (ms/1000) * frequency + (ms % 1000) * (frequency / 1000);
+  uint32_t frequency = alarm_internal_frequency();
+  uint32_t interval  = (ms / 1000) * frequency + (ms % 1000) * (frequency / 1000);
 
   repeating->interval = interval;
   repeating->cb       = cb;

--- a/userland/libtock/console.c
+++ b/userland/libtock/console.c
@@ -87,7 +87,3 @@ int putnstr_async(const char *str, size_t len, subscribe_cb cb, void* userdata) 
   ret = subscribe(0, 1, cb, userdata);
   return ret;
 }
-
-int putstr(const char *str) {
-  return putnstr(str, strlen(str));
-}

--- a/userland/libtock/ltc294x.c
+++ b/userland/libtock/ltc294x.c
@@ -239,7 +239,7 @@ int ltc294x_shutdown_sync(void) {
 
 int ltc294x_convert_to_coulomb_uah(int c, int Rsense, uint16_t prescaler, ltc294x_model_e model) {
   if (model == LTC2941 || model == LTC2942) {
-    return (int)(c * 85  * (50.0 / Rsense) * (prescaler / 128.0));
+    return (int)(c * 85 * (50.0 / Rsense) * (prescaler / 128.0));
   } else {
     return (int)(c * 340 * (50.0 / Rsense) * (prescaler / 4096.0));
   }

--- a/userland/support/warning_header.h
+++ b/userland/support/warning_header.h
@@ -1,0 +1,34 @@
+// With a heavy emphasis on security, Tock prefers to avoid several functions
+// that commonly introduce bugs in (embedded) code. This header is injected as
+// part of the tock build, where we add warning attributes to functions.
+
+#include <stdio.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wredundant-decls"
+
+
+// C++ doesn't have the `restrict` keyword so copy whole decl's in this section
+#ifdef __cplusplus
+extern "C" {
+
+__attribute__((warning ("prefer snprintf over sprintf")))
+int sprintf(char * str, const char * format, ...);
+
+__attribute__((warning ("prefer vsnprintf over vsprintf")))
+int vsprintf(char * str, const char * format, va_list ap);
+
+}
+#else // !defined __cplusplus
+
+__attribute__((warning ("prefer snprintf over sprintf")))
+int sprintf(char * restrict str, const char * restrict format, ...);
+
+__attribute__((warning ("prefer vsnprintf over vsprintf")))
+int vsprintf(char * restrict str, const char * restrict format, va_list ap);
+
+#endif // __cplusplus
+
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Inspired by a series of signpost bugs, there are some functions that,
while not inherently unsafe, are often dangerous to use and easy to
replace with something safer. The motivating example here being
`snprintf` in favor of `sprintf`. We could add more in the future*,
but for now this is a scaffolding

*Brad was lobbying for strlen, but that's a bit harder, critically
this warning only applies to _emitted_ function calls, so something
like `foo("buf", strlen("buf"))` would not emit a warning, but that's
a bridge for another day)