### PR TITLE
imix/README: use 'make program' to program over USB

### DIFF
--- a/boards/imix/README.md
+++ b/boards/imix/README.md
@@ -10,12 +10,18 @@ To program the Tock kernel onto the imix, `cd` into the `boards/imix` directory
 and run:
 
 ```bash
-$ make flash
+$ make program
 ```
 
 This will build `boards/imix/target/sam4l/release/imix/imix` and use tockloader to
 flash it to the board.
 
+If you have connected to the board over a JTAG interface, you should instead
+flash the kernel with:
+
+```bash
+$ make flash
+```
 
 ## Flashing apps
 


### PR DESCRIPTION
It previously said `make flash`.

I guess at some point we should clean up this nomenclature to say `make program-jtag` or something for the less-frequent case.
