### PR TITLE
Debug needs to issue command -- fixes bug introduced by #560

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -120,6 +120,10 @@ impl DebugWriter {
                     if driver.subscribe(1, KERNEL_CONSOLE_CALLBACK) != ReturnCode::SUCCESS {
                         panic!("Debug print subscribe fail");
                     }
+                    if driver.command(1, slice_len, AppId::kernel_new(APPID_IDX)) !=
+                       ReturnCode::SUCCESS {
+                        panic!("Debug print command fail");
+                    }
                 }
                 None => {
                     panic!("Platform has not yet configured kernel debug interface");


### PR DESCRIPTION
Without this fix, the debug system never actually writes the string, so you get no debug output.