### PR TITLE
Remove `data_start_pointer` from load_info

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -30,34 +30,32 @@ EXC_RETURN_PSP:
 
 #[no_mangle]
 #[inline(never)]
-/// r0 is top of user stack, r1 Process GOT
 pub unsafe extern "C" fn switch_to_user(mut user_stack: *const u8,
-                                        process_got: *const u8,
                                         process_regs: &mut [usize; 8])
                                         -> *mut u8 {
     asm!("
     /* Load non-hardware-stacked registers from Process stack */
-    ldmia $3!, {r4-r7}
+    ldmia $2!, {r4-r7}
     mov r11, r7
     mov r10, r6
     mov r9,  r5
     mov r8,  r4
-    ldmia $3!, {r4-r7}
-    subs $3, 32
+    ldmia $2!, {r4-r7}
+    subs $2, 32 /* Restore pointer to process_regs
+                /* ldmia! added a 32-byte offset */
 
     /* Load bottom of stack into Process Stack Pointer */
     msr psp, $0
 
-    /* Set PIC base pointer to the Process GOT */
-    mov r9, $2
-
-    mov r0, $3
+    /* Ensure process_regs is stored in a hardware stacked register */
+    /* so we have it when we return from SVC */
+    mov r0, $2
 
     /* SWITCH */
     svc 0xff /* It doesn't matter which SVC number we use here */
 
-    /* Push non-hardware-stacked registers onto Process stack */
-    /* r0 points to user stack (see to_kernel) */
+    /* Store non-hardware-stacked registers in process_regs */
+    /* r0 points to user stack */
     str r4, [r0, #16]
     str r5, [r0, #20]
     str r6, [r0, #24]
@@ -77,7 +75,7 @@ pub unsafe extern "C" fn switch_to_user(mut user_stack: *const u8,
 
     "
     : "=r"(user_stack)
-    : "r"(user_stack), "r"(process_got), "r"(process_regs)
+    : "r"(user_stack), "r"(process_regs)
     : "r4","r5","r6","r7","r8","r9","r10","r11");
     user_stack as *mut u8
 }

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -25,15 +25,12 @@ pub unsafe extern "C" fn systick_handler() {
         cmp lr, #0xfffffffd
         bne _systick_handler_no_stacking
 
-        /* We need the most recent kernel's version of r0, which points */
-        /* to the Process struct's stored registers field. The kernel's r0 */
-        /* lives in the first word of the hardware stacked registers on MSP */
-        mov r0, sp
-        ldr r0, [r0, #0]
-
-        /* Push non-hardware-stacked registers onto Process stack */
-        /* r0 points to user stack (see to_kernel) */
-        stmia r0, {r4-r11}
+        /* We need the most recent kernel's version of r1, which points */
+        /* to the Process struct's stored registers field. The kernel's r1 */
+        /* lives in the second word of the hardware stacked registers on MSP */
+        mov r1, sp
+        ldr r1, [r1, #4]
+        stmia r1, {r4-r11}
     _systick_handler_no_stacking:
         ldr r0, =OVERFLOW_FIRED
         mov r1, #1
@@ -63,15 +60,12 @@ pub unsafe extern "C" fn generic_isr() {
     cmp lr, #0xfffffffd
     bne _ggeneric_isr_no_stacking
 
-    /* We need the most recent kernel's version of r0, which points */
-    /* to the Process struct's stored registers field. The kernel's r0 */
-    /* lives in the first word of the hardware stacked registers on MSP */
-    mov r0, sp
-    ldr r0, [r0, #0]
-
-    /* Push non-hardware-stacked registers onto Process stack */
-    /* r0 points to user stack (see to_kernel) */
-    stmia r0, {r4-r11}
+    /* We need the most recent kernel's version of r1, which points */
+    /* to the Process struct's stored registers field. The kernel's r1 */
+    /* lives in the second word of the hardware stacked registers on MSP */
+    mov r1, sp
+    ldr r1, [r1, #4]
+    stmia r1, {r4-r11}
 _ggeneric_isr_no_stacking:
     /* Find the ISR number by looking at the low byte of the IPSR registers */
     mrs r0, IPSR
@@ -138,30 +132,28 @@ pub unsafe extern "C" fn switch_to_user(user_stack: *const u8, process_got: *con
 
 #[cfg(target_os = "none")]
 #[no_mangle]
-#[inline(never)]
 /// r0 is top of user stack, r1 Process GOT
 pub unsafe extern "C" fn switch_to_user(mut user_stack: *const u8,
                                         process_regs: &mut [usize; 8])
                                         -> *mut u8 {
     asm!("
-    /* Load non-hardware-stacked registers from Process stack */
-    ldmia $2, {r4-r11}
     /* Load bottom of stack into Process Stack Pointer */
     msr psp, $0
 
+    /* Load non-hardware-stacked registers from Process stack */
     /* Ensure that $2 is stored in a callee saved register */
-    mov r0, $2
+    ldmia $2, {r4-r11}
 
     /* SWITCH */
     svc 0xff /* It doesn't matter which SVC number we use here */
 
     /* Push non-hardware-stacked registers into Process struct's */
     /* regs field */
-    stmia r0, {r4-r11}
+    stmia $2, {r4-r11}
 
     mrs $0, PSP /* PSP into r0 */"
-    : "=r"(user_stack)
-    : "r"(user_stack), "r"(process_regs)
+    : "={r0}"(user_stack)
+    : "{r0}"(user_stack), "{r1}"(process_regs)
     : "r4","r5","r6","r7","r8","r9","r10","r11");
     user_stack as *mut u8
 }

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -141,20 +141,16 @@ pub unsafe extern "C" fn switch_to_user(user_stack: *const u8, process_got: *con
 #[inline(never)]
 /// r0 is top of user stack, r1 Process GOT
 pub unsafe extern "C" fn switch_to_user(mut user_stack: *const u8,
-                                        process_got: *const u8,
                                         process_regs: &mut [usize; 8])
                                         -> *mut u8 {
     asm!("
     /* Load non-hardware-stacked registers from Process stack */
-    ldmia $3, {r4-r11}
+    ldmia $2, {r4-r11}
     /* Load bottom of stack into Process Stack Pointer */
     msr psp, $0
 
-    /* Set PIC base pointer to the Process GOT */
-    mov r9, $2
-
-    /* Ensure that $3 is stored in a callee saved register */
-    mov r0, $3
+    /* Ensure that $2 is stored in a callee saved register */
+    mov r0, $2
 
     /* SWITCH */
     svc 0xff /* It doesn't matter which SVC number we use here */
@@ -165,7 +161,7 @@ pub unsafe extern "C" fn switch_to_user(mut user_stack: *const u8,
 
     mrs $0, PSP /* PSP into r0 */"
     : "=r"(user_stack)
-    : "r"(user_stack), "r"(process_got), "r"(process_regs)
+    : "r"(user_stack), "r"(process_regs)
     : "r4","r5","r6","r7","r8","r9","r10","r11");
     user_stack as *mut u8
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -37,7 +37,6 @@ pub static mut SCB_REGISTERS: [u32; 5] = [0; 5];
 #[allow(improper_ctypes)]
 extern "C" {
     pub fn switch_to_user(user_stack: *const u8,
-                          got_base: *const u8,
                           process_regs: &mut [usize; 8])
                           -> *mut u8;
 }
@@ -689,10 +688,6 @@ pub struct Process<'a> {
     /// Saved when the app switches to the kernel.
     current_stack_pointer: *const u8,
 
-    /// Needed only the first time the app is run to set R9 if the kernel did
-    /// the PIC setup for the app.
-    data_start_pointer: *const u8,
-
     /// Process text segment
     text: &'static [u8],
 
@@ -1043,10 +1038,6 @@ impl<'a> Process<'a> {
                     app_break: load_result.initial_sbrk_pointer,
                     current_stack_pointer: load_result.initial_stack_pointer,
 
-                    // We need to keep this to set R9 the first time we switch
-                    // to the process.
-                    data_start_pointer: load_result.data_start_pointer,
-
                     text: slice::from_raw_parts(app_flash_address, app_flash_size),
 
                     stored_regs: Default::default(),
@@ -1213,7 +1204,6 @@ impl<'a> Process<'a> {
     pub unsafe fn switch_to(&mut self) {
         write_volatile(&mut SYSCALL_FIRED, 0);
         let psp = switch_to_user(self.current_stack_pointer,
-                                 self.data_start_pointer,
                                  mem::transmute(&mut self.stored_regs));
         self.current_stack_pointer = psp;
         if self.current_stack_pointer < self.debug.min_stack_pointer {
@@ -1467,7 +1457,7 @@ impl<'a> Process<'a> {
         // SRAM sizes
         let sram_grant_size = sram_end - sram_grant_start;
         let sram_heap_size = sram_heap_end - sram_heap_start;
-        let sram_data_size = sram_heap_start - sram_heap_start;
+        let sram_data_size = sram_heap_start - sram_stack_start;
         let sram_stack_size = sram_stack_start - sram_stack_bottom;
         let sram_grant_allocated = sram_end - sram_grant_start;
         let sram_heap_allocated = sram_grant_start - sram_heap_start;
@@ -1622,9 +1612,6 @@ struct LoadResult {
     /// Where the sbrk initial end of process memory is set.
     initial_sbrk_pointer: *const u8,
 
-    /// Where the data section is.
-    data_start_pointer: *const u8,
-
     // Pass the header back to the caller.
     header: TbfHeader,
 }
@@ -1737,10 +1724,6 @@ unsafe fn load(tbf_header: TbfHeader,
                 // where the are.
                 initial_stack_pointer: mem_base.offset(aligned_stack_len as isize),
                 initial_sbrk_pointer: mem_base.offset(aligned_fixed_len as isize),
-                // Also need to keep track of where we put the data portion in
-                // RAM so that we can correctly set R9 when we first switch to
-                // the app.
-                data_start_pointer: got_base,
                 header: tbf_header,
             };
 
@@ -1753,12 +1736,10 @@ unsafe fn load(tbf_header: TbfHeader,
         // No PIC fixup requested from the kernel. We only need to set an
         // initial stack pointer and sbrk size. The app will do the rest on its
         // own.
-
         let load_result = LoadResult {
             // Set the initial stack and process memory size to 64 bytes.
             initial_stack_pointer: mem_base.offset(64),
             initial_sbrk_pointer: mem_base.offset(64),
-            data_start_pointer: ptr::null(),
             header: tbf_header,
         };
 

--- a/userland/libtock/crt1.c
+++ b/userland/libtock/crt1.c
@@ -15,10 +15,19 @@ extern int main(void);
 __attribute__ ((section(".start"), used))
 __attribute__ ((weak))
 __attribute__ ((noreturn))
+__attribute__ ((naked))
 void _start(void* mem_start __attribute__((unused)),
             void* app_heap_break __attribute__((unused)),
             void* kernel_memory_break __attribute__((unused))) {
-  main();
-  while (1) { yield(); }
+  /*
+   * 1. Setup r9 to point to the GOT (assumes the kernel places the GOT right
+   *    above the stack)
+   * 2. Call `main`
+   * 3. Loop on `yield` forever
+   */
+  asm volatile ("mov r9, sp; \
+                 bl main; \
+                 1: bl yield; \
+                 b 1b");
 }
 


### PR DESCRIPTION
This change is step 2 in reconciling how processes are loaded given that they may or may not use the kernel default PIC strategy. This step is a moderate cleanup phase, and I believe ends up leaving relocation related code in only one function in the kernel, basically.

`data_start_pointer` was only being used to set the value of r9 in
`switch_to_user`. However, first, that's dependent on the processes
(i.e. a processes that uses a different PIC strategy will point r9
somewhere else). Second, it was buggy for non-PIC processes (setting r9
to 0 in practice). Finally, we already have this value anyway from the
initial stack pointer in the default PIC strategy.

So, this removes that field, removes setting the r9 value in the kernel,
deferring it to the processes, and uses the initial stack pointer as the
reference for where the GOT starts.