### PR TITLE
Virtualization

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -49,7 +49,7 @@ static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, Non
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct Hail {
-    console: &'static capsules::console::Console<'static, sam4l::usart::USART>,
+    console: &'static capsules::console::Console<'static, sam4l::usart::USART<'static>>,
     gpio: &'static capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
     alarm: &'static capsules::alarm::AlarmDriver<'static,
                                                  VirtualMuxAlarm<'static,
@@ -60,7 +60,7 @@ struct Hail {
     humidity: &'static capsules::humidity::HumiditySensor<'static>,
     spi: &'static capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
     nrf51822: &'static capsules::nrf51822_serialization::Nrf51822Serialization<'static,
-                                                                               sam4l::usart::USART>,
+                                                         sam4l::usart::USART<'static>>,
     adc: &'static capsules::adc::Adc<'static, sam4l::adc::Adc>,
     led: &'static capsules::led::LED<'static, sam4l::gpio::GPIOPin>,
     button: &'static capsules::button::Button<'static, sam4l::gpio::GPIOPin>,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -51,7 +51,7 @@ type RF233Device = capsules::rf233::RF233<'static,
                                           VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>;
 
 struct Imix {
-    console: &'static capsules::console::Console<'static, sam4l::usart::USART>,
+    console: &'static capsules::console::Console<'static, sam4l::usart::USART<'static>>,
     gpio: &'static capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
     alarm: &'static AlarmDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
     temp: &'static capsules::temperature::TemperatureSensor<'static>,
@@ -68,7 +68,7 @@ struct Imix {
     usb_driver: &'static capsules::usb_user::UsbSyscallDriver<'static,
                         capsules::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>>,
     nrf51822: &'static capsules::nrf51822_serialization::Nrf51822Serialization<'static,
-                                                                               sam4l::usart::USART>,
+                                                         sam4l::usart::USART<'static>>,
 }
 
 // The RF233 radio stack requires our buffers for its SPI operations:

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -90,7 +90,7 @@ pub struct Platform {
                                                            nrf51::radio::Radio,
                                                            VirtualMuxAlarm<'static, Rtc>>,
     button: &'static capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
-    console: &'static capsules::console::Console<'static, nrf51::uart::UART>,
+    console: &'static capsules::console::Console<'static, nrf51::uart::UART<'static>>,
     gpio: &'static capsules::gpio::GPIO<'static, nrf5x::gpio::GPIOPin>,
     led: &'static capsules::led::LED<'static, nrf5x::gpio::GPIOPin>,
     temp: &'static capsules::temperature::TemperatureSensor<'static>,

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -108,7 +108,7 @@ pub struct Platform {
     ble_radio: &'static nrf5x::ble_advertising_driver::BLE
         <'static, nrf52::radio::Radio, VirtualMuxAlarm<'static, Rtc>>,
     button: &'static capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
-    console: &'static capsules::console::Console<'static, nrf52::uart::UARTE>,
+    console: &'static capsules::console::Console<'static, nrf52::uart::UARTE<'static>>,
     gpio: &'static capsules::gpio::GPIO<'static, nrf5x::gpio::GPIOPin>,
     led: &'static capsules::led::LED<'static, nrf5x::gpio::GPIOPin>,
     rng: &'static capsules::rng::SimpleRng<'static, nrf5x::trng::Trng<'static>>,

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -67,7 +67,7 @@ impl Default for App {
 
 pub static mut WRITE_BUF: [u8; 64] = [0; 64];
 
-pub struct Console<'a, U: UART + 'a> {
+pub struct Console<'a, U: UART<'a> + 'a> {
     uart: &'a U,
     apps: Grant<App>,
     in_progress: Cell<Option<AppId>>,
@@ -75,7 +75,7 @@ pub struct Console<'a, U: UART + 'a> {
     baud_rate: u32,
 }
 
-impl<'a, U: UART> Console<'a, U> {
+impl<'a, U: UART<'a>> Console<'a, U> {
     pub fn new(uart: &'a U,
                baud_rate: u32,
                tx_buffer: &'static mut [u8],
@@ -160,7 +160,7 @@ impl<'a, U: UART> Console<'a, U> {
     }
 }
 
-impl<'a, U: UART> Driver for Console<'a, U> {
+impl<'a, U: UART<'a>> Driver for Console<'a, U> {
     /// Setup shared buffers.
     ///
     /// ### `allow_num`
@@ -230,7 +230,7 @@ impl<'a, U: UART> Driver for Console<'a, U> {
     }
 }
 
-impl<'a, U: UART> Client for Console<'a, U> {
+impl<'a, U: UART<'a>> Client for Console<'a, U> {
     fn transmit_complete(&self, buffer: &'static mut [u8], _error: uart::Error) {
         // Either print more from the AppSlice or send a callback to the
         // application.

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -24,6 +24,7 @@ pub mod virtual_flash;
 pub mod virtual_i2c;
 pub mod virtual_spi;
 pub mod virtual_radio;
+pub mod virtual_uart;
 pub mod adc;
 pub mod dac;
 pub mod i2c_master_slave_driver;

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -23,6 +23,7 @@ pub mod virtual_alarm;
 pub mod virtual_flash;
 pub mod virtual_i2c;
 pub mod virtual_spi;
+pub mod virtual_radio;
 pub mod adc;
 pub mod dac;
 pub mod i2c_master_slave_driver;

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -52,14 +52,14 @@ pub static mut READ_BUF: [u8; 600] = [0; 600];
 
 // We need two resources: a UART HW driver and driver state for each
 // application.
-pub struct Nrf51822Serialization<'a, U: UARTAdvanced + 'a> {
+pub struct Nrf51822Serialization<'a, U: UARTAdvanced<'a> + 'a> {
     uart: &'a U,
     app: MapCell<App>,
     tx_buffer: TakeCell<'static, [u8]>,
     rx_buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, U: UARTAdvanced> Nrf51822Serialization<'a, U> {
+impl<'a, U: UARTAdvanced<'a>> Nrf51822Serialization<'a, U> {
     pub fn new(uart: &'a U,
                tx_buffer: &'static mut [u8],
                rx_buffer: &'static mut [u8])
@@ -82,7 +82,7 @@ impl<'a, U: UARTAdvanced> Nrf51822Serialization<'a, U> {
     }
 }
 
-impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
+impl<'a, U: UARTAdvanced<'a>> Driver for Nrf51822Serialization<'a, U> {
     /// Pass application space memory to this driver.
     ///
     /// ### `allow_num`
@@ -169,7 +169,7 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
 }
 
 // Callbacks from the underlying UART driver.
-impl<'a, U: UARTAdvanced> Client for Nrf51822Serialization<'a, U> {
+impl<'a, U: UARTAdvanced<'a>> Client for Nrf51822Serialization<'a, U> {
     // Called when the UART TX has finished.
     fn transmit_complete(&self, buffer: &'static mut [u8], _error: uart::Error) {
         self.tx_buffer.replace(buffer);

--- a/capsules/src/virtual_radio.rs
+++ b/capsules/src/virtual_radio.rs
@@ -1,0 +1,185 @@
+//! Virtualizes the 802.15.4 sending interface to multiple clients.
+//!
+//! Usage
+//! -----
+//!
+//! ```
+//! // Create the mux.
+//! let mux_radio = static_init!(
+//!     capsules::virtual_radio::RadioMux<'static>,
+//!     capsules::virtual_radio::RadioMux::new(some_radio_ieee));
+//!
+//! // Everything that then uses the virtualized radio must use one of these.
+//! let virtual_radio_device = static_init!(
+//!     capsules::virtual_radio::VirtualRadioDevice<'static>,
+//!     capsules::virtual_radio::VirtualRadioDevice::new(mux_radio));
+//! ```
+//!
+//! About
+//! -----
+//!
+//! - Author: Philip Levis
+//! - Date: Jan 12 2017
+
+use core::cell::Cell;
+use ieee802154::mac;
+use kernel::ReturnCode;
+use kernel::common::virtualizer::{QueuedCall, CallQueue, Dequeued};
+use net::ieee802154::*;
+
+pub struct RadioMux<'a> {
+    mac: &'a mac::Mac<'a>,
+    busy: Cell<bool>,
+    queue: CallQueue<'a>,
+}
+
+pub struct VirtualRadioDevice<'a> {
+    tx_buffer: Cell<Option<mac::Frame>>,
+    queued_call: QueuedCall<'a>,
+    mux: &'a RadioMux<'a>,
+    client: Cell<Option<&'a mac::TxClient>>,
+}
+
+pub trait VirtualTransmit<'a> {
+    fn transmit(&'a self, frame: mac::Frame) -> (ReturnCode, Option<&'static mut [u8]>);
+}
+
+impl<'a> RadioMux<'a> {
+    pub fn new(mac: &'a mac::Mac<'a>) -> RadioMux<'a> {
+        RadioMux {
+            mac: mac,
+            busy: Cell::new(false),
+            queue: CallQueue::new(),
+        }
+    }
+
+    pub fn busy(&self) -> bool {
+        self.busy.get()
+    }
+
+    pub fn next(&self) -> ReturnCode {
+        if !self.busy() {
+            self.busy.set(true);
+            self.queue.dequeue_and_trigger();
+        }
+        ReturnCode::SUCCESS
+    }
+
+    pub fn clear_busy(&self) {
+        self.busy.set(false);
+    }
+
+    pub fn set_transmit_client(&self, client: &'a mac::TxClient) {
+        self.mac.set_transmit_client(client);
+    }
+}
+
+impl<'a> VirtualRadioDevice<'a> {
+    pub fn new(mux: &'a RadioMux<'a>) -> VirtualRadioDevice<'a> {
+        VirtualRadioDevice {
+            tx_buffer: Cell::new(None),
+            queued_call: QueuedCall::new(&mux.queue),
+            mux: mux,
+            client: Cell::new(None),
+        }
+    }
+
+    pub fn init(&'a self, client: &'a mac::TxClient) {
+        self.client.set(Some(client));
+        self.queued_call.set_callback(self);
+    }
+}
+
+impl<'a> mac::TxClient for VirtualRadioDevice<'a> {
+    fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
+        self.client.get().map(move |c| c.send_done(buf, acked, result));
+        self.mux.clear_busy();
+        self.mux.next();
+    }
+}
+
+impl<'a> Dequeued<'a> for VirtualRadioDevice<'a> {
+    fn id(&'a self) -> u32 {
+        0
+    }
+    fn dequeued(&'a self) {
+        self.mux.set_transmit_client(self);
+        //self.mac.transmit(self.tx_buffer.unwrap())
+    }
+}
+
+impl<'a> mac::Mac<'a> for VirtualRadioDevice<'a> {
+    fn get_address(&self) -> u16 {
+        self.mux.mac.get_address()
+    }
+    fn get_address_long(&self) -> [u8; 8] {
+        self.mux.mac.get_address_long()
+    }
+    fn get_pan(&self) -> u16 {
+        self.mux.mac.get_pan()
+    }
+    fn get_channel(&self) -> u8 {
+        self.mux.mac.get_channel()
+    }
+    fn get_tx_power(&self) -> i8 {
+        self.mux.mac.get_tx_power()
+    }
+    fn set_address(&self, addr: u16) {
+        self.mux.mac.set_address(addr);
+    }
+    fn set_address_long(&self, addr: [u8; 8]) {
+        self.mux.mac.set_address_long(addr);
+    }
+    fn set_pan(&self, id: u16) {
+        self.mux.mac.set_pan(id);
+    }
+    fn set_channel(&self, chan: u8) -> ReturnCode {
+        self.mux.mac.set_channel(chan)
+    }
+    fn set_tx_power(&self, power: i8) -> ReturnCode {
+        self.mux.mac.set_tx_power(power)
+    }
+
+    fn config_commit(&self) {
+        self.mux.mac.config_commit()
+    }
+    fn is_on(&self) -> bool {
+        self.mux.mac.is_on()
+    }
+    fn prepare_data_frame(&self,
+                          buf: &'static mut [u8],
+                          dst_pan: PanID,
+                          dst_addr: MacAddress,
+                          src_pan: PanID,
+                          src_addr: MacAddress,
+                          security_needed: Option<(SecurityLevel, KeyId)>)
+                          -> Result<mac::Frame, &'static mut [u8]> {
+        self.mux.mac.prepare_data_frame(buf, dst_pan, dst_addr, src_pan, src_addr, security_needed)
+    }
+
+    /// Transmits a frame that has been prepared by the above process. If the
+    /// transmission process fails, the buffer inside the frame is returned so
+    /// that it can be re-used.
+    fn transmit(&self, frame: mac::Frame) -> (ReturnCode, Option<&'static mut [u8]>) {
+        return (ReturnCode::ENOSUPPORT, Some(frame.into_buf()));
+    }
+    fn set_transmit_client(&self, client: &'a mac::TxClient) {
+        self.mux.mac.set_transmit_client(client);
+    }
+
+    fn set_receive_client(&self, client: &'a mac::RxClient) {
+        self.mux.mac.set_receive_client(client);
+    }
+}
+
+impl<'a> VirtualTransmit<'a> for VirtualRadioDevice<'a> {
+    fn transmit(&'a self, frame: mac::Frame) -> (ReturnCode, Option<&'static mut [u8]>) {
+        if self.queued_call.insert() {
+            self.tx_buffer.set(Some(frame));
+            self.mux.next(); // If already busy will do nothing
+            return (ReturnCode::SUCCESS, None);
+        } else {
+            return (ReturnCode::EBUSY, Some(frame.into_buf()));
+        }
+    }
+}

--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -1,0 +1,125 @@
+//! Virtualizes the UART interface to multiple clients.
+//!
+//! Intended as an example for a generic virtualization approach.
+//!
+//! - Author: Philip Levis
+//! - Date: Jan 12 2017
+
+use core::cell::Cell;
+use kernel::ReturnCode;
+use kernel::common::take_cell::TakeCell;
+use kernel::common::virtualizer::{QueuedCall, CallQueue, Dequeued};
+use kernel::hil::uart;
+
+pub struct UartMux<'a> {
+    uart: &'a uart::UART<'a>,
+    busy: Cell<bool>,
+    queue: CallQueue<'a>,
+}
+
+pub struct VirtualUartDevice<'a> {
+    tx_buffer: TakeCell<'static, [u8]>,
+    tx_len: Cell<usize>,
+    queued_call: QueuedCall<'a>,
+    mux: &'a UartMux<'a>,
+    client: Cell<Option<&'a uart::Client>>,
+}
+
+impl<'a> UartMux<'a> {
+    pub fn new(uart: &'a uart::UART<'a>) -> UartMux<'a> {
+        UartMux {
+            uart: uart,
+            busy: Cell::new(false),
+            queue: CallQueue::new(),
+        }
+    }
+
+    pub fn busy(&self) -> bool {
+        self.busy.get()
+    }
+
+    pub fn next(&self) -> ReturnCode {
+        if !self.busy() {
+            self.busy.set(true);
+            self.queue.dequeue_and_trigger();
+        }
+        ReturnCode::SUCCESS
+    }
+
+    pub fn clear_busy(&self) {
+        self.busy.set(false);
+    }
+
+    pub fn set_client(&self, client: &'a uart::Client) {
+        self.uart.set_client(client);
+    }
+}
+
+impl<'a> VirtualUartDevice<'a> {
+    pub fn new(mux: &'a UartMux<'a>) -> VirtualUartDevice<'a> {
+        VirtualUartDevice {
+            tx_buffer: TakeCell::empty(),
+            queued_call: QueuedCall::new(&mux.queue),
+            mux: mux,
+            client: Cell::new(None),
+            tx_len: Cell::new(0),
+        }
+    }
+
+    pub fn init(&'a self, client: &'static uart::Client) {
+        self.client.set(Some(client));
+        self.queued_call.set_callback(self);
+    }
+}
+
+impl<'a> uart::Client for VirtualUartDevice<'a> {
+    fn transmit_complete(&self, tx_buffer: &'static mut [u8], error: uart::Error) {
+        self.client.get().map(move |c| c.transmit_complete(tx_buffer, error));
+        self.mux.clear_busy();
+        self.mux.next();
+    }
+    fn receive_complete(&self,
+                        _rx_buffer: &'static mut [u8],
+                        _rx_len: usize,
+                        _error: uart::Error) {
+        // do nothing, this should not be called
+    }
+}
+
+impl<'a> Dequeued<'a> for VirtualUartDevice<'a> {
+    fn id(&'a self) -> u32 {
+        0
+    }
+    fn dequeued(&'a self) {
+        self.mux.set_client(self);
+        self.tx_buffer.take().map(|buf| { self.mux.uart.transmit(buf, self.tx_len.get()); });
+    }
+}
+
+impl<'a> uart::UART<'a> for VirtualUartDevice<'a> {
+    /// Set the client for this UART peripheral. The client will be
+    /// called when events finish.
+    fn set_client(&self, client: &'a uart::Client) {
+        self.client.set(Some(client));
+    }
+
+    /// Initialize UART
+    /// Panics if UARTParams are invalid for the current chip.
+    fn init(&self, _params: uart::UARTParams) {
+        // Do nothing, shouldn't have a control path here
+    }
+
+    /// Transmit data.
+    fn transmit(&'a self, tx_data: &'static mut [u8], tx_len: usize) {
+        if self.queued_call.insert() {
+            self.tx_len.set(tx_len);
+            self.tx_buffer.replace(tx_data);
+            self.mux.next();
+        }
+    }
+
+    /// Receive data until buffer is full.
+    fn receive(&self, _rx_buffer: &'static mut [u8], _rx_len: usize) {
+        // Should not be part of this trait.
+    }
+}

--- a/chips/nrf51/src/uart.rs
+++ b/chips/nrf51/src/uart.rs
@@ -48,9 +48,9 @@ pub struct Registers {
 
 const UART_BASE: u32 = 0x40002000;
 
-pub struct UART {
+pub struct UART<'a> {
     regs: *const Registers,
-    client: Cell<Option<&'static uart::Client>>,
+    client: Cell<Option<&'a uart::Client>>,
     buffer: TakeCell<'static, [u8]>,
     len: Cell<usize>,
     index: Cell<usize>,
@@ -68,8 +68,8 @@ pub static mut UART0: UART = UART::new();
 //   pin  9: TX
 //   pin 10: CTS
 //   pin 11: RX
-impl UART {
-    pub const fn new() -> UART {
+impl<'a> UART<'a> {
+    pub const fn new() -> UART<'a> {
         UART {
             regs: UART_BASE as *mut Registers,
             client: Cell::new(None),
@@ -194,8 +194,8 @@ impl UART {
     }
 }
 
-impl uart::UART for UART {
-    fn set_client(&self, client: &'static uart::Client) {
+impl<'a> uart::UART<'a> for UART<'a> {
+    fn set_client(&self, client: &'a uart::Client) {
         self.client.set(Some(client));
     }
 

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -16,9 +16,9 @@ const NRF_UARTE_INTR_ENDTX: u32 = 1 << 8;
 const NRF_UARTE_INTR_ENDRX: u32 = 1 << 4;
 const NRF_UARTE_ENABLE: u32 = 8;
 
-pub struct UARTE {
+pub struct UARTE<'a> {
     regs: *const peripheral_registers::UARTE,
-    client: Cell<Option<&'static kernel::hil::uart::Client>>,
+    client: Cell<Option<&'a kernel::hil::uart::Client>>,
     buffer: kernel::common::take_cell::TakeCell<'static, [u8]>,
     remaining_bytes: Cell<usize>,
     offset: Cell<usize>,
@@ -29,10 +29,10 @@ pub struct UARTParams {
     pub baud_rate: u32,
 }
 
-pub static mut UART0: UARTE = UARTE::new();
+pub static mut UART0: UARTE<'static> = UARTE::new();
 
-impl UARTE {
-    pub const fn new() -> UARTE {
+impl<'a> UARTE<'a> {
+    pub const fn new() -> UARTE<'a> {
         UARTE {
             regs: peripheral_registers::UARTE_BASE as *mut peripheral_registers::UARTE,
             client: Cell::new(None),
@@ -180,8 +180,8 @@ impl UARTE {
     }
 }
 
-impl kernel::hil::uart::UART for UARTE {
-    fn set_client(&self, client: &'static kernel::hil::uart::Client) {
+impl<'a> kernel::hil::uart::UART<'a> for UARTE<'a> {
+    fn set_client(&self, client: &'a kernel::hil::uart::Client) {
         self.client.set(Some(client));
     }
 

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -76,7 +76,7 @@ enum UsartClient<'a> {
     SpiMaster(&'a hil::spi::SpiMasterClient),
 }
 
-pub struct USART {
+pub struct USART<'a> {
     registers: *mut USARTRegisters,
     clock: pm::Clock,
 
@@ -92,7 +92,7 @@ pub struct USART {
     tx_dma_peripheral: dma::DMAPeripheral,
     tx_len: Cell<usize>,
 
-    client: Cell<Option<UsartClient<'static>>>,
+    client: Cell<Option<UsartClient<'a>>>,
 
     spi_chip_select: Cell<Option<&'static hil::gpio::Pin>>,
 }
@@ -115,12 +115,12 @@ pub static mut USART3: USART = USART::new(USART_BASE_ADDRS[3],
                                           dma::DMAPeripheral::USART3_RX,
                                           dma::DMAPeripheral::USART3_TX);
 
-impl USART {
+impl<'a> USART<'a> {
     const fn new(base_addr: *mut USARTRegisters,
                  clock: pm::PBAClock,
                  rx_dma_peripheral: dma::DMAPeripheral,
                  tx_dma_peripheral: dma::DMAPeripheral)
-                 -> USART {
+                 -> USART<'a> {
         USART {
             registers: base_addr,
             clock: pm::Clock::PBA(clock),
@@ -439,7 +439,7 @@ impl USART {
     }
 }
 
-impl dma::DMAClient for USART {
+impl<'a> dma::DMAClient for USART<'a> {
     fn xfer_done(&self, pid: dma::DMAPeripheral) {
         match self.usart_mode.get() {
             UsartMode::Uart => {
@@ -557,8 +557,8 @@ impl dma::DMAClient for USART {
 }
 
 /// Implementation of kernel::hil::UART
-impl hil::uart::UART for USART {
-    fn set_client(&self, client: &'static hil::uart::Client) {
+impl<'a> hil::uart::UART<'a> for USART<'a> {
+    fn set_client(&self, client: &'a hil::uart::Client) {
         let c = UsartClient::Uart(client);
         self.client.set(Some(c));
     }
@@ -608,7 +608,7 @@ impl hil::uart::UART for USART {
         self.disable_clock();
     }
 
-    fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {
+    fn transmit(&'a self, tx_data: &'static mut [u8], tx_len: usize) {
         // enable USART clock
         //  must do this before writing any registers
         self.enable_clock();
@@ -628,7 +628,7 @@ impl hil::uart::UART for USART {
         });
     }
 
-    fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize) {
+    fn receive(&'a self, rx_buffer: &'static mut [u8], rx_len: usize) {
         // enable USART clock
         //  must do this before writing any registers
         self.enable_clock();
@@ -656,7 +656,7 @@ impl hil::uart::UART for USART {
     }
 }
 
-impl hil::uart::UARTAdvanced for USART {
+impl<'a> hil::uart::UARTAdvanced<'a> for USART<'a> {
     fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8) {
         // enable USART clock
         //  must do this before writing any registers
@@ -710,7 +710,7 @@ impl hil::uart::UARTAdvanced for USART {
 
 
 /// SPI
-impl hil::spi::SpiMaster for USART {
+impl<'a> hil::spi::SpiMaster for USART<'a> {
     type ChipSelect = Option<&'static hil::gpio::Pin>;
 
     fn init(&self) {

--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -8,6 +8,7 @@ pub mod volatile_cell;
 pub mod static_ref;
 pub mod list;
 pub mod math;
+pub mod virtualizer;
 
 pub use self::list::{List, ListLink, ListNode};
 pub use self::queue::Queue;

--- a/kernel/src/common/virtualizer.rs
+++ b/kernel/src/common/virtualizer.rs
@@ -1,0 +1,128 @@
+//! Provide a queue-based callback for virtualizing OS abstractions.
+
+use common::list::{List, ListLink, ListNode};
+use core::cell::Cell;
+
+pub trait Dequeued<'a> {
+    fn dequeued(&'a self);
+    fn id(&'a self) -> u32;
+}
+
+pub struct QueuedCall<'a> {
+    next: ListLink<'a, QueuedCall<'a>>,
+    callback: Cell<Option<&'a Dequeued<'a>>>,
+    active: Cell<bool>,
+    queue: &'a CallQueue<'a>,
+}
+
+impl<'a> ListNode<'a, QueuedCall<'a>> for QueuedCall<'a> {
+    fn next(&self) -> &'a ListLink<QueuedCall<'a>> {
+        &self.next
+    }
+}
+
+impl<'a> QueuedCall<'a> {
+    pub fn new(queue: &'a CallQueue<'a>) -> QueuedCall<'a> {
+        QueuedCall {
+            next: ListLink::empty(),
+            callback: Cell::new(None),
+            active: Cell::new(false),
+            queue: queue,
+        }
+    }
+
+    pub fn set_callback(&'a self, callback: &'a Dequeued<'a>) {
+        self.callback.set(Some(callback));
+        self.queue.queued_calls.push_head(self);
+    }
+
+    /// Returns true if it was inserted, false if it was already
+    /// in the queue.
+    pub fn insert(&'a self) -> bool {
+        let rval = !self.active.get();
+        self.active.set(true);
+        rval
+    }
+
+    /// Returns true if removed from the queue, false if it was not
+    /// in the queue.
+    pub fn remove(&'a self) -> bool {
+        let rval = self.active.get();
+        self.active.set(false);
+        rval
+    }
+
+    pub fn is_inserted(&'a self) -> bool {
+        self.active.get()
+    }
+}
+
+pub struct CallQueue<'a> {
+    queued_calls: List<'a, QueuedCall<'a>>,
+    next: Cell<Option<&'a QueuedCall<'a>>>,
+}
+
+impl<'a> CallQueue<'a> {
+    pub const fn new() -> CallQueue<'a> {
+        CallQueue {
+            queued_calls: List::new(),
+            next: Cell::new(None),
+        }
+    }
+
+    // This triggers the next queued element by performing
+    // a linear scan of the list, starting at the front. It
+    // keeps a reference to the 'next' element after the last one
+    // triggered (or None, if it was the tail of the queue).
+    // It keeps track of the 'first' active element before
+    // the 'next' element. It then walks forward from next,
+    // triggering the earlist active element. If it reaches the
+    // end of the queue, it triggers 'first' if there is one,
+    // or returns false if there is no 'first' (no element in the
+    // queue was marked active).
+    pub fn dequeue_and_trigger(&self) -> bool {
+        // If the last scan reached the end of the queue,
+        // set the first element to look at to be the first element
+        // of the queue.
+        if self.next.get().is_none() {
+            self.next.set(self.queued_calls.head());
+        }
+        let mut next = false;
+        let mut passed = false;
+        let mut first = None;
+        for call in self.queued_calls.iter() {
+            // Haven't passed next
+            if !passed {
+                // Reached next
+                if call as *const QueuedCall == self.next.get().unwrap() as *const QueuedCall {
+                    passed = true;
+                    self.next.set(None);
+                    if call.active.get() {
+                        next = true;
+                        call.active.set(false);
+                        call.callback.get().map(|c| c.dequeued());
+                    }
+                } else if call.active.get() && first.is_none() {
+                    // We're before next, so set first
+                    first = Some(call);
+                }
+            } else if next {
+                // Previous item triggered, so set next
+                self.next.set(Some(call));
+                return true;
+            } else if call.active.get() {
+                call.active.set(false);
+                call.callback.get().map(|c| c.dequeued());
+                next = true;
+                self.next.set(None);
+            }
+        }
+        if first.is_some() {
+            let val = first.unwrap();
+            val.active.set(false);
+            val.callback.get().map(|c| c.dequeued());
+            return true;
+        }
+        next
+    }
+}

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -43,10 +43,10 @@ pub enum Error {
     CommandComplete,
 }
 
-pub trait UART {
+pub trait UART<'a> {
     /// Set the client for this UART peripheral. The client will be
     /// called when events finish.
-    fn set_client(&self, client: &'static Client);
+    fn set_client(&self, client: &'a Client);
 
     /// Initialize UART
     ///
@@ -54,13 +54,13 @@ pub trait UART {
     fn init(&self, params: UARTParams);
 
     /// Transmit data.
-    fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize);
+    fn transmit(&'a self, tx_data: &'static mut [u8], tx_len: usize);
 
     /// Receive data until buffer is full.
-    fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize);
+    fn receive(&'a self, rx_buffer: &'static mut [u8], rx_len: usize);
 }
 
-pub trait UARTAdvanced: UART {
+pub trait UARTAdvanced<'a>: UART<'a> {
     /// Receive data until `interbyte_timeout` bit periods have passed since the
     /// last byte or buffer is full. Does not timeout until at least one byte
     /// has been received.


### PR DESCRIPTION
### Pull Request Overview

This pull request proposes a general approach for virtualizing abstractions, through a queue. In thi approach, each virtual instance allocates an entry in the queue and marks it active when it wants to use the abstraction. It receives a callback when it can access the abstraction. The virtual instance implementation is then responsible for, when it is done using the abstraction, to dequeue the next one.

The key file is kernel::common:virtualizer, which is the queue. There are two examples of its use, in capsules::virtual_radio, which is a virtualized radio implementation, and capsules::virtual_uart, which is a virtualized UART sending interface. 

kernel::common::virtualizer defines one trait, Dequeued<'a>, which has two functions:

pub trait Dequeued<'a> {
    fn dequeued( &'a self) ;
    fn id(&'a self) -> u32;
}

The queue is non-blocking; a client enqueues itself by having an instance of QueuedCall, which maintains its position in the queue. The client implements Dequeued and registers itself with the QueuedCall by calling set_callback(). 

One of QueuedCall's new() parameters is the CallQueue of which it is a member (you've can't move a QueuedCall between different queues). The client inserts itself into the active elements in the queue by calling QueuedCall.insert().  Then, when elements are pulled out of the CallQueue, eventually this client's QueuedCall will be dequeued. What it is, the CallQueue calls dequeued() on the client, telling the client that it now has exclusive access to the singleton resource.

When the client is done (e.g., has sent a packet), then it releases the singleton by telling the virtualizer to let the next one run. Currently, this is not enforced; any client could invoke operations on the singleton at any time. I don't think it would be very hard to enforce it, though, e.g. by passing a token or just requiring it relinquish the reference to the struct that has the functional options when it says the next client can go.

The basic architecture is that, to virtualize an trait, there are two new structs. The first is the Mux struct, which encapsulates the singleton abstraction that is being virtualized and contains a queue of clients (CallQueue).  By itself, the Mux does very little: it mostly just checks if the singleton is busy and can dequeue the next client. The virtualized client has a QueuedCall and implements Dequeued. When the virtualized client is invoked, it stores the call parameters and enqueues itself. When it is dequeued, it makes the virtualized call.

So the call pattern looks like this (for a virtualized UART):

1) A capsule that wants to be able to write messages to the UART, shared with other capsules, has a reference to a VirtualizedUartDevice. It calls transmit() on this reference.

2) VirtualizedUartDevice has a QueuedCall in its structure. It also has a reference to the UartMux. The QueuedCell is part of UartMux's CallQueue. 

3) When VirtualizedUartDevice.transmit is called, it stores the tx buffer and length in its structure, and calls insert() on its QueuedCall. This marks that queue entry as active in the CallQueue. VirtualizedUartDevice tells the CallQueue to dequeue an element if it's not busy (which would mean dequeue its own queue entry). 

4) At some point, the UartMux dequeues this VirtualUartDevice's QueuedCall and invokes dequeued() on its client, which is the VirtualUartDevice. The VirtualUartDevice now has permission to use the UART. It invokes transmit() using the parameters it stored earlier. Importantly, it also installs itself as the UART's client, so the completion callback comes to it.

5_ When the transmit_done completion callback comes back, the VirtualizedUartDevice dequeues the next client (via Mux.next()) and then signals the completion callback to its caller capsule. From the perspective of this capsule, it called UART.transmit(), which gave a callback sometime later.

Both implementations are not clean as they should be due to some issues with the existing traits. Specifically, they do not separate the control and data paths, such that if you want to virtualize sending a packet you must also virtualize configuring the radio; the former is done by many services while the latter is probably done by the board.  As a result the virtualized radio sender has to implement all of these functions and pass them through to the underlying mac::Mac implementation. Without this, I think I could bring it down to 30 or so lines of code. Similarly, for the UART, the receive and transmit paths are in the same trait, which is problematic: send virtualization is usually through queueing, while receive virtualization is through dispatch.



### Testing Strategy

This has not been tested yet -- it's just for people to look at and comment on as a general strategy. I'm going to test it once people are somewhat on-board with the general idea.


### TODO or Help Wanted

This pull request still needs discussion on whether this generalization is helpful. It places some constraints on trait design (pushes towards fine-grained traits). But it could be a useful, general programming pattern.

### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [x] `make formatall` has been run.
