### PR TITLE
fix bsd/gnu sed problems

### DIFF
--- a/tools/build_all_docs.sh
+++ b/tools/build_all_docs.sh
@@ -4,6 +4,7 @@
 function get_known_crates {
 	FILE=$1
 
+	# This sed seems to be okay x-platform bsd/gnu
 	FOUND_CRATES=`sed -nE "s/.*searchIndex\[\"([a-z0-9_-]*)\"\].*/\1/gp" $FILE`
 	echo $FOUND_CRATES
 }
@@ -32,7 +33,10 @@ function add_board {
 
 		# Add the line to the search-index.js file.
 		SEARCHINDEX=`grep "searchIndex\[\"$item\"\]" boards/$BOARD/target/thumb*-none-eabi/doc/search-index.js`
-		sed -i "/var searchIndex = {};/a$SEARCHINDEX" doc/rustdoc/search-index.js
+
+		# nothing in-place is x-platform bsd/gnu (os x defaults...)
+		/usr/bin/awk -v var="$SEARCHINDEX" "/initSearch/{print var}1" doc/rustdoc/search-index.js > doc/rustdoc/search-index-new.js
+		mv doc/rustdoc/search-index-new.js doc/rustdoc/search-index.js
 	done
 }
 

--- a/userland/AppMakefile.mk
+++ b/userland/AppMakefile.mk
@@ -206,12 +206,15 @@ else
 	@# Get the offset between the init function and the start of text (0x80000000).
 	@# We then use that offset to calculate where the start of text was on the actual MCU.
 	@# Create a new LD file at the correct flash and ram locations.
+	@#
+	@# #616 #635: sed is not cross-platform
+	@# https://stackoverflow.com/a/22247781/358675 <-- Use perl in place of sed
 	$$(Q)set -e ;\
 	  ORIGINAL_ENTRY=`$$(READELF) -h $$(BUILDDIR)/$(1)/$(1).elf | grep Entry | awk '{print $$$$4}'` ;\
 	  INIT_OFFSET=$$$$(($$$$ORIGINAL_ENTRY - 0x80000000)) ;\
 	  FLASH_START=$$$$(($$$$FLASH_INIT-$$$$INIT_OFFSET)) ;\
-	  sed -i -E "s/(FLASH.*ORIGIN[ =]*)([x0-9]*)(,.*LENGTH)/\1$$$$FLASH_START\3/" $$@ ;\
-	  sed -i -E "s/(SRAM.*ORIGIN[ =]*)([x0-9]*)(,.*LENGTH)/\1$$$$RAM_START\3/" $$@
+	  perl -pi -e "s/(FLASH.*ORIGIN[ =]*)([x0-9]*)(,.*LENGTH)/\$$$${1}$$$$FLASH_START\$$$$3/" $$@ ;\
+	  perl -pi -e "s/(SRAM.*ORIGIN[ =]*)([x0-9]*)(,.*LENGTH)/\$$$${1}$$$$RAM_START\$$$$3/" $$@
 endif
 
 # Step 2: Create a new ELF with the layout that matches what's loaded


### PR DESCRIPTION
### Pull Request Overview

This was an awful chore, we had 3 uses of sed

 - in userland `make debug`, fixed by replacing with perl (thanks SO)
 - in doc building, `-nE` is fine
 - in doc building, use awk to inject behind last line instead of appending

Fixes #616.

### Testing Strategy

Validating the output of `make debug` doesn't change.

The rustdoc search index file technically changed. Effectively we now add elements in the opposite order (with sed was adding array entries to the top, with awk, we add them to the bottom). It's an array. It doesn't matter. Tested in browser and search still works.