### PR TITLE
ble_advertising: print progress

### DIFF
--- a/userland/examples/ble_advertising/main.c
+++ b/userland/examples/ble_advertising/main.c
@@ -27,26 +27,32 @@ int main (void) {
   // configure advertisement interval to 300ms
   // configure LE only and discoverable
   // configure advertisement address as 1,2,3,4,5,6
+  printf(" - Initializing BLE...\n");
   err = ble_initialize(advertising_interval_ms, true);
   if (err < TOCK_SUCCESS) printf("ble_initialize, error: %s\r\n", tock_strerror(err));
 
   // configure device name as TockOS
+  printf(" - Setting the device name...\n");
   err = ble_advertise_name(device_name, DEVICE_NAME_SIZE);
   if (err < TOCK_SUCCESS) printf("ble_advertise_name, error: %s\r\n", tock_strerror(err));
 
   // configure list of UUIDs
+  printf(" - Setting the device UUID...\n");
   err = ble_advertise_uuid16(uuids, UUIDS_SIZE);
   if (err < TOCK_SUCCESS) printf("ble_advertise_uuid16, error: %s\r\n", tock_strerror(err));
 
   // configure manufacturer data
+  printf(" - Setting manufacturer data...\n");
   err = ble_advertise_manufacturer_specific_data(manufacturer_data, MANUFACTURER_DATA_SIZE);
   if (err < TOCK_SUCCESS) printf("ble_advertise_manufacturer_specific_data, error: %s\r\n", tock_strerror(err));
 
   // configure service data
+  printf(" - Setting service data...\n");
   err = ble_advertise_service_data(uuids[1], fake_temperature_data, FAKE_TEMPERATURE_DATA_SIZE);
   if (err < TOCK_SUCCESS) printf("ble_advertise_service_data, error: %s\r\n", tock_strerror(err));
 
   // start advertising
+  printf(" - Begin advertising!\n");
   err = ble_start_advertising();
   if (err < TOCK_SUCCESS) printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
 

--- a/userland/examples/ble_advertising/main.c
+++ b/userland/examples/ble_advertising/main.c
@@ -56,5 +56,7 @@ int main (void) {
   err = ble_start_advertising();
   if (err < TOCK_SUCCESS) printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
 
+  // configuration complete
+  printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms, device_name);
   return 0;
 }


### PR DESCRIPTION
### Pull Request Overview

It's nice to see progress and most importantly to know that the chip
thinks it's advertising when running this example


### Testing Strategy

BLE wasn't working before this PR either, but this just adds some prints, so feels pretty safe.

### Documentation Updated

- [x] Kernel: ~~The relevant files in `/docs` have been updated or~~ no updates are required.
- [x] Userland: ~~The application README has been added, updated, or~~ no updates are required.

### Formatting

- [x] `make formatall` has been run.
