### PR TITLE
I2CMasterSlaveDriver: add `write_read` command.

### DIFF
--- a/userland/libtock/i2c_master_slave.c
+++ b/userland/libtock/i2c_master_slave.c
@@ -46,6 +46,11 @@ int i2c_master_slave_write(uint8_t address, uint8_t length) {
   return command(DRIVER_NUM_I2CMASTERSLAVE, 1, a, 0);
 }
 
+int i2c_master_slave_write_read(uint8_t address, uint8_t write_length, uint8_t read_length) {
+  uint32_t a = (((uint32_t) write_length) << 16) | ((uint32_t) read_length << 8) | address;
+  return command(DRIVER_NUM_I2CMASTERSLAVE, 7, a, 0);
+}
+
 int i2c_master_slave_read(uint16_t address, uint16_t len) {
   uint32_t a = (((uint32_t) len) << 16) | address;
   return command(DRIVER_NUM_I2CMASTERSLAVE, 2, a, 0);
@@ -71,6 +76,22 @@ int i2c_master_slave_write_sync(uint8_t address, uint8_t len) {
   if (err < 0) return err;
 
   err = i2c_master_slave_write(address, len);
+  if (err < 0) return err;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return result.length;
+}
+
+int i2c_master_slave_write_read_sync(uint8_t address, uint8_t wlen, uint8_t rlen) {
+  int err;
+  result.fired = false;
+
+  err = i2c_master_slave_set_callback(i2c_master_slave_cb, (void*) &result);
+  if (err < 0) return err;
+
+  err = i2c_master_slave_write_read(address, wlen, rlen);
   if (err < 0) return err;
 
   // Wait for the callback.

--- a/userland/libtock/i2c_master_slave.h
+++ b/userland/libtock/i2c_master_slave.h
@@ -20,12 +20,14 @@ int i2c_master_slave_set_master_read_buffer(uint8_t* buffer, uint32_t len);
 int i2c_master_slave_set_slave_read_buffer(uint8_t* buffer, uint32_t len);
 int i2c_master_slave_set_slave_write_buffer(uint8_t* buffer, uint32_t len);
 int i2c_master_slave_write(uint8_t address, uint8_t length);
+int i2c_master_slave_write_read(uint8_t address, uint8_t write_length, uint8_t read_length);
 int i2c_master_slave_read(uint16_t address, uint16_t len);
 int i2c_master_slave_listen(void);
 int i2c_master_slave_set_slave_address(uint8_t address);
 int i2c_master_slave_enable_slave_read(uint32_t len);
 
 int i2c_master_slave_write_sync(uint8_t address, uint8_t length);
+int i2c_master_slave_write_read_sync(uint8_t address, uint8_t wlen, uint8_t rlen);
 int i2c_master_slave_read_sync(uint16_t address, uint16_t len);
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a libtock wrapper for the i2c `write_read` trait because previously it was not possible to call it from userland.

### Testing Strategy

I tested using a Salae and the NRF52:
![write_read](https://user-images.githubusercontent.com/86412/32509568-81db2470-c3a2-11e7-9763-1c60beead7c0.png)

This was a i2c write-read transaction against a i2c EEPROM peripheral.

### TODO or Help Wanted

This pull request should be ready to merge. The only question is the buffer overwrite behaviour of `write_read`. It is not clear if the received bytes are written to the beginning of the buffer, or written after the bytes that were transmitted. Currently we assume the received bytes are written starting at index 0 of the buffer.

### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [x] `make formatall` has been run.


@JayKickliter also contributed to this.