### PR TITLE
kernel: enable and disable MPU for process

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -413,7 +413,6 @@ pub unsafe fn reset_handler() {
     hail.nrf51822.initialize();
 
     let mut chip = sam4l::chip::Sam4l::new();
-    chip.mpu().enable_mpu();
 
     // Uncomment to measure overheads for TakeCell and MapCell:
     // test_take_map_cell::test_take_map_cell();

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -402,8 +402,6 @@ pub unsafe fn reset_handler() {
 
     let mut chip = sam4l::chip::Sam4l::new();
 
-    chip.mpu().enable_mpu();
-
     rf233.reset();
     rf233.config_set_pan(0xABCD);
     rf233.config_set_address(0x1008);

--- a/boards/imixv1/src/main.rs
+++ b/boards/imixv1/src/main.rs
@@ -414,8 +414,6 @@ pub unsafe fn reset_handler() {
 
     let mut chip = sam4l::chip::Sam4l::new();
 
-    chip.mpu().enable_mpu();
-
     rf233.reset();
     rf233.config_set_pan(0xABCD);
     rf233.config_set_address(0x1008);

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -3,6 +3,7 @@
 use core::nonzero::NonZero;
 use memop;
 use platform::{Chip, Platform};
+use platform::mpu::MPU;
 use platform::systick::SysTick;
 use process;
 use process::{Process, Task};
@@ -27,9 +28,11 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &P,
         match process.current_state() {
             process::State::Running => {
                 process.setup_mpu(chip.mpu());
+                chip.mpu().enable_mpu();
                 systick.enable(true);
                 process.switch_to();
                 systick.enable(false);
+                chip.mpu().disable_mpu();
             }
             process::State::Yielded => {
                 match process.dequeue_task() {


### PR DESCRIPTION
This will disable the MPU entirely when the kernel runs.

This also means that `enable_mpu()` does not need to be called in board/main.rs.