### PR TITLE
Fix broken travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 
 os:
   - linux
-  - osx
 
 # If you change this, you must also change Getting_Started.md, Makefile.common,
 # and Vagrantfile.
@@ -17,23 +16,20 @@ rust:
   - nightly-2017-09-20
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./.travis-install-gcc; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH="$PATH:$HOME/gcc-arm-none-eabi-6_2-2016q4/bin"; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH="$PATH:$HOME/uncrustify-uncrustify-0.65/build"; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then brew tap ARMmbed/homebrew-formulae; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then brew install arm-none-eabi-gcc uncrustify; fi
+  - ./.travis-install-gcc
+  - export PATH="$PATH:$HOME/gcc-arm-none-eabi-6_2-2016q4/bin"
+  - export PATH="$PATH:$HOME/uncrustify-uncrustify-0.65/build"
 
 before_script:
   - (cargo install --vers 0.7.1 rustfmt || true)
   - (cargo install xargo || true)
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then npm install -g markdown-toc; fi
+  - npm install -g markdown-toc
 
 script:
   - export PATH=$HOME/.cargo/bin:$PATH
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then tools/run_cargo_fmt.sh diff; fi
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then make allboards; fi
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then pushd userland/examples; ./build_all.sh || exit; popd; fi
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then pushd userland/examples; ./format_all.sh || exit; popd; fi
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]] || [[ "$TRAVIS_BRANCH$TRAVIS_EVENT_TYPE" == "masterpush" ]]; then tools/toc.sh; fi
+  - tools/run_cargo_fmt.sh diff
+  - make allboards
+  - pushd userland/examples; ./build_all.sh || exit; popd
+  - pushd userland/examples; ./format_all.sh || exit; popd
+  - tools/toc.sh
 


### PR DESCRIPTION
It is too slow and is broken, plus we are running the same tests on mac, and
have no mac specific code.

### Pull Request Overview

This pull request changes travis so that it doesn't try our build on mac. There is a really long wait to get a mac on travis to run your job, and something changed so that our mac builds were no longer completing. Since we don't do anything mac specific, it seems better to just save the resources and not run our test build on mac.


### Testing Strategy

This pull request was tested by waiting for travis to finish successfully.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.


