### PR TITLE
RadioDriver: remove unwrap from receive callback

### DIFF
--- a/capsules/src/radio.rs
+++ b/capsules/src/radio.rs
@@ -212,18 +212,15 @@ impl<'a, M: mac::Mac> mac::RxClient for RadioDriver<'a, M> {
                    data_offset: usize,
                    data_len: usize,
                    result: ReturnCode) {
-        if self.app.is_some() {
-            self.app.map(move |app| if app.app_read.is_some() {
-                let dest = app.app_read.as_mut().unwrap();
-                let d = &mut dest.as_mut();
-                let len = cmp::min(d.len(), data_offset + data_len);
-                d[..len].copy_from_slice(&buf[..len]);
-                app.rx_callback
+        self.app.map(move |app| if let Some(dest) = app.app_read.as_mut() {
+            let d = &mut dest.as_mut();
+            let len = cmp::min(d.len(), data_offset + data_len);
+            d[..len].copy_from_slice(&buf[..len]);
+            app.rx_callback
                     .take()
                     .map(|mut cb| {
                         cb.schedule(usize::from(result), data_offset, data_offset + data_len);
                     });
-            });
-        }
+        });
     }
 }


### PR DESCRIPTION
Slight cleanup following @alevy's comment in the last PR: [remove the unwrap](https://github.com/helena-project/tock/pull/524#discussion_r131992062) in the `RadioDriver` receive callback.