### PR TITLE
ELF2TBF: Use text region base addr not a fixed one

### DIFF
--- a/userland/tools/elf2tbf/src/main.rs
+++ b/userland/tools/elf2tbf/src/main.rs
@@ -318,7 +318,7 @@ fn do_work(input: &elf::File,
     let post_appstate_pad = relocation_data_offset - (appstate_offset + appstate_size);
     let text_offset = relocation_data_offset + (relocation_data_size as u32);
     let text_size = text.shdr.size as u32;
-    let init_fn_offset = (input.ehdr.entry ^ 0x80000000) as u32 + text_offset;
+    let init_fn_offset = (input.ehdr.entry - text.shdr.addr) as u32 + text_offset;
     let got_offset = text_offset + text_size;
     let got_size = got.shdr.size as u32;
     let data_offset = got_offset + got_size;


### PR DESCRIPTION
Somewhat urgent, @bradjc, but hopefully simple to review.

elf2tbf was assuming the text segment started at 0x80000000 in order to
correctly set the _start symbol. Instead, use whatever the base address
is in the text segment. This is important to make it possible for
the Rust userland to not have to assume a 0x80000000 base.

The change doesn't impact any existing apps since the base address for C process text segments is 0x80000000 anyway right now. 