### PR TITLE
Example app that sends sensor data over 15.4

### DIFF
--- a/userland/examples/ip_sense/Makefile
+++ b/userland/examples/ip_sense/Makefile
@@ -1,0 +1,13 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+APP_HEAP_SIZE := 2048
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/ip_sense/README.md
+++ b/userland/examples/ip_sense/README.md
@@ -1,24 +1,33 @@
 IP Sensor App
 =============
 
-An example app for platforms with sensors and an 802.15.4 radio that broadcasts period sensor readings over the network. Currently, it sends packets in raw 802.15.4 packets with statically configured PAN, source and destination addresses, but as support is added for 6lowpan, Thread, etc, this app will evolve to use those instead.
+An example app for platforms with sensors and an 802.15.4 radio that broadcasts
+periodic sensor readings over the network. Currently, it sends raw 802.15.4
+packets with statically configured PAN, source and destination addresses, but
+as support is added for 6lowpan, Thread, etc, this app will evolve to use those
+instead.
 
 ## Running
 
-Program the kernel on two imixs. On one, program the `radio_rx` app in `userland/examples/tests/ieee802154/radio_rx` with the `PRINT_PAYLOAD` and `PRINT_STRING` options enabled (this app simply prints received 802154 packets to the console). On the other, program the `ip_sense` app. You'll see packets printed on the console of the form:
+Program the kernel on two imixs. On one, program the `radio_rx` app in
+`userland/examples/tests/ieee802154/radio_rx` with the `PRINT_PAYLOAD` and
+`PRINT_STRING` options enabled (this app simply prints received 802.15.4
+packets to the console). On the other, program the `ip_sense` app.
+
+You'll see packets printed on the console of the form:
 
 ```
-Packet destination PAN ID: 0xabcd                         
-Packet destination address: 0x0802                        
-Packet source PAN ID: 0xabcd                              
-Packet source address: 0x1540                             
-Received packet with payload of 28 bytes from offset 11   
-2848 deg C; 3457%; 500 lux;                               
+Packet destination PAN ID: 0xabcd
+Packet destination address: 0x0802
+Packet source PAN ID: 0xabcd
+Packet source address: 0x1540
+Received packet with payload of 28 bytes from offset 11
+2848 deg C; 3457%; 500 lux;
 
-Packet destination PAN ID: 0xabcd                         
-Packet destination address: 0x0802                        
-Packet source PAN ID: 0xabcd                              
-Packet source address: 0x1540                             
-Received packet with payload of 28 bytes from offset 11   
-2848 deg C; 3456%; 500 lux; 
+Packet destination PAN ID: 0xabcd
+Packet destination address: 0x0802
+Packet source PAN ID: 0xabcd
+Packet source address: 0x1540
+Received packet with payload of 28 bytes from offset 11
+2848 deg C; 3456%; 500 lux;
 ```

--- a/userland/examples/ip_sense/README.md
+++ b/userland/examples/ip_sense/README.md
@@ -1,6 +1,24 @@
 IP Sensor App
 =============
 
-Reads on board sensors periodically and transmits them over the network.
-Currently, it "simulates" a real IP network with a raw 802.15.4 interface, but
-that will evolve. Only works, currently, on the imix board.
+An example app for platforms with sensors and an 802.15.4 radio that broadcasts period sensor readings over the network. Currently, it sends packets in raw 802.15.4 packets with statically configured PAN, source and destination addresses, but as support is added for 6lowpan, Thread, etc, this app will evolve to use those instead.
+
+## Running
+
+Program the kernel on two imixs. On one, program the `radio_rx` app in `userland/examples/tests/ieee802154/radio_rx` with the `PRINT_PAYLOAD` and `PRINT_STRING` options enabled (this app simply prints received 802154 packets to the console). On the other, program the `ip_sense` app. You'll see packets printed on the console of the form:
+
+```
+Packet destination PAN ID: 0xabcd                         
+Packet destination address: 0x0802                        
+Packet source PAN ID: 0xabcd                              
+Packet source address: 0x1540                             
+Received packet with payload of 28 bytes from offset 11   
+2848 deg C; 3457%; 500 lux;                               
+
+Packet destination PAN ID: 0xabcd                         
+Packet destination address: 0x0802                        
+Packet source PAN ID: 0xabcd                              
+Packet source address: 0x1540                             
+Received packet with payload of 28 bytes from offset 11   
+2848 deg C; 3456%; 500 lux; 
+```

--- a/userland/examples/ip_sense/README.md
+++ b/userland/examples/ip_sense/README.md
@@ -1,0 +1,6 @@
+IP Sensor App
+=============
+
+Reads on board sensors periodically and transmits them over the network.
+Currently, it "simulates" a real IP network with a raw 802.15.4 interface, but
+that will evolve. Only works, currently, on the imix board.

--- a/userland/examples/ip_sense/main.c
+++ b/userland/examples/ip_sense/main.c
@@ -1,0 +1,47 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <ambient_light.h>
+#include <humidity.h>
+#include <temperature.h>
+#include <timer.h>
+
+#include <ieee802154.h>
+
+int main(void) {
+  printf("[Sensors] Starting Sensors App.\n");
+  printf("[Sensors] All available sensors on the platform will be sampled.\n");
+
+  unsigned int humi;
+  int temp, lux;
+
+  char packet[64];
+
+  /* { IEEE802.15.4 configuration... temporary until we have full IP */
+  ieee802154_set_address(0x1540);
+  ieee802154_set_pan(0xABCD);
+  ieee802154_config_commit();
+  ieee802154_up();
+  /* } IEEE802.15.4 configuration */
+
+  while (1) {
+    temperature_read_sync(&temp);
+    humidity_read_sync(&humi);
+    lux = ambient_light_read_intensity();
+
+    int len = snprintf(packet, sizeof(packet), "%d deg C; %d%%; %d lux;\n",
+                       temp, humi, lux);
+
+    int err = ieee802154_send(0x0802, // destination address (short MAC address)
+                              SEC_LEVEL_NONE, // No encryption
+                              0, // unused since SEC_LEVEL_NONE
+                              NULL, // unused since SEC_LEVEL_NONE
+                              packet,
+                              len);
+    if (err != TOCK_SUCCESS) {
+      printf("Error sending packet %d\n", err);
+    }
+
+    delay_ms(1000);
+  }
+}

--- a/userland/examples/tests/ieee802154/radio_rx/main.c
+++ b/userland/examples/tests/ieee802154/radio_rx/main.c
@@ -23,16 +23,20 @@ static void callback(__attribute__ ((unused)) int pans,
                      __attribute__ ((unused)) void* ud) {
   led_toggle(0);
 
-#define PRINT_PAYLOAD 0
+#define PRINT_PAYLOAD 1
+#define PRINT_STRING 1
 #if PRINT_PAYLOAD
   int payload_offset = ieee802154_frame_get_payload_offset(packet_rx);
   int payload_length = ieee802154_frame_get_payload_length(packet_rx);
   printf("Received packet with payload of %d bytes from offset %d\n", payload_length, payload_offset);
-  int i;
+#if PRINT_STRING
+  printf("%.*s\n", payload_length, packet_rx + payload_offset);
+#else
   for (i = 0; i < payload_length; i++) {
     printf("%02x%c", packet_rx[payload_offset + i],
            ((i + 1) % 16 == 0 || i + 1 == payload_length) ? '\n' : ' ');
   }
+#endif //PRINT_STRING
 
   unsigned short pan;
   unsigned short short_addr;
@@ -52,7 +56,7 @@ static void callback(__attribute__ ((unused)) int pans,
     printf("Packet destination address: 0x%04x\n", short_addr);
   } else if (mode == ADDR_LONG) {
     printf("Packet destination address:");
-    for (i = 0; i < 8; i++) {
+    for (int i = 0; i < 8; i++) {
       printf(" %02x", long_addr[i]);
     }
     printf("\n");
@@ -71,7 +75,7 @@ static void callback(__attribute__ ((unused)) int pans,
     printf("Packet source address: 0x%04x\n", short_addr);
   } else if (mode == ADDR_LONG) {
     printf("Packet source address:");
-    for (i = 0; i < 8; i++) {
+    for (int i = 0; i < 8; i++) {
       printf(" %02x", long_addr[i]);
     }
     printf("\n");


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an example app for platforms with sensors and an 802.15.4 radio that broadcasts period sensor readings over the network. Currently, it sends packets in raw 802.15.4 packets with statically configured PAN, source and destination addresses, but as support is added for 6lowpan, Thread, etc, this app will evolve to use those instead.

### Testing Strategy

Program the kernel on two imixs. On one, program the `radio_rx` app in `userland/examples/tests/ieee802154/radio_rx` with the `PRINT_PAYLOAD` and `PRINT_STRING` options enabled (this app simply prints received 802154 packets to the console). On the other, program the `ip_sense` app. You'll see packets printed on the console of the form:

```
Packet destination PAN ID: 0xabcd                         
Packet destination address: 0x0802                        
Packet source PAN ID: 0xabcd                              
Packet source address: 0x1540                             
Received packet with payload of 28 bytes from offset 11   
2848 deg C; 3457%; 500 lux;                               

Packet destination PAN ID: 0xabcd                         
Packet destination address: 0x0802                        
Packet source PAN ID: 0xabcd                              
Packet source address: 0x1540                             
Received packet with payload of 28 bytes from offset 11   
2848 deg C; 3456%; 500 lux; 
```

### Formatting

- [x] `make formatall` has been run.
