### PR TITLE
Remove manual conversions from process::Error to ReturnCode

### DIFF
--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -16,7 +16,6 @@
 use core::cell::Cell;
 use kernel::{AppId, Callback, Container, Driver, ReturnCode};
 use kernel::hil;
-use kernel::process::Error;
 
 /// Per-process metdata
 #[derive(Default)]
@@ -52,11 +51,7 @@ impl<'a> AmbientLight<'a> {
                 }
                 ReturnCode::SUCCESS
             })
-            .unwrap_or_else(|err| match err {
-                Error::OutOfMemory => ReturnCode::ENOMEM,
-                Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                Error::NoSuchApp => ReturnCode::EINVAL,
-            })
+            .unwrap_or_else(|err| err.into())
     }
 }
 
@@ -75,11 +70,7 @@ impl<'a> Driver for AmbientLight<'a> {
                         app.callback = Some(callback);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -25,7 +25,6 @@ use core::cmp;
 use kernel::{AppId, AppSlice, Callback, Container, Driver, ReturnCode, Shared};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
-use kernel::process::Error;
 
 pub struct App {
     callback: Option<Callback>,
@@ -107,11 +106,7 @@ impl<'a> AppFlash<'a> {
                     }
                 }
             })
-            .unwrap_or_else(|err| match err {
-                Error::OutOfMemory => ReturnCode::ENOMEM,
-                Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                Error::NoSuchApp => ReturnCode::EINVAL,
-            })
+            .unwrap_or_else(|err| err.into())
     }
 }
 
@@ -181,11 +176,7 @@ impl<'a> Driver for AppFlash<'a> {
                         app.buffer = Some(slice);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }
@@ -204,11 +195,7 @@ impl<'a> Driver for AppFlash<'a> {
                         app.callback = Some(callback);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -23,7 +23,6 @@ use core::cell::Cell;
 use kernel::{AppId, Container, Callback, Driver, ReturnCode};
 use kernel::hil;
 use kernel::hil::gpio::{Client, InterruptMode};
-use kernel::process::Error;
 
 pub type SubscribeMap = u32;
 
@@ -63,11 +62,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
                         cntr.0 = Some(callback);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
 
             // default
@@ -105,11 +100,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
                             pins[data].enable_interrupt(data, InterruptMode::EitherEdge);
                             ReturnCode::SUCCESS
                         })
-                        .unwrap_or_else(|err| match err {
-                            Error::OutOfMemory => ReturnCode::ENOMEM,
-                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                            Error::NoSuchApp => ReturnCode::EINVAL,
-                        })
+                        .unwrap_or_else(|err| err.into())
                 } else {
                     ReturnCode::EINVAL /* impossible button */
                 }
@@ -125,11 +116,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
                             cntr.1 &= !(1 << data);
                             ReturnCode::SUCCESS
                         })
-                        .unwrap_or_else(|err| match err {
-                            Error::OutOfMemory => ReturnCode::ENOMEM,
-                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                            Error::NoSuchApp => ReturnCode::EINVAL,
-                        });
+                        .unwrap_or_else(|err| err.into());
 
                     // are any processes waiting for this button?
                     let interrupt_count = Cell::new(0);

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -177,11 +177,7 @@ impl<'a, U: UART> Driver for Console<'a, U> {
                         app.read_idx = 0;
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             1 => {
                 self.apps
@@ -189,11 +185,7 @@ impl<'a, U: UART> Driver for Console<'a, U> {
                         app.write_buffer = Some(slice);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -176,11 +176,7 @@ impl<'a, C: hil::crc::CRC> Driver for Crc<'a, C> {
                         app.buffer = Some(slice);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }
@@ -212,11 +208,7 @@ impl<'a, C: hil::crc::CRC> Driver for Crc<'a, C> {
                         app.callback = Some(callback);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }
@@ -310,11 +302,7 @@ impl<'a, C: hil::crc::CRC> Driver for Crc<'a, C> {
                                 }
                             }
                         })
-                        .unwrap_or_else(|err| match err {
-                            Error::OutOfMemory => ReturnCode::ENOMEM,
-                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                            Error::NoSuchApp => ReturnCode::EINVAL,
-                        })
+                        .unwrap_or_else(|err| err.into())
                 } else {
                     ReturnCode::EINVAL
                 };

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -50,7 +50,6 @@ use core::cell::Cell;
 use kernel::{AppId, Callback, Container, Driver};
 use kernel::ReturnCode;
 use kernel::hil;
-use kernel::process::Error;
 
 #[derive(Clone,Copy,PartialEq)]
 pub enum HumidityCommand {
@@ -90,11 +89,7 @@ impl<'a> HumiditySensor<'a> {
             } else {
                 ReturnCode::EBUSY
             })
-            .unwrap_or_else(|err| match err {
-                Error::OutOfMemory => ReturnCode::ENOMEM,
-                Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                Error::NoSuchApp => ReturnCode::EINVAL,
-            })
+            .unwrap_or_else(|err| err.into())
     }
 
     fn call_driver(&self, command: HumidityCommand, _: usize) -> ReturnCode {
@@ -110,11 +105,7 @@ impl<'a> HumiditySensor<'a> {
                 app.callback = Some(callback);
                 ReturnCode::SUCCESS
             })
-            .unwrap_or_else(|err| match err {
-                Error::OutOfMemory => ReturnCode::ENOMEM,
-                Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                Error::NoSuchApp => ReturnCode::EINVAL,
-            })
+            .unwrap_or_else(|err| err.into())
     }
 }
 

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -16,7 +16,6 @@ use core::cell::Cell;
 use kernel::{AppId, Callback, Container, Driver};
 use kernel::ReturnCode;
 use kernel::hil;
-use kernel::process::Error;
 
 
 #[derive(Clone,Copy,PartialEq)]
@@ -78,11 +77,7 @@ impl<'a> NineDof<'a> {
                     ReturnCode::SUCCESS
                 }
             })
-            .unwrap_or_else(|err| match err {
-                Error::OutOfMemory => ReturnCode::ENOMEM,
-                Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                Error::NoSuchApp => ReturnCode::EINVAL,
-            })
+            .unwrap_or_else(|err| err.into())
     }
 
     fn call_driver(&self, command: NineDofCommand, _: usize) -> ReturnCode {
@@ -146,11 +141,7 @@ impl<'a> Driver for NineDof<'a> {
                         app.callback = Some(callback);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -54,7 +54,6 @@ use core::cmp;
 use kernel::{AppId, AppSlice, Callback, Container, Driver, ReturnCode, Shared};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
-use kernel::process::Error;
 
 pub static mut BUFFER: [u8; 512] = [0; 512];
 
@@ -263,11 +262,7 @@ impl<'a> NonvolatileStorage<'a> {
                                 }
                             }
                         })
-                        .unwrap_or_else(|err| match err {
-                            Error::OutOfMemory => ReturnCode::ENOMEM,
-                            Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                            Error::NoSuchApp => ReturnCode::EINVAL,
-                        })
+                        .unwrap_or_else(|err| err.into())
                 })
             }
             NonvolatileCommand::KernelRead |
@@ -475,11 +470,7 @@ impl<'a> Driver for NonvolatileStorage<'a> {
                 }
                 ReturnCode::SUCCESS
             })
-            .unwrap_or_else(|err| match err {
-                Error::OutOfMemory => ReturnCode::ENOMEM,
-                Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                Error::NoSuchApp => ReturnCode::EINVAL,
-            })
+            .unwrap_or_else(|err| err.into())
     }
 
     /// Setup callbacks.
@@ -498,11 +489,7 @@ impl<'a> Driver for NonvolatileStorage<'a> {
                 }
                 ReturnCode::SUCCESS
             })
-            .unwrap_or_else(|err| match err {
-                Error::OutOfMemory => ReturnCode::ENOMEM,
-                Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                Error::NoSuchApp => ReturnCode::EINVAL,
-            })
+            .unwrap_or_else(|err| err.into())
     }
 
     /// Command interface.

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -135,11 +135,7 @@ impl<'a, RNG: rng::RNG> Driver for SimpleRng<'a, RNG> {
                         app.buffer = Some(slice);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }
@@ -153,11 +149,7 @@ impl<'a, RNG: rng::RNG> Driver for SimpleRng<'a, RNG> {
                         app.callback = Some(callback);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
 
             // default

--- a/capsules/src/symmetric_encryption.rs
+++ b/capsules/src/symmetric_encryption.rs
@@ -73,7 +73,6 @@ use core::cell::Cell;
 use kernel::{AppId, AppSlice, Container, Callback, Driver, ReturnCode, Shared};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::symmetric_encryption::{SymmetricEncryption, Client};
-use kernel::process::Error;
 
 pub static mut BUF: [u8; 128] = [0; 128];
 pub static mut KEY: [u8; 16] = [0; 16];
@@ -212,11 +211,7 @@ impl<'a, E: SymmetricEncryption> Driver for Crypto<'a, E> {
                         app.key_buf = Some(slice);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             1 => {
                 self.apps
@@ -224,11 +219,7 @@ impl<'a, E: SymmetricEncryption> Driver for Crypto<'a, E> {
                         app.data_buf = Some(slice);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             4 => {
                 self.apps
@@ -236,11 +227,7 @@ impl<'a, E: SymmetricEncryption> Driver for Crypto<'a, E> {
                         app.ctr_buf = Some(slice);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }
@@ -254,11 +241,7 @@ impl<'a, E: SymmetricEncryption> Driver for Crypto<'a, E> {
                         app.callback = Some(callback);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -50,7 +50,6 @@ use core::cell::Cell;
 use kernel::{AppId, Callback, Container, Driver};
 use kernel::ReturnCode;
 use kernel::hil;
-use kernel::process::Error;
 
 #[derive(Default)]
 pub struct App {
@@ -84,11 +83,7 @@ impl<'a> TemperatureSensor<'a> {
             } else {
                 ReturnCode::EBUSY
             })
-            .unwrap_or_else(|err| match err {
-                Error::OutOfMemory => ReturnCode::ENOMEM,
-                Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                Error::NoSuchApp => ReturnCode::EINVAL,
-            })
+            .unwrap_or_else(|err| err.into())
     }
 
     fn configure_callback(&self, callback: Callback) -> ReturnCode {
@@ -97,11 +92,7 @@ impl<'a> TemperatureSensor<'a> {
                 app.callback = Some(callback);
                 ReturnCode::SUCCESS
             })
-            .unwrap_or_else(|err| match err {
-                Error::OutOfMemory => ReturnCode::ENOMEM,
-                Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                Error::NoSuchApp => ReturnCode::EINVAL,
-            })
+            .unwrap_or_else(|err| err.into())
     }
 }
 

--- a/capsules/src/timer.rs
+++ b/capsules/src/timer.rs
@@ -95,11 +95,7 @@ impl<'a, A: Alarm> Driver for TimerDriver<'a, A> {
                 td.callback = Some(callback);
                 ReturnCode::SUCCESS
             })
-            .unwrap_or_else(|err| match err {
-                Error::OutOfMemory => ReturnCode::ENOMEM,
-                Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                Error::NoSuchApp => ReturnCode::EINVAL,
-            })
+            .unwrap_or_else(|err| err.into())
     }
 
     /// Setup and read the MAX17205.

--- a/capsules/src/usb_user.rs
+++ b/capsules/src/usb_user.rs
@@ -27,7 +27,6 @@
 use core::cell::Cell;
 use kernel::{AppId, Container, Callback, Driver, ReturnCode};
 use kernel::hil;
-use kernel::process::Error;
 
 #[derive(Default)]
 pub struct App {
@@ -107,11 +106,7 @@ impl<'a, C> Driver for UsbSyscallDriver<'a, C>
                         app.callback = Some(callback);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }
@@ -138,11 +133,7 @@ impl<'a, C> Driver for UsbSyscallDriver<'a, C>
                             }
                         }
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    });
+                    .unwrap_or_else(|err| err.into());
 
                 if result == ReturnCode::SUCCESS {
                     self.serve_waiting_apps();

--- a/chips/nrf5x/src/ble_advertising_driver.rs
+++ b/chips/nrf5x/src/ble_advertising_driver.rs
@@ -70,7 +70,6 @@ use ble_advertising_hil;
 use core::cell::Cell;
 use kernel;
 use kernel::hil::time::Frequency;
-use kernel::process::Error;
 use kernel::returncode::ReturnCode;
 
 pub static mut BUF: [u8; 32] = [0; 32];
@@ -336,11 +335,7 @@ impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
                         app.app_write = Some(slice);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    });
+                    .unwrap_or_else(|err| err.into());
                 if ret == ReturnCode::SUCCESS {
                     self.set_adv_data(allow_num)
                 } else {
@@ -354,11 +349,7 @@ impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
                         app.app_write = Some(slice);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    });
+                    .unwrap_or_else(|err| err.into());
                 if ret == ReturnCode::SUCCESS {
                     self.set_adv_addr()
                 } else {
@@ -372,11 +363,7 @@ impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
                         app.app_read = Some(slice);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             (_, true) => ReturnCode::EBUSY,
 
@@ -394,11 +381,7 @@ impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
                         app.scan_callback = Some(callback);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or_else(|err| match err {
-                        Error::OutOfMemory => ReturnCode::ENOMEM,
-                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                        Error::NoSuchApp => ReturnCode::EINVAL,
-                    })
+                    .unwrap_or_else(|err| err.into())
             }
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -132,6 +132,16 @@ pub enum Error {
     AddressOutOfBounds,
 }
 
+impl From<Error> for ReturnCode {
+    fn from(err: Error) -> ReturnCode {
+        match err {
+            Error::OutOfMemory => ReturnCode::ENOMEM,
+            Error::AddressOutOfBounds => ReturnCode::EINVAL,
+            Error::NoSuchApp => ReturnCode::EINVAL,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum State {
     Running,


### PR DESCRIPTION
Implementing `From<process::Error> for ReturnCode` cuts out a bunch of code duplication.

I haven't run `rustfmt` to keep the diff simple. I can run it before merging if this patch is something you want.