### PR TITLE
Efficient app ram

### DIFF
--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -142,6 +142,8 @@ impl kernel::mpu::MPU for MPU {
             return None;
         }
 
+        //XXX: need to check if length is a power of two
+
         // There are two possibilities we support:
         //
         // 1. The base address is aligned exactly to the size of the region,
@@ -174,6 +176,7 @@ impl kernel::mpu::MPU for MPU {
         } else {
             // Memory base not aligned to memory size
 
+            /*
             // Which (power-of-two) subregion size would align with the base
             // address?
             //
@@ -192,6 +195,16 @@ impl kernel::mpu::MPU for MPU {
                     0
                 }
             };
+            */
+
+            // find smallest region that could encapsulate the app needs
+            let mut subregion_size = 32;
+            while subregion_size < 4*1024*1024/8 && 8*subregion_size < len {
+                subregion_size *= 2;
+            }
+            if start % subregion_size != 0 {
+                panic!("Infeasible MPU alignment!!\n");
+            }
 
             // Once we have a subregion size, we get a region size by
             // multiplying it by the number of subregions per region.
@@ -204,12 +217,14 @@ impl kernel::mpu::MPU for MPU {
                 // Sanity check that the amount left over space in the region
                 // after `start` is at least as large as the memory region we
                 // want to reference.
+                debug!("Fail1");
                 return None;
             }
             if len % subregion_size != 0 {
                 // Sanity check that there is some integer X such that
                 // subregion_size * X == len so none of `len` is left over when
                 // we take the max_subregion.
+                debug!("Fail2");
                 return None;
             }
 

--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -199,7 +199,7 @@ impl kernel::mpu::MPU for MPU {
 
             // find smallest region that could encapsulate the app needs
             let mut subregion_size = 32;
-            while subregion_size < 4*1024*1024/8 && 8*subregion_size < len {
+            while subregion_size < 4 * 1024 * 1024 / 8 && 8 * subregion_size < len {
                 subregion_size *= 2;
             }
             if start % subregion_size != 0 {

--- a/userland/examples/bigapp/Makefile
+++ b/userland/examples/bigapp/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/bigapp/main.c
+++ b/userland/examples/bigapp/main.c
@@ -1,0 +1,40 @@
+/* vim: set sw=2 expandtab tw=80: */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <console.h>
+
+//#define BUFSIZE 27*1024 works normally
+//#define BUFSIZE 45*1024 hardfaults
+#define BUFSIZE 38*1024
+static uint8_t bigbuf[BUFSIZE];
+
+int main(void) {
+  printf("Staring bigapp\n");
+
+  printf("Writing buffer...\n");
+  for (int i=0; i<BUFSIZE; i++) {
+    bigbuf[i] = (uint8_t)i;
+
+    if (i%1024 == 0) {
+      printf("At %d kB\n", i/1024);
+    }
+  }
+
+  printf("Checking buffer...\n");
+  for (int i=0; i<BUFSIZE; i++) {
+    if (bigbuf[i] != (uint8_t)i) {
+      printf("ERROR: bigbuf[%d] equals %u not %u\n", i, bigbuf[i], (uint8_t)i);
+    }
+
+    if (i%1024 == 0) {
+      printf("At %d kB\n", i/1024);
+    }
+  }
+
+  printf("Complete!\n");
+}
+


### PR DESCRIPTION
### Pull Request Overview

This pull request starts making app RAM usage more efficient. Currently, we just round up to the nearest power of two. So an app requiring 9 kB of RAM is allocated 16 kB. We can do better by using MPU subregions though, in the 9 kB example, the app would be allocated 10 kB with a 16 kB MPU region of which five 2 kB subregions are active. This would also allow bigger Tock applications, by enabling applications to use up to 48 kB of RAM, which is the original motivation for this pull request.

I spent a couple hours playing with this idea, but ran out of time to work on it at the moment. I will get back to this in mid-October after Signpost demos are complete.

The current status is not working. The testing app I created is allocated, but various hardfaults or MPU violation faults depending on how much RAM it uses. Needs debugging, cleanup, and serious testing.

### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

Debugging, testing, and cleanup


### Documentation Updated

- [ ] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [ ] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [ ] `make formatall` has been run.
