### PR TITLE
Signbus Implementation in Tock

### DIFF
--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -52,3 +52,4 @@ pub mod ieee802154;
 pub mod temperature;
 pub mod humidity;
 //pub mod nrf_internal_temp_sensor;
+pub mod signbus;

--- a/capsules/src/signbus/README.md
+++ b/capsules/src/signbus/README.md
@@ -1,0 +1,87 @@
+# Signbus Communication Layers
+
+```
+USERLAND
+ ↳ app_layer
+  ↳ protocol_layer
+   ↳ io_layer
+    ↳ port_layer
+     ↳ I2C DRIVER
+```
+
+## app_layer
+Userland buffers and callbacks.
+Concatenate app information (frame_type, api_type) to message.
+ 
+    pub trait AppLayerClient {
+      fn packet_received();
+      fn packet_sent();
+      fn packet_read_from_slave();
+    }
+
+    SignbusAppLayer {
+      fn signbus_app_send();
+      fn signbus_app_recv();
+    }
+
+## protocol_layer
+Encrypt/ decrypt message and concatenate HMAC to message.
+*Not implemented.*
+
+    pub trait ProtocolLayerClient {
+      fn packet_received();
+      fn packet_sent();
+      fn packet_read_from_slave();
+    }
+
+    SignbusProtocolLayer {
+      fn signbus_protocol_send();
+      fn signbus_protocol_recv();
+    }
+
+
+## io_layer
+Send/ receive Signbus packets and concatenate fragmented messages together.
+
+    pub trait IOLayerClient {
+      fn packet_received();
+      fn packet_sent();
+      fn packet_read_from_slave();
+    }
+
+    SignbusIOLayer {
+      fn signbus_io_init();
+      fn signbus_io_send();
+      fn signbus_io_recv();
+    }
+
+
+## port_layer
+Send/ receive I2C MTU (255 bytes). Communicates with I2C driver.
+Ability to use gpio and timer.
+
+    pub trait PortLayerClientI2C {
+      fn packet_received();
+      fn packet_sent();
+      fn packet_read_from_slave();
+    }
+
+    pub trait PortLayerClientGPIOTimer {
+      fn mod_in_interrupt();
+      fn delay_complete();
+    }
+
+    SignbusPortLayer {
+      fn init();
+      fn i2c_master_write();
+      fn i2c_slave_listen();
+      fn i2c_slave_read_setup();
+      fn mod_out_set();
+      fn mod_out_clear();
+      fn mod_in_read();
+      fn mod_in_enable_interrupt();
+      fn mod_in_disable_interrupt();
+      fn delay_ms();
+      fn debug_led_on();
+      fn debug_led_off();
+    }

--- a/capsules/src/signbus/README.md
+++ b/capsules/src/signbus/README.md
@@ -12,7 +12,7 @@ USERLAND
 ## app_layer
 Userland buffers and callbacks.
 Concatenate app information (frame_type, api_type) to message.
- 
+
     pub trait AppLayerClient {
       fn packet_received();
       fn packet_sent();
@@ -85,3 +85,63 @@ Ability to use gpio and timer.
       fn debug_led_on();
       fn debug_led_off();
     }
+
+Usage
+-----
+
+
+```rust
+// Signbus virtual alarm
+    let signbus_virtual_alarm = static_init!(
+        VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+        VirtualMuxAlarm::new(mux_alarm));
+
+    // Signbus port_layer
+    let port_layer = static_init!(
+        capsules::signbus::port_layer::SignbusPortLayer<'static,
+        VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
+        capsules::signbus::port_layer::SignbusPortLayer::new(
+            &sam4l::i2c::I2C1,
+            &mut capsules::signbus::port_layer::I2C_SEND,
+            &mut capsules::signbus::port_layer::I2C_RECV,
+            &sam4l::gpio::PB[14], // D0 mod_in
+            &sam4l::gpio::PB[15], // D1 mod_out
+            signbus_virtual_alarm,
+            Some(&sam4l::gpio::PA[13]), // RED LED
+		));
+
+    sam4l::i2c::I2C1.set_master_client(port_layer);
+    sam4l::i2c::I2C1.set_slave_client(port_layer);
+    signbus_virtual_alarm.set_client(port_layer);
+    sam4l::gpio::PB[14].set_client(port_layer);
+
+
+    // Signbus IO Interface
+    let io_layer = static_init!(
+        capsules::signbus::io_layer::SignbusIOLayer<'static>,
+        capsules::signbus::io_layer::SignbusIOLayer::new(port_layer,
+              	&mut capsules::signbus::io_layer::BUFFER0,
+                &mut capsules::signbus::io_layer::BUFFER1,
+                &mut capsules::signbus::io_layer::BUFFER2
+     ));
+
+    port_layer.set_io_client(io_layer);
+
+    // Signbus Protocol Layer
+    let protocol_layer = static_init!(
+        capsules::signbus::protocol_layer::SignbusProtocolLayer<'static>,
+        capsules::signbus::protocol_layer::SignbusProtocolLayer::new(io_layer,
+    ));
+
+    io_layer.set_client(protocol_layer);
+
+    // Signbus App Layer
+    let app_layer = static_init!(
+        capsules::signbus::app_layer::SignbusAppLayer<'static>,
+        capsules::signbus::app_layer::SignbusAppLayer::new(protocol_layer,
+            &mut capsules::signbus::app_layer::BUFFER0,
+              &mut capsules::signbus::app_layer::BUFFER1
+    ));
+
+protocol_layer.set_client(app_layer);
+```

--- a/capsules/src/signbus/app_layer.rs
+++ b/capsules/src/signbus/app_layer.rs
@@ -1,0 +1,127 @@
+//! Kernel implementation of signbus_app_layer
+//! apps/libsignpost/signbus_app_layer.c -> kernel/tock/capsules/src/signbus_app_layer.rs
+//! By: Justin Hsieh
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! // Signbus App Layer
+//! let app_layer = static_init!(
+//!     capsules::signbus::app_layer::SignbusAppLayer<'static>,
+//!     capsules::signbus::app_layer::SignbusAppLayer::new(protocol_layer,
+//!             &mut capsules::signbus::app_layer::BUFFER0,
+//!             &mut capsules::signbus::app_layer::BUFFER1
+//! ));
+//!
+//! ```
+
+
+use core::cell::Cell;
+use kernel::ReturnCode;
+use kernel::common::take_cell::TakeCell;
+
+// Capsules
+use signbus::{protocol_layer, support, test_signbus_init};
+
+/// Buffers used to concatenate message information.
+pub static mut BUFFER0: [u8; 256] = [0; 256];
+pub static mut BUFFER1: [u8; 256] = [0; 256];
+
+/// SignbusAppLayer to handle application messages.
+pub struct SignbusAppLayer<'a> {
+    protocol_layer: &'a protocol_layer::SignbusProtocolLayer<'a>,
+    payload: TakeCell<'static, [u8]>,
+    send_buf: TakeCell<'static, [u8]>,
+    client: Cell<Option<&'static test_signbus_init::SignbusInitialization<'static>>>,
+}
+
+/// AppLayerClient for I2C sending/receiving callbacks. Implemented by SignbusInitialization.
+pub trait AppLayerClient {
+    // Called when a new packet is received over I2C.
+    fn packet_received(&self, data: &'static mut [u8], length: usize, error: support::Error);
+
+    // Called when an I2C master write command is complete.
+    fn packet_sent(&self, data: &'static mut [u8], error: support::Error);
+
+    // Called when an I2C slave read has completed.
+    fn packet_read_from_slave(&self);
+}
+
+impl<'a> SignbusAppLayer<'a> {
+    pub fn new(protocol_layer: &'a protocol_layer::SignbusProtocolLayer,
+               payload: &'static mut [u8],
+               send_buf: &'static mut [u8])
+               -> SignbusAppLayer<'a> {
+
+        SignbusAppLayer {
+            protocol_layer: protocol_layer,
+            payload: TakeCell::new(payload),
+            send_buf: TakeCell::new(send_buf),
+            client: Cell::new(None),
+        }
+    }
+
+    pub fn set_client(&self,
+                      client: &'static test_signbus_init::SignbusInitialization)
+                      -> ReturnCode {
+        self.client.set(Some(client));
+        ReturnCode::SUCCESS
+    }
+
+    pub fn signbus_app_send(&self,
+                            address: u8,
+                            frame_type: u8,
+                            api_type: u8,
+                            message_type: u8,
+                            message_length: usize,
+                            message: &'static mut [u8])
+                            -> ReturnCode {
+
+        let len: usize = 1 + 1 + 1 + message_length;
+
+        // Concatenate info with message
+        self.payload.map(|payload| {
+            payload[0] = frame_type as u8;
+            payload[1] = api_type as u8;
+            payload[2] = message_type;
+
+            let d = &mut payload.as_mut()[3..len as usize];
+            for (i, c) in message[0..message_length as usize].iter().enumerate() {
+                d[i] = *c;
+            }
+        });
+
+
+        let rc = self.payload.take().map_or(ReturnCode::EBUSY, |payload| {
+            self.protocol_layer.signbus_protocol_send(address, payload, len)
+        });
+
+        return rc;
+    }
+
+    pub fn signbus_app_recv(&self, buffer: &'static mut [u8]) -> ReturnCode {
+        self.protocol_layer.signbus_protocol_recv(buffer)
+    }
+}
+
+impl<'a> protocol_layer::ProtocolLayerClient for SignbusAppLayer<'a> {
+    // Called when a new packet is received over I2C.
+    fn packet_received(&self, data: &'static mut [u8], length: usize, error: support::Error) {
+        self.client.get().map(move |client| { client.packet_received(data, length, error); });
+    }
+
+    // Called when an I2C master write command is complete.
+    fn packet_sent(&self, data: &'static mut [u8], error: support::Error) {
+        self.client.get().map(move |client| {
+            self.payload.replace(data);
+            self.send_buf.take().map(|send_buf| { client.packet_sent(send_buf, error); });
+        });
+    }
+
+    // Called when an I2C slave read has completed.
+    fn packet_read_from_slave(&self) {
+        // TODO: implement slave write/ master read
+        unimplemented!("Implement slave write/ master read.");
+    }
+}

--- a/capsules/src/signbus/io_layer.rs
+++ b/capsules/src/signbus/io_layer.rs
@@ -1,0 +1,337 @@
+//! Kernel implementation of signbus_io_interface
+//! apps/libsignpost/signbus_io_interface.c -> kernel/tock/capsules/src/signbus_io_interface.rs
+//! By: Justin Hsieh
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let io_layer = static_init!(
+//!     capsules::signbus::io_layer::SignbusIOLayer<'static>,
+//!     capsules::signbus::io_layer::SignbusIOLayer::new(port_layer,
+//!     	&mut capsules::signbus::io_layer::BUFFER0,
+//!     	&mut capsules::signbus::io_layer::BUFFER1
+//!  ));
+//!
+//! ```
+
+use core::cell::Cell;
+use kernel::ReturnCode;
+use kernel::common::take_cell::TakeCell;
+
+// Capsules
+use signbus;
+use signbus::{support, port_layer, protocol_layer};
+
+/// Buffers used for receiving and data storage.
+pub static mut BUFFER0: [u8; 256] = [0; 256];
+pub static mut BUFFER1: [u8; 256] = [0; 256];
+pub static mut BUFFER2: [u8; 256] = [0; 256];
+
+
+/// SignbusIOLayer handles packet sending and receiving.
+pub struct SignbusIOLayer<'a> {
+    port_layer: &'a port_layer::PortLayer,
+
+    this_device_address: Cell<u8>,
+    sequence_number: Cell<u16>,
+
+    message_seq_no: Cell<u16>,
+    message_src: Cell<u8>,
+    length_received: Cell<usize>,
+
+    client: Cell<Option<&'static protocol_layer::SignbusProtocolLayer<'static>>>,
+
+    send_buf: TakeCell<'static, [u8]>,
+    recv_buf: TakeCell<'static, [u8]>,
+    data_buf: TakeCell<'static, [u8]>,
+}
+
+/// IOLayerClient for I2C sending/receiving callbacks. Implemented by SignbusProtocolLayer.
+pub trait IOLayerClient {
+    // Called when a new packet is received over I2C.
+    fn packet_received(&self, data: &'static mut [u8], length: usize, error: support::Error);
+
+    // Called when an I2C master write command is complete.
+    fn packet_sent(&self, data: &'static mut [u8], error: support::Error);
+
+    // Called when an I2C slave read has completed.
+    fn packet_read_from_slave(&self);
+}
+
+impl<'a> SignbusIOLayer<'a> {
+    pub fn new(port_layer: &'a port_layer::PortLayer,
+               send_buf: &'static mut [u8],
+               recv_buf: &'static mut [u8],
+               data_buf: &'static mut [u8])
+               -> SignbusIOLayer<'a> {
+
+        SignbusIOLayer {
+            port_layer: port_layer,
+
+            this_device_address: Cell::new(0),
+            sequence_number: Cell::new(0),
+
+            message_seq_no: Cell::new(0),
+            message_src: Cell::new(0),
+            length_received: Cell::new(0),
+
+            client: Cell::new(None),
+
+            send_buf: TakeCell::new(send_buf),
+            recv_buf: TakeCell::new(recv_buf),
+            data_buf: TakeCell::new(data_buf),
+        }
+    }
+
+    pub fn set_client(&self, client: &'static protocol_layer::SignbusProtocolLayer) -> ReturnCode {
+        self.client.set(Some(client));
+        ReturnCode::SUCCESS
+    }
+
+    // Initialization routine to set up the slave address for this device.
+    // MUST be called before any other methods.
+    pub fn signbus_io_init(&self, address: u8) -> ReturnCode {
+        self.this_device_address.set(address);
+        self.port_layer.init(address);
+
+        ReturnCode::SUCCESS
+    }
+
+
+    // Send call, callback will handle sending multiple packets if data is
+    // longer than I2C_MAX_DATA_LEN.
+    pub fn signbus_io_send(&self,
+                           dest: u8,
+                           encrypted: bool,
+                           data: &'static mut [u8],
+                           len: usize)
+                           -> ReturnCode {
+
+        self.sequence_number.set(self.sequence_number.get() + 1);
+
+        // Network Flags
+        let flags: support::SignbusNetworkFlags = support::SignbusNetworkFlags {
+            is_fragment: (len > support::I2C_MAX_DATA_LEN) as u8,
+            is_encrypted: encrypted as u8,
+            rsv_wire_bit5: 0,
+            rsv_wire_bit4: 0,
+            version: 0x1,
+        };
+
+        // Network Header
+        let header: support::SignbusNetworkHeader = support::SignbusNetworkHeader {
+            flags: flags,
+            src: self.this_device_address.get(),
+            sequence_number: self.sequence_number.get(),
+            length: (support::HEADER_SIZE + len) as u16,
+            fragment_offset: 0,
+        };
+
+        if header.flags.is_fragment == 1 {
+            // Save all data in order to send in multiple packets
+            self.data_buf.map(|data_buf| {
+                let d = &mut data_buf.as_mut()[0..len];
+                for (i, c) in data[0..len].iter().enumerate() {
+                    d[i] = *c;
+                }
+            });
+
+            // Copy data from slice into sized array to package into packet
+            let mut data_copy: [u8; support::I2C_MAX_DATA_LEN] = [0; support::I2C_MAX_DATA_LEN];
+            for (i, c) in data[0..support::I2C_MAX_DATA_LEN].iter().enumerate() {
+                data_copy[i] = *c;
+            }
+
+            // Packet
+            let packet: support::Packet = support::Packet {
+                header: header,
+                data: data_copy,
+            };
+
+            let rc = self.port_layer.i2c_master_write(dest, packet, support::I2C_MAX_LEN);
+            if rc != ReturnCode::SUCCESS {
+                return rc;
+            }
+
+        } else {
+            // Copy data from slice into sized array to package into packet
+            let mut data_copy: [u8; support::I2C_MAX_DATA_LEN] = [0; support::I2C_MAX_DATA_LEN];
+            for (i, c) in data[0..len].iter().enumerate() {
+                data_copy[i] = *c;
+            }
+
+            // Packet
+            let packet: support::Packet = support::Packet {
+                header: header,
+                data: data_copy,
+            };
+
+            let rc = self.port_layer.i2c_master_write(dest, packet, len + support::HEADER_SIZE);
+            if rc != ReturnCode::SUCCESS {
+                return rc;
+            }
+        }
+
+        self.send_buf.replace(data);
+
+        ReturnCode::SUCCESS
+    }
+
+    // Recv call, listen for messages and callback handles stitching multiple packets together.
+    pub fn signbus_io_recv(&self, buffer: &'static mut [u8]) -> ReturnCode {
+
+        self.recv_buf.replace(buffer);
+
+        let rc = self.port_layer.i2c_slave_listen();
+        if rc != ReturnCode::SUCCESS {
+            return rc;
+        }
+
+        ReturnCode::SUCCESS
+    }
+}
+
+
+impl<'a> signbus::port_layer::PortLayerClientI2C for SignbusIOLayer<'a> {
+    // Packet received, decipher packet and if needed, stitch packets together or callback upward.
+    fn packet_received(&self, packet: support::Packet, length: u8, error: support::Error) {
+
+        // Error checking
+        if error != support::Error::CommandComplete {
+            // Callback protocol_layer
+            self.client.get().map(|client| {
+                self.recv_buf
+                    .take()
+                    .map(|recv_buf| { client.packet_received(recv_buf, length as usize, error); });
+            });
+            // Reset
+            self.length_received.set(0);
+            return;
+            // TODO: implement sending error message to source
+        }
+
+        // Record needed packet data
+        let seq_no = packet.header.sequence_number;
+        let src = packet.header.src;
+        let more_packets = packet.header.flags.is_fragment;
+        let offset = packet.header.fragment_offset as usize;
+        let remainder = packet.header.length as usize - support::HEADER_SIZE -
+                        packet.header.fragment_offset as usize;
+
+        // First packet
+        if self.length_received.get() == 0 {
+            // Save src and seq_no
+            self.message_seq_no.set(seq_no);
+            self.message_src.set(src);
+        }
+        // Subsequent packets
+        else {
+            // If new src, drop current packet
+            if self.message_seq_no.get() != seq_no || self.message_src.get() != src {
+                // Save new src and seq_no
+                self.message_seq_no.set(seq_no);
+                self.message_src.set(src);
+                // TODO: call some error?
+
+                // Reset
+                self.length_received.set(0);
+            }
+        }
+
+        // More packets
+        if more_packets == 1 {
+            // Copy data and update length_received
+            self.recv_buf.map(|recv_buf| {
+                let d = &mut recv_buf.as_mut()[offset..offset + support::I2C_MAX_DATA_LEN];
+                for (i, c) in packet.data[0..support::I2C_MAX_DATA_LEN].iter().enumerate() {
+                    d[i] = *c;
+                }
+            });
+            self.length_received.set(self.length_received.get() + support::I2C_MAX_DATA_LEN);
+        }
+        // Last packet
+        else {
+            // Copy data and update length_received
+            self.recv_buf.map(|recv_buf| {
+                let d = &mut recv_buf.as_mut()[offset..offset + remainder];
+                for (i, c) in packet.data[0..remainder].iter().enumerate() {
+                    d[i] = *c;
+                }
+            });
+            self.length_received.set(self.length_received.get() + remainder);
+
+            // Callback protocol_layer
+            self.client.get().map(|client| {
+                self.recv_buf.take().map(|recv_buf| {
+                    client.packet_received(recv_buf, self.length_received.get(), error);
+                });
+            });
+
+            // Reset
+            self.length_received.set(0);
+        }
+
+    }
+
+    // Packet has finished sending. If needed, send more or callback upward.
+    fn packet_sent(&self, mut packet: support::Packet, error: signbus::support::Error) {
+
+        // If error, stop sending and propogate up
+        if error != support::Error::CommandComplete {
+            // Callback protocol_layer
+            self.client.get().map(move |client| {
+                self.send_buf.take().map(|send_buf| { client.packet_sent(send_buf, error); });
+            });
+            return;
+        }
+
+        if packet.header.flags.is_fragment == 1 {
+            // Update fragment offset
+            let offset = support::I2C_MAX_DATA_LEN + packet.header.fragment_offset as usize;
+            packet.header.fragment_offset = offset as u16;
+
+            // Determines if this is last packet and update is_fragment
+            let data_left_to_send = packet.header.length as usize - support::HEADER_SIZE - offset;
+            let more_packets = data_left_to_send as usize > support::I2C_MAX_DATA_LEN;
+            packet.header.flags.is_fragment = more_packets as u8;
+
+            if more_packets {
+                // Copy next frame of data from data_buf into packet
+                self.data_buf.map(|data_buf| {
+                    let d = &mut data_buf.as_mut()[offset..offset + support::I2C_MAX_DATA_LEN];
+                    for (i, c) in packet.data[0..support::I2C_MAX_DATA_LEN].iter_mut().enumerate() {
+                        *c = d[i];
+                    }
+                });
+
+                self.port_layer.i2c_master_write(packet.header.src, packet, support::I2C_MAX_LEN);
+
+            } else {
+                // Copy next frame of data from data_buf into packet
+                self.data_buf.map(|data_buf| {
+                    let d = &mut data_buf.as_mut()[offset..offset + data_left_to_send];
+                    for (i, c) in packet.data[0..data_left_to_send].iter_mut().enumerate() {
+                        *c = d[i];
+                    }
+                });
+
+                self.port_layer.i2c_master_write(packet.header.src,
+                                                 packet,
+                                                 data_left_to_send + support::HEADER_SIZE);
+            }
+
+        } else {
+            // Callback protocol_layer
+            self.client.get().map(move |client| {
+                self.send_buf.take().map(|send_buf| { client.packet_sent(send_buf, error); });
+            });
+        }
+
+    }
+
+    fn packet_read_from_slave(&self) {
+        // TODO: implement slave write/ master read
+        unimplemented!("Implement slave write/ master read.");
+    }
+}

--- a/capsules/src/signbus/mod.rs
+++ b/capsules/src/signbus/mod.rs
@@ -1,0 +1,12 @@
+//! Capsules that make up Signbus communication support.
+
+// testing purposes
+pub mod test_signbus_init;
+
+// internal use only
+mod support;
+
+pub mod port_layer;
+pub mod io_layer;
+pub mod protocol_layer;
+pub mod app_layer;

--- a/capsules/src/signbus/port_layer.rs
+++ b/capsules/src/signbus/port_layer.rs
@@ -1,0 +1,382 @@
+//! Kernel implementation of port_signpost_tock
+//! apps/libsignpost/port_signpost_tock.c -> kernel/tock/capsules/src/port_signpost_tock.rs
+//! By: Justin Hsieh
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let port_layer = static_init!(
+//! 	capsules::signbus::port_layer::SignbusPortLayer<'static,
+//!     	VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
+//!     capsules::signbus::port_layer::SignbusPortLayer::new(
+//!        	&sam4l::i2c::I2C1,
+//!        	&mut capsules::signbus::port_layer::I2C_BUFFER,
+//!        	&sam4l::gpio::PB[14], // D0 mod_in
+//!        	&sam4l::gpio::PB[15], // D1 mod_out
+//!        	signbus_virtual_alarm,
+//!        	Some(&sam4l::gpio::PA[13]), // RED LED
+//!  ));
+//!
+//! ```
+
+
+use core::cell::Cell;
+use kernel::ReturnCode;
+use kernel::common::take_cell::TakeCell;
+use kernel::hil;
+use kernel::hil::gpio;
+use kernel::hil::time::Frequency;
+
+//Capsules
+use signbus::{io_layer, support, test_signbus_init};
+
+/// Buffer to use for I2C messages. Messages are at most 255 bytes in length.
+pub static mut I2C_SEND: [u8; 255] = [0; 255];
+pub static mut I2C_RECV: [u8; 255] = [0; 255];
+
+/// Signbus port layer. Implements hardware functionality for Signbus.
+pub struct SignbusPortLayer<'a, A: hil::time::Alarm + 'a> {
+    i2c: &'a hil::i2c::I2CMasterSlave,
+    i2c_send: TakeCell<'static, [u8]>,
+    i2c_recv: TakeCell<'static, [u8]>,
+
+    mod_in_pin: &'a hil::gpio::Pin,
+    mod_out_pin: &'a hil::gpio::Pin,
+
+    alarm: &'a A,
+
+    debug_led: Cell<Option<&'a hil::gpio::Pin>>,
+
+    init_client: Cell<Option<&'static test_signbus_init::SignbusInitialization<'static>>>,
+    io_client: Cell<Option<&'static io_layer::SignbusIOLayer<'static>>>,
+
+    listening: Cell<bool>,
+    master_action: Cell<support::MasterAction>,
+}
+
+/// PortLayerClient for I2C sending/receiving callbacks. Implemented by SignbusIOLayer.
+pub trait PortLayerClientI2C {
+    // Called when a new packet is received over I2C.
+    fn packet_received(&self, packet: support::Packet, length: u8, error: support::Error);
+
+    // Called when an I2C master write command is complete.
+    fn packet_sent(&self, packet: support::Packet, error: support::Error);
+
+    // Called when an I2C slave read has completed.
+    fn packet_read_from_slave(&self);
+}
+
+/// PortLayerClient for GPIO and timer callbacks. Implemented by SignbusInitialization.
+pub trait PortLayerClientGPIOTimer {
+    // Called when the mod_in GPIO goes low.
+    fn mod_in_interrupt(&self);
+
+    // Called when a delay_ms has completed.
+    fn delay_complete(&self);
+}
+
+pub trait PortLayer {
+    fn init(&self, i2c_address: u8) -> ReturnCode;
+    fn i2c_master_write(&self, i2c_address: u8, packet: support::Packet, len: usize) -> ReturnCode;
+    fn i2c_slave_listen(&self) -> ReturnCode;
+    fn i2c_slave_read_setup(&self, buf: support::Packet, len: usize) -> ReturnCode;
+    fn mod_out_set(&self) -> ReturnCode;
+    fn mod_out_clear(&self) -> ReturnCode;
+    fn mod_in_read(&self) -> ReturnCode;
+    fn mod_in_enable_interrupt(&self) -> ReturnCode;
+    fn mod_in_disable_interrupt(&self) -> ReturnCode;
+    fn delay_ms(&self, time: u32) -> ReturnCode;
+    fn debug_led_on(&self) -> ReturnCode;
+    fn debug_led_off(&self) -> ReturnCode;
+}
+
+impl<'a, A: hil::time::Alarm + 'a> SignbusPortLayer<'a, A> {
+    pub fn new(i2c: &'a hil::i2c::I2CMasterSlave,
+               i2c_send: &'static mut [u8; 255],
+               i2c_recv: &'static mut [u8; 255],
+               mod_in_pin: &'a hil::gpio::Pin,
+               mod_out_pin: &'a hil::gpio::Pin,
+               alarm: &'a A,
+               debug_led: Option<&'a hil::gpio::Pin>)
+               -> SignbusPortLayer<'a, A> {
+
+        SignbusPortLayer {
+            i2c: i2c,
+            i2c_send: TakeCell::new(i2c_send),
+            i2c_recv: TakeCell::new(i2c_recv),
+            mod_in_pin: mod_in_pin,
+            mod_out_pin: mod_out_pin,
+            alarm: alarm,
+            debug_led: Cell::new(debug_led),
+            init_client: Cell::new(None),
+            io_client: Cell::new(None),
+            listening: Cell::new(false),
+            master_action: Cell::new(support::MasterAction::Write),
+        }
+    }
+
+    pub fn set_io_client(&self, client: &'static io_layer::SignbusIOLayer) -> ReturnCode {
+        self.io_client.set(Some(client));
+        ReturnCode::SUCCESS
+    }
+
+    pub fn set_init_client(&self,
+                           client: &'static test_signbus_init::SignbusInitialization)
+                           -> ReturnCode {
+        self.init_client.set(Some(client));
+        ReturnCode::SUCCESS
+    }
+}
+
+impl<'a, A: hil::time::Alarm + 'a> PortLayer for SignbusPortLayer<'a, A> {
+    // Set address for this device
+    fn init(&self, i2c_address: u8) -> ReturnCode {
+
+        if i2c_address > 0x7f {
+            return ReturnCode::EINVAL;
+        }
+        hil::i2c::I2CSlave::set_address(self.i2c, i2c_address);
+        ReturnCode::SUCCESS
+    }
+
+    // Do a write to another I2C device
+    fn i2c_master_write(&self, i2c_address: u8, packet: support::Packet, len: usize) -> ReturnCode {
+        self.master_action.set(support::MasterAction::Write);
+
+        self.i2c_send.take().map(|buf| {
+            // packet -> buffer
+            support::serialize_packet(packet, len - support::HEADER_SIZE, buf);
+
+            // Very hacky... add HMAC and change length
+            // Should do this in protocol_layer, but no HMAC in rust
+            buf[5] = 0x2C;
+            buf[12] = 0x96;
+            buf[13] = 0xD3;
+            buf[14] = 0x61;
+            buf[15] = 0x32;
+            buf[16] = 0xEB;
+            buf[17] = 0x6B;
+            buf[18] = 0x0E;
+            buf[19] = 0xBD;
+            buf[20] = 0x09;
+            buf[21] = 0xF0;
+            buf[22] = 0xE4;
+            buf[23] = 0xE5;
+            buf[24] = 0x69;
+            buf[25] = 0x19;
+            buf[26] = 0xA6;
+            buf[27] = 0x3F;
+            buf[28] = 0x78;
+            buf[29] = 0xE2;
+            buf[30] = 0xD6;
+            buf[31] = 0xDE;
+            buf[32] = 0xC8;
+            buf[33] = 0xD5;
+            buf[34] = 0x9A;
+            buf[35] = 0xCA;
+            buf[36] = 0x08;
+            buf[37] = 0x28;
+            buf[38] = 0x9A;
+            buf[39] = 0x17;
+            buf[40] = 0x49;
+            buf[41] = 0xD2;
+            buf[42] = 0xF2;
+            buf[43] = 0xB3;
+
+            hil::i2c::I2CMaster::enable(self.i2c);
+            hil::i2c::I2CMaster::write(self.i2c, i2c_address, buf, 44 as u8);
+        });
+
+        ReturnCode::SUCCESS
+    }
+
+    // Listen for messages to this device as a slave.
+    fn i2c_slave_listen(&self) -> ReturnCode {
+
+        self.i2c_recv
+            .take()
+            .map(|buffer| {
+                hil::i2c::I2CSlave::write_receive(self.i2c, buffer, support::I2C_MAX_LEN as u8);
+            });
+
+        hil::i2c::I2CSlave::enable(self.i2c);
+        hil::i2c::I2CSlave::listen(self.i2c);
+
+        self.listening.set(true);
+
+        ReturnCode::SUCCESS
+    }
+
+    // Send messages as slave.
+    fn i2c_slave_read_setup(&self, _: support::Packet, len: usize) -> ReturnCode {
+        self.master_action.set(support::MasterAction::Read(len as u8));
+        unimplemented!("Implement slave write/ master read.");
+        /*
+		TODO: Needs to be tested.
+		self.i2c_send.take().map(|buf| {
+            // packet -> buffer
+            support::serialize_packet(packet, len - support::HEADER_SIZE, buf);
+
+			hil::i2c::I2CSlave::read_send(self.i2c, buf, len as u8);
+		});
+
+        ReturnCode::SUCCESS
+*/
+
+    }
+
+    fn mod_out_set(&self) -> ReturnCode {
+        self.mod_out_pin.make_output();
+        self.mod_out_pin.set();
+        ReturnCode::SUCCESS
+    }
+
+    fn mod_out_clear(&self) -> ReturnCode {
+        self.mod_out_pin.make_output();
+        self.mod_out_pin.clear();
+        ReturnCode::SUCCESS
+    }
+
+    fn mod_in_read(&self) -> ReturnCode {
+        let pin_state = self.mod_in_pin.read();
+        ReturnCode::SuccessWithValue { value: pin_state as usize }
+    }
+
+    fn mod_in_enable_interrupt(&self) -> ReturnCode {
+        self.mod_in_pin.make_input();
+        self.mod_in_pin.enable_interrupt(0, gpio::InterruptMode::FallingEdge);
+        ReturnCode::SUCCESS
+    }
+
+    fn mod_in_disable_interrupt(&self) -> ReturnCode {
+        self.mod_in_pin.disable_interrupt();
+        self.mod_in_pin.disable();
+        ReturnCode::SUCCESS
+    }
+
+    fn delay_ms(&self, time: u32) -> ReturnCode {
+        let interval = time * <A::Frequency>::frequency() / 1000;
+        let tics = self.alarm.now().wrapping_add(interval);
+        self.alarm.set_alarm(tics);
+        ReturnCode::SUCCESS
+    }
+
+    fn debug_led_on(&self) -> ReturnCode {
+        self.debug_led.get().map(|led| {
+            led.make_output();
+            led.set();
+        });
+        ReturnCode::SUCCESS
+    }
+
+    fn debug_led_off(&self) -> ReturnCode {
+        self.debug_led.get().map(|led| {
+            led.make_output();
+            led.clear();
+        });
+        ReturnCode::SUCCESS
+    }
+}
+
+/// Handle I2C Master callbacks.
+impl<'a, A: hil::time::Alarm + 'a> hil::i2c::I2CHwMasterClient for SignbusPortLayer<'a, A> {
+    // Master read or write completed.
+    fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
+
+        let err: support::Error = match error {
+            hil::i2c::Error::AddressNak => support::Error::AddressNak,
+            hil::i2c::Error::DataNak => support::Error::DataNak,
+            hil::i2c::Error::ArbitrationLost => support::Error::ArbitrationLost,
+            hil::i2c::Error::CommandComplete => support::Error::CommandComplete,
+        };
+
+        match self.master_action.get() {
+            support::MasterAction::Write => {
+
+                self.io_client.get().map(move |io_client| {
+                    let packet = support::unserialize_packet(buffer);
+                    self.i2c_send.replace(buffer);
+                    io_client.packet_sent(packet, err);
+                });
+
+            }
+
+            support::MasterAction::Read(_) => {
+                unimplemented!("Implement slave write/ master read.");
+                /*
+				// TODO: Need to replace i2c_recv on a master read.
+				// TODO: Needs to be tested.
+				self.i2c_recv.take().map(|i2c_recv| {
+					let d = &mut i2c_recv.as_mut()[0..(read_len as usize)];
+                    for (i, c) in buffer[0..(read_len as usize)].iter().enumerate() {
+                    	d[i] = *c;
+                    }
+				});
+*/
+            }
+        }
+
+
+        // Check to see if we were listening as an I2C slave and should re-enable that mode
+        if self.listening.get() {
+            hil::i2c::I2CSlave::enable(self.i2c);
+            hil::i2c::I2CSlave::listen(self.i2c);
+        }
+    }
+}
+
+/// Handle I2C Slave callbacks.
+impl<'a, A: hil::time::Alarm + 'a> hil::i2c::I2CHwSlaveClient for SignbusPortLayer<'a, A> {
+    // Slave write_receive or read_send completed
+    fn command_complete(&self,
+                        buffer: &'static mut [u8],
+                        length: u8,
+                        transmission_type: hil::i2c::SlaveTransmissionType) {
+
+        match transmission_type {
+            hil::i2c::SlaveTransmissionType::Read => {
+                //TODO: Implement slave write/ master read.
+                unimplemented!("Implement slave write/ master read.");
+            }
+
+            // Master write/ slave read.
+            hil::i2c::SlaveTransmissionType::Write => {
+                self.io_client.get().map(move |io_client| {
+                    let packet = support::unserialize_packet(buffer);
+                    self.i2c_recv.replace(buffer);
+                    io_client.packet_received(packet, length, support::Error::CommandComplete);
+                });
+            }
+        }
+    }
+
+    fn read_expected(&self) {
+        // TODO: Implement slave write/ master read.
+        unimplemented!("Implement slave write/ master read.");
+    }
+
+    // Slave received message, but does not have buffer. Call write_receive
+    // again to initiate callback.
+    fn write_expected(&self) {
+        self.i2c_recv
+            .take()
+            .map(|buffer| { hil::i2c::I2CSlave::write_receive(self.i2c, buffer, 255); });
+    }
+}
+
+/// Handle alarm callbacks.
+impl<'a, A: hil::time::Alarm + 'a> hil::time::Client for SignbusPortLayer<'a, A> {
+    // Timer done
+    fn fired(&self) {
+        self.init_client.get().map(|init_client| { init_client.delay_complete(); });
+    }
+}
+
+/// Handle GPIO callbacks.
+impl<'a, A: hil::time::Alarm + 'a> hil::gpio::Client for SignbusPortLayer<'a, A> {
+    // Interrupt
+    fn fired(&self, _: usize) {
+        self.init_client.get().map(|init_client| { init_client.mod_in_interrupt(); });
+    }
+}

--- a/capsules/src/signbus/protocol_layer.rs
+++ b/capsules/src/signbus/protocol_layer.rs
@@ -1,0 +1,90 @@
+//! Kernel implementation of signbus_protocol_layer
+//! apps/libsignpost/signbus_protocol_layer.c -> kernel/tock/capsules/src/signbus_protocol_layer.rs
+//! By: Justin Hsieh
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let protocol_layer = static_init!(
+//!     capsules::signbus::protocol_layer::SignbusProtocolLayer<'static>,
+//!     capsules::signbus::protocol_layer::SignbusProtocolLayer::new(io_layer,
+//! ));
+//!
+//! ```
+
+use core::cell::Cell;
+use kernel::ReturnCode;
+
+// Capsules
+use signbus::{support, io_layer, app_layer};
+
+/// Buffers not present because encryption and decryption not available.
+
+/// SignbusProtocolLayer to handle encryption and decryption of messages.
+pub struct SignbusProtocolLayer<'a> {
+    io_layer: &'a io_layer::SignbusIOLayer<'a>,
+
+    client: Cell<Option<&'static app_layer::SignbusAppLayer<'static>>>,
+}
+
+/// ProtocolLayerClient for I2C sending/receiving callbacks. Implemented by SignbusAppLayer.
+pub trait ProtocolLayerClient {
+    // Called when a new packet is received over I2C.
+    fn packet_received(&self, data: &'static mut [u8], length: usize, error: support::Error);
+
+    // Called when an I2C master write command is complete.
+    fn packet_sent(&self, data: &'static mut [u8], error: support::Error);
+
+    // Called when an I2C slave read has completed.
+    fn packet_read_from_slave(&self);
+}
+
+impl<'a> SignbusProtocolLayer<'a> {
+    pub fn new(io_layer: &'a io_layer::SignbusIOLayer) -> SignbusProtocolLayer<'a> {
+
+        SignbusProtocolLayer {
+            io_layer: io_layer,
+            client: Cell::new(None),
+        }
+    }
+
+    pub fn set_client(&self, client: &'static app_layer::SignbusAppLayer) -> ReturnCode {
+        self.client.set(Some(client));
+        ReturnCode::SUCCESS
+    }
+
+    pub fn signbus_protocol_send(&self,
+                                 dest: u8,
+                                 data: &'static mut [u8],
+                                 len: usize)
+                                 -> ReturnCode {
+        // TODO: encryption not availabe in Rust
+        let encrypted: bool = false;
+
+        self.io_layer.signbus_io_send(dest, encrypted, data, len)
+    }
+
+    pub fn signbus_protocol_recv(&self, buffer: &'static mut [u8]) -> ReturnCode {
+        self.io_layer.signbus_io_recv(buffer)
+    }
+}
+
+impl<'a> io_layer::IOLayerClient for SignbusProtocolLayer<'a> {
+    // Called when a new packet is received over I2C.
+    fn packet_received(&self, data: &'static mut [u8], length: usize, error: support::Error) {
+        // TODO: decryption not available in Rust
+        self.client.get().map(move |client| { client.packet_received(data, length, error); });
+    }
+
+    // Called when an I2C master write command is complete.
+    fn packet_sent(&self, data: &'static mut [u8], error: support::Error) {
+        self.client.get().map(move |client| { client.packet_sent(data, error); });
+    }
+
+    // Called when an I2C slave read has completed.
+    fn packet_read_from_slave(&self) {
+        // TODO: implement slave write/ master read
+        unimplemented!("Implement slave write/ master read.");
+    }
+}

--- a/capsules/src/signbus/support.rs
+++ b/capsules/src/signbus/support.rs
@@ -1,0 +1,153 @@
+/// Helper code for Signbus
+
+/// Signbus Constants
+pub const I2C_MAX_LEN: usize = 255;
+pub const HEADER_SIZE: usize = 8;
+pub const I2C_MAX_DATA_LEN: usize = I2C_MAX_LEN - HEADER_SIZE;
+
+/// Signbus Errors
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    CommandComplete,
+    AddressNak,
+    DataNak,
+    ArbitrationLost,
+}
+
+/// Signbus Port Layer
+#[derive(Clone,Copy,PartialEq)]
+pub enum MasterAction {
+    Read(u8),
+    Write,
+}
+
+/// Signbus Packet
+#[repr(C, packed)]
+#[derive(Copy)]
+pub struct SignbusNetworkFlags {
+    pub is_fragment: u8, // full message contained multiple packets
+    pub is_encrypted: u8,
+    pub rsv_wire_bit5: u8,
+    pub rsv_wire_bit4: u8,
+    pub version: u8,
+}
+
+#[repr(C, packed)]
+#[derive(Copy)]
+pub struct SignbusNetworkHeader {
+    pub flags: SignbusNetworkFlags,
+    pub src: u8, // address of message
+    pub sequence_number: u16, // specific to message not packet
+    pub length: u16, // data length + header_size
+    pub fragment_offset: u16, // offset of data
+}
+
+#[repr(C, packed)]
+#[derive(Copy)]
+pub struct Packet {
+    pub header: SignbusNetworkHeader,
+    pub data: [u8; I2C_MAX_DATA_LEN],
+}
+
+/// Signbus Packet Clone trait
+impl Clone for Packet {
+    fn clone(&self) -> Packet {
+        *self
+    }
+}
+impl Clone for SignbusNetworkHeader {
+    fn clone(&self) -> SignbusNetworkHeader {
+        *self
+    }
+}
+impl Clone for SignbusNetworkFlags {
+    fn clone(&self) -> SignbusNetworkFlags {
+        *self
+    }
+}
+
+/// Host to network short
+pub fn htons(a: u16) -> u16 {
+    (((a & 0x00FF) << 8) | ((a & 0xFF00) >> 8))
+}
+
+/// Signbus packet -> [u8]
+pub fn serialize_packet(packet: Packet, data_len: usize, buf: &mut [u8]) {
+
+    // Network Flags
+    buf[0] = packet.header.flags.is_fragment | (packet.header.flags.is_encrypted << 1) |
+             (packet.header.flags.rsv_wire_bit5 << 2) |
+             (packet.header.flags.rsv_wire_bit4 << 3) |
+             (packet.header.flags.version << 4);
+
+    let seq_no = htons(packet.header.sequence_number);
+    let length = htons(packet.header.length);
+    let fragment_offset = htons(packet.header.fragment_offset);
+
+    // Network Header
+    buf[1] = packet.header.src;
+    buf[2] = (seq_no & 0x00FF) as u8;
+    buf[3] = ((seq_no & 0xFF00) >> 8) as u8;
+    buf[4] = (length & 0x00FF) as u8;
+    buf[5] = ((length & 0xFF00) >> 8) as u8;
+    buf[6] = (fragment_offset & 0x00FF) as u8;
+    buf[7] = ((fragment_offset & 0xFF00) >> 8) as u8;
+
+    // Copy packet.data to buf
+    for (i, c) in packet.data[0..data_len].iter().enumerate() {
+        buf[i + HEADER_SIZE] = *c;
+    }
+
+}
+
+/// [u8] -> Signbus packet
+pub fn unserialize_packet(buf: &[u8]) -> Packet {
+    // Network Flags
+    let flags: SignbusNetworkFlags = SignbusNetworkFlags {
+        is_fragment: buf[0] & 0x1,
+        is_encrypted: (buf[0] >> 1) & 0x1,
+        rsv_wire_bit5: (buf[0] >> 2) & 0x1,
+        rsv_wire_bit4: (buf[0] >> 3) & 0x1,
+        version: (buf[0] >> 4) & 0xF,
+    };
+
+    let seq_no = htons((buf[2] as u16) | ((buf[3] as u16) << 8));
+    let length = htons((buf[4] as u16) | ((buf[5] as u16) << 8));
+    let fragment_offset = htons((buf[6] as u16) | ((buf[7] as u16) << 8));
+
+    // Network Header
+    let header: SignbusNetworkHeader = SignbusNetworkHeader {
+        flags: flags,
+        src: buf[1],
+        sequence_number: seq_no,
+        length: length,
+        fragment_offset: fragment_offset,
+    };
+
+    if header.flags.is_fragment == 1 {
+        // Copy data from slice to fixed sized array to package into packet
+        let mut data: [u8; I2C_MAX_DATA_LEN] = [0; I2C_MAX_DATA_LEN];
+        for (i, c) in buf[HEADER_SIZE..I2C_MAX_LEN].iter().enumerate() {
+            data[i] = *c;
+        }
+
+        // Packet
+        Packet {
+            header: header,
+            data: data,
+        }
+    } else {
+        // Copy data from slice to fixed size array to package into packet
+        let end = (header.length - HEADER_SIZE as u16 - header.fragment_offset) as usize;
+        let mut data: [u8; I2C_MAX_DATA_LEN] = [0; I2C_MAX_DATA_LEN];
+        for (i, c) in buf[HEADER_SIZE..end].iter().enumerate() {
+            data[i] = *c;
+        }
+
+        // Packet
+        Packet {
+            header: header,
+            data: data,
+        }
+    }
+}

--- a/capsules/src/signbus/test_signbus_init.rs
+++ b/capsules/src/signbus/test_signbus_init.rs
@@ -1,0 +1,205 @@
+// Capsule to test signbus intialization functions in tock
+// By: Justin Hsieh
+
+use core::cell::Cell;
+use kernel::ReturnCode;
+use kernel::common::take_cell::TakeCell;
+use signbus::{io_layer, support, app_layer, port_layer};
+
+pub static mut BUFFER0: [u8; 256] = [0; 256];
+pub static mut BUFFER1: [u8; 256] = [0; 256];
+
+// Signpost specific enums used only for testing.
+#[derive(Clone,Copy,PartialEq)]
+pub enum ModuleAddress {
+    Controller = 0x20,
+    Storage = 0x21,
+    Radio = 0x22,
+}
+
+#[derive(Clone,Copy,PartialEq)]
+pub enum SignbusFrameType {
+    NotificationFrame = 0,
+    CommandFrame = 1,
+    ResponseFrame = 2,
+    ErrorFrame = 3,
+}
+
+#[derive(Clone,Copy,PartialEq)]
+pub enum SignbusApiType {
+    InitializationApiType = 1,
+    StorageApiType = 2,
+    NetworkingApiType = 3,
+    ProcessingApiType = 4,
+    EnergyApiType = 5,
+    TimeLocationApiType = 6,
+    EdisonApiType = 7,
+    JsonApiType = 8,
+    WatchdogApiType = 9,
+    HighestApiType = 10,
+}
+
+#[derive(Clone,Copy,PartialEq)]
+pub enum InitMessageType {
+    Declare = 0,
+    KeyExchange = 1,
+    GetMods = 2,
+}
+
+#[derive(Clone,Copy,PartialEq)]
+pub enum DelayState {
+    Idle,
+    RequestIsolation,
+}
+
+pub struct SignbusInitialization<'a> {
+    // app_layer used to send/ recv messages
+    app_layer: &'a app_layer::SignbusAppLayer<'a>,
+    // io_layer used to init
+    io_layer: &'a io_layer::SignbusIOLayer<'a>,
+    // port_layer used for gpio and timer
+    port_layer: &'a port_layer::PortLayer,
+
+    device_address: Cell<u8>,
+    delay_state: Cell<DelayState>,
+    send_buf: TakeCell<'static, [u8]>,
+    recv_buf: TakeCell<'static, [u8]>,
+}
+
+impl<'a> SignbusInitialization<'a> {
+    pub fn new(app_layer: &'a app_layer::SignbusAppLayer,
+               io_layer: &'a io_layer::SignbusIOLayer,
+               port_layer: &'a port_layer::PortLayer,
+               send_buf: &'static mut [u8],
+               recv_buf: &'static mut [u8])
+               -> SignbusInitialization<'a> {
+
+        SignbusInitialization {
+            app_layer: app_layer,
+            io_layer: io_layer,
+            port_layer: port_layer,
+
+            device_address: Cell::new(0),
+            delay_state: Cell::new(DelayState::Idle),
+            send_buf: TakeCell::new(send_buf),
+            recv_buf: TakeCell::new(recv_buf),
+        }
+    }
+
+    // Send declaration I2C message.
+    pub fn signpost_initialization_declare_controller(&self) {
+        debug!("Declare controller...");
+
+        self.send_buf.take().map(|buf| {
+            // Will only work for 0x32 because of concatenated HMAC
+            buf[0] = self.device_address.get();
+
+            self.app_layer.signbus_app_send(ModuleAddress::Controller as u8,
+                                            SignbusFrameType::CommandFrame as u8,
+                                            SignbusApiType::InitializationApiType as u8,
+                                            InitMessageType::Declare as u8,
+                                            1,
+                                            buf);
+        });
+    }
+
+    // Use mod out/in gpio to request isolation.
+    pub fn signpost_initialization_request_isolation(&self) {
+        debug!("Request I2C isolation");
+        // intialize mod out/in gpio
+        self.port_layer.mod_out_set();
+        self.port_layer.debug_led_off();
+        self.port_layer.mod_in_enable_interrupt();
+
+        // pull mod out low to signal controller
+        // wait on controller interrupt on mod_in
+        self.port_layer.mod_out_clear();
+        self.port_layer.debug_led_on();
+    }
+
+    // Intialize HAIL
+    pub fn signpost_initialization_module_init(&self, i2c_address: u8) {
+        debug!("Start Initialization");
+        // intialize lower layers
+        self.io_layer.signbus_io_init(i2c_address);
+        self.device_address.set(i2c_address);
+
+        // listen for messages
+        self.recv_buf.take().map(|buf| { self.app_layer.signbus_app_recv(buf); });
+
+        // communicate with controller and request 1:1 talk (isolation)
+        self.signpost_initialization_request_isolation();
+    }
+}
+
+impl<'a> port_layer::PortLayerClientGPIOTimer for SignbusInitialization<'a> {
+    // Called when the mod_in GPIO goes low.
+    fn mod_in_interrupt(&self) {
+        self.delay_state.set(DelayState::RequestIsolation);
+        self.port_layer.delay_ms(50);
+    }
+
+    // Called when a delay_ms has completed.
+    fn delay_complete(&self) {
+        match self.delay_state.get() {
+
+            DelayState::Idle => {}
+
+            DelayState::RequestIsolation => {
+                match self.port_layer.mod_in_read() {
+
+                    ReturnCode::SuccessWithValue { value } => {
+                        if value != 0 {
+                            debug!("Spurrious interrupt");
+                        } else {
+                            self.signpost_initialization_declare_controller();
+                        }
+                    }
+
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+
+impl<'a> app_layer::AppLayerClient for SignbusInitialization<'a> {
+    // Called when a new packet is received over I2C.
+    fn packet_received(&self, data: &'static mut [u8], length: usize, error: support::Error) {
+        match error {
+            support::Error::AddressNak => debug!("Error: AddressNak"),
+            support::Error::DataNak => debug!("Error: DataNak"),
+            support::Error::ArbitrationLost => debug!("Error: ArbitrationNak"),
+            support::Error::CommandComplete => debug!("Command Complete!"),
+        };
+
+        // signpost_initialization_declared_callback
+        if length > 0 {
+            // check incoming_api_type and incoming_message_type
+            if data[1] == SignbusApiType::InitializationApiType as u8 &&
+               data[2] == InitMessageType::Declare as u8 {
+                debug!("Correct response for declaration.");
+            } else {
+                debug!("Incorrect response for declaration.");
+            }
+
+        } else {
+            debug!("Error: Length = 0");
+        }
+        self.send_buf.replace(data);
+    }
+    // Called when an I2C master write command is complete.
+    fn packet_sent(&self, data: &'static mut [u8], error: support::Error) {
+
+        if error != support::Error::CommandComplete {
+            debug!("Error: Packet sent incomplete");
+        }
+
+        self.send_buf.replace(data);
+    }
+
+
+    // Called when an I2C slave read has completed.
+    fn packet_read_from_slave(&self) {}
+}


### PR DESCRIPTION
## **Features** 
- Ability to act as master and write fragmented messages (longer than 255 bytes).
- Ability to act as a slave to receive fragmented messages (longer than 255 bytes).
- Able to use Hail running this kernel to request I2C bus isolation from the Signpost Controller.
- Able to use Hail running this kernel to communicate with the Signpost Controller to initialize an address and receive the correct initialization message. (tested in test_signbus_init.rs)

## **Future Plans** 
port_layer.rs
- Ability to act as slave to write messages.
- Ability to act as master to read messages.

io_layer.rs
- Send error message to dropped packet source.

protocol_layer.rs
- Add HMAC capabilities
- Add encryption/ decryption capabilities.
- Could be some userland app that handles this and talks directly to this capsule.

app_layer.rs
- Connect userland buffers to kernel buffers and add an userland callback.
- Add system calls.

test_signbus_init.rs
- Test next step in initializing a module (key_exchange, etc).

support.rs
- Move enums to specific files that use them or delete unnecessary ones.

## **General notes**
- Size of buffers are not set correctly. Running into the problem of too much RAM usage. Instead of using `&'static mut [u8]` could switch to `[u8; MAX_DATA_LENGTH]` declared on stack.





  