### PR TITLE
check gcc version in kernel build too

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -12,6 +12,7 @@ MINIMUM_XARGO_VERSION ?= 0.3.8
 # This will hopefully move into Cargo.toml (or Cargo.toml.local) eventually
 RUSTFLAGS_FOR_XARGO_LINKING := "-C link-arg=-nostartfiles -C link-arg=-Tlayout.ld"
 
+CC        := $(TOOLCHAIN)-gcc
 SIZE      ?= $(TOOLCHAIN)-size
 OBJCOPY   ?= $(TOOLCHAIN)-objcopy
 OBJDUMP   ?= $(TOOLCHAIN)-objdump
@@ -31,6 +32,26 @@ VERBOSE =
 endif
 
 export TOCK_KERNEL_VERSION := $(shell git describe --always || echo notgit)
+
+
+# Check that gcc version is new enough (> 5.1) - used during linking
+CC_VERSION_MAJOR := $(shell $(TOOLCHAIN)-gcc -dumpversion | cut -d '.' -f1)
+ifeq (1,$(shell expr $(CC_VERSION_MAJOR) \>= 6))
+  # no-op
+else
+  ifneq (5,$(CC_VERSION_MAJOR))
+    $(info CC=$(CC))
+    $(info $$(CC) -dumpversion: $(shell $(CC) -dumpversion))
+    $(error Your compiler is too old. Need gcc version > 5.1)
+  endif
+    CC_VERSION_MINOR := $(shell $(CC) -dumpversion | cut -d '.' -f2)
+  ifneq (1,$(shell expr $(CC_VERSION_MINOR) \> 1))
+    $(info CC=$(CC))
+    $(info $$(CC) -dumpversion: $(shell $(CC) -dumpversion))
+    $(error Your compiler is too old. Need gcc version > 5.1)
+  endif
+endif
+
 
 # Check that rustc is the right nightly - warn not error if wrong, sometimes useful to test others
 RUSTC_VERSION_STRING := rustc 1.19.0-nightly (04145943a 2017-06-19)


### PR DESCRIPTION
This basically copies the check we use from the userland build.

Fixes #567.