### PR TITLE
kernel: move kernel stack to bottom of RAM

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -196,6 +196,21 @@ SECTIONS
 
     .sram (NOLOAD) :
     {
+        /* Kernel stack.
+         *
+         * To keep all kernel memory contiguous (eases MPU protection of kernel
+         * data), Tock next places its own stack into SRAM.
+         */
+        . = ALIGN(8);
+         _sstack = .;
+
+        . = . + __stack_size__;
+
+        . = ALIGN(8);
+        _estack = .;
+
+
+
         /* Kernel BSS section. Memory that is expected to be initialized to
          * zero.
          *
@@ -214,21 +229,6 @@ SECTIONS
 
         . = ALIGN(4);
         _ezero = .;
-
-
-
-        /* Kernel stack.
-         *
-         * To keep all kernel memory contiguous (eases MPU protection of kernel
-         * data), Tock next places its own stack into SRAM.
-         */
-        . = ALIGN(8);
-         _sstack = .;
-
-        . = . + __stack_size__;
-
-        . = ALIGN(8);
-        _estack = .;
 
 
 

--- a/doc/Memory_Layout.md
+++ b/doc/Memory_Layout.md
@@ -57,9 +57,9 @@ or 0xFF.
 
 RAM contains four major regions:
 
-1. Kernel data: initialized memory, copied from flash at boot.
-2. Kernel BSS: uninitialized memory, zeroed at boot.
-3. Kernel stack.
+1. Kernel stack.
+2. Kernel data: initialized memory, copied from flash at boot.
+3. Kernel BSS: uninitialized memory, zeroed at boot.
 4. Process memory: memory space divided between all running apps.
 
 


### PR DESCRIPTION
### Pull Request Overview

Following the same argument from #289, move the kernel stack to
the bottom of RAM so that it faults rather than overwriting bss

### Testing Strategy

Loading several apps on a hail (hail test app, accel leds)

### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated.
- [x] Userland: No updates are required.

### Formatting

- [x] `make formatall` has been run.
