### PR TITLE
Rename `kernel::container::Container` to `kernel::grant::Grant`

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -187,7 +187,7 @@ pub unsafe fn reset_handler() {
         capsules::console::Console::new(&sam4l::usart::USART0,
                      115200,
                      &mut capsules::console::WRITE_BUF,
-                     kernel::Container::create()));
+                     kernel::Grant::create()));
     hil::uart::UART::set_client(&sam4l::usart::USART0, console);
 
     // Create the Nrf51822Serialization driver for passing BLE commands
@@ -227,13 +227,13 @@ pub unsafe fn reset_handler() {
     let temp = static_init!(
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(si7021,
-                                                 kernel::Container::create()), 96/8);
+                                                 kernel::Grant::create()), 96/8);
     kernel::hil::sensors::TemperatureDriver::set_client(si7021, temp);
 
     let humidity = static_init!(
         capsules::humidity::HumiditySensor<'static>,
         capsules::humidity::HumiditySensor::new(si7021,
-                                                 kernel::Container::create()), 96/8);
+                                                 kernel::Grant::create()), 96/8);
     kernel::hil::sensors::HumidityDriver::set_client(si7021, humidity);
 
 
@@ -252,7 +252,7 @@ pub unsafe fn reset_handler() {
 
     let ambient_light = static_init!(
         capsules::ambient_light::AmbientLight<'static>,
-        capsules::ambient_light::AmbientLight::new(isl29035, kernel::Container::create()));
+        capsules::ambient_light::AmbientLight::new(isl29035, kernel::Grant::create()));
     hil::sensors::AmbientLight::set_client(isl29035, ambient_light);
 
     // Timer
@@ -261,7 +261,7 @@ pub unsafe fn reset_handler() {
         VirtualMuxAlarm::new(mux_alarm));
     let timer = static_init!(
         capsules::timer::TimerDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
-        capsules::timer::TimerDriver::new(virtual_alarm1, kernel::Container::create()));
+        capsules::timer::TimerDriver::new(virtual_alarm1, kernel::Grant::create()));
     virtual_alarm1.set_client(timer);
 
     // FXOS8700CQ accelerometer, device address 0x1e
@@ -276,7 +276,7 @@ pub unsafe fn reset_handler() {
 
     let ninedof = static_init!(
         capsules::ninedof::NineDof<'static>,
-        capsules::ninedof::NineDof::new(fxos8700, kernel::Container::create()));
+        capsules::ninedof::NineDof::new(fxos8700, kernel::Grant::create()));
     hil::sensors::NineDof::set_client(fxos8700, ninedof);
 
     // Initialize and enable SPI HAL
@@ -319,7 +319,7 @@ pub unsafe fn reset_handler() {
         [&sam4l::gpio::PA[16]]);
     let button = static_init!(
         capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Container::create()));
+        capsules::button::Button::new(button_pins, kernel::Grant::create()));
     for btn in button_pins.iter() {
         btn.set_client(button);
     }
@@ -345,7 +345,7 @@ pub unsafe fn reset_handler() {
     // Setup RNG
     let rng = static_init!(
             capsules::rng::SimpleRng<'static, sam4l::trng::Trng>,
-            capsules::rng::SimpleRng::new(&sam4l::trng::TRNG, kernel::Container::create()));
+            capsules::rng::SimpleRng::new(&sam4l::trng::TRNG, kernel::Grant::create()));
     sam4l::trng::TRNG.set_client(rng);
 
 
@@ -366,7 +366,7 @@ pub unsafe fn reset_handler() {
     // CRC
     let crc = static_init!(
         capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
-        capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, kernel::Container::create()));
+        capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, kernel::Grant::create()));
     sam4l::crccu::CRCCU.set_client(crc);
 
     // DAC
@@ -378,7 +378,7 @@ pub unsafe fn reset_handler() {
     let aes = static_init!(
         capsules::symmetric_encryption::Crypto<'static, sam4l::aes::Aes>,
         capsules::symmetric_encryption::Crypto::new(&mut sam4l::aes::AES,
-                                                    kernel::Container::create(),
+                                                    kernel::Grant::create(),
                                                     &mut capsules::symmetric_encryption::KEY,
                                                     &mut capsules::symmetric_encryption::BUF,
                                                     &mut capsules::symmetric_encryption::IV));

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -206,7 +206,7 @@ pub unsafe fn reset_handler() {
         capsules::console::Console::new(&sam4l::usart::USART3,
                      115200,
                      &mut capsules::console::WRITE_BUF,
-                     kernel::Container::create()));
+                     kernel::Grant::create()));
     hil::uart::UART::set_client(&sam4l::usart::USART3, console);
     console.initialize();
 
@@ -230,7 +230,7 @@ pub unsafe fn reset_handler() {
         VirtualMuxAlarm::new(mux_alarm));
     let timer = static_init!(
         TimerDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
-        TimerDriver::new(virtual_alarm1, kernel::Container::create()));
+        TimerDriver::new(virtual_alarm1, kernel::Grant::create()));
     virtual_alarm1.set_client(timer);
 
     // # I2C Sensors
@@ -254,7 +254,7 @@ pub unsafe fn reset_handler() {
 
     let ambient_light = static_init!(
         capsules::ambient_light::AmbientLight<'static>,
-        capsules::ambient_light::AmbientLight::new(isl29035, kernel::Container::create()));
+        capsules::ambient_light::AmbientLight::new(isl29035, kernel::Grant::create()));
     hil::sensors::AmbientLight::set_client(isl29035, ambient_light);
 
     // Set up an SPI MUX, so there can be multiple clients
@@ -297,12 +297,12 @@ pub unsafe fn reset_handler() {
     let temp = static_init!(
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(si7021,
-                                                 kernel::Container::create()), 96/8);
+                                                 kernel::Grant::create()), 96/8);
     kernel::hil::sensors::TemperatureDriver::set_client(si7021, temp);
     let humidity = static_init!(
         capsules::humidity::HumiditySensor<'static>,
         capsules::humidity::HumiditySensor::new(si7021,
-                                                 kernel::Container::create()), 96/8);
+                                                 kernel::Grant::create()), 96/8);
     kernel::hil::sensors::HumidityDriver::set_client(si7021, humidity);
 
 
@@ -331,7 +331,7 @@ pub unsafe fn reset_handler() {
     sam4l::gpio::PC[13].set_client(fxos8700);
     let ninedof = static_init!(
         capsules::ninedof::NineDof<'static>,
-        capsules::ninedof::NineDof::new(fxos8700, kernel::Container::create()));
+        capsules::ninedof::NineDof::new(fxos8700, kernel::Grant::create()));
     hil::sensors::NineDof::set_client(fxos8700, ninedof);
 
     // Clear sensors enable pin to enable sensor rail
@@ -394,14 +394,14 @@ pub unsafe fn reset_handler() {
 
     let button = static_init!(
         capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Container::create()));
+        capsules::button::Button::new(button_pins, kernel::Grant::create()));
     for btn in button_pins.iter() {
         btn.set_client(button);
     }
 
     let crc = static_init!(
         capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
-        capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, kernel::Container::create()));
+        capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, kernel::Grant::create()));
 
     rf233_spi.set_client(rf233);
     rf233.initialize(&mut RF233_BUF, &mut RF233_REG_WRITE, &mut RF233_REG_READ);
@@ -427,7 +427,7 @@ pub unsafe fn reset_handler() {
     let radio_driver = static_init!(
         capsules::ieee802154::RadioDriver<'static>,
         capsules::ieee802154::RadioDriver::new(radio_mac,
-                                               kernel::Container::create(),
+                                               kernel::Grant::create(),
                                                &mut RADIO_BUF));
     rf233_mac.set_key_procedure(radio_driver);
     rf233_mac.set_device_procedure(radio_driver);
@@ -447,7 +447,7 @@ pub unsafe fn reset_handler() {
         capsules::usb_user::UsbSyscallDriver<'static,
             capsules::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>>,
         capsules::usb_user::UsbSyscallDriver::new(
-            usb_client, kernel::Container::create()));
+            usb_client, kernel::Grant::create()));
 
     let imix = Imix {
         console: console,

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -146,7 +146,7 @@ pub unsafe fn reset_handler() {
         4 * 4);
     let button = static_init!(
         capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Container::create()),
+        capsules::button::Button::new(button_pins, kernel::Grant::create()),
         96/8);
     for btn in button_pins.iter() {
         use kernel::hil::gpio::PinCtl;
@@ -187,7 +187,7 @@ pub unsafe fn reset_handler() {
         capsules::console::Console::new(&nrf51::uart::UART0,
                                         115200,
                                         &mut capsules::console::WRITE_BUF,
-                                        kernel::Container::create()),
+                                        kernel::Grant::create()),
                                         224/8);
     UART::set_client(&nrf51::uart::UART0, console);
     console.initialize();
@@ -212,7 +212,7 @@ pub unsafe fn reset_handler() {
     let timer = static_init!(
         TimerDriver<'static, VirtualMuxAlarm<'static, Rtc>>,
         TimerDriver::new(virtual_alarm1,
-                         kernel::Container::create()),
+                         kernel::Grant::create()),
                          12);
     virtual_alarm1.set_client(timer);
 
@@ -224,19 +224,19 @@ pub unsafe fn reset_handler() {
     let temp = static_init!(
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(&mut nrf5x::temperature::TEMP,
-                                                 kernel::Container::create()), 96/8);
+                                                 kernel::Grant::create()), 96/8);
     kernel::hil::sensors::TemperatureDriver::set_client(&nrf5x::temperature::TEMP, temp);
 
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, nrf5x::trng::Trng>,
-        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, kernel::Container::create()),
+        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, kernel::Grant::create()),
         96/8);
     nrf5x::trng::TRNG.set_client(rng);
 
     let aes = static_init!(
         capsules::symmetric_encryption::Crypto<'static, nrf5x::aes::AesECB>,
         capsules::symmetric_encryption::Crypto::new(&mut nrf5x::aes::AESECB,
-                                                    kernel::Container::create(),
+                                                    kernel::Grant::create(),
                                                     &mut capsules::symmetric_encryption::KEY,
                                                     &mut capsules::symmetric_encryption::BUF,
                                                     &mut capsules::symmetric_encryption::IV),
@@ -249,7 +249,7 @@ pub unsafe fn reset_handler() {
         <'static, nrf51::radio::Radio, VirtualMuxAlarm<'static, Rtc>>,
      nrf5x::ble_advertising_driver::BLE::new(
          &mut nrf51::radio::RADIO,
-         kernel::Container::create(),
+         kernel::Grant::create(),
          &mut nrf5x::ble_advertising_driver::BUF,
          ble_radio_virtual_alarm),
         256/8);

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -223,7 +223,7 @@ pub unsafe fn reset_handler() {
         4 * 4);
     let button = static_init!(
         capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Container::create()),
+        capsules::button::Button::new(button_pins, kernel::Grant::create()),
         96/8);
     for btn in button_pins.iter() {
         use kernel::hil::gpio::PinCtl;
@@ -247,7 +247,7 @@ pub unsafe fn reset_handler() {
         capsules::timer::TimerDriver<'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>>,
         capsules::timer::TimerDriver::new(virtual_alarm1,
-                         kernel::Container::create()),
+                         kernel::Grant::create()),
                          12);
     virtual_alarm1.set_client(timer);
     let ble_radio_virtual_alarm = static_init!(
@@ -264,7 +264,7 @@ pub unsafe fn reset_handler() {
         capsules::console::Console::new(&nrf52::uart::UART0,
                                         115200,
                                         &mut capsules::console::WRITE_BUF,
-                                        kernel::Container::create()),
+                                        kernel::Grant::create()),
                                         224/8);
     kernel::hil::uart::UART::set_client(&nrf52::uart::UART0, console);
     console.initialize();
@@ -282,7 +282,7 @@ pub unsafe fn reset_handler() {
         <'static, nrf52::radio::Radio, VirtualMuxAlarm<'static, Rtc>>,
      nrf5x::ble_advertising_driver::BLE::new(
          &mut nrf52::radio::RADIO,
-         kernel::Container::create(),
+         kernel::Grant::create(),
          &mut nrf5x::ble_advertising_driver::BUF,
          ble_radio_virtual_alarm),
         256/8);
@@ -293,20 +293,20 @@ pub unsafe fn reset_handler() {
     let temp = static_init!(
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(&mut nrf5x::temperature::TEMP,
-                                                 kernel::Container::create()), 96/8);
+                                                 kernel::Grant::create()), 96/8);
     kernel::hil::sensors::TemperatureDriver::set_client(&nrf5x::temperature::TEMP, temp);
 
 
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, nrf5x::trng::Trng>,
-        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, kernel::Container::create()),
+        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, kernel::Grant::create()),
         96/8);
     nrf5x::trng::TRNG.set_client(rng);
 
     let aes = static_init!(
         capsules::symmetric_encryption::Crypto<'static, nrf5x::aes::AesECB>,
         capsules::symmetric_encryption::Crypto::new(&mut nrf5x::aes::AESECB,
-                                                    kernel::Container::create(),
+                                                    kernel::Grant::create(),
                                                     &mut capsules::symmetric_encryption::KEY,
                                                     &mut capsules::symmetric_encryption::BUF,
                                                     &mut capsules::symmetric_encryption::IV),

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -9,12 +9,12 @@
 //! let ninedof = static_init!(
 //!     capsules::sensors::AmbientLight<'static>,
 //!     capsules::sensors::AmbientLight::new(isl29035,
-//!         kernel::Container::create()));
+//!         kernel::Grant::create()));
 //! hil::sensors::AmbientLight::set_client(isl29035, ambient_light);
 //! ```
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Container, Driver, ReturnCode};
+use kernel::{AppId, Callback, Grant, Driver, ReturnCode};
 use kernel::hil;
 
 /// Per-process metdata
@@ -27,15 +27,15 @@ pub struct App {
 pub struct AmbientLight<'a> {
     sensor: &'a hil::sensors::AmbientLight,
     command_pending: Cell<bool>,
-    apps: Container<App>,
+    apps: Grant<App>,
 }
 
 impl<'a> AmbientLight<'a> {
-    pub fn new(sensor: &'a hil::sensors::AmbientLight, container: Container<App>) -> AmbientLight {
+    pub fn new(sensor: &'a hil::sensors::AmbientLight, grant: Grant<App>) -> AmbientLight {
         AmbientLight {
             sensor: sensor,
             command_pending: Cell::new(false),
-            apps: container,
+            apps: grant,
         }
     }
 

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -17,12 +17,12 @@
 //! let app_flash = static_init!(
 //!     capsules::app_flash_driver::AppFlash<'static>,
 //!     capsules::app_flash_driver::AppFlash::new(nv_to_page,
-//!         kernel::Container::create(), &mut APP_FLASH_BUFFER));
+//!         kernel::Grant::create(), &mut APP_FLASH_BUFFER));
 //! ```
 
 use core::cell::Cell;
 use core::cmp;
-use kernel::{AppId, AppSlice, Callback, Container, Driver, ReturnCode, Shared};
+use kernel::{AppId, AppSlice, Callback, Grant, Driver, ReturnCode, Shared};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
 
@@ -46,19 +46,19 @@ impl Default for App {
 
 pub struct AppFlash<'a> {
     driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
-    apps: Container<App>,
+    apps: Grant<App>,
     current_app: Cell<Option<AppId>>,
     buffer: TakeCell<'static, [u8]>,
 }
 
 impl<'a> AppFlash<'a> {
     pub fn new(driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
-               container: Container<App>,
+               grant: Grant<App>,
                buffer: &'static mut [u8])
                -> AppFlash<'a> {
         AppFlash {
             driver: driver,
-            apps: container,
+            apps: grant,
             current_app: Cell::new(None),
             buffer: TakeCell::new(buffer),
         }

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -13,14 +13,14 @@
 //!     [&sam4l::gpio::PA[16]]);
 //! let button = static_init!(
 //!     capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
-//!     capsules::button::Button::new(button_pins, kernel::Container::create()));
+//!     capsules::button::Button::new(button_pins, kernel::Grant::create()));
 //! for btn in button_pins.iter() {
 //!     btn.set_client(button);
 //! }
 //! ```
 
 use core::cell::Cell;
-use kernel::{AppId, Container, Callback, Driver, ReturnCode};
+use kernel::{AppId, Grant, Callback, Driver, ReturnCode};
 use kernel::hil;
 use kernel::hil::gpio::{Client, InterruptMode};
 
@@ -28,13 +28,11 @@ pub type SubscribeMap = u32;
 
 pub struct Button<'a, G: hil::gpio::Pin + 'a> {
     pins: &'a [&'a G],
-    callback: Container<(Option<Callback>, SubscribeMap)>,
+    callback: Grant<(Option<Callback>, SubscribeMap)>,
 }
 
 impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Button<'a, G> {
-    pub fn new(pins: &'a [&'a G],
-               container: Container<(Option<Callback>, SubscribeMap)>)
-               -> Button<'a, G> {
+    pub fn new(pins: &'a [&'a G], grant: Grant<(Option<Callback>, SubscribeMap)>) -> Button<'a, G> {
         // Make all pins output and off
         for pin in pins.iter() {
             pin.make_input();
@@ -42,7 +40,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Button<'a, G> {
 
         Button {
             pins: pins,
-            callback: container,
+            callback: grant,
         }
     }
 }

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -11,7 +11,7 @@
 //!     Console::new(&usart::USART0,
 //!                  115200,
 //!                  &mut console::WRITE_BUF,
-//!                  kernel::Container::create()));
+//!                  kernel::Grant::create()));
 //! hil::uart::UART::set_client(&usart::USART0, console);
 //! ```
 //!
@@ -37,7 +37,7 @@
 
 use core::cell::Cell;
 use core::cmp;
-use kernel::{AppId, AppSlice, Container, Callback, Shared, Driver, ReturnCode};
+use kernel::{AppId, AppSlice, Grant, Callback, Shared, Driver, ReturnCode};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::uart::{self, UART, Client};
 use kernel::process::Error;
@@ -70,7 +70,7 @@ pub static mut WRITE_BUF: [u8; 64] = [0; 64];
 
 pub struct Console<'a, U: UART + 'a> {
     uart: &'a U,
-    apps: Container<App>,
+    apps: Grant<App>,
     in_progress: Cell<Option<AppId>>,
     tx_buffer: TakeCell<'static, [u8]>,
     baud_rate: u32,
@@ -80,11 +80,11 @@ impl<'a, U: UART> Console<'a, U> {
     pub fn new(uart: &'a U,
                baud_rate: u32,
                tx_buffer: &'static mut [u8],
-               container: Container<App>)
+               grant: Grant<App>)
                -> Console<'a, U> {
         Console {
             uart: uart,
-            apps: container,
+            apps: grant,
             in_progress: Cell::new(None),
             tx_buffer: TakeCell::new(tx_buffer),
             baud_rate: baud_rate,

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -3,14 +3,14 @@
 //! ## Instantiation
 //!
 //! Instantiate the capsule for use as a system call driver with a hardware
-//! implementation and a `Container` for the `App` type, and set the result as a
+//! implementation and a `Grant` for the `App` type, and set the result as a
 //! client of the hardware implementation. For example, using the SAM4L's `CRCU`
 //! driver:
 //!
 //! ```rust
 //! let crc = static_init!(
 //!     capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
-//!     capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, kernel::Container::create()));
+//!     capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, kernel::Grant::create()));
 //! sam4l::crccu::CRCCU.set_client(crc);
 //!
 //! ```
@@ -66,7 +66,7 @@
 //! the SAM4L.
 
 use core::cell::Cell;
-use kernel::{AppId, AppSlice, Container, Callback, Driver, ReturnCode, Shared};
+use kernel::{AppId, AppSlice, Grant, Callback, Driver, ReturnCode, Shared};
 use kernel::hil;
 use kernel::hil::crc::CrcAlg;
 use kernel::process::Error;
@@ -86,7 +86,7 @@ pub struct App {
 /// processes through the system call interface.
 pub struct Crc<'a, C: hil::crc::CRC + 'a> {
     crc_unit: &'a C,
-    apps: Container<App>,
+    apps: Grant<App>,
     serving_app: Cell<Option<AppId>>,
 }
 
@@ -95,17 +95,17 @@ impl<'a, C: hil::crc::CRC> Crc<'a, C> {
     ///
     /// The argument `crc_unit` must implement the abstract `CRC`
     /// hardware interface.  The argument `apps` should be an empty
-    /// kernel `Container`, and will be used to track application
+    /// kernel `Grant`, and will be used to track application
     /// requests.
     ///
     /// ## Example
     ///
     /// ```
-    /// capsules::crc::Crc::new(&sam4l::crccu::CRCCU, kernel::Container::create()),
+    /// capsules::crc::Crc::new(&sam4l::crccu::CRCCU, kernel::Grant::create()),
     ///
     /// ```
     ///
-    pub fn new(crc_unit: &'a C, apps: Container<App>) -> Crc<'a, C> {
+    pub fn new(crc_unit: &'a C, apps: Grant<App>) -> Crc<'a, C> {
         Crc {
             crc_unit: crc_unit,
             apps: apps,

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -42,12 +42,12 @@
 //! let humidity = static_init!(
 //!        capsules::humidity::HumiditySensor<'static>,
 //!        capsules::humidity::HumiditySensor::new(si7021,
-//!                                                 kernel::Container::create()), 96/8);
+//!                                                 kernel::Grant::create()), 96/8);
 //! kernel::hil::sensors::HumidityDriver::set_client(si7021, humidity);
 //! ```
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Container, Driver};
+use kernel::{AppId, Callback, Grant, Driver};
 use kernel::ReturnCode;
 use kernel::hil;
 
@@ -65,17 +65,15 @@ pub struct App {
 
 pub struct HumiditySensor<'a> {
     driver: &'a hil::sensors::HumidityDriver,
-    apps: Container<App>,
+    apps: Grant<App>,
     busy: Cell<bool>,
 }
 
 impl<'a> HumiditySensor<'a> {
-    pub fn new(driver: &'a hil::sensors::HumidityDriver,
-               container: Container<App>)
-               -> HumiditySensor<'a> {
+    pub fn new(driver: &'a hil::sensors::HumidityDriver, grant: Grant<App>) -> HumiditySensor<'a> {
         HumiditySensor {
             driver: driver,
-            apps: container,
+            apps: grant,
             busy: Cell::new(false),
         }
     }

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -7,7 +7,7 @@
 use core::cell::Cell;
 use core::cmp::min;
 use ieee802154::mac;
-use kernel::{AppId, Driver, Callback, AppSlice, Shared, Container, ReturnCode};
+use kernel::{AppId, Driver, Callback, AppSlice, Shared, Grant, ReturnCode};
 use kernel::common::take_cell::{MapCell, TakeCell};
 
 use net::ieee802154::{MacAddress, PanID, Header, SecurityLevel, KeyId, AddressMode};
@@ -178,8 +178,8 @@ pub struct RadioDriver<'a> {
     /// Actual number of keys in the fixed size array of keys.
     num_keys: Cell<usize>,
 
-    /// Container of apps that use this radio driver.
-    apps: Container<App>,
+    /// Grant of apps that use this radio driver.
+    apps: Grant<App>,
     /// ID of app whose transmission request is being processed.
     current_app: Cell<Option<AppId>>,
 
@@ -189,7 +189,7 @@ pub struct RadioDriver<'a> {
 
 impl<'a> RadioDriver<'a> {
     pub fn new(mac: &'a mac::Mac<'a>,
-               container: Container<App>,
+               grant: Grant<App>,
                kernel_tx: &'static mut [u8])
                -> RadioDriver<'a> {
         RadioDriver {
@@ -198,7 +198,7 @@ impl<'a> RadioDriver<'a> {
             num_neighbors: Cell::new(0),
             keys: MapCell::new(Default::default()),
             num_keys: Cell::new(0),
-            apps: container,
+            apps: grant,
             current_app: Cell::new(None),
             kernel_tx: TakeCell::new(kernel_tx),
         }

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -8,12 +8,12 @@
 //! ``rust
 //! let ninedof = static_init!(
 //!     capsules::ninedof::NineDof<'static>,
-//!     capsules::ninedof::NineDof::new(fxos8700, kernel::Container::create()));
+//!     capsules::ninedof::NineDof::new(fxos8700, kernel::Grant::create()));
 //! hil::sensors::NineDof::set_client(fxos8700, ninedof);
 //! ```
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Container, Driver};
+use kernel::{AppId, Callback, Grant, Driver};
 use kernel::ReturnCode;
 use kernel::hil;
 
@@ -46,15 +46,15 @@ impl Default for App {
 
 pub struct NineDof<'a> {
     driver: &'a hil::sensors::NineDof,
-    apps: Container<App>,
+    apps: Grant<App>,
     current_app: Cell<Option<AppId>>,
 }
 
 impl<'a> NineDof<'a> {
-    pub fn new(driver: &'a hil::sensors::NineDof, container: Container<App>) -> NineDof<'a> {
+    pub fn new(driver: &'a hil::sensors::NineDof, grant: Grant<App>) -> NineDof<'a> {
         NineDof {
             driver: driver,
-            apps: container,
+            apps: grant,
             current_app: Cell::new(None),
         }
     }

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -38,7 +38,7 @@
 //!     capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
 //!     capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
 //!         fm25cl,                      // The underlying storage driver.
-//!         kernel::Container::create(), // Storage for app-specific state.
+//!         kernel::Grant::create(), // Storage for app-specific state.
 //!         3000,                        // The byte start address for the userspace
 //!                                      // accessible memory region.
 //!         2000,                        // The length of the userspace region.
@@ -51,7 +51,7 @@
 
 use core::cell::Cell;
 use core::cmp;
-use kernel::{AppId, AppSlice, Callback, Container, Driver, ReturnCode, Shared};
+use kernel::{AppId, AppSlice, Callback, Grant, Driver, ReturnCode, Shared};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
 
@@ -101,7 +101,7 @@ pub struct NonvolatileStorage<'a> {
     // The underlying physical storage device.
     driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
     // Per-app state.
-    apps: Container<App>,
+    apps: Grant<App>,
 
     // Internal buffer for copying appslices into.
     buffer: TakeCell<'static, [u8]>,
@@ -134,7 +134,7 @@ pub struct NonvolatileStorage<'a> {
 
 impl<'a> NonvolatileStorage<'a> {
     pub fn new(driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
-               container: Container<App>,
+               grant: Grant<App>,
                userspace_start_address: usize,
                userspace_length: usize,
                kernel_start_address: usize,
@@ -143,7 +143,7 @@ impl<'a> NonvolatileStorage<'a> {
                -> NonvolatileStorage<'a> {
         NonvolatileStorage {
             driver: driver,
-            apps: container,
+            apps: grant,
             buffer: TakeCell::new(buffer),
             current_user: Cell::new(None),
             userspace_start_address: userspace_start_address,

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -10,12 +10,12 @@
 //! ```rust
 //! let rng = static_init!(
 //!         capsules::rng::SimpleRng<'static, sam4l::trng::Trng>,
-//!         capsules::rng::SimpleRng::new(&sam4l::trng::TRNG, kernel::Container::create()));
+//!         capsules::rng::SimpleRng::new(&sam4l::trng::TRNG, kernel::Grant::create()));
 //! sam4l::trng::TRNG.set_client(rng);
 //! ```
 
 use core::cell::Cell;
-use kernel::{AppId, AppSlice, Container, Callback, Driver, ReturnCode, Shared};
+use kernel::{AppId, AppSlice, Grant, Callback, Driver, ReturnCode, Shared};
 use kernel::hil::rng;
 use kernel::process::Error;
 
@@ -39,15 +39,15 @@ impl Default for App {
 
 pub struct SimpleRng<'a, RNG: rng::RNG + 'a> {
     rng: &'a RNG,
-    apps: Container<App>,
+    apps: Grant<App>,
     getting_randomness: Cell<bool>,
 }
 
 impl<'a, RNG: rng::RNG> SimpleRng<'a, RNG> {
-    pub fn new(rng: &'a RNG, container: Container<App>) -> SimpleRng<'a, RNG> {
+    pub fn new(rng: &'a RNG, grant: Grant<App>) -> SimpleRng<'a, RNG> {
         SimpleRng {
             rng: rng,
-            apps: container,
+            apps: grant,
             getting_randomness: Cell::new(false),
         }
     }

--- a/capsules/src/symmetric_encryption.rs
+++ b/capsules/src/symmetric_encryption.rs
@@ -70,7 +70,7 @@
 // Date: March 31, 2017
 
 use core::cell::Cell;
-use kernel::{AppId, AppSlice, Container, Callback, Driver, ReturnCode, Shared};
+use kernel::{AppId, AppSlice, Grant, Callback, Driver, ReturnCode, Shared};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::symmetric_encryption::{SymmetricEncryption, Client};
 
@@ -109,7 +109,7 @@ impl Default for App {
 
 pub struct Crypto<'a, E: SymmetricEncryption + 'a> {
     crypto: &'a E,
-    apps: Container<App>,
+    apps: Grant<App>,
     kernel_key: TakeCell<'static, [u8]>,
     kernel_data: TakeCell<'static, [u8]>,
     kernel_ctr: TakeCell<'static, [u8]>,
@@ -120,14 +120,14 @@ pub struct Crypto<'a, E: SymmetricEncryption + 'a> {
 
 impl<'a, E: SymmetricEncryption + 'a> Crypto<'a, E> {
     pub fn new(crypto: &'a E,
-               container: Container<App>,
+               grant: Grant<App>,
                key: &'static mut [u8],
                data: &'static mut [u8],
                ctr: &'static mut [u8])
                -> Crypto<'a, E> {
         Crypto {
             crypto: crypto,
-            apps: container,
+            apps: grant,
             kernel_key: TakeCell::new(key),
             kernel_data: TakeCell::new(data),
             kernel_ctr: TakeCell::new(ctr),

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -42,12 +42,12 @@
 //! let temp = static_init!(
 //!        capsules::temperature::TemperatureSensor<'static>,
 //!        capsules::temperature::TemperatureSensor::new(si7021,
-//!                                                 kernel::Container::create()), 96/8);
+//!                                                 kernel::Grant::create()), 96/8);
 //! kernel::hil::sensors::TemperatureDriver::set_client(si7021, temp);
 //! ```
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Container, Driver};
+use kernel::{AppId, Callback, Grant, Driver};
 use kernel::ReturnCode;
 use kernel::hil;
 
@@ -59,17 +59,17 @@ pub struct App {
 
 pub struct TemperatureSensor<'a> {
     driver: &'a hil::sensors::TemperatureDriver,
-    apps: Container<App>,
+    apps: Grant<App>,
     busy: Cell<bool>,
 }
 
 impl<'a> TemperatureSensor<'a> {
     pub fn new(driver: &'a hil::sensors::TemperatureDriver,
-               container: Container<App>)
+               grant: Grant<App>)
                -> TemperatureSensor<'a> {
         TemperatureSensor {
             driver: driver,
-            apps: container,
+            apps: grant,
             busy: Cell::new(false),
         }
     }

--- a/capsules/src/timer.rs
+++ b/capsules/src/timer.rs
@@ -1,7 +1,7 @@
 //! Provides userspace applications with a timer API.
 
 use core::cell::Cell;
-use kernel::{AppId, Callback, Container, Driver, ReturnCode};
+use kernel::{AppId, Callback, Grant, Driver, ReturnCode};
 use kernel::hil::time::{self, Alarm, Frequency};
 use kernel::process::Error;
 
@@ -33,15 +33,15 @@ impl Default for TimerData {
 pub struct TimerDriver<'a, A: Alarm + 'a> {
     alarm: &'a A,
     num_armed: Cell<usize>,
-    app_timer: Container<TimerData>,
+    app_timer: Grant<TimerData>,
 }
 
 impl<'a, A: Alarm> TimerDriver<'a, A> {
-    pub const fn new(alarm: &'a A, container: Container<TimerData>) -> TimerDriver<'a, A> {
+    pub const fn new(alarm: &'a A, grant: Grant<TimerData>) -> TimerDriver<'a, A> {
         TimerDriver {
             alarm: alarm,
             num_armed: Cell::new(0),
-            app_timer: container,
+            app_timer: grant,
         }
     }
 

--- a/capsules/src/usb_user.rs
+++ b/capsules/src/usb_user.rs
@@ -6,7 +6,7 @@
 //!
 //! The `UsbSyscallDriver` must be created by passing a reference to something
 //! that implements `hil::usb::Client` (that is, something that is connected to
-//! the USBC), as well as a `Container` for managing application requests.  For
+//! the USBC), as well as a `Grant` for managing application requests.  For
 //! example:
 //!
 //! ```rust
@@ -21,11 +21,11 @@
 //!     capsules::usb_user::UsbSyscallDriver<'static,
 //!         capsules::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>>,
 //!     capsules::usb_user::UsbSyscallDriver::new(
-//!         usb_client, kernel::Container::create()));
+//!         usb_client, kernel::Grant::create()));
 //! ```
 
 use core::cell::Cell;
-use kernel::{AppId, Container, Callback, Driver, ReturnCode};
+use kernel::{AppId, Grant, Callback, Driver, ReturnCode};
 use kernel::hil;
 
 #[derive(Default)]
@@ -36,14 +36,14 @@ pub struct App {
 
 pub struct UsbSyscallDriver<'a, C: hil::usb::Client + 'a> {
     usbc_client: &'a C,
-    apps: Container<App>,
+    apps: Grant<App>,
     serving_app: Cell<Option<AppId>>,
 }
 
 impl<'a, C> UsbSyscallDriver<'a, C>
     where C: hil::usb::Client
 {
-    pub fn new(usbc_client: &'a C, apps: Container<App>) -> Self {
+    pub fn new(usbc_client: &'a C, apps: Grant<App>) -> Self {
         UsbSyscallDriver {
             usbc_client: usbc_client,
             apps: apps,

--- a/chips/nrf5x/src/ble_advertising_driver.rs
+++ b/chips/nrf5x/src/ble_advertising_driver.rs
@@ -124,7 +124,7 @@ pub struct BLE<'a, B, A>
 {
     radio: &'a B,
     busy: Cell<bool>,
-    app: kernel::Container<App>,
+    app: kernel::Grant<App>,
     kernel_tx: kernel::common::take_cell::TakeCell<'static, [u8]>,
     alarm: &'a A,
     advertisement_interval: Cell<u32>,
@@ -137,7 +137,7 @@ impl<'a, B, A> BLE<'a, B, A>
           A: kernel::hil::time::Alarm + 'a
 {
     pub fn new(radio: &'a B,
-               container: kernel::Container<App>,
+               container: kernel::Grant<App>,
                tx_buf: &'static mut [u8],
                alarm: &'a A)
                -> BLE<'a, B, A> {

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -25,7 +25,7 @@ const BUF_SIZE: usize = 1024;
 
 pub struct DebugWriter {
     driver: Option<&'static Driver>,
-    pub container: Option<*mut u8>,
+    pub grant: Option<*mut u8>,
     output_buffer: [u8; BUF_SIZE],
     output_head: usize,
     output_tail: usize,
@@ -35,7 +35,7 @@ pub struct DebugWriter {
 
 static mut DEBUG_WRITER: DebugWriter = DebugWriter {
     driver: None,
-    container: None,
+    grant: None,
     output_buffer: [0; BUF_SIZE],
     output_head: 0, // ........ first valid index in output_buffer
     output_tail: 0, // ........ one past last valid index (wraps to 0)
@@ -43,16 +43,16 @@ static mut DEBUG_WRITER: DebugWriter = DebugWriter {
     count: 0, // .............. how many debug! calls
 };
 
-pub unsafe fn assign_console_driver<T>(driver: Option<&'static Driver>, container: &mut T) {
-    let ptr: *mut u8 = ::core::mem::transmute(container);
+pub unsafe fn assign_console_driver<T>(driver: Option<&'static Driver>, grant: &mut T) {
+    let ptr: *mut u8 = ::core::mem::transmute(grant);
     DEBUG_WRITER.driver = driver;
-    DEBUG_WRITER.container = Some(ptr);
+    DEBUG_WRITER.grant = Some(ptr);
 }
 
-pub unsafe fn get_container<T>() -> *mut T {
-    match DEBUG_WRITER.container {
-        Some(container) => ::core::mem::transmute(container),
-        None => panic!("Request for unallocated kernel container"),
+pub unsafe fn get_grant<T>() -> *mut T {
+    match DEBUG_WRITER.grant {
+        Some(grant) => ::core::mem::transmute(grant),
+        None => panic!("Request for unallocated kernel grant"),
     }
 }
 

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -3,7 +3,7 @@
 //! This is a special syscall driver that allows userspace applications to
 //! share memory.
 
-use {AppId, AppSlice, Container, Callback, Driver, Shared};
+use {AppId, AppSlice, Grant, Callback, Driver, Shared};
 use process;
 use returncode::ReturnCode;
 
@@ -24,12 +24,12 @@ impl Default for IPCData {
 }
 
 pub struct IPC {
-    data: Container<IPCData>,
+    data: Grant<IPCData>,
 }
 
 impl IPC {
     pub unsafe fn new() -> IPC {
-        IPC { data: Container::create() }
+        IPC { data: Grant::create() }
     }
 
     pub unsafe fn schedule_callback(&self,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -5,7 +5,7 @@
 pub mod common;
 
 pub mod callback;
-pub mod container;
+pub mod grant;
 #[macro_use]
 pub mod debug;
 pub mod driver;
@@ -29,8 +29,8 @@ mod syscall;
 mod platform;
 
 pub use callback::{AppId, Callback};
-pub use container::Container;
 pub use driver::Driver;
+pub use grant::Grant;
 pub use mem::{AppSlice, AppPtr, Private, Shared};
 pub use platform::{Chip, mpu, Platform, systick};
 pub use platform::systick::SysTick;


### PR DESCRIPTION
### Pull Request Overview

We've been talking about this structure as a "Grant" for a while, including now in a published paper. This change simply renames this structure to "Grant" instead of "Container". There is no change in functionality as this is only a change in the name.

### Testing Strategy

This pull request was tested by compiling all boards.

### TODO or Help Wanted

N/A

### Documentation Updated

The documentation generally already refers to these as grants.

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [x] `make formatall` has been run.
