### PR TITLE
Stick to a revision of compiler_builtins

### DIFF
--- a/boards/hail/Xargo.toml
+++ b/boards/hail/Xargo.toml
@@ -4,3 +4,4 @@
 features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1
+rev = "02ea9e5f540c61cad3cc26ffaba1bbaee657862d"

--- a/boards/imix/Xargo.toml
+++ b/boards/imix/Xargo.toml
@@ -4,3 +4,4 @@
 features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1
+rev = "02ea9e5f540c61cad3cc26ffaba1bbaee657862d"

--- a/boards/nrf51dk/Xargo.toml
+++ b/boards/nrf51dk/Xargo.toml
@@ -4,3 +4,4 @@
 features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1
+rev = "02ea9e5f540c61cad3cc26ffaba1bbaee657862d"

--- a/boards/nrf52dk/Xargo.toml
+++ b/boards/nrf52dk/Xargo.toml
@@ -4,3 +4,4 @@
 features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1
+rev = "02ea9e5f540c61cad3cc26ffaba1bbaee657862d"


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a specific commit hash to the compiler-builtins crate.

The compiler-builtins crate provides compiler intrinsics for ARM. However, it doesn't have any releases we could track and also seems to ride on top of nightly. They recently updated to use associated constants, which were released in a recently nightly but are not available in the nightly currently used by Tock.

While we should definitely update Tock's nightly at some point, we should be pegged to a certain revision of compiler-builtins to prevent this kind of problem in the future.

This particular commit, [02ea9e5f](https://github.com/rust-lang-nursery/compiler-builtins/commit/02ea9e5f540c61cad3cc26ffaba1bbaee657862d), was fairly arbitrarily selected from the commits right before the change to associated constants. It has been tested and works on Signpost.

**Note:** currently Tock does NOT build if you don't have a pre-compiled version of compiler-builtins cached. This PR fixes it.

### Testing Strategy

This pull request was tested by running `make allboards`.

### Documentation Updated

- [N/A] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [N/A] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [N/A] `make formatall` has been run.
