### PR TITLE
[nRF5X] sensors app work

### DIFF
--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -113,7 +113,7 @@ impl kernel::Platform for Platform {
             capsules::rng::DRIVER_NUM => f(Some(self.rng)),
             capsules::symmetric_encryption::DRIVER_NUM => f(Some(self.aes)),
             nrf5x::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
-            nrf5x::temperature::DRIVER_NUM => f(Some(self.temp)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
             _ => f(None),
         }
     }

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -132,7 +132,7 @@ impl kernel::Platform for Platform {
             capsules::rng::DRIVER_NUM => f(Some(self.rng)),
             capsules::symmetric_encryption::DRIVER_NUM => f(Some(self.aes)),
             nrf5x::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
-            nrf5x::temperature::DRIVER_NUM => f(Some(self.temp)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
             _ => f(None),
         }
     }

--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -15,7 +15,7 @@ use peripheral_interrupts;
 use peripheral_registers;
 
 /// Syscall Number
-pub const DRIVER_NUM: usize = 0x80_06_00_01;
+pub const DRIVER_NUM: usize = 0x60000;
 
 const NRF_TEMP_DATARDY_INTR: u32 = 1;
 const NRF_TEMP_ENABLE: u32 = 1;

--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -14,13 +14,9 @@ use nvic;
 use peripheral_interrupts;
 use peripheral_registers;
 
-/// Syscall Number
-pub const DRIVER_NUM: usize = 0x60000;
-
 const NRF_TEMP_DATARDY_INTR: u32 = 1;
 const NRF_TEMP_ENABLE: u32 = 1;
 const NRF_TEMP_DISABLE: u32 = 0;
-
 
 #[deny(no_mangle_const_items)]
 #[no_mangle]


### PR DESCRIPTION
Wrong driver number was used in chips/nrf5x/temperature.rs

### Pull Request Overview

Makes sensors app work nRF5X

### Testing Strategy

This pull request was tested by...
Tested sensors app
```bash
TOCK_DEBUG(0): src/main.rs:343: Initialization complete. Entering main loop
[Sensors] Starting Sensors App.
[Sensors] All available sensors on the platform will be sampled.
Temperature:                 23 deg C

Temperature:                 23 deg C

Temperature:                 23 deg C

Temperature:                 22 deg C

Temperature:                 23 deg C

```


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [X]  Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [X] `make formatall` has been run.
