### PR TITLE
added error messages when using program option for nRF5X

### DIFF
--- a/boards/nrf51dk/Makefile
+++ b/boards/nrf51dk/Makefile
@@ -1,4 +1,4 @@
-# Makefile for building the tock kernel for the nRF development kit
+# Makefile for building the tock kernel for the nRF51 development kit
 
 TOCK_ARCH=cortex-m0
 TARGET=thumbv6m-none-eabi
@@ -23,19 +23,10 @@ JLINK_OPTIONS+=-device nrf51422 -if swd -speed 1200 -AutoConnect 1
 JLINK_SCRIPTS_DIR=jtag/
 
 # Upload the kernel over JTAG
-.PHONY: program
+.PHONY: flash
 flash: target/$(TARGET)/release/nrf51dk.hex
 	$(JLINK) $(JLINK_OPTIONS) $(JLINK_SCRIPTS_DIR)/flash-kernel.jlink
 
-# Upload kernel + app over JTAG
-.PHONY: program-full
-flash-full: target/$(TARGET)/release/nrf51dk-$(APP).hex
-	@$(eval TEMPFILE := $(shell mktemp -t nrf51dk-$(APP).jlink.XXXXXXXXXX))
-	@echo r > $(TEMPFILE)
-	@echo loadfile $< >> $(TEMPFILE)
-	@echo r >> $(TEMPFILE)
-	@echo g >> $(TEMPFILE)
-	@echo q >> $(TEMPFILE)
-	$(JLINK) $(JLINK_OPTIONS) $(TEMPFILE)
-	@rm $(TEMPFILE)
-
+.PHONY: program
+program: target/$(TARGET)/release/nrf51dk.hex
+	$(error Cannot program nRF51DK over USB. Use \'make flash\' and JTAG)

--- a/boards/nrf51dk/Makefile-app
+++ b/boards/nrf51dk/Makefile-app
@@ -12,7 +12,7 @@ NRF_LOAD = $(TOCK_USERLAND_BASE_DIR)/tools/program/nrf51dk.py
 # Upload programs over uart (does not work for nRF)
 .PHONY: program
 program: $(BOARD_BUILDDIR)/$(TOCK_ARCH).bin $(BUILDDIR)/$(PACKAGE_NAME).tab
-	$(error No program rule for nRF)
+	$(error Cannot program nRF51DK over USB. Use \'make flash\' and JTAG))
 
 # Upload programs to nrf51dk
 .PHONY: flash

--- a/boards/nrf52dk/Makefile
+++ b/boards/nrf52dk/Makefile
@@ -23,19 +23,11 @@ JLINK_OPTIONS+=-device nrf52 -if swd -speed 1200 -AutoConnect 1
 JLINK_SCRIPTS_DIR=jtag/
 
 # Upload the kernel over JTAG
-.PHONY: program
+.PHONY: flash
 flash: target/$(TARGET)/release/nrf52dk.hex
 	$(JLINK) $(JLINK_OPTIONS) $(JLINK_SCRIPTS_DIR)/flash-kernel.jlink
 
-# Upload kernel + app over JTAG
-.PHONY: program-full
-flash-full: target/$(TARGET)/release/nrf52dk-$(APP).hex
-	@$(eval TEMPFILE := $(shell mktemp -t nrf52dk-$(APP).jlink.XXXXXXXXXX))
-	@echo r > $(TEMPFILE)
-	@echo loadfile $< >> $(TEMPFILE)
-	@echo r >> $(TEMPFILE)
-	@echo g >> $(TEMPFILE)
-	@echo q >> $(TEMPFILE)
-	$(JLINK) $(JLINK_OPTIONS) $(TEMPFILE)
-	@rm $(TEMPFILE)
-
+# Upload the kernel over serial/bootloader
+.PHONY: program
+program: target/$(TARGET)/release/nrf52dk.hex
+	$(error Cannot program nRF52DK over USB. Use \`make flash\` and JTAG)

--- a/boards/nrf52dk/Makefile-app
+++ b/boards/nrf52dk/Makefile-app
@@ -13,3 +13,7 @@ NRF_LOAD = $(TOCK_USERLAND_BASE_DIR)/tools/program/nrf52dk.py
 .PHONY: flash
 flash: $(BOARD_BUILDDIR)/$(TOCK_ARCH).bin $(BUILDDIR)/$(PACKAGE_NAME).tab
 	$(NRF_LOAD) $<
+
+.PHONY: program
+program: $(BOARD_BUILDDIR)/$(TOCK_ARCH).bin $(BUILDDIR)/$(PACKAGE_NAME).tab
+	$(error Cannot program nRF52DK over USB. Use \'make flash\' and JTAG)


### PR DESCRIPTION
Hi,

- Removed the flash-full option as it is not used by "root-build system"

- Added error messages when trying program nRF5X using ```program option (USB)``` according to @brghena's suggestion