### PR TITLE
Make pic information optional in `elf2tbf` through an argument

### DIFF
--- a/userland/Configuration.mk
+++ b/userland/Configuration.mk
@@ -34,7 +34,7 @@ TOCK_ARCHS ?= cortex-m0 cortex-m4
 
 # This could be replaced with an installed version of `elf2tbf`
 ELF2TBF ?= cargo run --manifest-path $(abspath $(TOCK_USERLAND_BASE_DIR))/tools/elf2tbf/Cargo.toml --
-ELF2TBF_ARGS += -n $(PACKAGE_NAME)
+ELF2TBF_ARGS += --include-pic-info -n $(PACKAGE_NAME)
 
 # Flags for building app Assembly, C, C++ files
 # n.b. make convention is that CPPFLAGS are shared for C and C++ sources


### PR DESCRIPTION
The kernel knows how to load processes without PIC information in their binaries, but `elf2tbf` didn't know how to exclude that header. So this excludes that header by default, adding a `-p` argument to include it.

It also adds the `-p` argument to C apps in `userland/`, so there should be no change for apps in practice.

This just sets us up to do Rust apps differently (and evaluate potentially moving the PIC handling code to C as well)