### PR TITLE
Standardize ambient light synchronous interface

### DIFF
--- a/userland/examples/ip_sense/main.c
+++ b/userland/examples/ip_sense/main.c
@@ -27,7 +27,7 @@ int main(void) {
   while (1) {
     temperature_read_sync(&temp);
     humidity_read_sync(&humi);
-    lux = ambient_light_read_intensity();
+    ambient_light_read_intensity_sync(&lux);
 
     int len = snprintf(packet, sizeof(packet), "%d deg C; %d%%; %d lux;\n",
                        temp, humi, lux);

--- a/userland/examples/sensors/main.c
+++ b/userland/examples/sensors/main.c
@@ -34,7 +34,7 @@ static void timer_fired(__attribute__ ((unused)) int arg0,
   int ninedof_x = 0, ninedof_y = 0, ninedof_z = 0;
 
   /* *INDENT-OFF* */
-  if (isl29035)     light = ambient_light_read_intensity();
+  if (isl29035)     ambient_light_read_intensity_sync(&light);
   if (tmp006)       tmp006_read_sync(&tmp006_temp);
   if (tsl2561)      tsl2561_lux = tsl2561_get_lux_sync();
   if (lps25hb)      lps25hb_pressure = lps25hb_get_pressure_sync();

--- a/userland/examples/tests/hail/main.c
+++ b/userland/examples/tests/hail/main.c
@@ -56,7 +56,8 @@ static void sample_sensors (void) {
   unsigned humi;
   humidity_read_sync(&humi);
   uint32_t accel_mag = ninedof_read_accel_mag();
-  int light          = ambient_light_read_intensity();
+  int light;
+  ambient_light_read_intensity_sync(&light);
 
   // Analog inputs: A0-A5
   uint16_t val;

--- a/userland/examples/tests/imix/main.c
+++ b/userland/examples/tests/imix/main.c
@@ -57,7 +57,8 @@ static void sample_sensors (void) {
   unsigned humi;
   humidity_read_sync(&humi);
   uint32_t accel_mag = ninedof_read_accel_mag();
-  int light          = ambient_light_read_intensity();
+  int light;
+  ambient_light_read_intensity_sync(&light);
 
   // Analog inputs: A0-A5
   uint16_t val;

--- a/userland/libtock/ambient_light.h
+++ b/userland/libtock/ambient_light.h
@@ -11,7 +11,7 @@ extern "C" {
 int ambient_light_subscribe(subscribe_cb callback, void* userdata);
 int ambient_light_start_intensity_reading(void);
 
-int ambient_light_read_intensity(void);
+int ambient_light_read_intensity_sync(int* lux_value);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Pull Request Overview

Standardizes the ambient light userland interface to match the `<action>_sync` naming scheme, return an error code, and return the value through an argument passed in to the function. This is particularly desirable since we are using it in the tutorial and it's interface was previously different from every other sensor in the tutorial.

### Testing Strategy

I compiled all the applications to make sure they still worked and tested the Hail app on a Hail.

### TODO or Help Wanted

None. This is ready to go after Travis says it's good.

### Documentation Updated

- ~[ ] Kernel: The relevant files in `/docs` have been updated or~ no updates are required.
- ~[ ] Userland: The application README has been added, updated, or~ no updates are required.

### Formatting

- [X] `make formatall` has been run.
