### PR TITLE
Travis to netlify

### DIFF
--- a/.travis-deploy-netlify
+++ b/.travis-deploy-netlify
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Bless the internet
+# https://therocketeers.github.io/blog/using-travis-ci-to-deploy-jekyll-on-netlify/
+
+set -e
+set -x
+
+./tools/build_all_docs.sh
+
+pushd doc
+
+zip -r website.zip rustdoc/
+
+# NETLIFYKEY is secret. Set in travis web config.
+NETLIFY_SITE_NAME=docs-tockosorg.netlify.com
+
+curl -H "Content-Type: application/zip" \
+     -H "Authorization: Bearer $NETLIFYKEY" \
+     --data-binary "@website.zip" \
+     https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_NAME/deploys

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ script:
   - tools/toc.sh
 
 after_success:
-  - ./.travis-deploy-netlify
+  - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && ./.travis-deploy-netlify
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,6 @@ script:
   - pushd userland/examples; ./format_all.sh || exit; popd
   - tools/toc.sh
 
+after_success:
+  - ./.travis-deploy-netlify
+


### PR DESCRIPTION
### Pull Request Overview

This automatically builds and pushes documentation to a netlify site for any commits to master. It does not run on PRs or branches.

### TODO or Help Wanted

This pushes to the netlify site https://docs-tockosorg.netlify.com/hail/index.html presently. I've added a CNAME record for docs.tockos.org -> docs-tockosorg.netlify.com, but that doesn't seem to be doing what I want/expect. I have an email out to netlify support.

We should also author a root index page of some kind at some point.