### PR TITLE
ieee802154: MAC security procedure minus CCM*

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -8,6 +8,7 @@ extern crate compiler_builtins;
 extern crate kernel;
 extern crate sam4l;
 
+use capsules::mac::Mac;
 use capsules::rf233::RF233;
 use capsules::timer::TimerDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -46,6 +47,7 @@ static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, Non
 // Save some deep nesting
 type RF233Device = capsules::rf233::RF233<'static,
                                           VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>;
+
 struct Imix {
     console: &'static capsules::console::Console<'static, sam4l::usart::USART>,
     gpio: &'static capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
@@ -391,19 +393,19 @@ pub unsafe fn reset_handler() {
 
     let radio_mac = static_init!(
         capsules::mac::MacDevice<'static, RF233Device>,
-        capsules::mac::MacDevice::new(rf233),
-        0);
+        capsules::mac::MacDevice::new(rf233));
     let radio_capsule = static_init!(
         capsules::radio::RadioDriver<'static,
                                      capsules::mac::MacDevice<'static, RF233Device>>,
-        capsules::radio::RadioDriver::new(radio_mac),
-        0);
+        capsules::radio::RadioDriver::new(radio_mac));
     radio_capsule.config_buffer(&mut RADIO_BUF);
     radio_mac.set_transmit_client(radio_capsule);
     radio_mac.set_receive_client(radio_capsule);
     rf233.set_transmit_client(radio_mac);
     rf233.set_receive_client(radio_mac, &mut RF233_RX_BUF);
     rf233.set_config_client(radio_mac);
+    radio_mac.set_pan(0xABCD);
+    radio_mac.set_address(0x1008);
 
     // Configure the USB controller
     let usb_client = static_init!(
@@ -437,11 +439,9 @@ pub unsafe fn reset_handler() {
 
     let mut chip = sam4l::chip::Sam4l::new();
 
+    // These two lines need to be below the creation of the chip for
+    // initialization to work.
     rf233.reset();
-    rf233.set_pan(0xABCD);
-    rf233.set_address(0x1008);
-    //    rf233.config_commit();
-
     rf233.start();
 
     debug!("Initialization complete. Entering main loop");

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -46,5 +46,6 @@ pub mod app_flash_driver;
 pub mod usb;
 pub mod usb_user;
 pub mod usbc_client;
+#[macro_use]
 pub mod net;
 pub mod mac;

--- a/capsules/src/net/ieee802154.rs
+++ b/capsules/src/net/ieee802154.rs
@@ -127,8 +127,8 @@ impl AddressMode {
     pub fn from_mode(mode: u16) -> Option<AddressMode> {
         match mode {
             0b00 => Some(AddressMode::NotPresent),
-            0b10 => Some(AddressMode::NotPresent),
-            0b11 => Some(AddressMode::NotPresent),
+            0b10 => Some(AddressMode::Short),
+            0b11 => Some(AddressMode::Long),
             _ => None,
         }
     }
@@ -707,7 +707,7 @@ impl<'a> Header<'a> {
         };
 
         // Sequence number
-        let (off, seq) = if seq_suppressed {
+        let (off, seq) = if !seq_suppressed {
             let (off, seq) = dec_try!(buf, off; decode_u8);
             (off, Some(seq))
         } else {

--- a/capsules/src/net/ieee802154.rs
+++ b/capsules/src/net/ieee802154.rs
@@ -167,6 +167,27 @@ impl SecurityLevel {
             _ => None,
         }
     }
+
+    pub fn encryption_needed(&self) -> bool {
+        match *self {
+            SecurityLevel::EncMic32 |
+            SecurityLevel::EncMic64 |
+            SecurityLevel::EncMic128 => true,
+            _ => false,
+        }
+    }
+
+    pub fn mic_len(&self) -> usize {
+        match *self {
+            SecurityLevel::Mic32 |
+            SecurityLevel::EncMic32 => 4,
+            SecurityLevel::Mic64 |
+            SecurityLevel::EncMic64 => 8,
+            SecurityLevel::Mic128 |
+            SecurityLevel::EncMic128 => 16,
+            _ => 0,
+        }
+    }
 }
 
 #[repr(u8)]
@@ -657,7 +678,12 @@ impl<'a> Header<'a> {
         stream_done!(off, pan_id_compression);
     }
 
-    pub fn decode<'b>(buf: &'b [u8]) -> SResult<(Header<'b>, usize)> {
+    /// Decodes an IEEE 802.15.4 MAC header from a byte slice, where the MAC
+    /// header may contain slices into the given byte slice to represent
+    /// undissected information elements (IE). `unsecured` controls whether or
+    /// not payload IEs (which are encrypted if the frame has not yet been
+    /// unsecured) can be parsed.
+    pub fn decode<'b>(buf: &'b [u8], unsecured: bool) -> SResult<(Header<'b>, usize)> {
         // Frame control field
         let (off, fcf_be) = dec_try!(buf; decode_u16);
         let fcf = u16::from_be(fcf_be);
@@ -728,9 +754,11 @@ impl<'a> Header<'a> {
                 }
             }
         }
-        // The MAC payload includes the payload IEs.
+        // The MAC payload includes the payload IEs. We can only parse them if
+        // the frame is not encrypted.
         let mac_payload_off = off;
-        if has_payload_ies {
+        let unencrypted = unsecured || !security_enabled;
+        if has_payload_ies && unencrypted {
             loop {
                 let (next_off, ie) = dec_try!(buf, off; PayloadIE::decode);
                 off = next_off;

--- a/capsules/src/radio.rs
+++ b/capsules/src/radio.rs
@@ -210,17 +210,18 @@ impl<'a, M: mac::Mac> mac::RxClient for RadioDriver<'a, M> {
                     * userspace */
                    _: Header<'b>,
                    data_offset: usize,
-                   data_len: usize,
-                   result: ReturnCode) {
+                   data_len: usize) {
         self.app.map(move |app| if let Some(dest) = app.app_read.as_mut() {
             let d = &mut dest.as_mut();
             let len = cmp::min(d.len(), data_offset + data_len);
             d[..len].copy_from_slice(&buf[..len]);
             app.rx_callback
-                    .take()
-                    .map(|mut cb| {
-                        cb.schedule(usize::from(result), data_offset, data_offset + data_len);
-                    });
+                .take()
+                .map(|mut cb| {
+                    cb.schedule(usize::from(ReturnCode::SUCCESS),
+                                data_offset,
+                                data_offset + data_len);
+                });
         });
     }
 }

--- a/capsules/src/radio.rs
+++ b/capsules/src/radio.rs
@@ -220,7 +220,7 @@ impl<'a, M: mac::Mac> mac::RxClient for RadioDriver<'a, M> {
                 .map(|mut cb| {
                     cb.schedule(usize::from(ReturnCode::SUCCESS),
                                 data_offset,
-                                data_offset + data_len);
+                                data_len);
                 });
         });
     }

--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -678,7 +678,7 @@ impl<'a, S: spi::SpiMasterDevice + 'a> spi::SpiMasterClient for RF233<'a, S> {
                 }
                 self.rx_client.get().map(|client| {
                     let rbuf = self.rx_buf.take().unwrap();
-                    let frame_len = rbuf[1] as usize;
+                    let frame_len = rbuf[1] as usize - radio::MFR_SIZE;
                     client.receive(rbuf, frame_len, crc_valid, ReturnCode::SUCCESS);
                 });
             }

--- a/userland/examples/tests/ieee802154/radio_ack/main.c
+++ b/userland/examples/tests/ieee802154/radio_ack/main.c
@@ -5,32 +5,35 @@
 #include <radio.h>
 #include <timer.h>
 
+#define RADIO_FRAME_SIZE 129
 #define BUF_SIZE 60
-char packet_rx[BUF_SIZE];
+char packet_rx[RADIO_FRAME_SIZE];
 char packet_tx[BUF_SIZE];
 bool toggle = true;
 
 static void callback(__attribute__ ((unused)) int err,
+                     __attribute__ ((unused)) int payload_offset,
                      __attribute__ ((unused)) int payload_length,
-                     __attribute__ ((unused)) int unused2,
                      __attribute__ ((unused)) void* ud) {
   led_toggle(0);
-  radio_receive_callback(callback, packet_rx, BUF_SIZE);
+  radio_receive_callback(callback, packet_rx, RADIO_FRAME_SIZE);
 }
 
 int main(void) {
   int i;
   char counter = 0;
   // printf("Starting 802.15.4 packet reception app.\n");
+  for (i = 0; i < RADIO_FRAME_SIZE; i++) {
+    packet_rx[i] = 0;
+  }
   for (i = 0; i < BUF_SIZE; i++) {
     packet_tx[i] = i;
-    packet_rx[i] = 0;
   }
   radio_set_addr(0x802);
   radio_set_pan(0xABCD);
   radio_commit();
   radio_init();
-  radio_receive_callback(callback, packet_rx, BUF_SIZE);
+  radio_receive_callback(callback, packet_rx, RADIO_FRAME_SIZE);
   while (1) {
     int err = radio_send(0x0802, packet_tx, BUF_SIZE);
     printf("Packet sent, return code: %i\n", err);

--- a/userland/examples/tests/ieee802154/radio_rx/main.c
+++ b/userland/examples/tests/ieee802154/radio_rx/main.c
@@ -5,31 +5,45 @@
 #include <radio.h>
 #include <timer.h>
 
+#define RADIO_FRAME_SIZE 129
 #define BUF_SIZE 60
-char packet_rx[BUF_SIZE];
+char packet_rx[RADIO_FRAME_SIZE];
 char packet_tx[BUF_SIZE];
 bool toggle = true;
 
 static void callback(__attribute__ ((unused)) int err,
+                     __attribute__ ((unused)) int payload_offset,
                      __attribute__ ((unused)) int payload_length,
-                     __attribute__ ((unused)) int unused2,
                      __attribute__ ((unused)) void* ud) {
   led_toggle(0);
-  radio_receive_callback(callback, packet_rx, BUF_SIZE);
+
+#define PRINT_PAYLOAD 0
+#if PRINT_PAYLOAD
+  printf("Received packet with payload of %d bytes from offset %d\n", payload_length, payload_offset);
+  int i;
+  for (i = 0; i < payload_length; i++) {
+    printf("%02x%c", packet_rx[payload_offset + i],
+           ((i + 1) % 16 == 0 || i + 1 == payload_length) ? '\n' : ' ');
+  }
+#endif
+
+  radio_receive_callback(callback, packet_rx, RADIO_FRAME_SIZE);
 }
 
 int main(void) {
   int i;
-  // printf("Starting 802.15.4 packet reception app.\n");
-  for (i = 0; i < BUF_SIZE; i++) {
+  /* printf("Starting 802.15.4 packet reception app.\n"); */
+  for (i = 0; i < RADIO_FRAME_SIZE; i++) {
     packet_rx[i] = 0;
+  }
+  for (i = 0; i < BUF_SIZE; i++) {
     packet_tx[i] = i;
   }
   radio_set_addr(0x802);
   radio_set_pan(0xABCD);
   radio_commit();
   radio_init();
-  radio_receive_callback(callback, packet_rx, BUF_SIZE);
+  radio_receive_callback(callback, packet_rx, RADIO_FRAME_SIZE);
   while (1) {
     delay_ms(4000);
   }

--- a/userland/libtock/radio.c
+++ b/userland/libtock/radio.c
@@ -30,6 +30,7 @@ int radio_init(void) {
 }
 
 int rx_result      = 0;
+int rx_payload_off = 0;
 int rx_payload_len = 0;
 int tx_acked       = 0;
 
@@ -42,10 +43,11 @@ static void cb_tx(__attribute__ ((unused)) int len,
 }
 
 static void cb_rx(int result,
+                  int payload_off,
                   int payload_len,
-                  __attribute__ ((unused)) int unused2,
                   void* ud) {
   rx_result      = result;
+  rx_payload_off = payload_off;
   rx_payload_len = payload_len;
   *((bool*)ud)   = true;
 }
@@ -117,7 +119,8 @@ int radio_receive(const char* packet, unsigned char len) {
   if (rx_result < 0) {
     return rx_result;
   }
-  return rx_payload_len;
+  // Return the end of the frame, including the two header bytes.
+  return rx_payload_off + rx_payload_len;
 }
 
 int radio_receive_callback(subscribe_cb callback,


### PR DESCRIPTION
This PR implements the incoming and outgoing frame security procedures, save for the actual calls to CCM* encryption/decryption. That will have to wait for CBC encryption to be in mainline. Along the way, it also does the following things:

- Update the userspace code using the radio. I think some of the tiny changes (offsets and lengths and the way they are passed between kernel and userspace) must have gotten lost when the test files were moved.
- Mirror the imixv1 initialization code over to the imix initialization code.
- Remove unnecessary config callback logic from `capsules::mac`: it turns out the radio already does this.
- When parsing headers of secured frames, we must be careful not to try to parse payload IEs. This is accomplished by a flag into the decode function.
- Two hilarious bugs in the ieee802154 parsing code: `AddressMode#from_mode` and `seq_suppressed` in `Header#decode`. Thanks @ptcrews.

Here's a few notes on the incoming security procedure: When a secured frame arrives, the process in this PR parses the header portion of the frame, unsecures it, and then re-parses the full header (including payload IEs). One could conceivably store the parts of the header that were already parsed and update them after unsecuring, but I chose not to do that because parsing is relatively fast (it's only a few bytes). Secondly, we expose plaintext frames to the user without removing the auxiliary security header. Technically, the IEEE 802.15.4 spec says that the unsecuring process should also remove this auxiliary security header and update the "Security present" bit, but this would prevent the user from ever knowing if the frame was secured. While this currently makes no difference, I think there might be a use-case for checking if the frame had link-layer security and performing some kind of business logic.