### PR TITLE
make: generate target file if not exist

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -96,8 +96,11 @@ all:	target/$(TARGET)/release/$(PLATFORM).bin
 .PHONY: debug
 debug:	target/$(TARGET)/debug/$(PLATFORM).bin
 
+target:
+	@mkdir -p target
+
 .PHONY: doc
-doc:
+doc: | target
 	@# Need to make a wrapper script so we can pass flags to `rustdoc`.
 	@# This allows us to tell rustdoc to document internal functions and fields.
 	$(Q)printf '#!/bin/bash\nexec rustdoc $$@ --no-defaults --passes "collapse-docs" --passes "unindent-comments"\n' > target/rustdoc


### PR DESCRIPTION
For some reason building docs won't generate a target folder if one doesn't already exist.