### PR TITLE
Remove all unsafe from capsules (looking at you 6lowpan)

### DIFF
--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(const_fn,const_cell_new)]
+#![forbid(unsafe_code)]
 #![no_std]
 
 #[allow(unused_imports)]

--- a/capsules/src/net/ip.rs
+++ b/capsules/src/net/ip.rs
@@ -93,6 +93,36 @@ impl IP6Header {
     pub fn new() -> IP6Header {
         IP6Header::default()
     }
+
+    /// Parses a buffer into an `IP6Header`
+    ///
+    /// The buffer must be at least 40 bytes. This method performs no checking
+    /// on the validity of the header.
+    pub fn parse(buf: &[u8]) -> Result<IP6Header, ()> {
+        if buf.len() < 40 {
+            return Err(())
+        }
+        let version_class_flow: [u8; 4] = [buf[0], buf[1], buf[2], buf[3]];
+
+        let payload_len: u16 = buf[4] as u16 | (buf[5] as u16) << 8;
+        let next_header: u8 = buf[5];
+        let hop_limit: u8 = buf[6];
+
+        let mut src_addr = IPAddr::new();
+        src_addr.0.copy_from_slice(&buf[7..24]);
+        let mut dst_addr = IPAddr::new();
+        dst_addr.0.copy_from_slice(&buf[24..40]);
+
+        Ok(IP6Header {
+            version_class_flow: version_class_flow,
+            payload_len: payload_len,
+            next_header: next_header,
+            hop_limit: hop_limit,
+            src_addr: src_addr,
+            dst_addr: dst_addr,
+        })
+    }
+
     // Version should always be 6
     pub fn get_version(&self) -> u8 {
         (self.version_class_flow[0] & 0xf0) >> 4

--- a/capsules/src/net/lowpan.rs
+++ b/capsules/src/net/lowpan.rs
@@ -282,7 +282,7 @@ pub fn compress(ctx_store: &ContextStore,
                 dst_mac_addr: MacAddress,
                 mut buf: &mut [u8])
                 -> Result<(usize, usize), ()> {
-    let ip6_header: &IP6Header = unsafe { mem::transmute(ip6_datagram.as_ptr()) };
+    let ip6_header = IP6Header::parse(ip6_datagram)?;
     let mut consumed: usize = mem::size_of::<IP6Header>();
     let mut next_headers: &[u8] = &ip6_datagram[consumed..];
 
@@ -314,15 +314,15 @@ pub fn compress(ctx_store: &ContextStore,
     compress_cie(&src_ctx, &dst_ctx, &mut buf, &mut written);
 
     // Traffic Class & Flow Label
-    compress_tf(ip6_header, &mut buf, &mut written);
+    compress_tf(&ip6_header, &mut buf, &mut written);
 
     // Next Header
     let (mut is_nhc, mut nh_len): (bool, u8) = is_ip6_nh_compressible(ip6_header.next_header,
                                                                       next_headers)?;
-    compress_nh(ip6_header, is_nhc, &mut buf, &mut written);
+    compress_nh(&ip6_header, is_nhc, &mut buf, &mut written);
 
     // Hop Limit
-    compress_hl(ip6_header, &mut buf, &mut written);
+    compress_hl(&ip6_header, &mut buf, &mut written);
 
     // Source Address
     compress_src(&ip6_header.src_addr,

--- a/capsules/src/net/lowpan.rs
+++ b/capsules/src/net/lowpan.rs
@@ -778,10 +778,8 @@ pub fn decompress(ctx_store: &ContextStore,
     let iphc_header_2: u8 = buf[1];
     let mut consumed: usize = 2;
 
-    // First, reset the IPv6 fixed header to the default values
-    let mut ip6_header: &mut IP6Header = unsafe { mem::transmute(out_buf.as_mut_ptr()) };
+    let mut ip6_header = IP6Header::new();
     let mut written: usize = mem::size_of::<IP6Header>();
-    *ip6_header = IP6Header::new();
 
     // Decompress CID and CIE fields if they exist
     let (src_ctx, dst_ctx) = decompress_cie(ctx_store, iphc_header_1, &buf, &mut consumed)?;
@@ -941,6 +939,7 @@ pub fn decompress(ctx_store: &ContextStore,
         written + (buf.len() - consumed) - mem::size_of::<IP6Header>()
     };
     ip6_header.payload_len = (payload_len as u16).to_be();
+    ip6_header.serialize(&mut out_buf[0..40])?;
     Ok((consumed, written))
 }
 


### PR DESCRIPTION
### Pull Request Overview

Somehow we let some `unsafe`s get into the capsules crate via the 6lowpan stack, used to serialized/deserialize the IPv6 header with an uncast. This pull request replaces those casts with explicit serialization and deserialization and adds the `forbid(unsafe_code)` flag to the capsules crates to make sure such code fails the build in the future.

### Testing Strategy

TODO: Needs to be tested

### TODO or Help Wanted

@ptcrews can you help verify that my serialization and deserialization code still work?


### Documentation Updated

- [x] ~~Kernel: The relevant files in `/docs` have been updated or no updates are required.~~
- [x] ~~Userland: The application README has been added, updated, or no updates are required.~~

### Formatting

- [x] `make formatall` has been run.
