### PR TITLE
sam4l: flash: update driver

### DIFF
--- a/chips/sam4l/src/flashcalw.rs
+++ b/chips/sam4l/src/flashcalw.rs
@@ -67,25 +67,6 @@ enum RegKey {
     GPFRLO,
 }
 
-/// High level commands to issue to the flash. Usually to track the state of
-/// a command especially if it's multiple FlashCMDs.
-///
-/// For example an erase is:
-///
-///  1. Unlock Page  (UP)
-///  2. Erase Page   (EP)
-///  3. Lock Page    (LP)
-///
-/// Store what high level command we're doing allows us to track the state and
-/// continue the steps of the command in handle_interrupt.
-#[derive(Clone, Copy, PartialEq)]
-pub enum Command {
-    Read,
-    Write { page: i32 },
-    Erase { page: i32 },
-    None,
-}
-
 /// There are 18 recognized commands for the flash. These are "bare-bones"
 /// commands and values that are written to the Flash's command register to
 /// inform the flash what to do. Table 14-5.
@@ -118,18 +99,17 @@ pub enum Speed {
     HighSpeed,
 }
 
-/// FlashState is used to track the current state of the flash in high level
-/// command.
-///
-/// Combined with Command, it defines a unique function the flash is preforming.
+/// FlashState is used to track the current state and command of the flash.
 #[derive(Clone, Copy, PartialEq)]
 pub enum FlashState {
-    Locking, // The Flash is locking a region
-    Unlocking, // The Flash is unlocking a region
-    Writing, // The Flash is writing a page
-    Erasing, // The Flash is erasing a page
-    Ready, // The Flash is ready to complete a command
-    Unconfigured, // The Flash is unconfigured, call configure()
+    Unconfigured, //                 Flash is unconfigured, call configure().
+    Ready, //                        Flash is ready to complete a command.
+    Read, //                         Performing a read operation.
+    WriteUnlocking { page: i32 }, // Started a write operation.
+    WriteErasing { page: i32 }, //   Waiting on the page to erase.
+    WriteWriting, //                 Waiting on the page to actually be written.
+    EraseUnlocking { page: i32 }, // Started an erase operation.
+    EraseErasing, //                 Waiting on the erase to finish.
 }
 
 /// This is a wrapper around a u8 array that is sized to a single page for the
@@ -179,11 +159,8 @@ pub struct FLASHCALW {
     ahb_clock: pm::Clock,
     hramc1_clock: pm::Clock,
     pb_clock: pm::Clock,
-    error_status: Cell<u32>,
-    ready: Cell<bool>,
     client: Cell<Option<&'static hil::flash::Client<FLASHCALW>>>,
     current_state: Cell<FlashState>,
-    current_command: Cell<Command>,
     buffer: TakeCell<'static, Sam4lPage>,
 }
 
@@ -228,11 +205,8 @@ impl FLASHCALW {
             ahb_clock: pm::Clock::HSB(ahb_clk),
             hramc1_clock: pm::Clock::HSB(hramc1_clk),
             pb_clock: pm::Clock::PBB(pb_clk),
-            error_status: Cell::new(0),
-            ready: Cell::new(true),
             client: Cell::new(None),
             current_state: Cell::new(FlashState::Unconfigured),
-            current_command: Cell::new(Command::None),
             buffer: TakeCell::empty(),
         }
     }
@@ -292,45 +266,46 @@ impl FLASHCALW {
 
     pub fn handle_interrupt(&self) {
         unsafe {
-            //  mark the controller as ready and clear pending interrupt
-            self.ready.set(true);
+            //  Clear pending interrupt
             nvic::clear_pending(nvic::NvicIdx::HFLASHC);
         }
 
         let error_status = self.get_error_status();
-        self.error_status.set(error_status);
 
-        //  Since the only interrupt on is FRDY, a command should have
-        //  either completed or failed at this point.
+        // Since the only interrupt on is FRDY, a command should have
+        // either completed or failed at this point.
 
         // Check for errors and report to Client if there are any
         if error_status != 0 {
-            // reset commands / ready
-            self.current_command.set(Command::None);
+            let attempted_operation = self.current_state.get();
+
+            // Reset state now that we are ready to do a new operation.
             self.current_state.set(FlashState::Ready);
 
-            self.client.get().map(|client| match self.current_command.get() {
-                Command::Read => {
+            self.client.get().map(|client| match attempted_operation {
+                FlashState::Read => {
                     self.buffer.take().map(|buffer| {
-                            client.read_complete(buffer, hil::flash::Error::FlashError);
-                        });
+                        client.read_complete(buffer, hil::flash::Error::FlashError);
+                    });
                 }
-                Command::Write { .. } => {
+                FlashState::WriteUnlocking { .. } |
+                FlashState::WriteErasing { .. } |
+                FlashState::WriteWriting => {
                     self.buffer.take().map(|buffer| {
-                            client.write_complete(buffer, hil::flash::Error::FlashError);
-                        });
+                        client.write_complete(buffer, hil::flash::Error::FlashError);
+                    });
                 }
-                Command::Erase { .. } => {
+                FlashState::EraseUnlocking { .. } |
+                FlashState::EraseErasing => {
                     client.erase_complete(hil::flash::Error::FlashError);
                 }
-                Command::None => {}
+                _ => {}
             });
         }
 
-        //  Part of a command succeeded -- continue onto next steps.
-
-        match self.current_command.get() {
-            Command::Read => {
+        // Part of a command succeeded -- continue onto next steps.
+        match self.current_state.get() {
+            FlashState::Read => {
                 self.current_state.set(FlashState::Ready);
 
                 self.client.get().map(|client| {
@@ -339,68 +314,50 @@ impl FLASHCALW {
                     });
                 });
             }
-            Command::Write { page } => {
-                match self.current_state.get() {
-                    FlashState::Unlocking => {
-                        self.current_state.set(FlashState::Erasing);
-                        self.flashcalw_erase_page(page, true);
-                    }
-                    FlashState::Erasing => {
-                        //  Write page buffer isn't really a command, and
-                        //  clear page buffer doesn't trigger an interrupt thus
-                        //  I'm combining these with an actual command, write_page,
-                        //  which generates and interrupt and saves the page.
-                        self.clear_page_buffer();
-                        self.write_to_page_buffer(page as usize * PAGE_SIZE as usize);
-
-                        self.current_state.set(FlashState::Writing);
-                        self.flashcalw_write_page(page);
-                    }
-                    FlashState::Writing => {
-                        // Flush the cache
-                        self.invalidate_cache();
-
-                        self.current_state.set(FlashState::Ready);
-                        self.current_command.set(Command::None);
-
-                        self.client.get().map(|client| {
-                            self.buffer.take().map(|buffer| {
-                                client.write_complete(buffer, hil::flash::Error::CommandComplete);
-                            });
-                        });
-                    }
-                    _ => {
-                        assert!(false) /* should never reach here */
-                    }
-
-                }
+            FlashState::WriteUnlocking { page } => {
+                self.current_state.set(FlashState::WriteErasing { page: page });
+                self.flashcalw_erase_page(page);
             }
-            Command::Erase { page } => {
-                match self.current_state.get() {
-                    FlashState::Unlocking => {
-                        self.current_state.set(FlashState::Erasing);
-                        self.flashcalw_erase_page(page, true);
-                    }
-                    FlashState::Erasing => {
-                        self.current_state.set(FlashState::Ready);
-                        self.current_command.set(Command::None);
+            FlashState::WriteErasing { page } => {
+                //  Write page buffer isn't really a command, and
+                //  clear page buffer doesn't trigger an interrupt thus
+                //  I'm combining these with an actual command, write_page,
+                //  which generates and interrupt and saves the page.
+                self.clear_page_buffer();
+                self.write_to_page_buffer(page as usize * PAGE_SIZE as usize);
 
-                        self.client.get().map(|client| {
-                            client.erase_complete(hil::flash::Error::CommandComplete);
-                        });
-                    }
-                    _ => {
-                        assert!(false); /* should never happen. */
-                    }
-                }
+                self.current_state.set(FlashState::WriteWriting);
+                self.flashcalw_write_page(page);
             }
-            Command::None => {
+            FlashState::WriteWriting => {
+                // Flush the cache
+                self.invalidate_cache();
+
+                self.current_state.set(FlashState::Ready);
+
+                self.client.get().map(|client| {
+                    self.buffer.take().map(|buffer| {
+                        client.write_complete(buffer, hil::flash::Error::CommandComplete);
+                    });
+                });
+            }
+            FlashState::EraseUnlocking { page } => {
+                self.current_state.set(FlashState::EraseErasing);
+                self.flashcalw_erase_page(page);
+            }
+            FlashState::EraseErasing => {
+                self.current_state.set(FlashState::Ready);
+
+                self.client
+                    .get()
+                    .map(|client| { client.erase_complete(hil::flash::Error::CommandComplete); });
+            }
+            _ => {
                 self.current_state.set(FlashState::Ready);
             }
 
         }
     }
-
 
     /// FLASH properties.
     pub fn get_flash_size(&self) -> u32 {
@@ -634,8 +591,7 @@ impl FLASHCALW {
         }
         if command != FlashCMD::QPRUP && command != FlashCMD::QPR && command != FlashCMD::CPB &&
            command != FlashCMD::HSEN {
-            //  enable ready int and mark the controller as being unavaliable.
-            self.ready.set(false);
+            // Enable ready interrupt.
             self.enable_ready_int(true);
         }
 
@@ -654,9 +610,12 @@ impl FLASHCALW {
 
         cmd_regs.fcmd.set(reg_val); // write the cmd
 
+        // Since we don't enable interrupts for these commands, spin wait
+        // until they are finished. In particular, QPR and QPRUP will not issue
+        // interrupts (see datasheet 14.6 paragraph 2).
         if command == FlashCMD::QPRUP || command == FlashCMD::QPR || command == FlashCMD::CPB ||
            command == FlashCMD::HSEN {
-            self.error_status.set(self.get_error_status());
+            while (cmd_regs.fsr.get() & 0x01) != 0x01 {}
         }
     }
 
@@ -715,33 +674,22 @@ impl FLASHCALW {
         (status & bit!(5)) != 0
     }
 
+    #[allow(dead_code)]
     fn quick_page_read(&self, page_number: i32) -> bool {
         self.issue_command(FlashCMD::QPR, page_number);
         self.is_page_erased()
     }
 
-    fn flashcalw_erase_page(&self, page_number: i32, check: bool) -> bool {
-        let mut page_erased = true;
-
+    fn flashcalw_erase_page(&self, page_number: i32) {
         self.issue_command(FlashCMD::EP, page_number);
-        if check {
-            let mut error_status: u32 = self.error_status.get();
-            page_erased = self.quick_page_read(-1);
-
-            //  issue command should have changed the error status.
-            error_status |= self.error_status.get();
-            self.error_status.set(error_status);
-        }
-
-        page_erased
     }
 
     fn flashcalw_write_page(&self, page_number: i32) {
         self.issue_command(FlashCMD::WP, page_number);
     }
 
-    /// There's a user_page that isn't contigous with the rest of the flash. Currently
-    /// it's not being used.
+    /// There's a user_page that isn't contiguous with the rest of the flash.
+    /// Currently it's not being used.
     #[allow(dead_code)]
     fn quick_user_page_read(&self) -> bool {
         self.issue_command(FlashCMD::QPRUP, -1);
@@ -763,8 +711,8 @@ impl FLASHCALW {
         self.issue_command(FlashCMD::WUP, -1);
     }
 
-    //  Instead of having several memset/memcpy functions as Atmel's ASF
-    //  implementation will only have one to write to the page buffer.
+    // Instead of having several memset/memcpy functions as Atmel's ASF
+    // implementation will only have one to write to the page buffer.
     fn write_to_page_buffer(&self, pg_buff_addr: usize) {
         let mut page_buffer: *mut u8 = pg_buff_addr as *mut u8;
 
@@ -791,11 +739,6 @@ impl FLASHCALW {
                 }
             }
         });
-    }
-
-    // returns the error_status (useful for debugging).
-    pub fn debug_error_status(&self) -> u32 {
-        self.error_status.get()
     }
 }
 
@@ -866,6 +809,7 @@ impl FLASHCALW {
             return ReturnCode::EINVAL;
         }
 
+        // Actually do a copy from flash into the buffer.
         let mut byte: *const u8 = address as *const u8;
         unsafe {
             for i in 0..size {
@@ -874,7 +818,7 @@ impl FLASHCALW {
             }
         }
 
-        self.current_command.set(Command::Read);
+        self.current_state.set(FlashState::Read);
         // Hold on to the buffer for the callback.
         self.buffer.replace(buffer);
 
@@ -894,7 +838,7 @@ impl FLASHCALW {
             pm::enable_clock(self.ahb_clock);
         }
 
-        // Ff we're not ready don't take the command.
+        // If we're not ready don't take the command.
         if self.current_state.get() != FlashState::Ready {
             return ReturnCode::EBUSY;
         }
@@ -902,8 +846,7 @@ impl FLASHCALW {
         // Save the buffer for the future write.
         self.buffer.replace(data);
 
-        self.current_state.set(FlashState::Unlocking);
-        self.current_command.set(Command::Write { page: page_num });
+        self.current_state.set(FlashState::WriteUnlocking { page: page_num });
         self.lock_page_region(page_num, false);
         ReturnCode::SUCCESS
     }
@@ -917,8 +860,7 @@ impl FLASHCALW {
             return ReturnCode::EBUSY;
         }
 
-        self.current_state.set(FlashState::Unlocking);
-        self.current_command.set(Command::Erase { page: page_num });
+        self.current_state.set(FlashState::EraseUnlocking { page: page_num });
         self.lock_page_region(page_num, false);
         ReturnCode::SUCCESS
     }


### PR DESCRIPTION
This PR makes two main changes to the SAM4L flash driver:

- Remove the "is flash actually erased check". This was a bit of a hack
since it required the flash to be ready without actually checking it
before issuing the quick page read. In addition, we weren't reading the
correct page and we weren't checking the return value, so this check has
been an NOP so far. We just remove it to keep things simpler.

- Otherwise simplify the driver. This get's rid of state variables that
were set but never checked and consolidates state variables.



### Testing Strategy

This pull request was tested by running the `nonvolatile_storage` userland app in conjunction with commit 93eb229e.



### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [x] `make formatall` has been run.
