### PR TITLE
[NRF5X] use program option instead of flash

### DIFF
--- a/boards/nrf51dk/Makefile
+++ b/boards/nrf51dk/Makefile
@@ -1,4 +1,4 @@
-# Makefile for building the tock kernel for the nRF development kit
+# Makefile for building the tock kernel for the nRF51-DK development kit
 
 TOCK_ARCH=cortex-m0
 TARGET=thumbv6m-none-eabi
@@ -24,18 +24,21 @@ JLINK_SCRIPTS_DIR=jtag/
 
 # Upload the kernel over JTAG
 .PHONY: program
-flash: target/$(TARGET)/release/nrf51dk.hex
+program: target/$(TARGET)/release/nrf51dk.hex
 	$(JLINK) $(JLINK_OPTIONS) $(JLINK_SCRIPTS_DIR)/flash-kernel.jlink
 
+# ---------------------------------------------------------
+# THIS IS NOT ENABLED BY THE MAIN MAKEFILE AND NOT USED!!!
+# ---------------------------------------------------------
 # Upload kernel + app over JTAG
-.PHONY: program-full
-flash-full: target/$(TARGET)/release/nrf51dk-$(APP).hex
-	@$(eval TEMPFILE := $(shell mktemp -t nrf51dk-$(APP).jlink.XXXXXXXXXX))
-	@echo r > $(TEMPFILE)
-	@echo loadfile $< >> $(TEMPFILE)
-	@echo r >> $(TEMPFILE)
-	@echo g >> $(TEMPFILE)
-	@echo q >> $(TEMPFILE)
-	$(JLINK) $(JLINK_OPTIONS) $(TEMPFILE)
-	@rm $(TEMPFILE)
+#.PHONY: program-full
+# flash-full: target/$(TARGET)/release/nrf51dk-$(APP).hex
+#   @$(eval TEMPFILE := $(shell mktemp -t nrf51dk-$(APP).jlink.XXXXXXXXXX))
+#   @echo r > $(TEMPFILE)
+#   @echo loadfile $< >> $(TEMPFILE)
+#   @echo r >> $(TEMPFILE)
+#   @echo g >> $(TEMPFILE)
+#   @echo q >> $(TEMPFILE)
+#   $(JLINK) $(JLINK_OPTIONS) $(TEMPFILE)
+#   @rm $(TEMPFILE)
 

--- a/boards/nrf51dk/Makefile-app
+++ b/boards/nrf51dk/Makefile-app
@@ -9,12 +9,7 @@ BOARD_BUILDDIR = $(BUILDDIR)/$(TOCK_ARCH)
 
 NRF_LOAD = $(TOCK_USERLAND_BASE_DIR)/tools/program/nrf51dk.py
 
-# Upload programs over uart (does not work for nRF)
+# Upload programs to nrf51dk
 .PHONY: program
 program: $(BOARD_BUILDDIR)/$(TOCK_ARCH).bin $(BUILDDIR)/$(PACKAGE_NAME).tab
-	$(error No program rule for nRF)
-
-# Upload programs to nrf51dk
-.PHONY: flash
-flash: $(BOARD_BUILDDIR)/$(TOCK_ARCH).bin $(BUILDDIR)/$(PACKAGE_NAME).tab
 	$(NRF_LOAD) $<

--- a/boards/nrf52dk/Makefile
+++ b/boards/nrf52dk/Makefile
@@ -1,4 +1,4 @@
-# Makefile for building the tock kernel for the nRF development kit
+# Makefile for building the tock kernel for the nRF52-DK development kit
 
 TOCK_ARCH=cortex-m4
 TARGET=thumbv7em-none-eabi
@@ -24,18 +24,21 @@ JLINK_SCRIPTS_DIR=jtag/
 
 # Upload the kernel over JTAG
 .PHONY: program
-flash: target/$(TARGET)/release/nrf52dk.hex
+program: target/$(TARGET)/release/nrf52dk.hex
 	$(JLINK) $(JLINK_OPTIONS) $(JLINK_SCRIPTS_DIR)/flash-kernel.jlink
 
+# ---------------------------------------------------------
+# THIS IS NOT ENABLED BY THE MAIN MAKEFILE AND NOT USED!!!
+# ---------------------------------------------------------
 # Upload kernel + app over JTAG
-.PHONY: program-full
-flash-full: target/$(TARGET)/release/nrf52dk-$(APP).hex
-	@$(eval TEMPFILE := $(shell mktemp -t nrf52dk-$(APP).jlink.XXXXXXXXXX))
-	@echo r > $(TEMPFILE)
-	@echo loadfile $< >> $(TEMPFILE)
-	@echo r >> $(TEMPFILE)
-	@echo g >> $(TEMPFILE)
-	@echo q >> $(TEMPFILE)
-	$(JLINK) $(JLINK_OPTIONS) $(TEMPFILE)
-	@rm $(TEMPFILE)
+# .PHONY: program-full
+# flash-full: target/$(TARGET)/release/nrf52dk-$(APP).hex
+#   @$(eval TEMPFILE := $(shell mktemp -t nrf52dk-$(APP).jlink.XXXXXXXXXX))
+#   @echo r > $(TEMPFILE)
+#   @echo loadfile $< >> $(TEMPFILE)
+#   @echo r >> $(TEMPFILE)
+#   @echo g >> $(TEMPFILE)
+#   @echo q >> $(TEMPFILE)
+#   $(JLINK) $(JLINK_OPTIONS) $(TEMPFILE)
+#   @rm $(TEMPFILE)
 

--- a/boards/nrf52dk/Makefile-app
+++ b/boards/nrf52dk/Makefile-app
@@ -10,6 +10,6 @@ BOARD_BUILDDIR = $(BUILDDIR)/$(TOCK_ARCH)
 NRF_LOAD = $(TOCK_USERLAND_BASE_DIR)/tools/program/nrf52dk.py
 
 # Upload programs to nrf52dk
-.PHONY: flash
-flash: $(BOARD_BUILDDIR)/$(TOCK_ARCH).bin $(BUILDDIR)/$(PACKAGE_NAME).tab
+.PHONY: program
+program: $(BOARD_BUILDDIR)/$(TOCK_ARCH).bin $(BUILDDIR)/$(PACKAGE_NAME).tab
 	$(NRF_LOAD) $<


### PR DESCRIPTION
Hi,

This removes the replaces the ```flash option``` with ```program option``` for nRF5X both for the kernel and the userapps and fixes [#570](https://github.com/helena-project/tock/issues/570)

Later when tockloader works reliable for uploading userapps nRF5X we should migrate to it rather than using: 
[https://github.com/helena-project/tock/blob/master/userland/tools/program/nrf51dk.py](https://github.com/helena-project/tock/blob/master/userland/tools/program/nrf51dk.py)
[https://github.com/helena-project/tock/blob/master/userland/tools/program/nrf52dk.py](https://github.com/helena-project/tock/blob/master/userland/tools/program/nrf52dk.py)

Furthermore, I have "commented-away" the flash-full option since the root makefile don't support that option and is therefore not used?!
