### PR TITLE
Getting started and imix tutorial fixes

### DIFF
--- a/boards/imix/README.md
+++ b/boards/imix/README.md
@@ -33,7 +33,7 @@ To compile an app, `cd` to the desired app and `make`. For example:
 
 ```bash
 $ cd userland/examples/blink/
-$ make
+$ make TOCK_BOARD=imix
 ```
 
 This will build the app, generate a binary in Tock Binary Format (using the
@@ -43,19 +43,29 @@ This will build the app, generate a binary in Tock Binary Format (using the
 Apps can be built and automatically uploaded from the root directory of Tock:
 
 ```bash
-$ make examples/blink
+$ make TOCK_BOARD=imix examples/blink
 ```
 
-Apps can be uploaded with `make program` (to use the serial bootloader):
+Apps can be uploaded with `make program` (to use the serial bootloader), but
+the tock board being programmed must be specified:
 
 ```bash
 $ cd userland/examples/blink/
-$ make program
+$ make TOCK_BOARD=imix program
 ```
 
 This builds and loads only a single app. Tock is capable of running multiple apps
-concurrently. Use `tockloader install` to add additional apps, and `tockloader list`
-to see the list of installed applications.
+concurrently:
+
+Use `tockloader install -a 0x40000` to add additional apps, and 
+`tockloader list -a 0x40000` to see the list of installed applications. The `-a`
+flag specifies the address of the application space, which is different between
+boards.
+
+Please note that forgetting to specify `TOCK_BOARD=imix` when using `make program`
+or forgetting to specify `-a 0x40000` when using `tockloader install` can result
+in overwriting a portion of the kernel, which should be fixed by flashing the 
+kernel again.
 
 ## Debugging
 

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -181,7 +181,7 @@ such as easy to manage serial connections, and the ability to list, add,
 replace, and remove applications over JTAG (or USB if a bootloader is
 installed).
 
-1. [tockloader](https://github.com/helena-project/tockloader) (version 0.7.1)
+1. [tockloader](https://github.com/helena-project/tockloader) (version 0.7.2)
 
 Installing applications over JTAG, depending on your JTAG Debugger, you will
 need one of:
@@ -191,11 +191,11 @@ need one of:
 
 #### `tockloader`
 
-Tock requires `tockloader` version `0.7.1`. To install:
+Tock requires `tockloader` version `0.7.2`. To install:
 
 ```bash
-(Linux): sudo pip3 install tockloader==0.7.1
-(MacOS): pip3 install tockloader==0.7.1
+(Linux): sudo pip3 install tockloader==0.7.2
+(MacOS): pip3 install tockloader==0.7.2
 ```
 
 #### `openocd`

--- a/doc/tutorials/01_running_blink.md
+++ b/doc/tutorials/01_running_blink.md
@@ -58,10 +58,11 @@ compiled and loaded much like the kernel is. See the [getting started README](..
 
     ```bash
     cd userland/examples/blink
-    make program  # Load code via bootloader
+    make TOCK_BOARD=imix program  # Load code via bootloader
       -- or --    # Check the README in your board folder
-    make flash    # Load code via jtag
+    make TOCK_BOARD=imix flash    # Load code via jtag
     ```
-
+    
+    If you have another board than Imix replace imix with your board.
     When the `make` command finishes you should see the LEDs on the board blinking.
     Congratulations! You have just programmed your first Tock application.


### PR DESCRIPTION
### Pull Request Overview

Made changes to three README documents: 

1) Changed the Getting Started Guide to recommend users install tockloader v0.7.2 to prevent warnings.

2) Modified the Imix hardware README to instruct users to upload programs with `make TOCK_BOARD=imix program`, to prevent users from overwriting a section of the kernel when simply running `make program` as the tutorial currently instructs. Further modified this same README to also instruct users to always use `-a 0x40000` when executing tockloader instructions which require knowledge of the location of apps on the Imix (such as `tockloader install` and `tockloader list`)

3) Modified Tutorial 01 to also instruct users to upload programs with `make TOCK_BOARD=imix program`, seeing as it already presents the example user as working on an Imix.

Notably, these changes are temporary fixes to serve until Shane provides an update to store the app location as an attribute in flash or elsewhere.


### Testing Strategy

Hudson and Shane verified that these procedures are needed in order to correctly upload applications on Imix v2.0


### Documentation Updated

Changes were only made to documentation, so no further updates are needed.
