### PR TITLE
userland: handles spaces in absolute path

### DIFF
--- a/userland/Configuration.mk
+++ b/userland/Configuration.mk
@@ -27,13 +27,13 @@ APP_HEAP_SIZE    ?= 1024
 KERNEL_HEAP_SIZE ?= 1024
 
 # PACKAGE_NAME is used to identify the application for IPC and for error reporting
-PACKAGE_NAME ?= $(notdir $(shell pwd))
+PACKAGE_NAME ?= $(shell basename "$(shell pwd)")
 
 # Tock supported architectures
 TOCK_ARCHS ?= cortex-m0 cortex-m4
 
 # This could be replaced with an installed version of `elf2tbf`
-ELF2TBF ?= cargo run --manifest-path $(abspath $(TOCK_USERLAND_BASE_DIR))/tools/elf2tbf/Cargo.toml --
+ELF2TBF ?= cargo run --manifest-path $(TOCK_USERLAND_BASE_DIR)/tools/elf2tbf/Cargo.toml --
 ELF2TBF_ARGS += --include-pic-info -n $(PACKAGE_NAME)
 
 # Flags for building app Assembly, C, C++ files


### PR DESCRIPTION
1. Don't need to do abspath for elf2tbf.
2. notdir can't escape spaces in path, must use basename instead.

I can't promise I tried everything, but I flashed a kernel and multiple apps on to a board.