### PR TITLE
provide a target to build lst for kernel

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -93,6 +93,9 @@ endif
 .PHONY: all
 all:	target/$(TARGET)/release/$(PLATFORM).bin
 
+.PHONY: lst
+lst:	target/$(TARGET)/release/$(PLATFORM).lst
+
 .PHONY: debug
 debug:	target/$(TARGET)/debug/$(PLATFORM).bin
 
@@ -109,6 +112,9 @@ doc: | target
 
 target/$(TARGET)/release/$(PLATFORM).elf: target/$(TARGET)/release/$(PLATFORM)
 	$(Q)cp target/$(TARGET)/release/$(PLATFORM) target/$(TARGET)/release/$(PLATFORM).elf
+
+target/$(TARGET)/release/$(PLATFORM).lst: target/$(TARGET)/release/$(PLATFORM).elf
+	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $< > target/$(TARGET)/release/$(PLATFORM).lst
 
 .PHONY: target/$(TARGET)/release/$(PLATFORM)
 target/$(TARGET)/release/$(PLATFORM):


### PR DESCRIPTION
There's an asymmetry right now between userland and kernel, where
in the kernel `make debug` does a different build and in userland
it makes the lst file. We should rectify that interface at some
point, but in the immediate term, it's useful to have any way to
generate an lst file for the kernel