### PR TITLE
TBF header: pad all TLV blocks to 4

### DIFF
--- a/doc/Compilation.md
+++ b/doc/Compilation.md
@@ -186,7 +186,7 @@ struct TbfHeader {
     flags: u32,              // Various flags associated with the application
     checksum: u32,           // XOR of all 4 byte words in the header, including existing optional structs
 
-    // Optional structs.
+    // Optional structs. All optional structs start on a 4-byte boundary.
     main: Option<TbfHeaderMain>,
     pic_options: Option<TbfHeaderPicOption1Fields>,
     name: Option<TbfHeaderPackageName>,

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -20,6 +20,11 @@ macro_rules! align8 {
     ( $e:expr ) => ( ($e) + ((8 - (($e) % 8)) % 8 ) );
 }
 
+/// Takes a value and rounds it up to be aligned % 4
+macro_rules! align4 {
+    ( $e:expr ) => ( ($e) + ((4 - (($e) % 4)) % 4 ) );
+}
+
 #[no_mangle]
 pub static mut SYSCALL_FIRED: usize = 0;
 
@@ -589,8 +594,10 @@ unsafe fn parse_and_validate_tbf_header(address: *const u8) -> Option<TbfHeader>
                         }
                     }
 
-                    remaining_length -= tbf_tlv_header.length as usize;
-                    offset += tbf_tlv_header.length as isize;
+                    // All TLV blocks are padded to 4 bytes, so we need to skip
+                    // more if the length is not a multiple of 4.
+                    remaining_length -= align4!(tbf_tlv_header.length) as usize;
+                    offset += align4!(tbf_tlv_header.length) as isize;
                 }
 
                 main_pointer.map_or(None, |mp| {


### PR DESCRIPTION
To help with avoiding unaligned accesses, all TLV blocks are now aligned to 4 bytes. The length field still specifies the length of the Value section, but if that length is not a multiple of 4, there is padding so
that the next header starts on a multiple of 4.