### PR TITLE
Bigger serialization write buffer

### DIFF
--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -47,7 +47,7 @@ impl Default for App {
 
 // Local buffer for passing data between applications and the underlying
 // transport hardware.
-pub static mut WRITE_BUF: [u8; 256] = [0; 256];
+pub static mut WRITE_BUF: [u8; 600] = [0; 600];
 pub static mut READ_BUF: [u8; 600] = [0; 600];
 
 // We need two resources: a UART HW driver and driver state for each


### PR DESCRIPTION
Increase size of write buffer in the nRF serialization capsule.

### Pull Request Overview

The write buffer is only 256 Bytes in the nRF serialization capsule, but you can create characteristics that are up to 510 Bytes in length, which then cause buffer overruns in the kernel (which Rust does catch and panic about). Bumping it up to 600 like the read buffer fixes it.


### Testing Strategy

Tested on Signpost radio module.


### Documentation Updated

- [N/A] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [N/A] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [N/A] `make formatall` has been run.
