### PR TITLE
makefile: remove default TOCK_BOARD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,35 @@
-# default board
-TOCK_BOARD ?= hail
-
-
-# rules for making the kernel
-.PHONY: all
-all: $(TOCK_BOARD)
-
-.PHONY: $(TOCK_BOARD)
-$(TOCK_BOARD): boards/$(TOCK_BOARD)/
-	$(MAKE) -C $<
+# By default, let's print out some help
+.PHONY: usage
+usage:
+	@echo "$$(tput bold)Welcome to Tock!$$(tput sgr0)"
+	@echo
+	@echo "First things first, if you haven't yet, check out doc/Getting_Started."
+	@echo "You'll need to install a few requirements before we get going."
+	@echo
+	@echo "The next step is to choose a board to build Tock for."
+	@echo "Mainline Tock currently includes support for:"
+	@ls -p boards/ | grep '/$$' | cut -d'/' -f1 | xargs echo "  "
+	@echo
+	@echo "Run 'make' in a board directory to build Tock for that board,"
+	@echo "and usually 'make program' or 'make flash' to load Tock onto hardware."
+	@echo "Check out the README in your board's folder for more information."
+	@echo
+	@echo "This root Makefile has a few useful targets as well:"
+	@echo "  allboards: Compiles Tock for all supported boards"
+	@echo "     alldoc: Builds Tock documentation for all boards"
+	@echo "     format: Runs the rustfmt tool on all kernel sources"
+	@echo "  formatall: Runs formatting tools over kernel and userland sources"
+	@echo "       list: Lists available boards"
+	@echo
+	@echo "$$(tput bold)Happy Hacking!$$(tput sgr0)"
 
 .PHONY: allboards
 allboards:
 	@for f in `./tools/list_boards.sh -1`; do echo "$$(tput bold)Build $$f"; $(MAKE) -C "boards/$$f" || exit 1; done
 
-.PHONY: clean
-clean:: boards/$(TOCK_BOARD)/
-	$(MAKE) clean -C $<
-
-.PHONY: doc
-doc: boards/$(TOCK_BOARD)/
-	$(MAKE) doc -C $<
-
-.PHONY: debug
-debug: boards/$(TOCK_BOARD)/
-	$(MAKE) debug -C $<
-
-.PHONY: program
-program: boards/$(TOCK_BOARD)/
-	$(MAKE) program -C $<
-
-.PHONY: flash
-flash: boards/$(TOCK_BOARD)/
-	$(MAKE) flash -C $<
+.PHONY: alldoc
+alldoc:
+	@for f in `./tools/list_boards.sh -1`; do echo "$$(tput bold)Documenting $$f"; $(MAKE) -C "boards/$$f" doc || exit 1; done
 
 .PHONY: fmt format
 fmt format:
@@ -45,10 +42,4 @@ formatall: format
 .PHONY: list list-boards list-platforms
 list list-boards list-platforms:
 	@./tools/list_boards.sh
-
-# rule for making userland example applications
-# 	automatically upload after making
-examples/%: userland/examples/%
-	$(MAKE) -C $< TOCK_BOARD=$(TOCK_BOARD)
-	$(MAKE) program -C $< TOCK_BOARD=$(TOCK_BOARD)
 

--- a/boards/nrf51dk/README.md
+++ b/boards/nrf51dk/README.md
@@ -19,9 +19,7 @@ software](../../doc/Getting_Started.md#optional-requirements).
 ### Programming the kernel
 
 Once you have all software installed, you should be able to simply run
-`make TOCK_BOARD=nrf51dk flash` to install a fresh kernel.
-
-You can omit `TOCK_BOARD` if you run `make flash` in the nrf51dk directory.
+`make flash` in this directory to install a fresh kernel.
 
 ### Programming user-level applications
 
@@ -29,7 +27,7 @@ After building (`make` in the application folder), you can program an
 application using tockloader:
 
     tockloader install --jtag --board nrf51dk --arch cortex-m0
-    
+
 If you run this in the application folder, `tockloader` will automatically
 find the tab to flash, otherwise you need to specify the path.
 

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -125,37 +125,22 @@ you can use the build scripts in the `tools` directory, in this order:
 
 ## Compiling the Kernel
 
-To build the kernel, just type `make` in the root directory.  The root
-Makefile selects a board and architecture to build the kernel for and
-routes all calls to that board's specific Makefile. The root Makefile
-is set up with the following defaults:
+Tock builds a unique kernel for every _board_ it supports. Boards include
+details like pulling together the correct chips and pin assignments. To
+build a kernel, first choose a board, then navigate to that board directory.
+e.g. `cd boards/hail ; make`.
 
-```
-TOCK_BOARD ?= hail
-```
+Some boards have special build options that can only be used within the board's
+directory.  All boards share a few common targets:
 
-Thus it compiles for the Hail board by default. There are two ways to
-build for a different board:
+  - `all` (default): Compile Tock for this board.
+  - `debug`: Generate build(s) for debugging support, details vary per board.
+  - `doc`: Build documentation for this board.
+  - `clean`: Remove built artifacts for this board.
+  - `flash`: Load code using JTAG, if available.
+  - `program`: Load code using a bootloader, if available.
 
- * You can compile the kernel for a specific board by running the command
-   from inside the board's directory:
-
-    ```bash
-    $ cd boards/nrf51dk/
-    $ make
-    ```
-
- * Alternatively, you can add a `TOCK_BOARD` environment variable where
-    `TOCK_BOARD` is the directory name inside `boards/`.
-
-    ```bash
-    $ make TOCK_BOARD=nrf51dk
-    ```
-
-Board specific Makefiles are located in `boards/<BOARD>/`. Some boards have
-special build options that can only be used within the board's directory.
-Generic options such as `clean`, `doc`, `debug`, `program`, and `flash` can be
-accessed from Tock's root.
+The READMEs in each board provide more details for each platform.
 
 ## Compiling applications
 


### PR DESCRIPTION
  - Add a usage for empty `make` invocation in the root
  - Add an `alldoc` target to mirror the `allboards` target
  - Remove board-specific directives from the root

Closes #575 as well.