### PR TITLE
Use LLVM size optimizations and debug symbols on release builds for boards

### DIFF
--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -13,6 +13,8 @@ debug = true
 [profile.release]
 panic = "abort"
 lto = true
+opt-level = "z"
+debug = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 [profile.dev]
 panic = "abort"
 lto = true
-opt-level = 0
+opt-level = "z"
 debug = true
 
 [profile.release]

--- a/boards/imix/Cargo.toml
+++ b/boards/imix/Cargo.toml
@@ -13,6 +13,8 @@ debug = true
 [profile.release]
 panic = "abort"
 lto = true
+opt-level = "z"
+debug = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/boards/imix/Cargo.toml
+++ b/boards/imix/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 [profile.dev]
 panic = "abort"
 lto = true
-opt-level = 0
+opt-level = "z"
 debug = true
 
 [profile.release]

--- a/boards/nrf51dk/Cargo.toml
+++ b/boards/nrf51dk/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 [profile.dev]
 panic = "abort"
 lto = true
-opt-level = 0
+opt-level = "z"
 debug = true
 
 [profile.release]

--- a/boards/nrf51dk/Cargo.toml
+++ b/boards/nrf51dk/Cargo.toml
@@ -13,6 +13,8 @@ debug = true
 [profile.release]
 panic = "abort"
 lto = true
+opt-level = "z"
+debug = true
 
 [dependencies]
 cortexm0 = { path = "../../arch/cortex-m0" }

--- a/boards/nrf52dk/Cargo.toml
+++ b/boards/nrf52dk/Cargo.toml
@@ -13,6 +13,8 @@ debug = true
 [profile.release]
 panic = "abort"
 lto = true
+opt-level = "z"
+debug = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/boards/nrf52dk/Cargo.toml
+++ b/boards/nrf52dk/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 [profile.dev]
 panic = "abort"
 lto = true
-opt-level = 0
+opt-level = "z"
 debug = true
 
 [profile.release]

--- a/doc/Compilation.md
+++ b/doc/Compilation.md
@@ -72,10 +72,10 @@ $ cargo build --release --target=sam4l.json
 ```
 
 The `--release` argument tells Cargo to invoke the Rust compiler with
-optimizations turned on and without debug symbols. `--target` points Cargo to
-the target specification which includes the LLVM data-layout definition,
-architecture definitions for the compiler, arguments to pass to the linker and
-compilation options such as floating-point support.
+optimizations turned on. `--target` points Cargo to the target specification
+which includes the LLVM data-layout definition, architecture definitions for
+the compiler, arguments to pass to the linker and compilation options such as
+floating-point support.
 
 ### Xargo
 


### PR DESCRIPTION
### Pull Request Overview

Adds `opt-level="z"` and `debug=true` to release builds of each of the boards.

`opt-level="z"` is LLVMs size optimization, which saves about 20kB of flash for
Hail and imix (with more modest savings for the smaller NRF boards, but still
a win) and a few kBs of RAM.

`debug=true` works with LTO these days, so no harm in adding that to get slightly nicer debugging in GDB.

### Testing Strategy

There are no code changes so there shouldn't be any issues, but tested by running a few apps on Hail, including the `tests/hail` app.

### Documentation Updated

- [x] ~~Kernel: The relevant files in `/docs` have been updated or no updates are required.~~
- [x] ~~Userland: The application README has been added, updated, or no updates are required.~~

### Formatting

- [x] `make formatall` has been run.
