### PR TITLE
Generalize nrf5x GPIOTE to work more channels

### DIFF
--- a/chips/nrf51/Cargo.toml
+++ b/chips/nrf51/Cargo.toml
@@ -6,4 +6,7 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 [dependencies]
 cortexm0 = { path = "../../arch/cortex-m0" }
 kernel = { path = "../../kernel" }
-nrf5x = { path = "../nrf5x" }
+
+[dependencies.nrf5x]
+path = "../nrf5x"
+features = ["nrf51"]

--- a/chips/nrf52/Cargo.toml
+++ b/chips/nrf52/Cargo.toml
@@ -6,5 +6,8 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
-nrf5x = { path = "../nrf5x" }
 bitfield = "0.11.0"
+
+[dependencies.nrf5x]
+path = "../nrf5x"
+features = ["nrf52"]

--- a/chips/nrf5x/Cargo.toml
+++ b/chips/nrf5x/Cargo.toml
@@ -5,3 +5,9 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 
 [dependencies]
 kernel = { path = "../../kernel" }
+
+[features]
+default = []
+
+nrf51 = []
+nrf52 = []


### PR DESCRIPTION
### Pull Request Overview

The NRF51 and NRF52 have a different number of GPIOTE channels (four and
eight, respectively). This pull request generalizes the GPIOTE structure to
accomodate both using a const that's feature gated on either the `nrf51` or `nrf521` feature.

To choose between them, the depending chip crate uses:

```
[dependencies.nrf5x]
path = "../nrf5x"
features = ["nrf51"]
```

Closes #676 

### Testing Strategy

_TODO_

### TODO or Help Wanted

@niklasad1 or @JayKickliter might be able to help test this (I'm out of reach of my nrf5's for about another week).

### Documentation Updated

- [ ] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [ ] ~~Userland: The application README has been added, updated, or no updates are required.~~

### Formatting

- [x] `make formatall` has been run.
