### PR TITLE
Add nRF52 SPI master (SPIM) driver.

### DIFF
--- a/boards/nrf52dk/Cargo.lock
+++ b/boards/nrf52dk/Cargo.lock
@@ -10,6 +10,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitfield"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "capsules"
 version = "0.1.0"
 dependencies = [
@@ -36,6 +41,7 @@ version = "0.1.0"
 name = "nrf52"
 version = "0.1.0"
 dependencies = [
+ "bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortexm4 0.1.0",
  "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel 0.1.0",
@@ -50,4 +56,5 @@ dependencies = [
 ]
 
 [metadata]
+"checksum bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f989ae9b9fff3271a712a309fce47f0c46dd3476cb40074ddfcc06ad4a76cf6a"
 "checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"

--- a/chips/nrf52/Cargo.toml
+++ b/chips/nrf52/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
 nrf5x = { path = "../nrf5x" }
+bitfield = "0.11.0"
 
 [build-dependencies]
 gcc = "0.3"

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -3,6 +3,7 @@ use kernel::common::{RingBuffer, Queue};
 use nrf5x;
 use nrf5x::peripheral_interrupts::NvicIdx;
 use radio;
+use spi;
 use uart;
 
 const IQ_SIZE: usize = 100;
@@ -33,22 +34,28 @@ impl kernel::Chip for NRF52 {
 
     fn service_pending_interrupts(&mut self) {
         unsafe {
-            INTERRUPT_QUEUE.as_mut().unwrap().dequeue().map(|interrupt| {
-                match interrupt {
-                    NvicIdx::ECB => nrf5x::aes::AESECB.handle_interrupt(),
-                    NvicIdx::GPIOTE => nrf5x::gpio::PORT.handle_interrupt(),
-                    NvicIdx::RADIO => radio::RADIO.handle_interrupt(),
-                    NvicIdx::RNG => nrf5x::trng::TRNG.handle_interrupt(),
-                    NvicIdx::RTC1 => nrf5x::rtc::RTC.handle_interrupt(),
-                    NvicIdx::TEMP => nrf5x::temperature::TEMP.handle_interrupt(),
-                    NvicIdx::TIMER0 => nrf5x::timer::TIMER0.handle_interrupt(),
-                    NvicIdx::TIMER1 => nrf5x::timer::ALARM1.handle_interrupt(),
-                    NvicIdx::TIMER2 => nrf5x::timer::TIMER2.handle_interrupt(),
-                    NvicIdx::UART0 => uart::UART0.handle_interrupt(),
-                    _ => debug!("NvicIdx not supported by Tock\r\n"),
-                }
-                nrf5x::nvic::enable(interrupt);
-            });
+            INTERRUPT_QUEUE.as_mut()
+                .unwrap()
+                .dequeue()
+                .map(|interrupt| {
+                    match interrupt {
+                        NvicIdx::ECB => nrf5x::aes::AESECB.handle_interrupt(),
+                        NvicIdx::GPIOTE => nrf5x::gpio::PORT.handle_interrupt(),
+                        NvicIdx::RADIO => radio::RADIO.handle_interrupt(),
+                        NvicIdx::RNG => nrf5x::trng::TRNG.handle_interrupt(),
+                        NvicIdx::RTC1 => nrf5x::rtc::RTC.handle_interrupt(),
+                        NvicIdx::TEMP => nrf5x::temperature::TEMP.handle_interrupt(),
+                        NvicIdx::TIMER0 => nrf5x::timer::TIMER0.handle_interrupt(),
+                        NvicIdx::TIMER1 => nrf5x::timer::ALARM1.handle_interrupt(),
+                        NvicIdx::TIMER2 => nrf5x::timer::TIMER2.handle_interrupt(),
+                        NvicIdx::UART0 => uart::UART0.handle_interrupt(),
+                        NvicIdx::SPI0_TWI0 => spi::SPIM0.handle_interrupt(),
+                        NvicIdx::SPI1_TWI1 => spi::SPIM1.handle_interrupt(),
+                        NvicIdx::SPIM2_SPIS2_SPI2 => spi::SPIM2.handle_interrupt(),
+                        _ => debug!("NvicIdx not supported by Tock\r\n"),
+                    }
+                    nrf5x::nvic::enable(interrupt);
+                });
         }
     }
 

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -6,6 +6,9 @@
 extern crate kernel;
 extern crate nrf5x;
 
+#[macro_use]
+extern crate bitfield;
+
 use kernel::common::Queue;
 
 extern "C" {
@@ -20,6 +23,7 @@ pub mod nvmc;
 pub mod radio;
 pub mod uart;
 pub mod uicr;
+pub mod spi;
 
 
 #[no_mangle]

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -307,7 +307,10 @@ impl SPIM {
             // End of RXD buffer and TXD buffer reached
             match self.chip_select.get() {
                 Some(cs) => cs.set(),
-                None => panic!("Chip select not configured."),
+                None => {
+                    debug_assert!(false, "Invariant violated. Chip-select must be Some.");
+                    return;
+                }
             }
             self.regs().events_end.set(0);
 

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -100,7 +100,6 @@ mod registers {
             Enabled = 7,
         }
 
-        #[allow(non_snake_case)]
         #[repr(C, packed)]
         pub struct SPIM {
             _reserved0: [u32; 4],

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -359,12 +359,14 @@ impl hil::spi::SpiMaster for SPIM {
             None => {
                 self.regs().rxd_ptr.set(ptr::null_mut());
                 self.regs().rxd_maxcnt.set(0);
+                self.transfer_len.set(tx_len as usize);
                 self.rx_buf.put(None);
             }
             Some(buf) => {
                 self.regs().rxd_ptr.set(buf.as_mut_ptr());
                 let rx_len: u32 = cmp::min(len, buf.len()) as u32;
                 self.regs().rxd_maxcnt.set(rx_len);
+                self.transfer_len.set(cmp::min(tx_len, rx_len) as usize);
                 self.rx_buf.put(Some(buf));
             }
         }

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -1,0 +1,501 @@
+use chip;
+use core::cell::Cell;
+use core::cmp;
+use core::ptr;
+use kernel::ReturnCode;
+use kernel::common::take_cell::TakeCell;
+use kernel::hil;
+use nrf5x::nvic;
+use nrf5x::peripheral_interrupts::NvicIdx;
+use nrf5x::pinmux::Pinmux;
+
+pub static mut SPIM0: SPIM = SPIM::new(0);
+pub static mut SPIM1: SPIM = SPIM::new(1);
+pub static mut SPIM2: SPIM = SPIM::new(2);
+
+mod registers {
+    pub mod spim {
+        #![allow(dead_code)]
+        use kernel::common::VolatileCell;
+        use nrf5x::peripheral_interrupts::NvicIdx;
+        use nrf5x::pinmux::Pinmux;
+
+        pub const INSTANCES: [(*const SPIM, NvicIdx); 3] =
+            [(0x40003000 as *const SPIM, NvicIdx::SPI0_TWI0),
+             (0x40004000 as *const SPIM, NvicIdx::SPI1_TWI1),
+             (0x40023000 as *const SPIM, NvicIdx::SPIM2_SPIS2_SPI2)];
+
+        bitfield!{
+            // Represents bitfields in INTENSET and INTENCLR registers.
+            #[derive(Copy, Clone)]
+            pub struct InterruptEnable(u32);
+            impl Debug;
+            pub stopped, set_stopped:  1,  1;
+            pub end_rx,  set_end_rx:   4,  4;
+            pub end,     set_end:      6,  6;
+            pub end_tx,  set_end_tx:   8,  8;
+            pub started, set_started: 19, 19;
+        }
+
+        bitfield!{
+            // Represents bitfields in CONFIG register.
+            #[derive(Copy, Clone)]
+            pub struct Config(u32);
+            impl Debug;
+            pub order,          set_order:          0,  0;
+            pub clock_phase,    set_clock_phase:    1,  1;
+            pub clock_polarity, set_clock_polarity: 2,  2;
+        }
+
+        #[repr(u32)]
+        #[derive(Copy, Clone)]
+        pub enum Frequency {
+            K125 = 0x02000000,
+            K250 = 0x04000000,
+            K500 = 0x08000000,
+            M1 = 0x10000000,
+            M2 = 0x20000000,
+            M4 = 0x40000000,
+            M8 = 0x80000000,
+        }
+
+        impl From<Frequency> for u32 {
+            fn from(freq: Frequency) -> u32 {
+                match freq {
+                    Frequency::K125 => 125_000,
+                    Frequency::K250 => 250_000,
+                    Frequency::K500 => 500_000,
+                    Frequency::M1 => 1_000_000,
+                    Frequency::M2 => 2_000_000,
+                    Frequency::M4 => 4_000_000,
+                    Frequency::M8 => 8_000_000,
+                }
+            }
+        }
+
+        impl From<u32> for Frequency {
+            fn from(freq: u32) -> Frequency {
+                if freq < 250_000 {
+                    Frequency::K125
+                } else if freq < 500_000 {
+                    Frequency::K250
+                } else if freq < 1_000_000 {
+                    Frequency::K500
+                } else if freq < 2_000_000 {
+                    Frequency::M1
+                } else if freq < 4_000_000 {
+                    Frequency::M2
+                } else if freq < 8_000_000 {
+                    Frequency::M4
+                } else {
+                    Frequency::M8
+                }
+            }
+        }
+
+        #[repr(u32)]
+        #[derive(Copy, Clone)]
+        pub enum Enable {
+            Disabled = 0,
+            Enabled = 7,
+        }
+
+        #[allow(non_snake_case)]
+        #[repr(C, packed)]
+        pub struct SPIM {
+            _reserved0: [u32; 4],
+            // Start SPI transaction
+            // base + 0x010
+            pub tasks_start: VolatileCell<u32>,
+            // Stop SPI transaction
+            // base + 0x014
+            pub tasks_stop: VolatileCell<u32>,
+            _reserved1: u32,
+            // Suspend SPI transaction
+            // base + 0x01C
+            pub tasks_suspend: VolatileCell<u32>,
+            // Resume SPI transaction
+            // base + 0x020
+            pub tasks_resume: VolatileCell<u32>,
+            _reserved2: [u32; 56],
+            // SPI transaction has stopped
+            // base + 0x104
+            pub events_stopped: VolatileCell<u32>,
+            _reserved3: [u32; 2],
+            // End of RXD buffer reached
+            // base + 0x110
+            pub events_endrx: VolatileCell<u32>,
+            _reserved4: u32,
+            // End of RXD buffer and TXD buffer reached
+            // base + 0x118
+            pub events_end: VolatileCell<u32>,
+            _reserved5: u32,
+            // End of TXD buffer reached
+            // base + 0x120
+            pub events_endtx: VolatileCell<u32>,
+            _reserved6: [u32; 10],
+            // Transaction started
+            // base + 0x14C
+            pub events_started: VolatileCell<u32>,
+            _reserved7: [u32; 44],
+            // Shortcut register
+            // base + 0x200
+            pub shorts: VolatileCell<u32>,
+            _reserved8: [u32; 64],
+            // Enable interrupt
+            // base + 0x304
+            pub intenset: VolatileCell<InterruptEnable>,
+            // Disable interrupt
+            // base + 0x308
+            pub intenclr: VolatileCell<InterruptEnable>,
+            _reserved9: [u32; 125],
+            // Enable SPIM
+            // base + 0x500
+            pub enable: VolatileCell<Enable>,
+            _reserved10: u32,
+            // Pin select for SCK
+            // base + 0x508
+            pub psel_sck: VolatileCell<Pinmux>,
+            // Pin select for MOSI signal
+            // base + 0x50C
+            pub psel_mosi: VolatileCell<Pinmux>,
+            // Pin select for MISO signal
+            // base + 0x510
+            pub psel_miso: VolatileCell<Pinmux>,
+            _reserved11: [u32; 4],
+            // SPI frequency
+            // base + 0x524
+            pub frequency: VolatileCell<Frequency>,
+            _reserved12: [u32; 3],
+            // Data pointer
+            // base + 0x534
+            pub rxd_ptr: VolatileCell<*mut u8>,
+            // Maximum number of bytes in receive buffer
+            // base + 0x538
+            pub rxd_maxcnt: VolatileCell<u32>,
+            // Number of bytes transferred in the last transaction
+            // base + 0x53C
+            pub rxd_amount: VolatileCell<u32>,
+            // EasyDMA list type
+            // base + 0x540
+            pub rxd_list: VolatileCell<u32>,
+            // Data pointer
+            // base + 0x544
+            pub txd_ptr: VolatileCell<*const u8>,
+            // Maximum number of bytes in transmit buffer
+            // base + 0x548
+            pub txd_maxcnt: VolatileCell<u32>,
+            // Number of bytes transferred in the last transaction
+            // base + 0x54C
+            pub txd_amount: VolatileCell<u32>,
+            // EasyDMA list type
+            // base + 0x550
+            pub txd_list: VolatileCell<u32>,
+            // Configuration register
+            // base + 0x554
+            pub config: VolatileCell<Config>,
+            _reserved13: [u32; 26],
+            // Over-read character. Character clocked out in case and over-read of the TXD buffer.
+            // base + 0x5C0
+            pub orc: VolatileCell<u32>,
+        }
+    }
+}
+
+
+// SPI-Master peripheral.
+pub struct SPIM {
+    registers: *const registers::spim::SPIM,
+    nvic_idx: NvicIdx,
+    client: Cell<Option<&'static hil::spi::SpiMasterClient>>,
+    chip_select: Cell<Option<&'static hil::gpio::Pin>>,
+    initialized: Cell<bool>,
+    busy: Cell<bool>,
+    tx_buf: TakeCell<'static, [u8]>,
+    rx_buf: TakeCell<'static, [u8]>,
+    transfer_len: Cell<usize>,
+}
+
+impl SPIM {
+    pub const fn new(instance: usize) -> SPIM {
+        SPIM {
+            registers: registers::spim::INSTANCES[instance].0,
+            nvic_idx: registers::spim::INSTANCES[instance].1,
+            client: Cell::new(None),
+            chip_select: Cell::new(None),
+            initialized: Cell::new(false),
+            busy: Cell::new(false),
+            tx_buf: TakeCell::empty(),
+            rx_buf: TakeCell::empty(),
+            transfer_len: Cell::new(0),
+        }
+    }
+
+    fn regs(&self) -> &registers::spim::SPIM {
+        unsafe { &*self.registers }
+    }
+
+    #[inline(never)]
+    pub fn handle_interrupt(&self) {
+
+        if self.regs().events_end.get() == 1 {
+            // End of RXD buffer and TXD buffer reached
+            match self.chip_select.get() {
+                Some(cs) => cs.set(),
+                None => panic!("Chip select not configured."),
+            }
+            self.regs().events_end.set(0);
+
+            match self.client.get() {
+                None => (),
+                Some(client) => {
+                    match self.tx_buf.take() {
+                        None => (),
+                        Some(tx_buf) => {
+                            client.read_write_done(tx_buf,
+                                                   self.rx_buf.take(),
+                                                   self.transfer_len.take())
+                        }
+                    }
+                }
+            };
+
+            self.busy.set(false);
+        }
+
+        // Although we only configured the chip interrupt on the
+        // above 'end' event, the other event fields also get set by
+        // the chip. Let's clear those flags.
+
+        if self.regs().events_stopped.get() == 1 {
+            // SPI transaction has stopped
+            self.regs().events_stopped.set(0);
+        }
+
+        if self.regs().events_endrx.get() == 1 {
+            // End of RXD buffer reached
+            self.regs().events_endrx.set(0);
+        }
+
+        if self.regs().events_endtx.get() == 1 {
+            // End of TXD buffer reached
+            self.regs().events_endtx.set(0);
+        }
+
+        if self.regs().events_started.get() == 1 {
+            // Transaction started
+            self.regs().events_started.set(0);
+        }
+    }
+
+    pub fn configure(&self, mosi: Pinmux, miso: Pinmux, sck: Pinmux) {
+        let regs = self.regs();
+        regs.psel_mosi.set(mosi);
+        regs.psel_miso.set(miso);
+        regs.psel_sck.set(sck);
+        self.enable();
+        self.enable_nvic();
+    }
+
+    fn enable_nvic(&self) {
+        nvic::enable(self.nvic_idx);
+    }
+
+    pub fn enable(&self) {
+        use self::registers::spim::Enable;
+        self.regs().enable.set(Enable::Enabled);
+    }
+
+    pub fn disable(&self) {
+        use self::registers::spim::Enable;
+        self.regs().enable.set(Enable::Disabled);
+    }
+}
+
+
+impl hil::spi::SpiMaster for SPIM {
+    type ChipSelect = &'static hil::gpio::Pin;
+
+    fn set_client(&self, client: &'static hil::spi::SpiMasterClient) {
+        self.client.set(Some(client));
+    }
+
+    fn init(&self) {
+        use self::registers::spim::InterruptEnable;
+        let mut enabled_ints = InterruptEnable(0);
+        enabled_ints.set_end(1);
+        self.regs().intenset.set(enabled_ints);
+        self.initialized.set(true);
+    }
+
+    fn is_busy(&self) -> bool {
+        self.busy.get()
+    }
+
+    fn read_write_bytes(&self,
+                        tx_buf: &'static mut [u8],
+                        rx_buf: Option<&'static mut [u8]>,
+                        len: usize)
+                        -> ReturnCode {
+        debug_assert!(self.initialized.get());
+        debug_assert!(!self.busy.get());
+        debug_assert!(self.tx_buf.is_none());
+        debug_assert!(self.rx_buf.is_none());
+
+        // Clear (set to low) chip-select
+        match self.chip_select.get() {
+            Some(cs) => cs.clear(),
+            None => return ReturnCode::ENODEVICE,
+        }
+
+        // Setup transmit data registers
+        let tx_len: u32 = cmp::min(len, tx_buf.len()) as u32;
+        self.regs().txd_ptr.set(tx_buf.as_ptr());
+        self.regs().txd_maxcnt.set(tx_len);
+        self.tx_buf.replace(tx_buf);
+
+        // Setup receive data registers
+        match rx_buf {
+            None => {
+                self.regs().rxd_ptr.set(ptr::null_mut());
+                self.regs().rxd_maxcnt.set(0);
+                self.rx_buf.put(None);
+            }
+            Some(buf) => {
+                self.regs().rxd_ptr.set(buf.as_mut_ptr());
+                let rx_len: u32 = cmp::min(len, buf.len()) as u32;
+                self.regs().rxd_maxcnt.set(rx_len);
+                self.rx_buf.put(Some(buf));
+            }
+        }
+
+        // Start the transfer
+        self.busy.set(true);
+        self.regs().tasks_start.set(1);
+        ReturnCode::SUCCESS
+    }
+
+    fn write_byte(&self, _val: u8) {
+        debug_assert!(self.initialized.get());
+        unimplemented!("SPI: Use `read_write_bytes()` instead.");
+    }
+
+    fn read_byte(&self) -> u8 {
+        debug_assert!(self.initialized.get());
+        unimplemented!("SPI: Use `read_write_bytes()` instead.");
+    }
+
+    fn read_write_byte(&self, _val: u8) -> u8 {
+        debug_assert!(self.initialized.get());
+        unimplemented!("SPI: Use `read_write_bytes()` instead.");
+    }
+
+    // Tell the SPI peripheral what to use as a chip select pin.
+    // The type of the argument is based on what makes sense for the
+    // peripheral when this trait is implemented.
+    fn specify_chip_select(&self, cs: Self::ChipSelect) {
+        cs.make_output();
+        cs.set();
+        self.chip_select.set(Some(cs));
+    }
+
+    // Returns the actual rate set
+    fn set_rate(&self, rate: u32) -> u32 {
+        debug_assert!(self.initialized.get());
+        let f = registers::spim::Frequency::from(rate);
+        self.regs().frequency.set(f);
+        f.into()
+    }
+
+    fn get_rate(&self) -> u32 {
+        debug_assert!(self.initialized.get());
+        self.regs().frequency.get().into()
+    }
+
+    fn set_clock(&self, polarity: hil::spi::ClockPolarity) {
+        debug_assert!(self.initialized.get());
+        debug_assert!(self.initialized.get());
+        use self::hil::spi::ClockPolarity;
+        let mut config = self.regs().config.get();
+        config.set_clock_polarity(match polarity {
+            ClockPolarity::IdleLow => 0,
+            ClockPolarity::IdleHigh => 1,
+        });
+        self.regs().config.set(config);
+    }
+
+    fn get_clock(&self) -> hil::spi::ClockPolarity {
+        debug_assert!(self.initialized.get());
+        use self::hil::spi::ClockPolarity;
+        let config = self.regs().config.get();
+        match config.clock_polarity() {
+            0 => ClockPolarity::IdleLow,
+            1 => ClockPolarity::IdleHigh,
+            _ => unreachable!(),
+        }
+    }
+
+    fn set_phase(&self, phase: hil::spi::ClockPhase) {
+        debug_assert!(self.initialized.get());
+        use self::hil::spi::ClockPhase;
+        let mut config = self.regs().config.get();
+        config.set_clock_phase(match phase {
+            ClockPhase::SampleLeading => 0,
+            ClockPhase::SampleTrailing => 1,
+        });
+        self.regs().config.set(config);
+    }
+
+    fn get_phase(&self) -> hil::spi::ClockPhase {
+        debug_assert!(self.initialized.get());
+        use self::hil::spi::ClockPhase;
+        let config = self.regs().config.get();
+        match config.clock_phase() {
+            0 => ClockPhase::SampleLeading,
+            1 => ClockPhase::SampleTrailing,
+            _ => unreachable!(),
+        }
+    }
+
+    // The following two trait functions are not implemented for
+    // SAM4L, and appear to not provide much functionality. Let's not
+    // bother implementing them unless needed.
+    fn hold_low(&self) {
+        unimplemented!("SPI: Use `read_write_bytes()` instead.");
+    }
+
+    fn release_low(&self) {
+        unimplemented!("SPI: Use `read_write_bytes()` instead.");
+    }
+}
+
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn SPI0_TWI0_Handler() {
+    use kernel::common::Queue;
+    nvic::disable(NvicIdx::SPI0_TWI0);
+    chip::INTERRUPT_QUEUE.as_mut()
+        .unwrap()
+        .enqueue(NvicIdx::SPI0_TWI0);
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn SPI1_TWI1_Handler() {
+    use kernel::common::Queue;
+    nvic::disable(NvicIdx::SPI1_TWI1);
+    chip::INTERRUPT_QUEUE.as_mut()
+        .unwrap()
+        .enqueue(NvicIdx::SPI1_TWI1);
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn SPIM2_SPIS2_SPI2_Handler() {
+    use kernel::common::Queue;
+    nvic::disable(NvicIdx::SPIM2_SPIS2_SPI2);
+    chip::INTERRUPT_QUEUE.as_mut()
+        .unwrap()
+        .enqueue(NvicIdx::SPIM2_SPIS2_SPI2);
+}


### PR DESCRIPTION
### Pull Request Overview

This PR adds a SPI master driver to the nrf52 crate. It uses SPIM peripherals with EasyDMA. It does not use the non-DMA SPI peripheral.

### Testing Strategy

Testing requires modifying the `nRF52DK` board crate to use the driver. I have a separate branch that does this and has been tested with `userland/examples/tests/rf233`.

### TODO or Help Wanted

I have not implemented any of single-byte read/write operations. It looks like they aren't used anywhere in the code base. If I'm wrong, and they are required, I can add them.

### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or **no updates are required**.
- [x] Userland: The application README has been added, updated, or **no updates are required**.

### Formatting

- [x] `make formatall` has been run.

### Working Example

Configuring the ST S2-LP radio:

```c
void
s2lp_write_registers(uint8_t addr, uint8_t const * data, size_t data_len)
{
    uint8_t write_buf[64] = {0, addr};
    uint8_t read_buf[64]  = {0, addr};
    memcpy(&write_buf[2], data, data_len);
    int rc = spi_read_write_sync((const char *)write_buf,
                                 (char *)read_buf,
                                 data_len + 2);
    CHECK_ERR(rc);
}

void
s2lp_init(void)
{
    uint8_t tmp[6];
    tmp[0] = 0x40; /* reg. FIFO_CONFIG3 (0x3C) */
    tmp[1] = 0x40; /* reg. FIFO_CONFIG2 (0x3D) */
    tmp[2] = 0x40; /* reg. FIFO_CONFIG1 (0x3E) */
    tmp[3] = 0x40; /* reg. FIFO_CONFIG0 (0x3F) */
    tmp[4] = 0x41; /* reg. PCKT_FLT_OPTIONS (0x40) */
    s2lp_write_registers(0x3C, tmp, 5);
}
```

![screenshot 2017-09-07 14 52 53](https://user-images.githubusercontent.com/2551201/30186989-aec4e048-93dc-11e7-8316-742266396d88.png)

