### PR TITLE
Macro and linker script update for embedding storage regions within kernel.

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -43,6 +43,7 @@ SECTIONS
     {
         . = ALIGN(4);
         _textstart = .;         /* Symbol expected by some MS build toolchains */
+        _stext = .;
 
         /* Place vector table at the beginning of ROM.
          *
@@ -135,15 +136,19 @@ SECTIONS
     } > rom
     PROVIDE_HIDDEN (__exidx_end = .);
 
-
     /* Mark the end of static elements */
     . = ALIGN(4);
+    . = ALIGN(512);
+    .storage :
+    {
+       _sstorage = .;
+       *(.storage* storage*)
+       _estorage = .;
+    } > rom
+    . = ALIGN(512);
+
     _etext = .;
     _textend = .;   /* alias for _etext expected by some MS toolchains */
-
-
-
-
 
     /* STATIC ELEMENTS FOR TOCK APPLICATIONS */
     .apps :
@@ -155,9 +160,8 @@ SECTIONS
         /* Optional .app sections a convenience mechanism to bundle tock
            kernel and apps into a single image */
         KEEP (*(.app.*))
+        _eapps = PROG_ORIGIN + PROG_LENGTH - 1;
     } > prog
-
-
 
     /* Kernel data that must be relocated. This is program data that is
      * exepected to live in SRAM, but is initialized with a value. This data is
@@ -177,9 +181,6 @@ SECTIONS
         . = ALIGN(4);
         _erelocate = .;
     } > ram
-
-
-
 
     .sram (NOLOAD) :
     {

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -53,7 +53,6 @@ macro_rules! static_init {
 /// initialize their state. The linker script kernel_layout.ld makes
 /// sure that the .storage section is aligned on a 512-byte boundary
 /// and the next section is aligned as well.
-
 #[macro_export]
 macro_rules! storage_volume {
     ($N:ident, $kB:expr) => {

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -1,4 +1,4 @@
-//! Utility macros including `static_init!`.
+//! Utility macros including `static_init!` and `storage_volume!`
 
 /// Allocates a global array of static size to initialize data structures.
 ///
@@ -34,5 +34,31 @@ macro_rules! static_init {
             ptr::write(tmp as *mut $T, $e);
             tmp
         };
+    }
+}
+
+/// Allocates space in the kernel image for on-chip non-volatile storage.
+/// Storage volumes are placed after the kernel code and before relocated
+/// variables (those copied into RAM on boot). They are placed in
+/// a section called ".storage".
+///
+/// Non-volatile storage abstractions can then refer to the block of
+/// allocate flash in terms of the name of the volume. For example,
+///
+/// `storage_volume(LOG, 32);`
+///
+/// will allocate 32kB of space in the flash and define a symbol LOG
+/// at the start address of that flash region. The intention is that
+/// storage abstractions can then be passed this address and size to
+/// initialize their state. The linker script kernel_layout.ld makes
+/// sure that the .storage section is aligned on a 512-byte boundary
+/// and the next section is aligned as well.
+
+#[macro_export]
+macro_rules! storage_volume {
+    ($N:ident, $kB:expr) => {
+        #[link_section = ".storage"]
+        #[no_mangle]
+        static mut $N : [u8; $kB * 1024] = [0x00; $kB * 1024];
     }
 }


### PR DESCRIPTION
This includes two pieces of code, one minor and one major.

The minor change is adding a storage_volume macro to utils.rs that allows you to declare a variable that resides in a new region for non-volatile storage volumes.

The major change is the update to the linker script that adds this region (.storage). 

This is the first step to allowing the kernel to allocate volumes for storage (e.g., logs).