### PR TITLE
Update rustc nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ os:
   - linux
   - osx
 
-# If you change this, you must also change README and Common.mk
+# If you change this, you must also change Getting_Started.md, Makefile.common,
+# and Vagrantfile.
 rust:
-  - nightly-2017-06-20
+  - nightly-2017-09-20
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./.travis-install-gcc; fi

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -3,7 +3,7 @@
 MAKEFLAGS += -r
 MAKEFLAGS += -R
 
-export RUSTUP_TOOLCHAIN ?= nightly-2017-06-20
+export RUSTUP_TOOLCHAIN ?= nightly-2017-09-20
 
 TOOLCHAIN ?= arm-none-eabi
 
@@ -54,7 +54,7 @@ endif
 
 
 # Check that rustc is the right nightly - warn not error if wrong, sometimes useful to test others
-RUSTC_VERSION_STRING := rustc 1.19.0-nightly (04145943a 2017-06-19)
+RUSTC_VERSION_STRING := rustc 1.22.0-nightly (325ba23d5 2017-09-19)
 ifneq ($(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VERSION_STRING))
   DUMMY := $(shell rustup install $(RUSTUP_TOOLCHAIN))
   ifneq ($(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VERSION_STRING))

--- a/boards/hail/Xargo.toml
+++ b/boards/hail/Xargo.toml
@@ -4,4 +4,4 @@
 features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1
-rev = "02ea9e5f540c61cad3cc26ffaba1bbaee657862d"
+rev = "67e0908d7f2fd86423ec32fc4d904952fe96e7a9"

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -5,10 +5,9 @@
 
 #![no_std]
 #![no_main]
-#![feature(asm,const_fn,drop_types_in_const,lang_items,compiler_builtins_lib)]
+#![feature(asm,const_fn,lang_items,compiler_builtins_lib)]
 
 extern crate capsules;
-extern crate cortexm4;
 extern crate compiler_builtins;
 #[allow(unused_imports)]
 #[macro_use(debug,static_init)]

--- a/boards/imix/Xargo.toml
+++ b/boards/imix/Xargo.toml
@@ -4,4 +4,4 @@
 features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1
-rev = "02ea9e5f540c61cad3cc26ffaba1bbaee657862d"
+rev = "67e0908d7f2fd86423ec32fc4d904952fe96e7a9"

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(asm,const_fn,drop_types_in_const,lang_items,compiler_builtins_lib)]
+#![feature(asm,const_fn,lang_items,compiler_builtins_lib,const_cell_new)]
 
 extern crate capsules;
 extern crate compiler_builtins;

--- a/boards/imix/src/power.rs
+++ b/boards/imix/src/power.rs
@@ -19,9 +19,6 @@
 //  of correctly turning the submodules on and off. It allows the caller to
 //  conveniently disable and enable the individual submodules at will.
 
-extern crate kernel;
-extern crate sam4l;
-
 use kernel::hil::Controller;
 use sam4l::gpio::{PA, PB, PC};
 use sam4l::gpio::GPIOPin;

--- a/boards/imix/src/spi_dummy.rs
+++ b/boards/imix/src/spi_dummy.rs
@@ -1,6 +1,5 @@
 //! A dummy SPI client to test the SPI implementation
 
-extern crate kernel;
 use kernel::ReturnCode;
 use kernel::hil::gpio;
 use kernel::hil::gpio::Pin;

--- a/boards/nrf51dk/Xargo.toml
+++ b/boards/nrf51dk/Xargo.toml
@@ -4,4 +4,4 @@
 features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1
-rev = "02ea9e5f540c61cad3cc26ffaba1bbaee657862d"
+rev = "67e0908d7f2fd86423ec32fc4d904952fe96e7a9"

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -37,7 +37,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(lang_items,drop_types_in_const,compiler_builtins_lib)]
+#![feature(lang_items,compiler_builtins_lib)]
 
 extern crate cortexm0;
 extern crate capsules;

--- a/boards/nrf52dk/Xargo.toml
+++ b/boards/nrf52dk/Xargo.toml
@@ -4,4 +4,4 @@
 features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1
-rev = "02ea9e5f540c61cad3cc26ffaba1bbaee657862d"
+rev = "67e0908d7f2fd86423ec32fc4d904952fe96e7a9"

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -60,7 +60,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(lang_items,drop_types_in_const,compiler_builtins_lib)]
+#![feature(lang_items,compiler_builtins_lib)]
 
 extern crate cortexm4;
 extern crate capsules;

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -137,13 +137,13 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Adc<'a, A> {
     /// closure - function to run on the found buffer
     fn take_and_map_buffer<F: FnOnce(&'static mut [u16])>(&self, closure: F) {
         if self.adc_buf1.is_some() {
-            self.adc_buf1.take().map(|mut val| { closure(val); });
+            self.adc_buf1.take().map(|val| { closure(val); });
 
         } else if self.adc_buf2.is_some() {
-            self.adc_buf2.take().map(|mut val| { closure(val); });
+            self.adc_buf2.take().map(|val| { closure(val); });
 
         } else if self.adc_buf3.is_some() {
-            self.adc_buf3.take().map(|mut val| { closure(val); });
+            self.adc_buf3.take().map(|val| { closure(val); });
         }
     }
 

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn)]
+#![feature(const_fn,const_cell_new)]
 #![no_std]
 
 #[allow(unused_imports)]

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -174,7 +174,7 @@ impl<'a, U: UARTAdvanced> Client for Nrf51822Serialization<'a, U> {
         //               Can't just use 0!
         self.app.map(|appst| {
             // Call the callback after TX has finished
-            appst.callback.as_mut().map(|mut cb| { cb.schedule(1, 0, 0); });
+            appst.callback.as_mut().map(|cb| { cb.schedule(1, 0, 0); });
         });
     }
 

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -259,8 +259,8 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
     fn send_command(&self,
                     cmd: SDCmd,
                     arg: u32,
-                    mut write_buffer: &'static mut [u8],
-                    mut read_buffer: &'static mut [u8],
+                    write_buffer: &'static mut [u8],
+                    read_buffer: &'static mut [u8],
                     recv_len: usize) {
         // Note: a good default recv_len is 10 bytes. Reading too many bytes
         //  rarely matters. However, it occasionally matters a lot, so we
@@ -315,8 +315,8 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
 
     /// wrapper for easy reading of bytes over SPI
     fn read_bytes(&self,
-                  mut write_buffer: &'static mut [u8],
-                  mut read_buffer: &'static mut [u8],
+                  write_buffer: &'static mut [u8],
+                  read_buffer: &'static mut [u8],
                   recv_len: usize) {
 
         self.set_spi_fast_mode();
@@ -334,8 +334,8 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
 
     /// wrapper for easy writing of bytes over SPI
     fn write_bytes(&self,
-                   mut write_buffer: &'static mut [u8],
-                   mut read_buffer: &'static mut [u8],
+                   write_buffer: &'static mut [u8],
+                   read_buffer: &'static mut [u8],
                    recv_len: usize) {
 
         self.set_spi_fast_mode();
@@ -391,8 +391,8 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
 
     /// updates SD card state on SPI transaction returns
     fn process_spi_states(&self,
-                          mut write_buffer: &'static mut [u8],
-                          mut read_buffer: &'static mut [u8],
+                          write_buffer: &'static mut [u8],
+                          read_buffer: &'static mut [u8],
                           _: usize) {
 
         match self.state.get() {

--- a/chips/nrf51/src/lib.rs
+++ b/chips/nrf51/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm,concat_idents,const_fn)]
+#![feature(asm,concat_idents,const_fn,const_cell_new)]
 #![no_std]
 
 #[allow(unused_imports)]

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm,concat_idents,const_fn)]
+#![feature(asm,concat_idents,const_fn,const_cell_new)]
 #![no_std]
 
 #[allow(unused_imports)]

--- a/chips/nrf5x/src/lib.rs
+++ b/chips/nrf5x/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm,concat_idents,const_fn)]
+#![feature(asm,concat_idents,const_fn,const_cell_new)]
 #![no_std]
 
 #[allow(unused_imports)]

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -4,7 +4,8 @@
 
 #![crate_name = "sam4l"]
 #![crate_type = "rlib"]
-#![feature(asm,core_intrinsics,concat_idents,const_fn,repr_align,attr_literals)]
+#![feature(repr_align,attr_literals,const_cell_new,const_atomic_usize_new,const_ptr_null_mut)]
+#![feature(asm,core_intrinsics,concat_idents,const_fn)]
 #![no_std]
 
 extern crate cortexm4;

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -15,7 +15,7 @@ developing Tock.
 
 #### Rust (nightly)
 
-We are using `rustc 1.19.0-nightly (04145943a 2017-06-19)`. We recommend
+We are using `rustc 1.22.0-nightly (325ba23d5 2017-09-19)`. We recommend
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
@@ -30,7 +30,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2017-06-20
+$ rustup install nightly-2017-09-20
 ```
 
 #### Xargo

--- a/kernel/src/common/math.rs
+++ b/kernel/src/common/math.rs
@@ -24,7 +24,7 @@ pub fn sqrtf32(num: f32) -> f32 {
 // errno from stdlib for use in Rust
 
 extern "C" {
-    fn __errno() -> &mut i32;
+    fn __errno() -> &'static mut i32;
 }
 
 // return errno value and zero it out

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -30,7 +30,7 @@ macro_rules! static_init {
             // initial value into it (without dropping the initial zeros) and
             // return a reference to it.
             static mut BUF: Option<$T> = None;
-            let mut tmp : &'static mut $T = mem::transmute(&mut BUF);
+            let tmp : &'static mut $T = mem::transmute(&mut BUF);
             ptr::write(tmp as *mut $T, $e);
             tmp
         };

--- a/kernel/src/container.rs
+++ b/kernel/src/container.rs
@@ -55,7 +55,7 @@ pub struct Owned<T: ?Sized> {
 impl<T: ?Sized> Owned<T> {
     pub unsafe fn new(data: *mut T, app_id: usize) -> Owned<T> {
         Owned {
-            data: Unique::new(data),
+            data: Unique::new_unchecked(data),
             app_id: app_id,
         }
     }

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -75,14 +75,14 @@ impl Driver for IPC {
     /// when notify() is called.
     fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
         match subscribe_num {
-            /// subscribe(0)
-            ///
-            /// Subscribe with subscribe_num == 0 is how a process registers
-            /// itself as an IPC service. Each process can only register as a
-            /// single IPC service. The identifier for the IPC service is the
-            /// application name stored in the TBF header of the application.
-            /// The callback that is passed to subscribe is called when another
-            /// process notifies the server process.
+            // subscribe(0)
+            //
+            // Subscribe with subscribe_num == 0 is how a process registers
+            // itself as an IPC service. Each process can only register as a
+            // single IPC service. The identifier for the IPC service is the
+            // application name stored in the TBF header of the application.
+            // The callback that is passed to subscribe is called when another
+            // process notifies the server process.
             0 => {
                 self.data
                     .enter(callback.app_id(), |data, _| {
@@ -92,13 +92,13 @@ impl Driver for IPC {
                     .unwrap_or(ReturnCode::EBUSY)
             }
 
-            /// subscribe(>=1)
-            ///
-            /// Subscribe with subscribe_num >= 1 is how a client registers
-            /// a callback for a given service. The service number (passed
-            /// here as subscribe_num) is returned from the allow() call.
-            /// Once subscribed, the client will receive callbacks when the
-            /// service process calls notify_client().
+            // subscribe(>=1)
+            //
+            // Subscribe with subscribe_num >= 1 is how a client registers
+            // a callback for a given service. The service number (passed
+            // here as subscribe_num) is returned from the allow() call.
+            // Once subscribed, the client will receive callbacks when the
+            // service process calls notify_client().
             svc_id => {
                 if svc_id - 1 >= 8 {
                     ReturnCode::EINVAL /* Maximum of 8 IPC's exceeded */

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,4 +1,5 @@
-#![feature(asm,core_intrinsics,unique,nonzero,const_fn,lang_items)]
+#![feature(asm,core_intrinsics,unique,nonzero)]
+#![feature(const_fn,const_cell_new,const_unsafe_cell_new,lang_items)]
 #![no_std]
 
 pub mod common;

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -21,7 +21,7 @@ pub struct AppPtr<L, T> {
 impl<L, T> AppPtr<L, T> {
     pub unsafe fn new(ptr: *mut T, appid: AppId) -> AppPtr<L, T> {
         AppPtr {
-            ptr: Unique::new(ptr),
+            ptr: Unique::new_unchecked(ptr),
             process: appid,
             _phantom: PhantomData,
         }

--- a/kernel/src/memop.rs
+++ b/kernel/src/memop.rs
@@ -41,39 +41,39 @@ pub fn memop(process: &mut Process) -> ReturnCode {
     let r1 = process.r1();
 
     match op_type {
-        /// Op Type 0: BRK
+        // Op Type 0: BRK
         0 /* BRK */ => {
             process.brk(r1 as *const u8)
                 .map(|_| ReturnCode::SUCCESS)
                 .unwrap_or(ReturnCode::ENOMEM)
         },
 
-        /// Op Type 1: SBRK
+        // Op Type 1: SBRK
         1 /* SBRK */ => {
             process.sbrk(r1 as isize)
                 .map(|addr| ReturnCode::SuccessWithValue { value: addr as usize })
                 .unwrap_or(ReturnCode::ENOMEM)
         },
 
-        /// Op Type 2: Process memory start
+        // Op Type 2: Process memory start
         2 => ReturnCode::SuccessWithValue { value: process.mem_start() as usize },
 
-        /// Op Type 3: Process memory end
+        // Op Type 3: Process memory end
         3 => ReturnCode::SuccessWithValue { value: process.mem_end() as usize },
 
-        /// Op Type 4: Process flash start
+        // Op Type 4: Process flash start
         4 => ReturnCode::SuccessWithValue { value: process.flash_start() as usize },
 
-        /// Op Type 5: Process flash end
+        // Op Type 5: Process flash end
         5 => ReturnCode::SuccessWithValue { value: process.flash_end() as usize },
 
-        /// Op Type 6: Grant region begin
+        // Op Type 6: Grant region begin
         6 => ReturnCode::SuccessWithValue { value: process.kernel_memory_break() as usize },
 
-        /// Op Type 7: Number of defined writeable regions in the TBF header.
+        // Op Type 7: Number of defined writeable regions in the TBF header.
         7 => ReturnCode::SuccessWithValue { value: process.number_writeable_flash_regions() },
 
-        /// Op Type 8: The start address of the writeable region indexed by r1.
+        // Op Type 8: The start address of the writeable region indexed by r1.
         8 => {
             let flash_start = process.flash_start() as usize;
             let (offset, size) = process.get_writeable_flash_region(r1);
@@ -84,9 +84,9 @@ pub fn memop(process: &mut Process) -> ReturnCode {
             }
         }
 
-        /// Op Type 9: The end address of the writeable region indexed by r1.
-        /// Returns (void*) -1 on failure, meaning the selected writeable region
-        /// does not exist.
+        // Op Type 9: The end address of the writeable region indexed by r1.
+        // Returns (void*) -1 on failure, meaning the selected writeable region
+        // does not exist.
         9 => {
             let flash_start = process.flash_start() as usize;
             let (offset, size) = process.get_writeable_flash_region(r1);
@@ -99,13 +99,13 @@ pub fn memop(process: &mut Process) -> ReturnCode {
             }
         }
 
-        /// Op Type 10: Specify where the start of the app stack is.
+        // Op Type 10: Specify where the start of the app stack is.
         10 => {
             process.update_stack_start_pointer(r1 as *const u8);
             ReturnCode::SUCCESS
         }
 
-        /// Op Type 11: Specify where the start of the app heap is.
+        // Op Type 11: Specify where the start of the app heap is.
         11 => {
             process.update_heap_start_pointer(r1 as *const u8);
             ReturnCode::SUCCESS

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -91,7 +91,7 @@ pub unsafe fn do_process<P: Platform, C: Chip>(platform: &P,
                 let res = if callback_ptr_raw as usize == 0 {
                     ReturnCode::EINVAL
                 } else {
-                    let callback_ptr = NonZero::new(callback_ptr_raw);
+                    let callback_ptr = NonZero::new_unchecked(callback_ptr_raw);
 
                     let callback = ::Callback::new(appid, appdata, callback_ptr);
                     platform.with_driver(driver_num, |driver| match driver {

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -63,7 +63,7 @@ Vagrant.configure("2") do |config|
   # Set up rust development environment
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     wget https://sh.rustup.rs -O rustup.sh && sh rustup.sh -y
-    source ~/.profile && rustup install nightly-2017-06-20
+    source ~/.profile && rustup install nightly-2017-09-20
   SHELL
 
   # Copy git configuration


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the version of rustc to a recent nightly. It also makes the changes needed to ensure everything compiles.

- `new()` became `new_unchecked()` for a few things in `std::core`. I thought about use the new `new()` (which returns an option and checks for null) but I wasn't sure how to handle that option (if it's None), and I'm not sure if the kernel components that use it would ever even hit that case anyway.
- Some new things have to be added to the crate attributes.
- Unnecessary `///` comments are now warnings.
- Unnecessary crate includes are warnings. This causes weird behavior for the nrf boards where the includes generate a warning, but without them it doesn't compile.


### Testing Strategy

This pull request has been tested on hail by running the `tests/hail` and `tests/printf_long` apps simultaneously.


### TODO or Help Wanted

This pull request should be good to go.


### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [x] `make formatall` has been run.
