### PR TITLE
Stabilize `_start` for Tock 1.0

### DIFF
--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -78,6 +78,18 @@ In Tock, a process can be in one of three states:
  Tock. Processes enter the Fault state by performing an illegal operation, such
  as accessing memory outside of their address space.
 
+## Startup
+
+Upon process initialization, a single function call task is added to it's
+callback queue. The function is determined by the ENTRY point in the process
+TBF header (typically the `_start` symbol) and is passed the following
+arguments in registers `r0` - `r3`:
+
+  * r0: The base address of the processes allocated memory region.
+  * r1: The current process break.
+  * r2: The current kernel memory break.
+  * r3: unused
+
 ## The System Calls
 
 All system calls except Yield (which cannot fail) return an integer return code

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -11,6 +11,7 @@ tutorial on how to use them in drivers or applications.
 
 - [Overview of System Calls in Tock](#overview-of-system-calls-in-tock)
 - [Process State](#process-state)
+- [Startup](#startup)
 - [The System Calls](#the-system-calls)
   * [0: Yield](#0-yield)
     + [Arguments](#arguments)

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1082,12 +1082,15 @@ impl<'a> Process<'a> {
                            init_fn);
                 }
 
+                let flash_protected_size = process.header.get_protected_size() as usize;
+                let flash_app_start = app_flash_address as usize + flash_protected_size;
+
                 process.tasks.enqueue(Task::FunctionCall(FunctionCall {
                     pc: init_fn,
-                    r0: process.memory.as_ptr() as usize,
-                    r1: process.app_break as usize,
-                    r2: process.kernel_memory_break as usize,
-                    r3: 0,
+                    r0: flash_app_start,
+                    r1: process.memory.as_ptr() as usize,
+                    r2: process.memory.len() as usize,
+                    r3: process.app_break as usize,
                 }));
 
                 HAVE_WORK.set(HAVE_WORK.get() + 1);

--- a/userland/libtock/crt0.c
+++ b/userland/libtock/crt0.c
@@ -1,11 +1,5 @@
 #include <tock.h>
 
-extern unsigned int* _etext;
-extern unsigned int* _edata;
-extern unsigned int* _got;
-extern unsigned int* _egot;
-extern unsigned int* _bss;
-extern unsigned int* _ebss;
 extern int main(void);
 
 // Allow _start to go undeclared
@@ -16,9 +10,10 @@ __attribute__ ((section(".start"), used))
 __attribute__ ((weak))
 __attribute__ ((noreturn))
 __attribute__ ((naked))
-void _start(void* mem_start __attribute__((unused)),
-            void* app_heap_break __attribute__((unused)),
-            void* kernel_memory_break __attribute__((unused))) {
+void _start(void* text_start __attribute__((unused)),
+            void* mem_start __attribute__((unused)),
+            void* memory_len __attribute__((unused)),
+            void* app_heap_break __attribute__((unused))) {
   /*
    * 1. Setup r9 to point to the GOT (assumes the kernel places the GOT right
    *    above the stack)


### PR DESCRIPTION
This is currently mostly a proposal with only the _existing_ interface documented, not the proposed one. I'm looking for feedback people!

### Pull Request Overview

This pull request proposes and documents a stabilized signature for the processes initialization function (typically `_start`).

The current implementation passes the following arguments:

  * r0: The base address of the processes allocated memory region.
  * r1: The current process break.
  * r2: The current kernel memory break.
  * r3: unused

However, none of them are actually used anywhere in practice. Instead, we should pass in actually useful information. But for what?

Ideally a process ought to be able to do it's own loading (especially for apps that use TBF header vs 2, which doesn't do any of the got section re-writing in the kernel), and memory region management. The most important details to accomplish this are:

  * the base address of the processes allocated memory region
  * the base address of the processes code (excluding the TBF header)

This lets the process find data in flash that needs to be copied (e.g. the data segment) and figure out where to copy it to.

It should also be able to get information about:

  * The total amount of memory in its region
  * The currently allocated amount of grant memory
  * The current process memory break

The process can already get most of this information from the `memop` system call, but the most important stuff for process loading would be passed to `_start` to avoid unnecessary system call overhead. Proposed:

  * r0: the base address of the processes code (excluding the TBF header)
  * r1: the base address of the processes allocated memory region
  * r2: the total amount of memory in its region
  * r3: the current process memory break

### Testing Strategy

Implement process loading in libtock (instead of in the kernel) using these new arguments, then run a bunch of applications.

### TODO or Help Wanted

Feedback please?

### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [ ] `make formatall` has been run.

Resolves #632 