### PR TITLE
Have JLinke scripts exit with a non-zero return code on error

### DIFF
--- a/boards/nrf51dk/jtag/flash-full.jlink
+++ b/boards/nrf51dk/jtag/flash-full.jlink
@@ -1,3 +1,4 @@
+eoe 1
 r
 loadfile target/thumbv6m-none-eabi/release/nrf51dk-blink.hex
 r

--- a/boards/nrf51dk/jtag/flash-kernel.jlink
+++ b/boards/nrf51dk/jtag/flash-kernel.jlink
@@ -1,3 +1,4 @@
+eoe 1
 r
 loadfile target/thumbv6m-none-eabi/release/nrf51dk.hex
 r

--- a/boards/nrf52dk/jtag/flash-full.jlink
+++ b/boards/nrf52dk/jtag/flash-full.jlink
@@ -1,3 +1,4 @@
+eoe 1
 r
 loadfile target/thumbv7em-none-eabi/release/nrf52dk-blink.hex
 r

--- a/boards/nrf52dk/jtag/flash-kernel.jlink
+++ b/boards/nrf52dk/jtag/flash-kernel.jlink
@@ -1,3 +1,4 @@
+eoe 1
 r
 loadfile target/thumbv7em-none-eabi/release/nrf52dk.hex
 r

--- a/userland/tools/flash/storm-flash-app.py
+++ b/userland/tools/flash/storm-flash-app.py
@@ -34,6 +34,7 @@ with open(build_dir+'/app_bundle.bin', 'w') as app_bin:
 
 # create jlink script
 with open(build_dir+'/flash-app.jtag', 'w') as jlink_file:
+    jlink_file.write('eoe 1\n');
     jlink_file.write('r\n');
     jlink_file.write('loadbin ' + build_dir + '/app_bundle.bin, ' + APP_BASE_ADDR + '\n');
     jlink_file.write('verifybin ' + build_dir + '/app_bundle.bin, ' + APP_BASE_ADDR + '\n');

--- a/userland/tools/program/nrf51dk.py
+++ b/userland/tools/program/nrf51dk.py
@@ -34,6 +34,7 @@ with open(build_dir+'/app_bundle.bin', 'w') as app_bin:
 
 # create jlink script
 with open(build_dir+'/flash-app.jtag', 'w') as jlink_file:
+    jlink_file.write('eoe 1\n');
     jlink_file.write('r\n');
     jlink_file.write('loadbin ' + build_dir + '/app_bundle.bin, ' + APP_BASE_ADDR + '\n');
     jlink_file.write('verifybin ' + build_dir + '/app_bundle.bin, ' + APP_BASE_ADDR + '\n');

--- a/userland/tools/program/nrf52dk.py
+++ b/userland/tools/program/nrf52dk.py
@@ -34,6 +34,7 @@ with open(build_dir+'/app_bundle.bin', 'w') as app_bin:
 
 # create jlink script
 with open(build_dir+'/flash-app.jtag', 'w') as jlink_file:
+    jlink_file.write('eoe 1\n');
     jlink_file.write('r\n');
     jlink_file.write('loadbin ' + build_dir + '/app_bundle.bin, ' + APP_BASE_ADDR + '\n');
     jlink_file.write('verifybin ' + build_dir + '/app_bundle.bin, ' + APP_BASE_ADDR + '\n');


### PR DESCRIPTION
### Pull Request Overview

This PR modifies JLink scripts they exit with a non-zero return code on error.

### Testing Strategy

1. Checkout current master (or any branch that isn't this PR).
1. Detach all JLink hardware and any board that has a JLink boot loader.
1. Run `make -C boards/nrf52dk flash`.
1. Run `echo $?`.
1. Observe that the return code is `0`, falsely representing success.
1. Checkout this branch.
1. Repeat steps 3 & 4.
1. Observe a non-zero return code, correctly representing an error.

### TODO or Help Wanted

N/A.

### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or **no updates are required**.
- [x] Userland: The application README has been added, updated, or **no updates are required**.

### Formatting

- [x] `make formatall` has been run.