### PR TITLE
Max17205 RomID

### DIFF
--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -37,7 +37,7 @@
 //! ```
 
 use core::cell::Cell;
-use kernel::{AppSlice, AppId, Callback, Driver, ReturnCode, Shared};
+use kernel::{AppId, Callback, Driver, ReturnCode};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::i2c;
 
@@ -411,17 +411,6 @@ impl<'a> Driver for MAX17205Driver<'a> {
                 ReturnCode::SUCCESS
             }
 
-            // default
-            _ => ReturnCode::ENOSUPPORT,
-        }
-    }
-
-    /// Allow buffer for the MAX17205
-    ///
-    /// ### `allow_num`
-    ///
-    fn allow(&self, _: AppId, allow_num: usize, _: AppSlice<Shared, u8>) -> ReturnCode {
-        match allow_num {
             // default
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -13,8 +13,8 @@
 //! -----
 //!
 //! ```rust
-//! 
-//! // Two i2c addresses are necessary. 
+//!
+//! // Two i2c addresses are necessary.
 //! // Registers 0x000-0x0FF are accessed by address 0x36.
 //! // Registers 0x100-0x1FF are accessed by address 0x0B.
 //! let max17205_i2c_lower = static_init!(
@@ -38,7 +38,7 @@
 
 use core::cell::Cell;
 use kernel::{AppSlice, AppId, Callback, Driver, ReturnCode, Shared};
-use kernel::common::take_cell::{TakeCell};
+use kernel::common::take_cell::TakeCell;
 use kernel::hil::i2c;
 
 pub static mut BUFFER: [u8; 8] = [0; 8];
@@ -330,7 +330,10 @@ impl<'a> i2c::I2CClient for MAX17205<'a> {
             State::ReadRomID => {
 
                 // u64 from 8 bytes
-                let rid = buffer.iter().take(8).enumerate().fold(0u64, |rid, (i, b)| rid | ((*b as u64) << i * 8));
+                let rid = buffer.iter()
+                    .take(8)
+                    .enumerate()
+                    .fold(0u64, |rid, (i, b)| rid | ((*b as u64) << i * 8));
                 self.buffer.replace(buffer);
 
                 let error = if _error != i2c::Error::CommandComplete {
@@ -387,7 +390,11 @@ impl<'a> MAX17205Client for MAX17205Driver<'a> {
     }
 
     fn romid(&self, rid: u64, error: ReturnCode) {
-        self.callback.get().map(|mut cb| cb.schedule(From::from(error), (rid & 0xffffffff) as usize, (rid >> 32) as usize));
+        self.callback.get().map(|mut cb| {
+            cb.schedule(From::from(error),
+                        (rid & 0xffffffff) as usize,
+                        (rid >> 32) as usize)
+        });
     }
 }
 

--- a/userland/examples/tests/max17205/Makefile
+++ b/userland/examples/tests/max17205/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/max17205/README.md
+++ b/userland/examples/tests/max17205/README.md
@@ -1,0 +1,9 @@
+MAX17205 Battery Monitor Test App
+================================
+
+This application tests the 5 functions of the max17205 battery monitor.
+
+It should return valid values (depending on the batter you are plugged into).
+
+When run when it is not connected to a max17205 it should return TOCK_ENOACK.
+

--- a/userland/examples/tests/max17205/main.c
+++ b/userland/examples/tests/max17205/main.c
@@ -13,14 +13,10 @@
 int main (void) {
   printf("[MAX17205] Test App\n");
 
-  uint8_t rom_id[8];
-  int rc = max17205_read_rom_id_sync(rom_id);
+  uint64_t rom_id;
+  int rc = max17205_read_rom_id_sync(&rom_id);
   if (rc == TOCK_SUCCESS) {
-    printf("Found ROM ID: 0x");
-    for (int i = 0; i < 8; i++) {
-      printf("%02X",rom_id[i]);
-    }
-    printf("\n");
+    printf("Found ROM ID: 0x%llX\n", rom_id);
   } else {
     printf("Got error: %s\n", tock_strerror(rc));
   }
@@ -49,7 +45,8 @@ int main (void) {
 
   printf("\n");
 
-  uint16_t voltage, current;
+  uint16_t voltage;
+  int16_t current;
   rc = max17205_read_voltage_current_sync(&voltage, &current);
   if (rc == TOCK_SUCCESS) {
     printf("Voltage (mV): %ld\n", lrint(max17205_get_voltage_mV(voltage)));

--- a/userland/examples/tests/max17205/main.c
+++ b/userland/examples/tests/max17205/main.c
@@ -15,10 +15,10 @@ int main (void) {
 
   uint8_t rom_id[8];
   int rc = max17205_read_rom_id_sync(rom_id);
-  if(rc == TOCK_SUCCESS) {
+  if (rc == TOCK_SUCCESS) {
     printf("Found ROM ID: 0x");
     for (int i = 0; i < 8; i++) {
-        printf("%02X",rom_id[i]);
+      printf("%02X",rom_id[i]);
     }
     printf("\n");
   } else {
@@ -29,7 +29,7 @@ int main (void) {
 
   uint16_t status;
   rc = max17205_read_status_sync(&status);
-  if(rc == TOCK_SUCCESS) {
+  if (rc == TOCK_SUCCESS) {
     printf("Status: 0x%04X\n", status);
   } else {
     printf("Got error: %d - %s\n", rc, tock_strerror(rc));
@@ -39,7 +39,7 @@ int main (void) {
 
   uint16_t percent, soc_mah, soc_mah_full;
   rc = max17205_read_soc_sync(&percent, &soc_mah, &soc_mah_full);
-  if(rc == TOCK_SUCCESS) {
+  if (rc == TOCK_SUCCESS) {
     printf("Percent (.001%%): %ld\n",lrint(max17205_get_percentage_mP(percent)));
     printf("State of charge in uAh: %ld\n", lrint(max17205_get_capacity_uAh(soc_mah)));
     printf("Full charge in uAh: %ld\n", lrint(max17205_get_capacity_uAh(soc_mah_full)));
@@ -51,7 +51,7 @@ int main (void) {
 
   uint16_t voltage, current;
   rc = max17205_read_voltage_current_sync(&voltage, &current);
-  if(rc == TOCK_SUCCESS) {
+  if (rc == TOCK_SUCCESS) {
     printf("Voltage (mV): %ld\n", lrint(max17205_get_voltage_mV(voltage)));
     printf("Current (uA): %ld\n", lrint(max17205_get_current_uA(current)));
   } else {

--- a/userland/examples/tests/max17205/main.c
+++ b/userland/examples/tests/max17205/main.c
@@ -1,0 +1,60 @@
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <console.h>
+#include <max17205.h>
+#include <tock.h>
+
+int main (void) {
+  printf("[MAX17205] Test App\n");
+
+  uint8_t rom_id[8];
+  int rc = max17205_read_rom_id_sync(rom_id);
+  if(rc == TOCK_SUCCESS) {
+    printf("Found ROM ID: 0x");
+    for (int i = 0; i < 8; i++) {
+        printf("%02X",rom_id[i]);
+    }
+    printf("\n");
+  } else {
+    printf("Got error: %s\n", tock_strerror(rc));
+  }
+
+  printf("\n");
+
+  uint16_t status;
+  rc = max17205_read_status_sync(&status);
+  if(rc == TOCK_SUCCESS) {
+    printf("Status: 0x%04X\n", status);
+  } else {
+    printf("Got error: %d - %s\n", rc, tock_strerror(rc));
+  }
+
+  printf("\n");
+
+  uint16_t percent, soc_mah, soc_mah_full;
+  rc = max17205_read_soc_sync(&percent, &soc_mah, &soc_mah_full);
+  if(rc == TOCK_SUCCESS) {
+    printf("Percent (.001%%): %ld\n",lrint(max17205_get_percentage_mP(percent)));
+    printf("State of charge in uAh: %ld\n", lrint(max17205_get_capacity_uAh(soc_mah)));
+    printf("Full charge in uAh: %ld\n", lrint(max17205_get_capacity_uAh(soc_mah_full)));
+  } else {
+    printf("Got error: %d - %s\n", rc, tock_strerror(rc));
+  }
+
+  printf("\n");
+
+  uint16_t voltage, current;
+  rc = max17205_read_voltage_current_sync(&voltage, &current);
+  if(rc == TOCK_SUCCESS) {
+    printf("Voltage (mV): %ld\n", lrint(max17205_get_voltage_mV(voltage)));
+    printf("Current (uA): %ld\n", lrint(max17205_get_current_uA(current)));
+  } else {
+    printf("Got error: %d - %s\n", rc, tock_strerror(rc));
+  }
+}

--- a/userland/libtock/max17205.c
+++ b/userland/libtock/max17205.c
@@ -202,10 +202,10 @@ int max17205_read_rom_id_sync(uint64_t* rom_id) {
 
   // Wait for the callback.
   yield_for(&result.fired);
-  
+
   uint64_t temp = result.value0;
-  temp <<= 32;
-  temp |= result.value1 & 0x00000000FFFFFFFF; 
+  temp  <<= 32;
+  temp   |= result.value1 & 0x00000000FFFFFFFF;
   *rom_id = temp;
 
   return result.rc;

--- a/userland/libtock/max17205.c
+++ b/userland/libtock/max17205.c
@@ -9,16 +9,16 @@ struct max17205_data {
 };
 
 static struct max17205_data result = { .fired = false, .rc = 0, .value0 = 0, .value1 = 0 };
-static subscribe_cb* user_cb = NULL;
+static subscribe_cb* user_cb       = NULL;
 
 // Internal callback for faking synchronous reads
 static void internal_user_cb(int return_code,
-                            int value0,
-                            int value1,
-                            void* ud) {
+                             int value0,
+                             int value1,
+                             void* ud) {
 
   struct max17205_data* data = (struct max17205_data*) ud;
-  data-> rc = return_code;
+  data->rc     = return_code;
   data->value0 = value0;
   data->value1 = value1;
   data->fired  = true;
@@ -31,7 +31,7 @@ static void max17205_cb(int return_code,
                         int value1,
                         void* ud) {
   is_busy = false;
-  if(user_cb) {
+  if (user_cb) {
     user_cb(return_code, value0, value1, ud);
   }
 }
@@ -46,13 +46,13 @@ int max17205_set_callback (subscribe_cb callback, void* callback_args) {
 }
 
 int max17205_read_status(void) {
-  if(is_busy){
+  if (is_busy) {
     return TOCK_EBUSY;
   } else {
     is_busy = true;
     int rc = command(DRIVER_NUM_MAX17205, 1, 0, 0);
-    if(rc != TOCK_SUCCESS) {
-        is_busy = false;
+    if (rc != TOCK_SUCCESS) {
+      is_busy = false;
     }
 
     return rc;
@@ -60,13 +60,13 @@ int max17205_read_status(void) {
 }
 
 int max17205_read_soc(void) {
-  if(is_busy){
+  if (is_busy) {
     return TOCK_EBUSY;
   } else {
     is_busy = true;
     int rc = command(DRIVER_NUM_MAX17205, 2, 0, 0);
-    if(rc != TOCK_SUCCESS) {
-        is_busy = false;
+    if (rc != TOCK_SUCCESS) {
+      is_busy = false;
     }
 
     return rc;
@@ -74,13 +74,13 @@ int max17205_read_soc(void) {
 }
 
 int max17205_read_voltage_current(void) {
-  if(is_busy){
+  if (is_busy) {
     return TOCK_EBUSY;
   } else {
     is_busy = true;
     int rc = command(DRIVER_NUM_MAX17205, 3, 0, 0);
-    if(rc != TOCK_SUCCESS) {
-        is_busy = false;
+    if (rc != TOCK_SUCCESS) {
+      is_busy = false;
     }
 
     return rc;
@@ -88,13 +88,13 @@ int max17205_read_voltage_current(void) {
 }
 
 int max17205_read_coulomb(void) {
-  if(is_busy){
+  if (is_busy) {
     return TOCK_EBUSY;
   } else {
     is_busy = true;
     int rc = command(DRIVER_NUM_MAX17205, 4, 0, 0);
-    if(rc != TOCK_SUCCESS) {
-        is_busy = false;
+    if (rc != TOCK_SUCCESS) {
+      is_busy = false;
     }
 
     return rc;
@@ -102,19 +102,19 @@ int max17205_read_coulomb(void) {
 }
 
 int max17205_read_rom_id(uint8_t* rom_id_buffer) {
-  if(is_busy){
+  if (is_busy) {
     return TOCK_EBUSY;
   } else {
     is_busy = true;
     int rc = allow(DRIVER_NUM_MAX17205, 0, rom_id_buffer, 8);
-    if(rc != TOCK_SUCCESS) {
-        is_busy = false;
-        return rc;
+    if (rc != TOCK_SUCCESS) {
+      is_busy = false;
+      return rc;
     }
 
     rc = command(DRIVER_NUM_MAX17205, 5, 0, 0);
-    if(rc != TOCK_SUCCESS) {
-        is_busy = false;
+    if (rc != TOCK_SUCCESS) {
+      is_busy = false;
     }
 
     return rc;

--- a/userland/libtock/max17205.c
+++ b/userland/libtock/max17205.c
@@ -159,7 +159,7 @@ int max17205_read_soc_sync(uint16_t* percent, uint16_t* soc_mah, uint16_t* soc_m
   return result.rc;
 }
 
-int max17205_read_voltage_current_sync(uint16_t* voltage, uint16_t* current) {
+int max17205_read_voltage_current_sync(uint16_t* voltage, int16_t* current) {
   int err;
   result.fired = false;
 

--- a/userland/libtock/max17205.c
+++ b/userland/libtock/max17205.c
@@ -2,49 +2,130 @@
 #include "tock.h"
 
 struct max17205_data {
+  int rc;
   int value0;
   int value1;
   bool fired;
 };
 
-static struct max17205_data result = { .fired = false, .value0 = 0, .value1 = 0 };
+static struct max17205_data result = { .fired = false, .rc = 0, .value0 = 0, .value1 = 0 };
+static subscribe_cb* user_cb = NULL;
 
 // Internal callback for faking synchronous reads
-static void max17205_cb(__attribute__ ((unused)) int callback_type,
-                        int value0,
-                        int value1,
-                        void* ud) {
+static void internal_user_cb(int return_code,
+                            int value0,
+                            int value1,
+                            void* ud) {
+
   struct max17205_data* data = (struct max17205_data*) ud;
+  data-> rc = return_code;
   data->value0 = value0;
   data->value1 = value1;
   data->fired  = true;
 }
 
+static bool is_busy = false;
+// Lower level CB that allows us to stop more commands while busy
+static void max17205_cb(int return_code,
+                        int value0,
+                        int value1,
+                        void* ud) {
+  is_busy = false;
+  if(user_cb) {
+    user_cb(return_code, value0, value1, ud);
+  }
+}
+
 int max17205_set_callback (subscribe_cb callback, void* callback_args) {
-  return subscribe(DRIVER_NUM_MAX17205, 0, callback, callback_args);
+  // Set the user-level calllback to the provided one
+  user_cb = callback;
+
+  // Subscribe to the callback with our lower-layer callback, but pass
+  // callback arugments.
+  return subscribe(DRIVER_NUM_MAX17205, 0, max17205_cb, callback_args);
 }
 
 int max17205_read_status(void) {
-  return command(DRIVER_NUM_MAX17205, 1, 0, 0);
+  if(is_busy){
+    return TOCK_EBUSY;
+  } else {
+    is_busy = true;
+    int rc = command(DRIVER_NUM_MAX17205, 1, 0, 0);
+    if(rc != TOCK_SUCCESS) {
+        is_busy = false;
+    }
+
+    return rc;
+  }
 }
 
 int max17205_read_soc(void) {
-  return command(DRIVER_NUM_MAX17205, 2, 0, 0);
+  if(is_busy){
+    return TOCK_EBUSY;
+  } else {
+    is_busy = true;
+    int rc = command(DRIVER_NUM_MAX17205, 2, 0, 0);
+    if(rc != TOCK_SUCCESS) {
+        is_busy = false;
+    }
+
+    return rc;
+  }
 }
 
 int max17205_read_voltage_current(void) {
-  return command(DRIVER_NUM_MAX17205, 3, 0, 0);
+  if(is_busy){
+    return TOCK_EBUSY;
+  } else {
+    is_busy = true;
+    int rc = command(DRIVER_NUM_MAX17205, 3, 0, 0);
+    if(rc != TOCK_SUCCESS) {
+        is_busy = false;
+    }
+
+    return rc;
+  }
 }
 
 int max17205_read_coulomb(void) {
-  return command(DRIVER_NUM_MAX17205, 4, 0, 0);
+  if(is_busy){
+    return TOCK_EBUSY;
+  } else {
+    is_busy = true;
+    int rc = command(DRIVER_NUM_MAX17205, 4, 0, 0);
+    if(rc != TOCK_SUCCESS) {
+        is_busy = false;
+    }
+
+    return rc;
+  }
+}
+
+int max17205_read_rom_id(uint8_t* rom_id_buffer) {
+  if(is_busy){
+    return TOCK_EBUSY;
+  } else {
+    is_busy = true;
+    int rc = allow(DRIVER_NUM_MAX17205, 0, rom_id_buffer, 8);
+    if(rc != TOCK_SUCCESS) {
+        is_busy = false;
+        return rc;
+    }
+
+    rc = command(DRIVER_NUM_MAX17205, 5, 0, 0);
+    if(rc != TOCK_SUCCESS) {
+        is_busy = false;
+    }
+
+    return rc;
+  }
 }
 
 int max17205_read_status_sync(uint16_t* status) {
   int err;
   result.fired = false;
 
-  err = max17205_set_callback(max17205_cb, (void*) &result);
+  err = max17205_set_callback(internal_user_cb, (void*) &result);
   if (err < 0) return err;
 
   err = max17205_read_status();
@@ -55,14 +136,14 @@ int max17205_read_status_sync(uint16_t* status) {
 
   *status = result.value0 & 0xFFFF;
 
-  return 0;
+  return result.rc;
 }
 
 int max17205_read_soc_sync(uint16_t* percent, uint16_t* soc_mah, uint16_t* soc_mah_full) {
   int err;
   result.fired = false;
 
-  err = max17205_set_callback(max17205_cb, (void*) &result);
+  err = max17205_set_callback(internal_user_cb, (void*) &result);
   if (err < 0) return err;
 
   err = max17205_read_soc();
@@ -75,14 +156,14 @@ int max17205_read_soc_sync(uint16_t* percent, uint16_t* soc_mah, uint16_t* soc_m
   *soc_mah      = (result.value1 & 0xFFFF0000) >> 16;
   *soc_mah_full = result.value1 & 0xFFFF;
 
-  return 0;
+  return result.rc;
 }
 
 int max17205_read_voltage_current_sync(uint16_t* voltage, uint16_t* current) {
   int err;
   result.fired = false;
 
-  err = max17205_set_callback(max17205_cb, (void*) &result);
+  err = max17205_set_callback(internal_user_cb, (void*) &result);
   if (err < 0) return err;
 
   err = max17205_read_voltage_current();
@@ -94,14 +175,14 @@ int max17205_read_voltage_current_sync(uint16_t* voltage, uint16_t* current) {
   *voltage = result.value0 & 0xFFFF;
   *current = result.value1 & 0xFFFF;
 
-  return 0;
+  return result.rc;
 }
 
 int max17205_read_coulomb_sync(uint16_t* coulomb) {
   int err;
   result.fired = false;
 
-  err = max17205_set_callback(max17205_cb, (void*) &result);
+  err = max17205_set_callback(internal_user_cb, (void*) &result);
   if (err < 0) return err;
 
   err = max17205_read_coulomb();
@@ -112,7 +193,23 @@ int max17205_read_coulomb_sync(uint16_t* coulomb) {
 
   *coulomb = result.value0 & 0xFFFF;
 
-  return 0;
+  return result.rc;
+}
+
+int max17205_read_rom_id_sync(uint8_t* rom_id_buffer) {
+  int err;
+  result.fired = false;
+
+  err = max17205_set_callback(internal_user_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = max17205_read_rom_id(rom_id_buffer);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.rc;
 }
 
 float max17205_get_voltage_mV(int vcount) {

--- a/userland/libtock/max17205.h
+++ b/userland/libtock/max17205.h
@@ -59,7 +59,7 @@ int max17205_read_rom_id (uint8_t* rom_id_buf);
 //
 int max17205_read_status_sync(uint16_t* state);
 int max17205_read_soc_sync(uint16_t* percent, uint16_t* soc_mah, uint16_t* soc_mah_full);
-int max17205_read_voltage_current_sync(uint16_t* voltage, uint16_t* current);
+int max17205_read_voltage_current_sync(uint16_t* voltage, int16_t* current);
 int max17205_read_coulomb_sync (uint16_t* coulomb);
 int max17205_read_rom_id_sync (uint8_t* rom_id_buf);
 

--- a/userland/libtock/max17205.h
+++ b/userland/libtock/max17205.h
@@ -52,7 +52,7 @@ int max17205_read_coulomb (void);
 // Get the unique 64bit RomID of the chip
 // Result is stored in the passed in buffer
 // Buffer must be at least 8 bytes long
-int max17205_read_rom_id (uint8_t* rom_id_buf);
+int max17205_read_rom_id (void);
 
 //
 // Synchronous Versions
@@ -61,7 +61,7 @@ int max17205_read_status_sync(uint16_t* state);
 int max17205_read_soc_sync(uint16_t* percent, uint16_t* soc_mah, uint16_t* soc_mah_full);
 int max17205_read_voltage_current_sync(uint16_t* voltage, int16_t* current);
 int max17205_read_coulomb_sync (uint16_t* coulomb);
-int max17205_read_rom_id_sync (uint8_t* rom_id_buf);
+int max17205_read_rom_id_sync (uint64_t* rom_id_buf);
 
 //
 // Helper functions

--- a/userland/libtock/max17205.h
+++ b/userland/libtock/max17205.h
@@ -12,21 +12,26 @@ extern "C" {
 //
 // The callback function should look like:
 //
-//     void callback (int callback_type, int data, int data2, void* callback_args)
+//     void callback (int return_code, int data, int data2, void* callback_args)
 //
 // callback_type is one of:
-//    0: Got the battery status. `data` is:
+//    read_status `data` is:
 //          status
-//    1: Got the state of charge. `data` is:
+//    read_soc `data` is:
 //          percent charged in %/255
 //        and `data2` is the capacity and full capacity:
 //          word 0 (u16): full capacity in 0.5mAh
 //          word 1 (u16): current capacity in 0.5mAh
-//     2: Got voltage and current. `data` is:
+//    read_voltage_current `data` is:
 //          voltage in 1.25mV
 //        and 'data2' is:
 //          current in 156.25uA
-//     3: A write operation finished.
+//    read_coulomb `data` is:
+//          raw coulombs
+//
+// The callback will be associated the most recent successful
+// call to the driver. If a command is called during an outstanding
+// command, EBUSY will be returned.
 int max17205_set_callback (subscribe_cb callback, void* callback_args);
 
 // Get the current status of the battery
@@ -41,8 +46,13 @@ int max17205_read_soc(void);
 // Result is returned in callback.
 int max17205_read_voltage_current(void);
 
-//get current count on the coulomb counter
+// Get current count on the coulomb counter
 int max17205_read_coulomb (void);
+
+// Get the unique 64bit RomID of the chip
+// Result is stored in the passed in buffer
+// Buffer must be at least 8 bytes long
+int max17205_read_rom_id (uint8_t* rom_id_buf);
 
 //
 // Synchronous Versions
@@ -51,11 +61,16 @@ int max17205_read_status_sync(uint16_t* state);
 int max17205_read_soc_sync(uint16_t* percent, uint16_t* soc_mah, uint16_t* soc_mah_full);
 int max17205_read_voltage_current_sync(uint16_t* voltage, uint16_t* current);
 int max17205_read_coulomb_sync (uint16_t* coulomb);
+int max17205_read_rom_id_sync (uint8_t* rom_id_buf);
 
+//
+// Helper functions
+//
 float max17205_get_voltage_mV(int vcount) __attribute__((const));
 float max17205_get_current_uA(int ccount) __attribute__((const));
 float max17205_get_percentage_mP(int percent) __attribute__((const));
 float max17205_get_capacity_uAh(int cap) __attribute__((const));
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the ability to read the RomID field, a unique 64bit chip ID, from the max17205 battery monitor. It also changes the callback structure to propagate I2C errors and makes the userland driver safe against multiple in-flight commands. This guarantees that a callback will always be associated with the last command  called, and therefore allows removing the command ID from the callback arguments and replacing it with a return_code argument.

### Testing Strategy

/examples/tests/max17205 application was created for testing the new driver updates. All function calls are working as expected, and the proper I2C error codes are propagating when no battery monitor is present.

### TODO or Help Wanted

Someone should look over my allow function and the way I copy data from the I2C buffer to the buffer supplied by userland for RomID. Specifically https://github.com/helena-project/tock/blob/e85f8cef319e83d3edd96a957fd64d8bf01596ec/capsules/src/max17205.rs#L331-356 and https://github.com/helena-project/tock/blob/e85f8cef319e83d3edd96a957fd64d8bf01596ec/capsules/src/max17205.rs#L429-440.


### Documentation Updated

- [x] Kernel: I don't think any kernel docs need to be updated? I can't find anything obvious.
- [x] Userland: There is an application README.

### Formatting

- [x] `make formatall` has been run.
