### PR TITLE
userland/support/warning_header.h: Include stdarg.h explicitly

### DIFF
--- a/userland/support/warning_header.h
+++ b/userland/support/warning_header.h
@@ -2,6 +2,7 @@
 // that commonly introduce bugs in (embedded) code. This header is injected as
 // part of the tock build, where we add warning attributes to functions.
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
stdio.h doesn't automatically imply it, and the version in newlib
defines __need___va_list which causes <stdarg.h> to only define
__gnuc_va_list, not va_list. This leads to:

./../../../support/warning_header.h:29:65: error: unknown type name 'va_list'
 int vsprintf(char * restrict str, const char * restrict format, va_list ap);

Fix this by including stdarg.h explicitly.