### PR TITLE
docs: tell rustdoc to document private fields

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -98,7 +98,11 @@ debug:	target/$(TARGET)/debug/$(PLATFORM).bin
 
 .PHONY: doc
 doc:
-	$(Q)$(XARGO) doc $(VERBOSE) --release --target=$(TARGET)
+	@# Need to make a wrapper script so we can pass flags to `rustdoc`.
+	@# This allows us to tell rustdoc to document internal functions and fields.
+	$(Q)printf '#!/bin/bash\nexec rustdoc $$@ --no-defaults --passes "collapse-docs" --passes "unindent-comments"\n' > target/rustdoc
+	$(Q)chmod +x target/rustdoc
+	$(Q)RUSTDOC=target/rustdoc $(XARGO) doc $(VERBOSE) --release --target=$(TARGET)
 
 target/$(TARGET)/release/$(PLATFORM).elf: target/$(TARGET)/release/$(PLATFORM)
 	$(Q)cp target/$(TARGET)/release/$(PLATFORM) target/$(TARGET)/release/$(PLATFORM).elf


### PR DESCRIPTION
By default, rustdoc only documents public fields. This is great for users of crates, and less great for developers of crates. This commit tells rustdoc to document everything.