### PR TITLE
Low Power MAC Protocol (X-MAC)

### DIFF
--- a/boards/imix/src/lowpan_frag_dummy.rs
+++ b/boards/imix/src/lowpan_frag_dummy.rs
@@ -29,7 +29,7 @@
 //! ...
 //! // Radio initialization code
 //! ...
-//! let lowpan_frag_test = lowpan_frag_dummy::initialize_all(radio_mac as &'static Mac,
+//! let lowpan_frag_test = lowpan_frag_dummy::initialize_all(radio_mac as &'static MacDevice,
 //!                                                          mux_alarm as &'static
 //!                                                             MuxAlarm<'static,
 //!                                                                 sam4l::ast::Ast>);
@@ -40,7 +40,7 @@
 
 use capsules;
 extern crate sam4l;
-use capsules::ieee802154::mac::Mac;
+use capsules::ieee802154::device::MacDevice;
 use capsules::net::ieee802154::MacAddress;
 use capsules::net::ip::{IP6Header, IPAddr, ip6_nh};
 use capsules::net::sixlowpan::{Sixlowpan, SixlowpanClient};
@@ -122,7 +122,7 @@ pub struct LowpanTest<'a, A: time::Alarm + 'a, T: time::Alarm + 'a> {
 }
 
 pub unsafe fn initialize_all(
-    radio_mac: &'static Mac,
+    radio_mac: &'static MacDevice,
     mux_alarm: &'static MuxAlarm<'static, sam4l::ast::Ast>,
 ) -> &'static LowpanTest<
     'static,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -10,7 +10,8 @@ extern crate kernel;
 extern crate sam4l;
 
 use capsules::alarm::AlarmDriver;
-use capsules::ieee802154::mac::Mac;
+use capsules::ieee802154::device::MacDevice;
+use capsules::ieee802154::mac::{AwakeMac, Mac};
 use capsules::rf233::RF233;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
@@ -89,6 +90,7 @@ static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0x00; radio::MAX_BUF_SIZE];
 static mut RF233_RX_BUF: [u8; radio::MAX_BUF_SIZE] = [0x00; radio::MAX_BUF_SIZE];
 static mut RF233_REG_WRITE: [u8; 2] = [0x00; 2];
 static mut RF233_REG_READ: [u8; 2] = [0x00; 2];
+
 // The RF233 system call interface ("radio") requires one buffer, which it
 // copies application transmissions into or copies out to application buffers
 // for reception.
@@ -475,20 +477,26 @@ pub unsafe fn reset_handler() {
     rf233_spi.set_client(rf233);
     rf233.initialize(&mut RF233_BUF, &mut RF233_REG_WRITE, &mut RF233_REG_READ);
 
-    let rf233_mac = static_init!(
-        capsules::ieee802154::mac::MacDevice<'static, RF233Device>,
-        capsules::ieee802154::mac::MacDevice::new(rf233)
+    // Keeps the radio on permanently; pass-through layer
+    let awake_mac: &AwakeMac<RF233Device> =
+        static_init!(AwakeMac<'static, RF233Device>, AwakeMac::new(rf233));
+    rf233.set_transmit_client(awake_mac);
+    rf233.set_receive_client(awake_mac, &mut RF233_RX_BUF);
+
+    let mac_device = static_init!(
+        capsules::ieee802154::framer::Framer<'static, AwakeMac<'static, RF233Device>>,
+        capsules::ieee802154::framer::Framer::new(awake_mac)
     );
-    rf233.set_transmit_client(rf233_mac);
-    rf233.set_receive_client(rf233_mac, &mut RF233_RX_BUF);
-    rf233.set_config_client(rf233_mac);
+    awake_mac.set_transmit_client(mac_device);
+    awake_mac.set_receive_client(mac_device);
+    awake_mac.set_config_client(mac_device);
 
     let mux_mac = static_init!(
         capsules::ieee802154::virtual_mac::MuxMac<'static>,
-        capsules::ieee802154::virtual_mac::MuxMac::new(rf233_mac)
+        capsules::ieee802154::virtual_mac::MuxMac::new(mac_device)
     );
-    rf233_mac.set_transmit_client(mux_mac);
-    rf233_mac.set_receive_client(mux_mac);
+    mac_device.set_transmit_client(mux_mac);
+    mac_device.set_receive_client(mux_mac);
 
     let radio_mac = static_init!(
         capsules::ieee802154::virtual_mac::MacUser<'static>,
@@ -501,8 +509,8 @@ pub unsafe fn reset_handler() {
         capsules::ieee802154::RadioDriver::new(radio_mac, kernel::Grant::create(), &mut RADIO_BUF)
     );
 
-    rf233_mac.set_key_procedure(radio_driver);
-    rf233_mac.set_device_procedure(radio_driver);
+    mac_device.set_key_procedure(radio_driver);
+    mac_device.set_device_procedure(radio_driver);
     radio_mac.set_transmit_client(radio_driver);
     radio_mac.set_receive_client(radio_driver);
     radio_mac.set_pan(0xABCD);

--- a/capsules/src/ieee802154/device.rs
+++ b/capsules/src/ieee802154/device.rs
@@ -1,0 +1,114 @@
+//! The contract satisfied by an implementation of an IEEE 802.15.4 MAC device.
+//! Any IEEE 802.15.4 MAC device should expose the following high-level
+//! functionality:
+//!
+//! - Configuration of addresses and transmit power
+//! - Preparing frames (data frame, command frames, beacon frames)
+//! - Transmitting and receiving frames
+//!
+//! Outlining this in a trait allows other implementations of MAC devices that
+//! divide the responsibilities of software and hardware differently. For
+//! example, a radio chip might be able to completely inline the frame security
+//! procedure in hardware, as opposed to requiring a software implementation.
+
+use ieee802154::framer::Frame;
+use kernel::ReturnCode;
+use net::ieee802154::{Header, KeyId, MacAddress, PanID, SecurityLevel};
+
+pub trait MacDevice<'a> {
+    /// Sets the transmission client of this MAC device
+    fn set_transmit_client(&self, client: &'a TxClient);
+    /// Sets the receive client of this MAC device
+    fn set_receive_client(&self, client: &'a RxClient);
+
+    /// The short 16-bit address of the MAC device
+    fn get_address(&self) -> u16;
+    /// The long 64-bit address (EUI-64) of the MAC device
+    fn get_address_long(&self) -> [u8; 8];
+    /// The 16-bit PAN ID of the MAC device
+    fn get_pan(&self) -> u16;
+
+    /// Set the short 16-bit address of the MAC device
+    fn set_address(&self, addr: u16);
+    /// Set the long 64-bit address (EUI-64) of the MAC device
+    fn set_address_long(&self, addr: [u8; 8]);
+    /// Set the 16-bit PAN ID of the MAC device
+    fn set_pan(&self, id: u16);
+
+    /// This method must be called after one or more calls to `set_*`. If
+    /// `set_*` is called without calling `config_commit`, there is no guarantee
+    /// that the underlying hardware configuration (addresses, pan ID) is in
+    /// line with this MAC device implementation.
+    fn config_commit(&self);
+
+    /// Returns if the MAC device is currently on.
+    fn is_on(&self) -> bool;
+
+    /// Prepares a mutable buffer slice as an 802.15.4 frame by writing the appropriate
+    /// header bytes into the buffer. This needs to be done before adding the
+    /// payload because the length of the header is not fixed.
+    ///
+    /// - `buf`: The mutable buffer slice to use
+    /// - `dst_pan`: The destination PAN ID
+    /// - `dst_addr`: The destination MAC address
+    /// - `src_pan`: The source PAN ID
+    /// - `src_addr`: The source MAC address
+    /// - `security_needed`: Whether or not this frame should be secured. This
+    /// needs to be specified beforehand so that the auxiliary security header
+    /// can be pre-inserted.
+    ///
+    /// Returns either a Frame that is ready to have payload appended to it, or
+    /// the mutable buffer if the frame cannot be prepared for any reason
+    fn prepare_data_frame(
+        &self,
+        buf: &'static mut [u8],
+        dst_pan: PanID,
+        dst_addr: MacAddress,
+        src_pan: PanID,
+        src_addr: MacAddress,
+        security_needed: Option<(SecurityLevel, KeyId)>,
+    ) -> Result<Frame, &'static mut [u8]>;
+
+    /// Transmits a frame that has been prepared by the above process. If the
+    /// transmission process fails, the buffer inside the frame is returned so
+    /// that it can be re-used.
+    fn transmit(&self, frame: Frame) -> (ReturnCode, Option<&'static mut [u8]>);
+}
+
+/// Trait to be implemented by any user of the IEEE 802.15.4 device that
+/// transmits frames. Contains a callback through which the static mutable
+/// reference to the frame buffer is returned to the client.
+pub trait TxClient {
+    /// When transmission is complete or fails, return the buffer used for
+    /// transmission to the client. `result` indicates whether or not
+    /// the transmission was successful.
+    ///
+    /// - `spi_buf`: The buffer used to contain the transmitted frame is
+    /// returned to the client here.
+    /// - `acked`: Whether the transmission was acknowledged.
+    /// - `result`: This is `ReturnCode::SUCCESS` if the frame was transmitted,
+    /// otherwise an error occured in the transmission pipeline.
+    fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode);
+}
+
+/// Trait to be implemented by users of the IEEE 802.15.4 device that wish to
+/// receive frames. The callback is triggered whenever a valid frame is
+/// received, verified and unsecured (via the IEEE 802.15.4 security procedure)
+/// successfully.
+pub trait RxClient {
+    /// When a frame is received, this callback is triggered. The client only
+    /// receives an immutable borrow of the buffer. Only completely valid,
+    /// unsecured frames that have passed the incoming security procedure are
+    /// exposed to the client.
+    ///
+    /// - `buf`: The entire buffer containing the frame, including extra bytes
+    /// in front used for the physical layer.
+    /// - `header`: A fully-parsed representation of the MAC header, with the
+    /// caveat that the auxiliary security header is still included if the frame
+    /// was previously secured.
+    /// - `data_offset`: Offset of the data payload relative to
+    /// `buf`, so that the payload of the frame is contained in
+    /// `buf[data_offset..data_offset + data_len]`.
+    /// - `data_len`: Length of the data payload
+    fn receive<'a>(&self, buf: &'a [u8], header: Header<'a>, data_offset: usize, data_len: usize);
+}

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -6,7 +6,7 @@
 
 use core::cell::Cell;
 use core::cmp::min;
-use ieee802154::mac;
+use ieee802154::{device, framer};
 use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 use kernel::common::take_cell::{MapCell, TakeCell};
 use net::ieee802154::{AddressMode, Header, KeyId, MacAddress, PanID, SecurityLevel};
@@ -168,7 +168,7 @@ impl Default for App {
 
 pub struct RadioDriver<'a> {
     /// Underlying MAC device, possibly multiplexed
-    mac: &'a mac::Mac<'a>,
+    mac: &'a device::MacDevice<'a>,
 
     /// List of (short address, long address) pairs representing IEEE 802.15.4
     /// neighbors.
@@ -193,7 +193,7 @@ pub struct RadioDriver<'a> {
 
 impl<'a> RadioDriver<'a> {
     pub fn new(
-        mac: &'a mac::Mac<'a>,
+        mac: &'a device::MacDevice<'a>,
         grant: Grant<App>,
         kernel_tx: &'static mut [u8],
     ) -> RadioDriver<'a> {
@@ -492,7 +492,7 @@ impl<'a> RadioDriver<'a> {
     }
 }
 
-impl<'a> mac::DeviceProcedure for RadioDriver<'a> {
+impl<'a> framer::DeviceProcedure for RadioDriver<'a> {
     /// Gets the long address corresponding to the neighbor that matches the given
     /// MAC address. If no such neighbor exists, returns `None`.
     fn lookup_addr_long(&self, addr: MacAddress) -> Option<([u8; 8])> {
@@ -508,7 +508,7 @@ impl<'a> mac::DeviceProcedure for RadioDriver<'a> {
     }
 }
 
-impl<'a> mac::KeyProcedure for RadioDriver<'a> {
+impl<'a> framer::KeyProcedure for RadioDriver<'a> {
     /// Gets the key corresponding to the key that matches the given security
     /// level `level` and key ID `key_id`. If no such key matches, returns
     /// `None`.
@@ -640,12 +640,10 @@ impl<'a> Driver for RadioDriver<'a> {
                 self.mac.set_pan(arg1 as u16);
                 ReturnCode::SUCCESS
             }
-            5 => self.mac.set_channel(arg1 as u8),
-            6 => {
-                // Userspace casts the i8 to a u8 before casting to u32, so this works.
-                self.mac.set_tx_power(arg1 as i8);
-                ReturnCode::SUCCESS
-            }
+            // XXX: Setting channel DEPRECATED by MAC layer channel control
+            5 => ReturnCode::ENOSUPPORT,
+            // XXX: Setting tx power DEPRECATED by MAC layer tx power control
+            6 => ReturnCode::ENOSUPPORT,
             7 => {
                 self.mac.config_commit();
                 ReturnCode::SUCCESS
@@ -668,20 +666,10 @@ impl<'a> Driver for RadioDriver<'a> {
                     value: (pan as usize) + 1,
                 }
             }
-            11 => {
-                // Guarantee that the channel is positive by adding 1
-                let channel = self.mac.get_channel();
-                ReturnCode::SuccessWithValue {
-                    value: (channel as usize) + 1,
-                }
-            }
-            12 => {
-                // Cast the power to unsigned, then ensure it is positive
-                let power = self.mac.get_tx_power() as u8;
-                ReturnCode::SuccessWithValue {
-                    value: (power as usize) + 1,
-                }
-            }
+            // XXX: Getting channel DEPRECATED by MAC layer channel control
+            11 => ReturnCode::ENOSUPPORT,
+            // XXX: Getting tx power DEPRECATED by MAC layer tx power control
+            12 => ReturnCode::ENOSUPPORT,
             13 => {
                 // Guarantee that it is positive by adding 1
                 ReturnCode::SuccessWithValue {
@@ -795,7 +783,7 @@ impl<'a> Driver for RadioDriver<'a> {
     }
 }
 
-impl<'a> mac::TxClient for RadioDriver<'a> {
+impl<'a> device::TxClient for RadioDriver<'a> {
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.kernel_tx.replace(spi_buf);
         self.current_app.get().map(|appid| {
@@ -826,7 +814,7 @@ fn encode_address(addr: &Option<MacAddress>) -> usize {
     ((AddressMode::from(addr) as usize) << 16) | short_addr_only
 }
 
-impl<'a> mac::RxClient for RadioDriver<'a> {
+impl<'a> device::RxClient for RadioDriver<'a> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         self.apps.each(|app| {
             app.app_read.take().as_mut().map(|rbuf| {

--- a/capsules/src/ieee802154/framer.rs
+++ b/capsules/src/ieee802154/framer.rs
@@ -1,0 +1,793 @@
+//! Implements IEEE 802.15.4 MAC device abstraction over a 802.15.4 MAC interface.
+//! Allows its users to prepare and send frames in plaintext, handling 802.15.4
+//! encoding and security procedures (in the future) transparently.
+//!
+//! However, certain IEEE 802.15.4 MAC device concepts are not implemented in
+//! this layer of abstraction and instead handled in hardware for performance
+//! purposes. These include CSMA-CA backoff, FCS generation and authentication,
+//! and automatic acknowledgement. Radio power management and channel selection
+//! is also passed down to the MAC control layer.
+//!
+//! Usage
+//! -----
+//!
+//! To use this capsule, we need an implementation of a hardware
+//! `capsules::ieee802154::mac::Mac`. Suppose we have such an implementation of type
+//! `XMacDevice`.
+//!
+//! ```rust
+//! let xmac: &XMacDevice = /* ... */;
+//! let mac_device = static_init!(
+//!     capsules::ieee802154::mac::Framer<'static, XMacDevice>,
+//!     capsules::ieee802154::mac::Framer::new(xmac));
+//! xmac.set_transmit_client(mac_device);
+//! xmac.set_receive_client(mac_device, &mut MAC_RX_BUF);
+//! xmac.set_config_client(mac_device);
+//! ```
+//!
+//! The `mac_device` device is now set up. Users of the MAC device can now
+//! configure the underlying radio, prepare and send frames:
+//! ```rust
+//! mac_device.set_pan(0xABCD);
+//! mac_device.set_address(0x1008);
+//! mac_device.config_commit();
+//!
+//! let frame = mac_device
+//!     .prepare_data_frame(&mut STATIC_BUFFER,
+//!                         0xABCD, MacAddress::Short(0x1008),
+//!                         0xABCD, MacAddress::Short(0x1009),
+//!                         None)
+//!     .ok()
+//!     .map(|frame| {
+//!         let rval = frame.append_payload(&mut SOME_DATA[..10]);
+//!         if rval == ReturnCode::SUCCESS {
+//!             let (rval, _) = mac_device.transmit(frame);
+//!             rval
+//!         } else {
+//!             rval
+//!         }
+//!     });
+//! ```
+//!
+//! You should also be able to set up the userspace driver for receiving/sending
+//! 802.15.4 frames:
+//! ```rust
+//! let radio_capsule = static_init!(
+//!     capsules::ieee802154::RadioDriver<'static>,
+//!     capsules::ieee802154::RadioDriver::new(mac_device, kernel::Grant::create(), &mut RADIO_BUF));
+//! mac_device.set_key_procedure(radio_capsule);
+//! mac_device.set_device_procedure(radio_capsule);
+//! mac_device.set_transmit_client(radio_capsule);
+//! mac_device.set_receive_client(radio_capsule);
+//! ```
+
+//
+// TODO: Encryption/decryption
+// TODO: Sending beacon frames
+// TODO: Channel scanning
+//
+
+use core::cell::Cell;
+use ieee802154::device::{MacDevice, RxClient, TxClient};
+use ieee802154::mac::Mac;
+use kernel::ReturnCode;
+use kernel::common::take_cell::MapCell;
+use kernel::hil::radio;
+use net::ieee802154::*;
+use net::stream::{encode_bytes, encode_u32, encode_u8};
+use net::stream::SResult;
+
+/// A `Frame` wraps a static mutable byte slice and keeps just enough
+/// information about its header contents to expose a restricted interface for
+/// modifying its payload. This enables the user to abdicate any concerns about
+/// where the payload should be placed in the buffer.
+#[derive(Eq, PartialEq, Debug)]
+pub struct Frame {
+    buf: &'static mut [u8],
+    info: FrameInfo,
+}
+
+/// This contains just enough information about a frame to determine
+/// 1. How to encode it once its payload has been finalized
+/// 2. The sizes of the mac header, payload and MIC tag length to be added
+/// These offsets are relative to the PSDU or `buf[radio::PSDU_OFFSET..]` so
+/// that the mac frame length is `data_offset + data_len`
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+struct FrameInfo {
+    frame_type: FrameType,
+
+    // The MAC payload, including Payload IEs
+    mac_payload_offset: usize,
+    // The data payload, not including Payload IEs
+    data_offset: usize,
+    // The length of the data payload, not including MIC and FCS
+    data_len: usize,
+    // The length of the MIC
+    mic_len: usize,
+
+    // Security level, key, and nonce
+    security_params: Option<(SecurityLevel, [u8; 16], [u8; 13])>,
+}
+
+impl Frame {
+    /// Consumes the frame and retrieves the buffer it wraps
+    pub fn into_buf(self) -> &'static mut [u8] {
+        self.buf
+    }
+
+    /// Calculates how much more data this frame can hold
+    pub fn remaining_data_capacity(&self) -> usize {
+        self.buf.len() - radio::PSDU_OFFSET - radio::MFR_SIZE - self.info.secured_length()
+    }
+
+    /// Appends payload bytes into the frame if possible
+    pub fn append_payload(&mut self, payload: &[u8]) -> ReturnCode {
+        if payload.len() > self.remaining_data_capacity() {
+            return ReturnCode::ENOMEM;
+        }
+        let begin = radio::PSDU_OFFSET + self.info.unsecured_length();
+        self.buf[begin..begin + payload.len()].copy_from_slice(payload);
+        self.info.data_len += payload.len();
+
+        ReturnCode::SUCCESS
+    }
+}
+
+impl FrameInfo {
+    /// Current size of the frame, not including the MAC footer or the MIC
+    fn unsecured_length(&self) -> usize {
+        self.data_offset + self.data_len
+    }
+
+    /// Current size of the frame, not including the MAC footer but including
+    /// the MIC
+    fn secured_length(&self) -> usize {
+        self.data_offset + self.data_len + self.mic_len
+    }
+
+    /// Compute the offsets in the buffer for the a data and m data fields in
+    /// the CCM* authentication and encryption procedures which depends on the
+    /// frame type and security levels. Returns the (offset, len) of the m data
+    /// fields, not including the MIC. The a data is always the remaining prefix
+    /// of the header, so it can be determined implicitly.
+    #[allow(dead_code)]
+    fn ccm_encrypt_ranges(&self) -> (usize, usize) {
+        // IEEE 802.15.4-2015: Table 9-1. Exceptions to Private Payload field
+        // The boundary between open and private payload fields depends
+        // on the type of frame.
+        let private_payload_offset = match self.frame_type {
+            FrameType::Beacon => {
+                // Beginning of beacon payload field
+                unimplemented!()
+            }
+            FrameType::MACCommand => {
+                // Beginning of MAC command content field
+                unimplemented!()
+            }
+            _ => {
+                // MAC payload field, which includes payload IEs
+                self.mac_payload_offset
+            }
+        };
+
+        // IEEE 802.15.4-2015: Table 9-3. a data and m data
+        let encryption_needed = self.security_params
+            .map_or(false, |(level, _, _)| level.encryption_needed());
+        if encryption_needed {
+            // If only integrity is need, a data is the whole frame
+            (self.unsecured_length(), 0)
+        } else {
+            // Otherwise, a data is the header and the open payload, and
+            // m data is the private payload field
+            (
+                private_payload_offset,
+                self.unsecured_length() | private_payload_offset,
+            )
+        }
+    }
+}
+
+fn get_ccm_nonce(device_addr: &[u8; 8], frame_counter: u32, level: SecurityLevel) -> [u8; 13] {
+    let mut nonce = [0u8; 13];
+    let encode_ccm_nonce = |buf: &mut [u8]| {
+        let off = enc_consume!(buf; encode_bytes, device_addr.as_ref());
+        let off = enc_consume!(buf, off; encode_u32, frame_counter);
+        let off = enc_consume!(buf, off; encode_u8, level as u8);
+        stream_done!(off);
+    };
+    match encode_ccm_nonce(&mut nonce).done() {
+        None => {
+            // This should not be possible
+            panic!("Failed to produce ccm nonce");
+        }
+        Some(_) => nonce,
+    }
+}
+
+/// The needed buffer size might be bigger than an MTU, because
+/// the CCM* authentication procedure
+/// - adds an extra 16-byte block in front of the a and m data
+/// - prefixes the a data with a length encoding and pads the result
+/// - pads the m data to 16-byte blocks
+pub const CRYPT_BUF_SIZE: usize = radio::MAX_MTU + 3 * 16;
+
+/// IEEE 802.15.4-2015, 9.2.2, KeyDescriptor lookup procedure.
+/// Trait to be implemented by an upper layer that manages the list of 802.15.4
+/// key descriptors. This trait interface enables the lookup procedure to be
+/// implemented either explicitly (managing a list of KeyDescriptors) or
+/// implicitly with some equivalent logic.
+pub trait KeyProcedure {
+    /// Lookup the KeyDescriptor matching the provided security level and key ID
+    /// mode and return the key associatied with it.
+    fn lookup_key(&self, level: SecurityLevel, key_id: KeyId) -> Option<([u8; 16])>;
+}
+
+/// IEEE 802.15.4-2015, 9.2.5, DeviceDescriptor lookup procedure.
+/// Trait to be implemented by an upper layer that manages the list of 802.15.4
+/// device descriptors. This trait interface enables the lookup procedure to be
+/// implemented either explicitly (managing a list of DeviceDescriptors) or
+/// implicitly with some equivalent logic.
+pub trait DeviceProcedure {
+    /// Look up the extended MAC address of a device given either its short or
+    /// long address. As defined in the IEEE 802.15.4 spec, even if the provided
+    /// address is already long, a long address should be returned only if the
+    /// given address matches a known DeviceDescriptor.
+    fn lookup_addr_long(&self, addr: MacAddress) -> Option<([u8; 8])>;
+}
+
+/// This state enum describes the state of the transmission pipeline.
+/// Conditionally-present state is also included as fields in the enum variants.
+/// We can view the transmission process as a state machine driven by the
+/// following events:
+/// - calls to `Mac#transmit`
+/// - `send_done` callbacks from the underlying radio
+/// - `config_done` callbacks from the underlying radio (if, for example,
+/// configuration was in progress when a transmission was requested)
+/// - TODO: callbacks from the encryption facility
+#[derive(Eq, PartialEq, Debug)]
+enum TxState {
+    /// There is no frame to be transmitted.
+    Idle,
+    /// There is a valid frame that needs to be secured before transmission.
+    ReadyToEncrypt(FrameInfo, &'static mut [u8]),
+    /// There is currently a frame being encrypted by the encryption facility.
+    #[allow(dead_code)]
+    Encrypting(FrameInfo),
+    /// There is a frame that is completely secured or does not require
+    /// security, and is waiting to be passed to the radio.
+    ReadyToTransmit(FrameInfo, &'static mut [u8]),
+}
+
+#[derive(Eq, PartialEq, Debug)]
+enum RxState {
+    /// There is no frame that has been received.
+    Idle,
+    /// There is a secured frame that needs to be decrypted.
+    ReadyToDecrypt(FrameInfo, &'static mut [u8]),
+    /// A secured frame is currently being decrypted by the decryption facility.
+    #[allow(dead_code)]
+    Decrypting(FrameInfo),
+    /// There is an unsecured frame that needs to be re-parsed and exposed to
+    /// the client.
+    #[allow(dead_code)]
+    ReadyToYield(FrameInfo, &'static mut [u8]),
+    /// The buffer containing the frame needs to be returned to the radio.
+    ReadyToReturn(&'static mut [u8]),
+}
+
+/// This struct wraps an IEEE 802.15.4 radio device `kernel::hil::radio::Radio`
+/// and exposes IEEE 802.15.4 MAC device functionality as the trait
+/// `capsules::mac::Mac`. It hides header preparation, transmission and
+/// processing logic from the user by essentially maintaining multiple state
+/// machines corresponding to the transmission, reception and
+/// encryption/decryption pipelines. See the documentation in
+/// `capsules/src/mac.rs` for more details.
+pub struct Framer<'a, M: Mac + 'a> {
+    mac: &'a M,
+    data_sequence: Cell<u8>,
+
+    /// KeyDescriptor lookup procedure
+    key_procedure: Cell<Option<&'a KeyProcedure>>,
+    /// DeviceDescriptor lookup procedure
+    device_procedure: Cell<Option<&'a DeviceProcedure>>,
+
+    /// Transmision pipeline state. This should never be `None`, except when
+    /// transitioning between states. That is, any method that consumes the
+    /// current state should always remember to replace it along with the
+    /// associated state information.
+    tx_state: MapCell<TxState>,
+    tx_client: Cell<Option<&'a TxClient>>,
+
+    /// Reception pipeline state. Similar to the above, this should never be
+    /// `None`, except when transitioning between states.
+    rx_state: MapCell<RxState>,
+    rx_client: Cell<Option<&'a RxClient>>,
+}
+
+impl<'a, M: Mac + 'a> Framer<'a, M> {
+    pub fn new(mac: &'a M) -> Framer<'a, M> {
+        Framer {
+            mac: mac,
+            data_sequence: Cell::new(0),
+            key_procedure: Cell::new(None),
+            device_procedure: Cell::new(None),
+            tx_state: MapCell::new(TxState::Idle),
+            tx_client: Cell::new(None),
+            rx_state: MapCell::new(RxState::Idle),
+            rx_client: Cell::new(None),
+        }
+    }
+
+    /// Sets the IEEE 802.15.4 key lookup procedure to be used.
+    pub fn set_key_procedure(&self, key_procedure: &'a KeyProcedure) {
+        self.key_procedure.set(Some(key_procedure));
+    }
+
+    /// Sets the IEEE 802.15.4 key lookup procedure to be used.
+    pub fn set_device_procedure(&self, device_procedure: &'a DeviceProcedure) {
+        self.device_procedure.set(Some(device_procedure));
+    }
+
+    /// Look up the key using the IEEE 802.15.4 KeyDescriptor lookup prodecure
+    /// implemented elsewhere.
+    fn lookup_key(&self, level: SecurityLevel, key_id: KeyId) -> Option<([u8; 16])> {
+        self.key_procedure
+            .get()
+            .and_then(|key_procedure| key_procedure.lookup_key(level, key_id))
+    }
+
+    /// Look up the extended address of a device using the IEEE 802.15.4
+    /// DeviceDescriptor lookup prodecure implemented elsewhere.
+    fn lookup_addr_long(&self, src_addr: Option<MacAddress>) -> Option<([u8; 8])> {
+        src_addr.and_then(|addr| {
+            self.device_procedure
+                .get()
+                .and_then(|device_procedure| device_procedure.lookup_addr_long(addr))
+        })
+    }
+
+    /// IEEE 802.15.4-2015, 9.2.1, outgoing frame security procedure
+    /// Performs the first checks in the security procedure. The rest of the
+    /// steps are performed as part of the transmission pipeline.
+    /// Returns the next `TxState` to enter.
+    fn outgoing_frame_security(&self, buf: &'static mut [u8], frame_info: FrameInfo) -> TxState {
+        // IEEE 802.15.4-2015: 9.2.1, outgoing frame security
+        // Steps a-e have already been performed in the frame preparation step,
+        // so we only need to dispatch on the security parameters in the frame info
+        match frame_info.security_params {
+            Some((level, _, _)) => {
+                if level == SecurityLevel::None {
+                    // This case should never occur if the FrameInfo was
+                    // prepared by prepare_data_frame
+                    TxState::ReadyToTransmit(frame_info, buf)
+                } else {
+                    TxState::ReadyToEncrypt(frame_info, buf)
+                }
+            }
+            None => TxState::ReadyToTransmit(frame_info, buf),
+        }
+    }
+
+    /// IEEE 802.15.4-2015, 9.2.3, incoming frame security procedure
+    fn incoming_frame_security(&self, buf: &'static mut [u8], frame_len: usize) -> RxState {
+        // Try to decode the MAC header. Three possible results can occur:
+        // 1) The frame should be dropped and the buffer returned to the radio
+        // 2) The frame is unsecured. We immediately expose the frame to the
+        //    user and queue the buffer for returning to the radio.
+        // 3) The frame needs to be unsecured.
+        let result = Header::decode(&buf[radio::PSDU_OFFSET..], false)
+            .done()
+            .and_then(|(data_offset, (header, mac_payload_offset))| {
+                // Note: there is a complication here regarding the offsets.
+                // When the received frame has security enabled, the payload
+                // (including the payload IEs) is encrypted, and hence the data
+                // payload field includes the encrypted payload IEs too.
+                // However, when the frame is not encrypted, the data payload
+                // field does not include the payload IEs.
+                //
+                // This is fine because we re-parse the unsecured frame before
+                // exposing it to the user. At that time, the data payload field
+                // will not include the payload IEs.
+                let mic_len = header.security.map_or(0, |sec| sec.level.mic_len());
+                let data_len = frame_len - data_offset - mic_len;
+                if let Some(security) = header.security {
+                    // IEEE 802.15.4-2015: 9.2.3, incoming frame security procedure
+                    // for security-enabled headers
+                    if header.version == FrameVersion::V2003 {
+                        None
+                    } else {
+                        // Step e: Lookup the key.
+                        let key = match self.lookup_key(security.level, security.key_id) {
+                            Some(key) => key,
+                            None => {
+                                return None;
+                            }
+                        };
+
+                        // Step f: Obtain the extended source address
+                        // TODO: For Thread, when the frame's security header
+                        // specifies `KeyIdMode::Source4Index`, the source
+                        // address used for the nonce is actually a constant
+                        // defined in their spec
+                        let device_addr = match self.lookup_addr_long(header.src_addr) {
+                            Some(addr) => addr,
+                            None => {
+                                return None;
+                            }
+                        };
+
+                        // Step g, h: Check frame counter
+                        let frame_counter = match security.frame_counter {
+                            Some(frame_counter) => {
+                                if frame_counter == 0xffffffff {
+                                    // Counter error
+                                    return None;
+                                }
+                                // TODO: Check frame counter against source device
+                                frame_counter
+                            }
+                            // TSCH mode, where ASN is used instead, not supported
+                            None => {
+                                return None;
+                            }
+                        };
+
+                        // Compute ccm nonce
+                        let nonce = get_ccm_nonce(&device_addr, frame_counter, security.level);
+
+                        Some(FrameInfo {
+                            frame_type: header.frame_type,
+                            mac_payload_offset: mac_payload_offset,
+                            data_offset: data_offset,
+                            data_len: data_len,
+                            mic_len: mic_len,
+                            security_params: Some((security.level, key, nonce)),
+                        })
+                    }
+                } else {
+                    // No security needed, can yield the frame immediately
+                    self.rx_client.get().map(|client| {
+                        client.receive(&buf, header, radio::PSDU_OFFSET + data_offset, data_len);
+                    });
+                    None
+                }
+            });
+
+        match result {
+            None => RxState::ReadyToReturn(buf),
+            Some(frame_info) => RxState::ReadyToDecrypt(frame_info, buf),
+        }
+    }
+
+    /// Advances the transmission pipeline if it can be advanced.
+    fn step_transmit_state(&self) -> (ReturnCode, Option<&'static mut [u8]>) {
+        self.tx_state
+            .take()
+            .map_or((ReturnCode::FAIL, None), |state| {
+                // This mechanism is a little more clunky, but makes it
+                // difficult to forget to replace `tx_state`.
+                let (next_state, result) = match state {
+                    TxState::Idle => (TxState::Idle, (ReturnCode::SUCCESS, None)),
+                    TxState::ReadyToEncrypt(info, buf) => {
+                        match info.security_params {
+                            None => {
+                                // `ReadyToEncrypt` should only be entered when
+                                // `security_params` is not `None`.
+                                (TxState::Idle, (ReturnCode::FAIL, Some(buf)))
+                            }
+                            Some((_, _key, _nonce)) => {
+                                // let (m_off, m_len) = info.ccm_encrypt_ranges();
+                                // let (a_off, m_off) = (radio::PSDU_OFFSET,
+                                //                       radio::PSDU_OFFSET +
+                                //                       m_off);
+
+                                // TODO: Call CCM* auth/encryption routine with:
+                                // key: key
+                                // nonce: nonce
+                                // mic_len: info.mic_len
+                                // a data: buf[a_off..m_off]
+                                // m data: buf[m_off..m_off + m_len]
+
+                                (TxState::Idle, (ReturnCode::ENOSUPPORT, Some(buf)))
+                            }
+                        }
+                    }
+                    TxState::Encrypting(info) => {
+                        // This state should be advanced only by the hardware
+                        // encryption callback.
+                        (TxState::Encrypting(info), (ReturnCode::SUCCESS, None))
+                    }
+                    TxState::ReadyToTransmit(info, buf) => {
+                        let (rval, buf) = self.mac.transmit(buf, info.secured_length());
+                        match rval {
+                            // If the radio is busy, just wait for either a
+                            // transmit_done or config_done callback to trigger
+                            // this state transition again
+                            ReturnCode::EBUSY => {
+                                match buf {
+                                    None => {
+                                        // The radio forgot to return the buffer.
+                                        (TxState::Idle, (ReturnCode::FAIL, None))
+                                    }
+                                    Some(buf) => (
+                                        TxState::ReadyToTransmit(info, buf),
+                                        (ReturnCode::SUCCESS, None),
+                                    ),
+                                }
+                            }
+                            _ => (TxState::Idle, (rval, buf)),
+                        }
+                    }
+                };
+                self.tx_state.replace(next_state);
+                result
+            })
+    }
+
+    /// Advances the reception pipeline if it can be advanced.
+    fn step_receive_state(&self) {
+        self.rx_state.take().map(|state| {
+            let (next_state, buf) = match state {
+                RxState::Idle => (RxState::Idle, None),
+                RxState::ReadyToDecrypt(info, buf) => {
+                    match info.security_params {
+                        None => {
+                            // `ReadyToDecrypt` should only be entered when
+                            // `security_params` is not `None`.
+                            (RxState::Idle, Some(buf))
+                        }
+                        Some((_, _key, _nonce)) => {
+                            // let (m_off, m_len) = info.ccm_encrypt_ranges();
+                            // let (a_off, m_off) = (radio::PSDU_OFFSET,
+                            //                       radio::PSDU_OFFSET +
+                            //                       m_off);
+
+                            // TODO: Call CCM* auth/decryption routine with:
+                            // key: key
+                            // nonce: nonce
+                            // mic_len: info.mic_len
+                            // a data: buf[a_off..m_off]
+                            // c data: buf[m_off..m_off + m_len + mic_len]
+
+                            (RxState::Idle, Some(buf))
+                        }
+                    }
+                }
+                RxState::Decrypting(info) => {
+                    // This state should be advanced only by the hardware
+                    // encryption callback.
+                    (RxState::Decrypting(info), None)
+                }
+                RxState::ReadyToYield(info, buf) => {
+                    // Between the secured and unsecured frames, the
+                    // unsecured frame length remains constant but the data
+                    // offsets may change due to the presence of PayloadIEs.
+                    // Hence, we can only use the unsecured length from the
+                    // frame info, but not the offsets.
+                    let frame_len = info.unsecured_length();
+                    if let Some((data_offset, (header, _))) =
+                        Header::decode(&buf[radio::PSDU_OFFSET..], true).done()
+                    {
+                        // IEEE 802.15.4-2015 specifies that unsecured
+                        // frames do not have auxiliary security headers,
+                        // but we do not remove the auxiliary security
+                        // header before returning the frame to the client.
+                        // This is so that it is possible to tell if the
+                        // frame was secured or unsecured, while still
+                        // always receiving the frame payload in plaintext.
+                        self.rx_client.get().map(|client| {
+                            client.receive(
+                                &buf,
+                                header,
+                                radio::PSDU_OFFSET + data_offset,
+                                frame_len - data_offset,
+                            );
+                        });
+                    }
+                    (RxState::Idle, Some(buf))
+                }
+                RxState::ReadyToReturn(buf) => (RxState::Idle, Some(buf)),
+            };
+            self.rx_state.replace(next_state);
+
+            // Return the buffer to the radio if we are done with it.
+            if let Some(buf) = buf {
+                self.mac.set_receive_buffer(buf);
+            }
+        });
+    }
+}
+
+impl<'a, M: Mac + 'a> MacDevice<'a> for Framer<'a, M> {
+    fn set_transmit_client(&self, client: &'a TxClient) {
+        self.tx_client.set(Some(client));
+    }
+
+    fn set_receive_client(&self, client: &'a RxClient) {
+        self.rx_client.set(Some(client));
+    }
+
+    fn get_address(&self) -> u16 {
+        self.mac.get_address()
+    }
+
+    fn get_address_long(&self) -> [u8; 8] {
+        self.mac.get_address_long()
+    }
+
+    fn get_pan(&self) -> u16 {
+        self.mac.get_pan()
+    }
+
+    fn set_address(&self, addr: u16) {
+        self.mac.set_address(addr)
+    }
+
+    fn set_address_long(&self, addr: [u8; 8]) {
+        self.mac.set_address_long(addr)
+    }
+
+    fn set_pan(&self, id: u16) {
+        self.mac.set_pan(id)
+    }
+
+    fn config_commit(&self) {
+        self.mac.config_commit()
+    }
+
+    fn is_on(&self) -> bool {
+        self.mac.is_on()
+    }
+
+    fn prepare_data_frame(
+        &self,
+        buf: &'static mut [u8],
+        dst_pan: PanID,
+        dst_addr: MacAddress,
+        src_pan: PanID,
+        src_addr: MacAddress,
+        security_needed: Option<(SecurityLevel, KeyId)>,
+    ) -> Result<Frame, &'static mut [u8]> {
+        // IEEE 802.15.4-2015: 9.2.1, outgoing frame security
+        // Steps a-e of the security procedure are implemented here.
+
+        // TODO: For Thread, in the case of `KeyIdMode::Source4Index`, the source
+        // address should instead be some constant defined in their
+        // specification.
+        let src_addr_long = self.get_address_long();
+        let security_desc = security_needed.and_then(|(level, key_id)| {
+            self.lookup_key(level, key_id).map(|key| {
+                // TODO: lookup frame counter for device
+                let frame_counter = 0;
+                let nonce = get_ccm_nonce(&src_addr_long, frame_counter, level);
+                (
+                    Security {
+                        level: level,
+                        asn_in_nonce: false,
+                        frame_counter: Some(frame_counter),
+                        key_id: key_id,
+                    },
+                    key,
+                    nonce,
+                )
+            })
+        });
+        if security_needed.is_some() && security_desc.is_none() {
+            // If security was requested, fail when desired key was not found.
+            return Err(buf);
+        }
+
+        // Construct MAC header
+        let security = security_desc.map(|(sec, _, _)| sec);
+        let mic_len = security.map_or(0, |sec| sec.level.mic_len());
+        let header = Header {
+            frame_type: FrameType::Data,
+            /* TODO: determine this by looking at queue, and also set it in
+             * hardware so that ACKs set this flag to the right value. */
+            frame_pending: false,
+            // Unicast data frames request acknowledgement
+            ack_requested: true,
+            version: FrameVersion::V2015,
+            seq: Some(self.data_sequence.get()),
+            dst_pan: Some(dst_pan),
+            dst_addr: Some(dst_addr),
+            src_pan: Some(src_pan),
+            src_addr: Some(src_addr),
+            security: security,
+            header_ies: Default::default(),
+            header_ies_len: 0,
+            payload_ies: Default::default(),
+            payload_ies_len: 0,
+        };
+
+        match header.encode(&mut buf[radio::PSDU_OFFSET..], true).done() {
+            Some((data_offset, mac_payload_offset)) => Ok(Frame {
+                buf: buf,
+                info: FrameInfo {
+                    frame_type: FrameType::Data,
+                    mac_payload_offset: mac_payload_offset,
+                    data_offset: data_offset,
+                    data_len: 0,
+                    mic_len: mic_len,
+                    security_params: security_desc.map(|(sec, key, nonce)| (sec.level, key, nonce)),
+                },
+            }),
+            None => Err(buf),
+        }
+    }
+
+    fn transmit(&self, frame: Frame) -> (ReturnCode, Option<&'static mut [u8]>) {
+        let Frame { buf, info } = frame;
+        let state = match self.tx_state.take() {
+            None => {
+                return (ReturnCode::FAIL, Some(buf));
+            }
+            Some(state) => state,
+        };
+        match state {
+            TxState::Idle => {
+                let next_state = self.outgoing_frame_security(buf, info);
+                self.tx_state.replace(next_state);
+                self.step_transmit_state()
+            }
+            other_state => {
+                self.tx_state.replace(other_state);
+                (ReturnCode::EBUSY, Some(buf))
+            }
+        }
+    }
+}
+
+impl<'a, M: Mac + 'a> radio::TxClient for Framer<'a, M> {
+    fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
+        self.data_sequence.set(self.data_sequence.get() + 1);
+        self.tx_client.get().map(move |client| {
+            client.send_done(buf, acked, result);
+        });
+    }
+}
+
+impl<'a, M: Mac + 'a> radio::RxClient for Framer<'a, M> {
+    fn receive(&self, buf: &'static mut [u8], frame_len: usize, crc_valid: bool, _: ReturnCode) {
+        // Drop all frames with invalid CRC
+        if !crc_valid {
+            self.mac.set_receive_buffer(buf);
+            return;
+        }
+
+        self.rx_state.take().map(move |state| {
+            let next_state = match state {
+                RxState::Idle => {
+                    // We can start processing a new received frame only if
+                    // the reception pipeline is free
+                    self.incoming_frame_security(buf, frame_len)
+                }
+                other_state => {
+                    // This should never occur unless something other than
+                    // this MAC layer provided a receive buffer to the
+                    // radio, but if this occurs then we have no choice but
+                    // to drop the frame.
+                    self.mac.set_receive_buffer(buf);
+                    other_state
+                }
+            };
+            self.rx_state.replace(next_state);
+            self.step_receive_state();
+        });
+    }
+}
+
+impl<'a, M: Mac + 'a> radio::ConfigClient for Framer<'a, M> {
+    fn config_done(&self, _: ReturnCode) {
+        // The transmission pipeline is the only state machine that
+        // waits for the configuration procedure to complete before
+        // advancing.
+        let (rval, buf) = self.step_transmit_state();
+        if let Some(buf) = buf {
+            // Return the buffer to the transmit client
+            self.tx_client.get().map(move |client| {
+                client.send_done(buf, false, rval);
+            });
+        }
+    }
+}

--- a/capsules/src/ieee802154/mac.rs
+++ b/capsules/src/ieee802154/mac.rs
@@ -1,744 +1,100 @@
-//! Implements IEEE 802.15.4 MAC device abstraction over a raw 802.15.4 radio.
-//! Allows its users to prepare and send frames in plaintext, handling 802.15.4
-//! encoding and security procedures (in the future) transparently.
+//! Specifies the interface for IEEE 802.15.4 MAC protocol layers. MAC protocols
+//! expose similar configuration (address, PAN, transmission power) options
+//! as ieee802154::device::MacDevice layers above it, but retain control over
+//! radio power management and channel selection. All frame processing should
+//! be completed above this layer such that Mac implementations receive fully
+//! formatted 802.15.4 MAC frames for transmission.
 //!
-//! However, certain IEEE 802.15.4 MAC device concepts are not implemented in
-//! this layer of abstraction and instead handled in hardware for performance
-//! purposes. These include CSMA-CA backoff, FCS generation and authentication,
-//! and automatic acknowledgement.
-//!
-//! TODO: Encryption/decryption
-//! TODO: Sending beacon frames
-//! TODO: Channel scanning
-//!
-//! Usage
-//! -----
-//!
-//! To use this capsule, we need an implementation of a hardware
-//! `kernel::hil::radio::Radio`. Suppose we have such an implementation of type
-//! `RF233Device`.
-//!
-//! ```rust
-//! let radio: RF233Device = /* ... */;
-//! let radio_mac = static_init!(
-//!     capsules::ieee802154::mac::MacDevice<'static, RF233Device>,
-//!     capsules::ieee802154::mac::MacDevice::new(radio));
-//! rf233.set_transmit_client(radio_mac);
-//! rf233.set_receive_client(radio_mac, &mut RF233_RX_BUF);
-//! rf233.set_config_client(radio_mac);
-//! ```
-//!
-//! The `radio_mac` device is now set up. Users of the MAC device can now
-//! configure the underlying radio, prepare and send frames:
-//! ```rust
-//! radio_mac.set_pan(0xABCD);
-//! radio_mac.set_address(0x1008);
-//! radio_mac.config_commit();
-//!
-//! let frame = radio_mac
-//!     .prepare_data_frame(&mut STATIC_BUFFER,
-//!                         0xABCD, MacAddress::Short(0x1008),
-//!                         0xABCD, MacAddress::Short(0x1009),
-//!                         None)
-//!     .ok()
-//!     .map(|frame| {
-//!         let rval = frame.append_payload(&mut SOME_DATA[..10]);
-//!         if rval == ReturnCode::SUCCESS {
-//!             let (rval, _) = radio_mac.transmit(frame);
-//!             rval
-//!         } else {
-//!             rval
-//!         }
-//!     });
-//! ```
-//!
-//! You should also be able to set up the userspace driver for receiving/sending
-//! 802.15.4 frames:
-//! ```rust
-//! let radio_capsule = static_init!(
-//!     capsules::ieee802154::RadioDriver<'static>,
-//!     capsules::ieee802154::RadioDriver::new(radio_mac));
-//! radio_capsule.config_buffer(&mut RADIO_BUF);
-//! radio_mac.set_transmit_client(radio_capsule);
-//! radio_mac.set_receive_client(radio_capsule);
-//! ```
+//! AwakeMac provides a default implementation of such a layer, maintaining
+//! the underlying kernel::hil::radio::Radio powered at all times and passing
+//! through each frame for transmission.
 
 use core::cell::Cell;
 use kernel::ReturnCode;
-use kernel::common::take_cell::MapCell;
 use kernel::hil::radio;
-use net::ieee802154::*;
-use net::stream::{encode_bytes, encode_u32, encode_u8};
-use net::stream::SResult;
+use net::ieee802154::{Header, MacAddress};
 
-/// A `Frame` wraps a static mutable byte slice and keeps just enough
-/// information about its header contents to expose a restricted interface for
-/// modifying its payload. This enables the user to abdicate any concerns about
-/// where the payload should be placed in the buffer.
-#[derive(Eq, PartialEq, Debug)]
-pub struct Frame {
-    buf: &'static mut [u8],
-    info: FrameInfo,
-}
+pub trait Mac {
+    /// Initializes the layer; may require a buffer to temporarily retaining frames to be
+    /// transmitted
+    fn initialize(&self, mac_buf: &'static mut [u8]) -> ReturnCode;
 
-/// This contains just enough information about a frame to determine
-/// 1. How to encode it once its payload has been finalized
-/// 2. The sizes of the mac header, payload and MIC tag length to be added
-/// These offsets are relative to the PSDU or `buf[radio::PSDU_OFFSET..]` so
-/// that the mac frame length is `data_offset + data_len`
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-struct FrameInfo {
-    frame_type: FrameType,
+    /// Sets the notified client for configuration changes
+    fn set_config_client(&self, client: &'static radio::ConfigClient);
+    /// Sets the notified client for transmission completions
+    fn set_transmit_client(&self, client: &'static radio::TxClient);
+    /// Sets the notified client for frame receptions
+    fn set_receive_client(&self, client: &'static radio::RxClient);
+    /// Sets the buffer for packet reception
+    fn set_receive_buffer(&self, buffer: &'static mut [u8]);
 
-    // The MAC payload, including Payload IEs
-    mac_payload_offset: usize,
-    // The data payload, not including Payload IEs
-    data_offset: usize,
-    // The length of the data payload, not including MIC and FCS
-    data_len: usize,
-    // The length of the MIC
-    mic_len: usize,
-
-    // Security level, key, and nonce
-    security_params: Option<(SecurityLevel, [u8; 16], [u8; 13])>,
-}
-
-impl Frame {
-    /// Consumes the frame and retrieves the buffer it wraps
-    pub fn into_buf(self) -> &'static mut [u8] {
-        self.buf
-    }
-
-    /// Calculates how much more data this frame can hold
-    pub fn remaining_data_capacity(&self) -> usize {
-        self.buf.len() - radio::PSDU_OFFSET - radio::MFR_SIZE - self.info.secured_length()
-    }
-
-    /// Appends payload bytes into the frame if possible
-    pub fn append_payload(&mut self, payload: &[u8]) -> ReturnCode {
-        if payload.len() > self.remaining_data_capacity() {
-            return ReturnCode::ENOMEM;
-        }
-        let begin = radio::PSDU_OFFSET + self.info.unsecured_length();
-        self.buf[begin..begin + payload.len()].copy_from_slice(payload);
-        self.info.data_len += payload.len();
-
-        ReturnCode::SUCCESS
-    }
-}
-
-impl FrameInfo {
-    /// Current size of the frame, not including the MAC footer or the MIC
-    fn unsecured_length(&self) -> usize {
-        self.data_offset + self.data_len
-    }
-
-    /// Current size of the frame, not including the MAC footer but including
-    /// the MIC
-    fn secured_length(&self) -> usize {
-        self.data_offset + self.data_len + self.mic_len
-    }
-
-    /// Compute the offsets in the buffer for the a data and m data fields in
-    /// the CCM* authentication and encryption procedures which depends on the
-    /// frame type and security levels. Returns the (offset, len) of the m data
-    /// fields, not including the MIC. The a data is always the remaining prefix
-    /// of the header, so it can be determined implicitly.
-    #[allow(dead_code)]
-    fn ccm_encrypt_ranges(&self) -> (usize, usize) {
-        // IEEE 802.15.4-2015: Table 9-1. Exceptions to Private Payload field
-        // The boundary between open and private payload fields depends
-        // on the type of frame.
-        let private_payload_offset = match self.frame_type {
-            FrameType::Beacon => {
-                // Beginning of beacon payload field
-                unimplemented!()
-            }
-            FrameType::MACCommand => {
-                // Beginning of MAC command content field
-                unimplemented!()
-            }
-            _ => {
-                // MAC payload field, which includes payload IEs
-                self.mac_payload_offset
-            }
-        };
-
-        // IEEE 802.15.4-2015: Table 9-3. a data and m data
-        let encryption_needed = self.security_params
-            .map_or(false, |(level, _, _)| level.encryption_needed());
-        if encryption_needed {
-            // If only integrity is need, a data is the whole frame
-            (self.unsecured_length(), 0)
-        } else {
-            // Otherwise, a data is the header and the open payload, and
-            // m data is the private payload field
-            (
-                private_payload_offset,
-                self.unsecured_length() | private_payload_offset,
-            )
-        }
-    }
-}
-
-fn get_ccm_nonce(device_addr: &[u8; 8], frame_counter: u32, level: SecurityLevel) -> [u8; 13] {
-    let mut nonce = [0u8; 13];
-    let encode_ccm_nonce = |buf: &mut [u8]| {
-        let off = enc_consume!(buf; encode_bytes, device_addr.as_ref());
-        let off = enc_consume!(buf, off; encode_u32, frame_counter);
-        let off = enc_consume!(buf, off; encode_u8, level as u8);
-        stream_done!(off);
-    };
-    match encode_ccm_nonce(&mut nonce).done() {
-        None => {
-            // This should not be possible
-            panic!("Failed to produce ccm nonce");
-        }
-        Some(_) => nonce,
-    }
-}
-
-/// The needed buffer size might be bigger than an MTU, because
-/// the CCM* authentication procedure
-/// - adds an extra 16-byte block in front of the a and m data
-/// - prefixes the a data with a length encoding and pads the result
-/// - pads the m data to 16-byte blocks
-pub const CRYPT_BUF_SIZE: usize = radio::MAX_MTU + 3 * 16;
-
-/// The contract satisfied by an implementation of an IEEE 802.15.4 MAC device.
-/// Any IEEE 802.15.4 MAC device should expose the following high-level
-/// functionality:
-///
-/// - Configuration of addresses and transmit power
-/// - Preparing frames (data frame, command frames, beacon frames)
-/// - Transmitting and receiving frames
-///
-/// Outlining this in a trait allows other implementations of MAC devices that
-/// divide the responsibilities of software and hardware differently. For
-/// example, a radio chip might be able to completely inline the frame security
-/// procedure in hardware, as opposed to requiring a software implementation.
-pub trait Mac<'a> {
-    /// Sets the transmission client of this MAC device
-    fn set_transmit_client(&self, client: &'a TxClient);
-    /// Sets the receive client of this MAC device
-    fn set_receive_client(&self, client: &'a RxClient);
-
-    /// The short 16-bit address of the MAC device
+    /// The short 16-bit address of the radio
     fn get_address(&self) -> u16;
-    /// The long 64-bit address (EUI-64) of the MAC device
+    /// The long 64-bit address of the radio
     fn get_address_long(&self) -> [u8; 8];
-    /// The 16-bit PAN ID of the MAC device
+    /// The 16-bit PAN id of the radio
     fn get_pan(&self) -> u16;
-    /// The 802.15.4 channel ID of the MAC device
-    fn get_channel(&self) -> u8;
-    /// The transmission power of the MAC device, in dBm
-    fn get_tx_power(&self) -> i8;
 
-    /// Set the short 16-bit address of the MAC device
+    /// Sets the short 16-bit address of the radio
     fn set_address(&self, addr: u16);
-    /// Set the long 64-bit address (EUI-64) of the MAC device
+    /// Sets the long 64-bit address of the radio
     fn set_address_long(&self, addr: [u8; 8]);
-    /// Set the 16-bit PAN ID of the MAC device
+    /// Sets the 16-bit PAN id of the radio
     fn set_pan(&self, id: u16);
-    /// Set the 802.15.4 channel of the MAC device. `channel` should be a valid
-    /// channel `11 <= channel <= 26`, otherwise EINVAL will be returned
-    fn set_channel(&self, chan: u8) -> ReturnCode;
-    /// Set the transmission power of the MAC device, in dBm. `power` should
-    /// satisfy `-17 <= power <= 4`, otherwise EINVAL will be returned
-    fn set_tx_power(&self, power: i8) -> ReturnCode;
 
-    /// This method must be called after one or more calls to `set_*`. If
+    /// Must be called after one or more calls to `set_*`. If
     /// `set_*` is called without calling `config_commit`, there is no guarantee
     /// that the underlying hardware configuration (addresses, pan ID) is in
-    /// line with this MAC device implementation.
+    /// line with this MAC protocol implementation. The specificed config_client is
+    /// notified on completed reconfiguration.
     fn config_commit(&self);
 
-    /// Returns if the MAC device is currently on.
+    /// Indicates whether or not the MAC protocol is active and can send frames
     fn is_on(&self) -> bool;
 
-    /// Prepares a mutable buffer slice as an 802.15.4 frame by writing the appropriate
-    /// header bytes into the buffer. This needs to be done before adding the
-    /// payload because the length of the header is not fixed.
-    ///
-    /// - `buf`: The mutable buffer slice to use
-    /// - `dst_pan`: The destination PAN ID
-    /// - `dst_addr`: The destination MAC address
-    /// - `src_pan`: The source PAN ID
-    /// - `src_addr`: The source MAC address
-    /// - `security_needed`: Whether or not this frame should be secured. This
-    /// needs to be specified beforehand so that the auxiliary security header
-    /// can be pre-inserted.
-    ///
-    /// Returns either a Frame that is ready to have payload appended to it, or
-    /// the mutable buffer if the frame cannot be prepared for any reason
-    fn prepare_data_frame(
+    /// Transmits complete MAC frames, which must be prepared by an ieee802154::device::MacDevice
+    /// before being passed to the Mac layer. Returns the frame buffer in case of an error.
+    fn transmit(
         &self,
-        buf: &'static mut [u8],
-        dst_pan: PanID,
-        dst_addr: MacAddress,
-        src_pan: PanID,
-        src_addr: MacAddress,
-        security_needed: Option<(SecurityLevel, KeyId)>,
-    ) -> Result<Frame, &'static mut [u8]>;
-
-    /// Transmits a frame that has been prepared by the above process. If the
-    /// transmission process fails, the buffer inside the frame is returned so
-    /// that it can be re-used.
-    fn transmit(&self, frame: Frame) -> (ReturnCode, Option<&'static mut [u8]>);
+        full_mac_frame: &'static mut [u8],
+        frame_len: usize,
+    ) -> (ReturnCode, Option<&'static mut [u8]>);
 }
 
-/// Trait to be implemented by any user of the IEEE 802.15.4 device that
-/// transmits frames. Contains a callback through which the static mutable
-/// reference to the frame buffer is returned to the client.
-pub trait TxClient {
-    /// When transmission is complete or fails, return the buffer used for
-    /// transmission to the client. `result` indicates whether or not
-    /// the transmission was successful.
-    ///
-    /// - `spi_buf`: The buffer used to contain the transmitted frame is
-    /// returned to the client here.
-    /// - `acked`: Whether the transmission was acknowledged.
-    /// - `result`: This is `ReturnCode::SUCCESS` if the frame was transmitted,
-    /// otherwise an error occured in the transmission pipeline.
-    fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode);
-}
-
-/// Trait to be implemented by users of the IEEE 802.15.4 device that wish to
-/// receive frames. The callback is triggered whenever a valid frame is
-/// received, verified and unsecured (via the IEEE 802.15.4 security procedure)
-/// successfully.
-pub trait RxClient {
-    /// When a frame is received, this callback is triggered. The client only
-    /// receives an immutable borrow of the buffer. Only completely valid,
-    /// unsecured frames that have passed the incoming security procedure are
-    /// exposed to the client.
-    ///
-    /// - `buf`: The entire buffer containing the frame, including extra bytes
-    /// in front used for the physical layer.
-    /// - `header`: A fully-parsed representation of the MAC header, with the
-    /// caveat that the auxiliary security header is still included if the frame
-    /// was previously secured.
-    /// - `data_offset`: Offset of the data payload relative to
-    /// `buf`, so that the payload of the frame is contained in
-    /// `buf[data_offset..data_offset + data_len]`.
-    /// - `data_len`: Length of the data payload
-    fn receive<'a>(&self, buf: &'a [u8], header: Header<'a>, data_offset: usize, data_len: usize);
-}
-
-/// IEEE 802.15.4-2015, 9.2.2, KeyDescriptor lookup procedure.
-/// Trait to be implemented by an upper layer that manages the list of 802.15.4
-/// key descriptors. This trait interface enables the lookup procedure to be
-/// implemented either explicitly (managing a list of KeyDescriptors) or
-/// implicitly with some equivalent logic.
-pub trait KeyProcedure {
-    /// Lookup the KeyDescriptor matching the provided security level and key ID
-    /// mode and return the key associatied with it.
-    fn lookup_key(&self, level: SecurityLevel, key_id: KeyId) -> Option<([u8; 16])>;
-}
-
-/// IEEE 802.15.4-2015, 9.2.5, DeviceDescriptor lookup procedure.
-/// Trait to be implemented by an upper layer that manages the list of 802.15.4
-/// device descriptors. This trait interface enables the lookup procedure to be
-/// implemented either explicitly (managing a list of DeviceDescriptors) or
-/// implicitly with some equivalent logic.
-pub trait DeviceProcedure {
-    /// Look up the extended MAC address of a device given either its short or
-    /// long address. As defined in the IEEE 802.15.4 spec, even if the provided
-    /// address is already long, a long address should be returned only if the
-    /// given address matches a known DeviceDescriptor.
-    fn lookup_addr_long(&self, addr: MacAddress) -> Option<([u8; 8])>;
-}
-
-/// This state enum describes the state of the transmission pipeline.
-/// Conditionally-present state is also included as fields in the enum variants.
-/// We can view the transmission process as a state machine driven by the
-/// following events:
-/// - calls to `Mac#transmit`
-/// - `send_done` callbacks from the underlying radio
-/// - `config_done` callbacks from the underlying radio (if, for example,
-/// configuration was in progress when a transmission was requested)
-/// - TODO: callbacks from the encryption facility
-#[derive(Eq, PartialEq, Debug)]
-enum TxState {
-    /// There is no frame to be transmitted.
-    Idle,
-    /// There is a valid frame that needs to be secured before transmission.
-    ReadyToEncrypt(FrameInfo, &'static mut [u8]),
-    /// There is currently a frame being encrypted by the encryption facility.
-    #[allow(dead_code)]
-    Encrypting(FrameInfo),
-    /// There is a frame that is completely secured or does not require
-    /// security, and is waiting to be passed to the radio.
-    ReadyToTransmit(FrameInfo, &'static mut [u8]),
-}
-
-#[derive(Eq, PartialEq, Debug)]
-enum RxState {
-    /// There is no frame that has been received.
-    Idle,
-    /// There is a secured frame that needs to be decrypted.
-    ReadyToDecrypt(FrameInfo, &'static mut [u8]),
-    /// A secured frame is currently being decrypted by the decryption facility.
-    #[allow(dead_code)]
-    Decrypting(FrameInfo),
-    /// There is an unsecured frame that needs to be re-parsed and exposed to
-    /// the client.
-    #[allow(dead_code)]
-    ReadyToYield(FrameInfo, &'static mut [u8]),
-    /// The buffer containing the frame needs to be returned to the radio.
-    ReadyToReturn(&'static mut [u8]),
-}
-
-/// This struct wraps an IEEE 802.15.4 radio device `kernel::hil::radio::Radio`
-/// and exposes IEEE 802.15.4 MAC device functionality as the trait
-/// `capsules::mac::Mac`. It hides header preparation, transmission and
-/// processing logic from the user by essentially maintaining multiple state
-/// machines corresponding to the transmission, reception and
-/// encryption/decryption pipelines. See the documentation in
-/// `capsules/src/mac.rs` for more details.
-pub struct MacDevice<'a, R: radio::Radio + 'a> {
+///
+/// Default implementation of a Mac layer. Acts as a pass-through between a MacDevice
+/// implementation and the underlying radio::Radio device. Does not change the power
+/// state of the radio during operation.
+///
+pub struct AwakeMac<'a, R: radio::Radio + 'a> {
     radio: &'a R,
-    data_sequence: Cell<u8>,
 
-    /// KeyDescriptor lookup procedure
-    key_procedure: Cell<Option<&'a KeyProcedure>>,
-    /// DeviceDescriptor lookup procedure
-    device_procedure: Cell<Option<&'a DeviceProcedure>>,
-
-    /// Transmision pipeline state. This should never be `None`, except when
-    /// transitioning between states. That is, any method that consumes the
-    /// current state should always remember to replace it along with the
-    /// associated state information.
-    tx_state: MapCell<TxState>,
-    tx_client: Cell<Option<&'a TxClient>>,
-
-    /// Reception pipeline state. Similar to the above, this should never be
-    /// `None`, except when transitioning between states.
-    rx_state: MapCell<RxState>,
-    rx_client: Cell<Option<&'a RxClient>>,
+    tx_client: Cell<Option<&'static radio::TxClient>>,
+    rx_client: Cell<Option<&'static radio::RxClient>>,
 }
 
-impl<'a, R: radio::Radio + 'a> MacDevice<'a, R> {
-    pub fn new(radio: &'a R) -> MacDevice<'a, R> {
-        MacDevice {
+impl<'a, R: radio::Radio + 'a> AwakeMac<'a, R> {
+    pub fn new(radio: &'a R) -> AwakeMac<'a, R> {
+        AwakeMac {
             radio: radio,
-            data_sequence: Cell::new(0),
-            key_procedure: Cell::new(None),
-            device_procedure: Cell::new(None),
-            tx_state: MapCell::new(TxState::Idle),
             tx_client: Cell::new(None),
-            rx_state: MapCell::new(RxState::Idle),
             rx_client: Cell::new(None),
         }
     }
-
-    /// Sets the IEEE 802.15.4 key lookup procedure to be used.
-    pub fn set_key_procedure(&self, key_procedure: &'a KeyProcedure) {
-        self.key_procedure.set(Some(key_procedure));
-    }
-
-    /// Sets the IEEE 802.15.4 key lookup procedure to be used.
-    pub fn set_device_procedure(&self, device_procedure: &'a DeviceProcedure) {
-        self.device_procedure.set(Some(device_procedure));
-    }
-
-    /// Look up the key using the IEEE 802.15.4 KeyDescriptor lookup prodecure
-    /// implemented elsewhere.
-    fn lookup_key(&self, level: SecurityLevel, key_id: KeyId) -> Option<([u8; 16])> {
-        self.key_procedure
-            .get()
-            .and_then(|key_procedure| key_procedure.lookup_key(level, key_id))
-    }
-
-    /// Look up the extended address of a device using the IEEE 802.15.4
-    /// DeviceDescriptor lookup prodecure implemented elsewhere.
-    fn lookup_addr_long(&self, src_addr: Option<MacAddress>) -> Option<([u8; 8])> {
-        src_addr.and_then(|addr| {
-            self.device_procedure
-                .get()
-                .and_then(|device_procedure| device_procedure.lookup_addr_long(addr))
-        })
-    }
-
-    /// IEEE 802.15.4-2015, 9.2.1, outgoing frame security procedure
-    /// Performs the first checks in the security procedure. The rest of the
-    /// steps are performed as part of the transmission pipeline.
-    /// Returns the next `TxState` to enter.
-    fn outgoing_frame_security(&self, buf: &'static mut [u8], frame_info: FrameInfo) -> TxState {
-        // IEEE 802.15.4-2015: 9.2.1, outgoing frame security
-        // Steps a-e have already been performed in the frame preparation step,
-        // so we only need to dispatch on the security parameters in the frame info
-        match frame_info.security_params {
-            Some((level, _, _)) => {
-                if level == SecurityLevel::None {
-                    // This case should never occur if the FrameInfo was
-                    // prepared by prepare_data_frame
-                    TxState::ReadyToTransmit(frame_info, buf)
-                } else {
-                    TxState::ReadyToEncrypt(frame_info, buf)
-                }
-            }
-            None => TxState::ReadyToTransmit(frame_info, buf),
-        }
-    }
-
-    /// IEEE 802.15.4-2015, 9.2.3, incoming frame security procedure
-    fn incoming_frame_security(&self, buf: &'static mut [u8], frame_len: usize) -> RxState {
-        // Try to decode the MAC header. Three possible results can occur:
-        // 1) The frame should be dropped and the buffer returned to the radio
-        // 2) The frame is unsecured. We immediately expose the frame to the
-        //    user and queue the buffer for returning to the radio.
-        // 3) The frame needs to be unsecured.
-        let result = Header::decode(&buf[radio::PSDU_OFFSET..], false)
-            .done()
-            .and_then(|(data_offset, (header, mac_payload_offset))| {
-                // Note: there is a complication here regarding the offsets.
-                // When the received frame has security enabled, the payload
-                // (including the payload IEs) is encrypted, and hence the data
-                // payload field includes the encrypted payload IEs too.
-                // However, when the frame is not encrypted, the data payload
-                // field does not include the payload IEs.
-                //
-                // This is fine because we re-parse the unsecured frame before
-                // exposing it to the user. At that time, the data payload field
-                // will not include the payload IEs.
-                let mic_len = header.security.map_or(0, |sec| sec.level.mic_len());
-                let data_len = frame_len - data_offset - mic_len;
-                if let Some(security) = header.security {
-                    // IEEE 802.15.4-2015: 9.2.3, incoming frame security procedure
-                    // for security-enabled headers
-                    if header.version == FrameVersion::V2003 {
-                        None
-                    } else {
-                        // Step e: Lookup the key.
-                        let key = match self.lookup_key(security.level, security.key_id) {
-                            Some(key) => key,
-                            None => {
-                                return None;
-                            }
-                        };
-
-                        // Step f: Obtain the extended source address
-                        // TODO: For Thread, when the frame's security header
-                        // specifies `KeyIdMode::Source4Index`, the source
-                        // address used for the nonce is actually a constant
-                        // defined in their spec
-                        let device_addr = match self.lookup_addr_long(header.src_addr) {
-                            Some(addr) => addr,
-                            None => {
-                                return None;
-                            }
-                        };
-
-                        // Step g, h: Check frame counter
-                        let frame_counter = match security.frame_counter {
-                            Some(frame_counter) => {
-                                if frame_counter == 0xffffffff {
-                                    // Counter error
-                                    return None;
-                                }
-                                // TODO: Check frame counter against source device
-                                frame_counter
-                            }
-                            // TSCH mode, where ASN is used instead, not supported
-                            None => {
-                                return None;
-                            }
-                        };
-
-                        // Compute ccm nonce
-                        let nonce = get_ccm_nonce(&device_addr, frame_counter, security.level);
-
-                        Some(FrameInfo {
-                            frame_type: header.frame_type,
-                            mac_payload_offset: mac_payload_offset,
-                            data_offset: data_offset,
-                            data_len: data_len,
-                            mic_len: mic_len,
-                            security_params: Some((security.level, key, nonce)),
-                        })
-                    }
-                } else {
-                    // No security needed, can yield the frame immediately
-                    self.rx_client.get().map(|client| {
-                        client.receive(&buf, header, radio::PSDU_OFFSET + data_offset, data_len);
-                    });
-                    None
-                }
-            });
-
-        match result {
-            None => RxState::ReadyToReturn(buf),
-            Some(frame_info) => RxState::ReadyToDecrypt(frame_info, buf),
-        }
-    }
-
-    /// Advances the transmission pipeline if it can be advanced.
-    fn step_transmit_state(&self) -> (ReturnCode, Option<&'static mut [u8]>) {
-        self.tx_state
-            .take()
-            .map_or((ReturnCode::FAIL, None), |state| {
-                // This mechanism is a little more clunky, but makes it
-                // difficult to forget to replace `tx_state`.
-                let (next_state, result) = match state {
-                    TxState::Idle => (TxState::Idle, (ReturnCode::SUCCESS, None)),
-                    TxState::ReadyToEncrypt(info, buf) => {
-                        match info.security_params {
-                            None => {
-                                // `ReadyToEncrypt` should only be entered when
-                                // `security_params` is not `None`.
-                                (TxState::Idle, (ReturnCode::FAIL, Some(buf)))
-                            }
-                            Some((_, _key, _nonce)) => {
-                                // let (m_off, m_len) = info.ccm_encrypt_ranges();
-                                // let (a_off, m_off) = (radio::PSDU_OFFSET,
-                                //                       radio::PSDU_OFFSET +
-                                //                       m_off);
-
-                                // TODO: Call CCM* auth/encryption routine with:
-                                // key: key
-                                // nonce: nonce
-                                // mic_len: info.mic_len
-                                // a data: buf[a_off..m_off]
-                                // m data: buf[m_off..m_off + m_len]
-
-                                (TxState::Idle, (ReturnCode::ENOSUPPORT, Some(buf)))
-                            }
-                        }
-                    }
-                    TxState::Encrypting(info) => {
-                        // This state should be advanced only by the hardware
-                        // encryption callback.
-                        (TxState::Encrypting(info), (ReturnCode::SUCCESS, None))
-                    }
-                    TxState::ReadyToTransmit(info, buf) => {
-                        let (rval, buf) = self.radio.transmit(buf, info.secured_length());
-                        match rval {
-                            // If the radio is busy, just wait for either a
-                            // transmit_done or config_done callback to trigger
-                            // this state transition again
-                            ReturnCode::EBUSY => {
-                                match buf {
-                                    None => {
-                                        // The radio forgot to return the buffer.
-                                        (TxState::Idle, (ReturnCode::FAIL, None))
-                                    }
-                                    Some(buf) => (
-                                        TxState::ReadyToTransmit(info, buf),
-                                        (ReturnCode::SUCCESS, None),
-                                    ),
-                                }
-                            }
-                            _ => (TxState::Idle, (rval, buf)),
-                        }
-                    }
-                };
-                self.tx_state.replace(next_state);
-                result
-            })
-    }
-
-    /// Advances the reception pipeline if it can be advanced.
-    fn step_receive_state(&self) {
-        self.rx_state.take().map(|state| {
-            let (next_state, buf) = match state {
-                RxState::Idle => (RxState::Idle, None),
-                RxState::ReadyToDecrypt(info, buf) => {
-                    match info.security_params {
-                        None => {
-                            // `ReadyToDecrypt` should only be entered when
-                            // `security_params` is not `None`.
-                            (RxState::Idle, Some(buf))
-                        }
-                        Some((_, _key, _nonce)) => {
-                            // let (m_off, m_len) = info.ccm_encrypt_ranges();
-                            // let (a_off, m_off) = (radio::PSDU_OFFSET,
-                            //                       radio::PSDU_OFFSET +
-                            //                       m_off);
-
-                            // TODO: Call CCM* auth/decryption routine with:
-                            // key: key
-                            // nonce: nonce
-                            // mic_len: info.mic_len
-                            // a data: buf[a_off..m_off]
-                            // c data: buf[m_off..m_off + m_len + mic_len]
-
-                            (RxState::Idle, Some(buf))
-                        }
-                    }
-                }
-                RxState::Decrypting(info) => {
-                    // This state should be advanced only by the hardware
-                    // encryption callback.
-                    (RxState::Decrypting(info), None)
-                }
-                RxState::ReadyToYield(info, buf) => {
-                    // Between the secured and unsecured frames, the
-                    // unsecured frame length remains constant but the data
-                    // offsets may change due to the presence of PayloadIEs.
-                    // Hence, we can only use the unsecured length from the
-                    // frame info, but not the offsets.
-                    let frame_len = info.unsecured_length();
-                    if let Some((data_offset, (header, _))) =
-                        Header::decode(&buf[radio::PSDU_OFFSET..], true).done()
-                    {
-                        // IEEE 802.15.4-2015 specifies that unsecured
-                        // frames do not have auxiliary security headers,
-                        // but we do not remove the auxiliary security
-                        // header before returning the frame to the client.
-                        // This is so that it is possible to tell if the
-                        // frame was secured or unsecured, while still
-                        // always receiving the frame payload in plaintext.
-                        self.rx_client.get().map(|client| {
-                            client.receive(
-                                &buf,
-                                header,
-                                radio::PSDU_OFFSET + data_offset,
-                                frame_len - data_offset,
-                            );
-                        });
-                    }
-                    (RxState::Idle, Some(buf))
-                }
-                RxState::ReadyToReturn(buf) => (RxState::Idle, Some(buf)),
-            };
-            self.rx_state.replace(next_state);
-
-            // Return the buffer to the radio if we are done with it.
-            if let Some(buf) = buf {
-                self.radio.set_receive_buffer(buf);
-            }
-        });
-    }
 }
 
-impl<'a, R: radio::Radio + 'a> Mac<'a> for MacDevice<'a, R> {
-    fn set_transmit_client(&self, client: &'a TxClient) {
-        self.tx_client.set(Some(client));
+impl<'a, R: radio::Radio + 'a> Mac for AwakeMac<'a, R> {
+    fn initialize(&self, _mac_buf: &'static mut [u8]) -> ReturnCode {
+        // do nothing, extra buffer unnecessary
+        ReturnCode::SUCCESS
     }
 
-    fn set_receive_client(&self, client: &'a RxClient) {
-        self.rx_client.set(Some(client));
+    fn is_on(&self) -> bool {
+        self.radio.is_on()
     }
 
-    fn get_address(&self) -> u16 {
-        self.radio.get_address()
-    }
-
-    fn get_address_long(&self) -> [u8; 8] {
-        self.radio.get_address_long()
-    }
-
-    fn get_pan(&self) -> u16 {
-        self.radio.get_pan()
-    }
-
-    fn get_channel(&self) -> u8 {
-        self.radio.get_channel()
-    }
-
-    fn get_tx_power(&self) -> i8 {
-        self.radio.get_tx_power()
+    fn set_config_client(&self, client: &'static radio::ConfigClient) {
+        self.radio.set_config_client(client)
     }
 
     fn set_address(&self, addr: u16) {
@@ -753,171 +109,76 @@ impl<'a, R: radio::Radio + 'a> Mac<'a> for MacDevice<'a, R> {
         self.radio.set_pan(id)
     }
 
-    fn set_channel(&self, chan: u8) -> ReturnCode {
-        self.radio.set_channel(chan)
+    fn get_address(&self) -> u16 {
+        self.radio.get_address()
     }
 
-    fn set_tx_power(&self, power: i8) -> ReturnCode {
-        self.radio.set_tx_power(power)
+    fn get_address_long(&self) -> [u8; 8] {
+        self.radio.get_address_long()
+    }
+
+    fn get_pan(&self) -> u16 {
+        self.radio.get_pan()
     }
 
     fn config_commit(&self) {
         self.radio.config_commit()
     }
 
-    fn is_on(&self) -> bool {
-        self.radio.is_on()
+    fn set_transmit_client(&self, client: &'static radio::TxClient) {
+        self.tx_client.set(Some(client));
     }
 
-    fn prepare_data_frame(
+    fn set_receive_client(&self, client: &'static radio::RxClient) {
+        self.rx_client.set(Some(client));
+    }
+
+    fn set_receive_buffer(&self, buffer: &'static mut [u8]) {
+        self.radio.set_receive_buffer(buffer);
+    }
+
+    fn transmit(
+        &self,
+        full_mac_frame: &'static mut [u8],
+        frame_len: usize,
+    ) -> (ReturnCode, Option<&'static mut [u8]>) {
+        self.radio.transmit(full_mac_frame, frame_len)
+    }
+}
+
+impl<'a, R: radio::Radio + 'a> radio::TxClient for AwakeMac<'a, R> {
+    fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
+        self.tx_client.get().map(move |c| {
+            c.send_done(buf, acked, result);
+        });
+    }
+}
+
+impl<'a, R: radio::Radio + 'a> radio::RxClient for AwakeMac<'a, R> {
+    fn receive(
         &self,
         buf: &'static mut [u8],
-        dst_pan: PanID,
-        dst_addr: MacAddress,
-        src_pan: PanID,
-        src_addr: MacAddress,
-        security_needed: Option<(SecurityLevel, KeyId)>,
-    ) -> Result<Frame, &'static mut [u8]> {
-        // IEEE 802.15.4-2015: 9.2.1, outgoing frame security
-        // Steps a-e of the security procedure are implemented here.
-
-        // TODO: For Thread, in the case of `KeyIdMode::Source4Index`, the source
-        // address should instead be some constant defined in their
-        // specification.
-        let src_addr_long = self.get_address_long();
-        let security_desc = security_needed.and_then(|(level, key_id)| {
-            self.lookup_key(level, key_id).map(|key| {
-                // TODO: lookup frame counter for device
-                let frame_counter = 0;
-                let nonce = get_ccm_nonce(&src_addr_long, frame_counter, level);
-                (
-                    Security {
-                        level: level,
-                        asn_in_nonce: false,
-                        frame_counter: Some(frame_counter),
-                        key_id: key_id,
-                    },
-                    key,
-                    nonce,
-                )
-            })
-        });
-        if security_needed.is_some() && security_desc.is_none() {
-            // If security was requested, fail when desired key was not found.
-            return Err(buf);
-        }
-
-        // Construct MAC header
-        let security = security_desc.map(|(sec, _, _)| sec);
-        let mic_len = security.map_or(0, |sec| sec.level.mic_len());
-        let header = Header {
-            frame_type: FrameType::Data,
-            /* TODO: determine this by looking at queue, and also set it in
-             * hardware so that ACKs set this flag to the right value. */
-            frame_pending: false,
-            // Unicast data frames request acknowledgement
-            ack_requested: true,
-            version: FrameVersion::V2015,
-            seq: Some(self.data_sequence.get()),
-            dst_pan: Some(dst_pan),
-            dst_addr: Some(dst_addr),
-            src_pan: Some(src_pan),
-            src_addr: Some(src_addr),
-            security: security,
-            header_ies: Default::default(),
-            header_ies_len: 0,
-            payload_ies: Default::default(),
-            payload_ies_len: 0,
-        };
-
-        match header.encode(&mut buf[radio::PSDU_OFFSET..], true).done() {
-            Some((data_offset, mac_payload_offset)) => Ok(Frame {
-                buf: buf,
-                info: FrameInfo {
-                    frame_type: FrameType::Data,
-                    mac_payload_offset: mac_payload_offset,
-                    data_offset: data_offset,
-                    data_len: 0,
-                    mic_len: mic_len,
-                    security_params: security_desc.map(|(sec, key, nonce)| (sec.level, key, nonce)),
-                },
-            }),
-            None => Err(buf),
-        }
-    }
-
-    fn transmit(&self, frame: Frame) -> (ReturnCode, Option<&'static mut [u8]>) {
-        let Frame { buf, info } = frame;
-        let state = match self.tx_state.take() {
-            None => {
-                return (ReturnCode::FAIL, Some(buf));
-            }
-            Some(state) => state,
-        };
-        match state {
-            TxState::Idle => {
-                let next_state = self.outgoing_frame_security(buf, info);
-                self.tx_state.replace(next_state);
-                self.step_transmit_state()
-            }
-            other_state => {
-                self.tx_state.replace(other_state);
-                (ReturnCode::EBUSY, Some(buf))
+        frame_len: usize,
+        crc_valid: bool,
+        result: ReturnCode,
+    ) {
+        // Filter packets by destination because radio is in promiscuous mode
+        let mut addr_match = false;
+        if let Some((_, (header, _))) = Header::decode(&buf[radio::PSDU_OFFSET..], false).done() {
+            if let Some(dst_addr) = header.dst_addr {
+                addr_match = match dst_addr {
+                    MacAddress::Short(addr) => addr == self.radio.get_address(),
+                    MacAddress::Long(long_addr) => long_addr == self.radio.get_address_long(),
+                };
             }
         }
-    }
-}
 
-impl<'a, R: radio::Radio + 'a> radio::TxClient for MacDevice<'a, R> {
-    fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
-        self.data_sequence.set(self.data_sequence.get() + 1);
-        self.tx_client.get().map(move |client| {
-            client.send_done(buf, acked, result);
-        });
-    }
-}
-
-impl<'a, R: radio::Radio + 'a> radio::RxClient for MacDevice<'a, R> {
-    fn receive(&self, buf: &'static mut [u8], frame_len: usize, crc_valid: bool, _: ReturnCode) {
-        // Drop all frames with invalid CRC
-        if !crc_valid {
-            self.radio.set_receive_buffer(buf);
-            return;
-        }
-
-        self.rx_state.take().map(move |state| {
-            let next_state = match state {
-                RxState::Idle => {
-                    // We can start processing a new received frame only if
-                    // the reception pipeline is free
-                    self.incoming_frame_security(buf, frame_len)
-                }
-                other_state => {
-                    // This should never occur unless something other than
-                    // this MAC layer provided a receive buffer to the
-                    // radio, but if this occurs then we have no choice but
-                    // to drop the frame.
-                    self.radio.set_receive_buffer(buf);
-                    other_state
-                }
-            };
-            self.rx_state.replace(next_state);
-            self.step_receive_state();
-        });
-    }
-}
-
-impl<'a, R: radio::Radio + 'a> radio::ConfigClient for MacDevice<'a, R> {
-    fn config_done(&self, _: ReturnCode) {
-        // The transmission pipeline is the only state machine that
-        // waits for the configuration procedure to complete before
-        // advancing.
-        let (rval, buf) = self.step_transmit_state();
-        if let Some(buf) = buf {
-            // Return the buffer to the transmit client
-            self.tx_client.get().map(move |client| {
-                client.send_done(buf, false, rval);
+        if addr_match {
+            self.rx_client.get().map(move |c| {
+                c.receive(buf, frame_len, crc_valid, result);
             });
+        } else {
+            self.radio.set_receive_buffer(buf);
         }
     }
 }

--- a/capsules/src/ieee802154/mod.rs
+++ b/capsules/src/ieee802154/mod.rs
@@ -1,5 +1,9 @@
+pub mod device;
+pub mod framer;
 pub mod mac;
 pub mod virtual_mac;
+pub mod xmac;
+
 mod driver;
 
 pub use self::driver::*;

--- a/capsules/src/ieee802154/virtual_mac.rs
+++ b/capsules/src/ieee802154/virtual_mac.rs
@@ -27,7 +27,7 @@
 //! ```
 
 use core::cell::Cell;
-use ieee802154::mac;
+use ieee802154::{device, framer};
 use kernel::ReturnCode;
 use kernel::common::{List, ListLink, ListNode};
 use kernel::common::take_cell::MapCell;
@@ -37,12 +37,12 @@ use net::ieee802154::*;
 /// any pending transmission requests. Any received frames from the underlying
 /// MAC device are sent to all users.
 pub struct MuxMac<'a> {
-    mac: &'a mac::Mac<'a>,
+    mac: &'a device::MacDevice<'a>,
     users: List<'a, MacUser<'a>>,
     inflight: Cell<Option<&'a MacUser<'a>>>,
 }
 
-impl<'a> mac::TxClient for MuxMac<'a> {
+impl<'a> device::TxClient for MuxMac<'a> {
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.inflight.get().map(move |user| {
             self.inflight.set(None);
@@ -52,7 +52,7 @@ impl<'a> mac::TxClient for MuxMac<'a> {
     }
 }
 
-impl<'a> mac::RxClient for MuxMac<'a> {
+impl<'a> device::RxClient for MuxMac<'a> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         for user in self.users.iter() {
             user.receive(buf, header, data_offset, data_len);
@@ -61,7 +61,7 @@ impl<'a> mac::RxClient for MuxMac<'a> {
 }
 
 impl<'a> MuxMac<'a> {
-    pub const fn new(mac: &'a mac::Mac<'a>) -> MuxMac<'a> {
+    pub const fn new(mac: &'a device::MacDevice<'a>) -> MuxMac<'a> {
         MuxMac {
             mac: mac,
             users: List::new(),
@@ -174,7 +174,7 @@ impl<'a> MuxMac<'a> {
 #[derive(Eq, PartialEq, Debug)]
 enum Op {
     Idle,
-    Transmit(mac::Frame),
+    Transmit(framer::Frame),
 }
 
 /// Keep state for each Mac user. All users of the virtualized MAC interface
@@ -188,8 +188,8 @@ pub struct MacUser<'a> {
     mux: &'a MuxMac<'a>,
     operation: MapCell<Op>,
     next: ListLink<'a, MacUser<'a>>,
-    tx_client: Cell<Option<&'a mac::TxClient>>,
-    rx_client: Cell<Option<&'a mac::RxClient>>,
+    tx_client: Cell<Option<&'a device::TxClient>>,
+    rx_client: Cell<Option<&'a device::RxClient>>,
 }
 
 impl<'a> MacUser<'a> {
@@ -224,12 +224,12 @@ impl<'a> ListNode<'a, MacUser<'a>> for MacUser<'a> {
     }
 }
 
-impl<'a> mac::Mac<'a> for MacUser<'a> {
-    fn set_transmit_client(&self, client: &'a mac::TxClient) {
+impl<'a> device::MacDevice<'a> for MacUser<'a> {
+    fn set_transmit_client(&self, client: &'a device::TxClient) {
         self.tx_client.set(Some(client));
     }
 
-    fn set_receive_client(&self, client: &'a mac::RxClient) {
+    fn set_receive_client(&self, client: &'a device::RxClient) {
         self.rx_client.set(Some(client));
     }
 
@@ -245,14 +245,6 @@ impl<'a> mac::Mac<'a> for MacUser<'a> {
         self.mux.mac.get_pan()
     }
 
-    fn get_channel(&self) -> u8 {
-        self.mux.mac.get_channel()
-    }
-
-    fn get_tx_power(&self) -> i8 {
-        self.mux.mac.get_tx_power()
-    }
-
     fn set_address(&self, addr: u16) {
         self.mux.mac.set_address(addr)
     }
@@ -263,14 +255,6 @@ impl<'a> mac::Mac<'a> for MacUser<'a> {
 
     fn set_pan(&self, id: u16) {
         self.mux.mac.set_pan(id)
-    }
-
-    fn set_channel(&self, chan: u8) -> ReturnCode {
-        self.mux.mac.set_channel(chan)
-    }
-
-    fn set_tx_power(&self, power: i8) -> ReturnCode {
-        self.mux.mac.set_tx_power(power)
     }
 
     fn config_commit(&self) {
@@ -289,13 +273,13 @@ impl<'a> mac::Mac<'a> for MacUser<'a> {
         src_pan: PanID,
         src_addr: MacAddress,
         security_needed: Option<(SecurityLevel, KeyId)>,
-    ) -> Result<mac::Frame, &'static mut [u8]> {
+    ) -> Result<framer::Frame, &'static mut [u8]> {
         self.mux
             .mac
             .prepare_data_frame(buf, dst_pan, dst_addr, src_pan, src_addr, security_needed)
     }
 
-    fn transmit(&self, frame: mac::Frame) -> (ReturnCode, Option<&'static mut [u8]>) {
+    fn transmit(&self, frame: framer::Frame) -> (ReturnCode, Option<&'static mut [u8]>) {
         // If the muxer is idle, immediately transmit the frame, otherwise
         // attempt to queue the transmission request. However, each MAC user can
         // only have one pending transmission request, so if there already is a

--- a/capsules/src/ieee802154/xmac.rs
+++ b/capsules/src/ieee802154/xmac.rs
@@ -1,0 +1,640 @@
+//! X-MAC protocol layer for low power 802.15.4 reception, intended primarily
+//! to manage an Atmel RF233 radio.
+//!
+//! Original X-MAC paper, on which this implementation is heavily based:
+//!     http://www.cs.cmu.edu/~andersoe/papers/xmac-sensys.pdf
+//!
+//! Nodes using this layer place their radios to sleep for the vast majority of
+//! the time, thereby reducing power consumption. Transmitters wake and send a
+//! stream of small, strobed `preamble` packets to the desired recipient. If a
+//! receiver wakes and ACKS a relevant preamble, the receiver waits for a data
+//! packet before returning to sleep. See comments below for implementation
+//! details.
+//!
+//! Additional notes:
+//!
+//!   * Since much of a node's time is spent sleeping, transmission latency is
+//!     much higher than using a radio that is always powered on.
+//!   * ReturnCode::ENOACKs may be generated when transmitting, if the
+//!     destination node cannot acknowledge within the maximum retry interval.
+//!   * Since X-MAC relies on proper sleep/wake behavior for all nodes, any
+//!     node with this implementation will not be able to communicate correctly
+//!     with non-XMAC-wrapped radios.
+//!
+//! Usage
+//! -----
+//! This capsule implements the `capsules::ieee802154::mac::Mac` interface while
+//! wrapping an actual `kernel::hil::radio::Radio' with a similar interface, and
+//! can be used as the backend for a `capsules::ieee802154::device::MacDevice`,
+//! which should fully encode frames before passing it to this layer.
+//!
+//! For imix, I've uploaded a sample main.rs/Xcargo.toml config in a gist that
+//! you can find [here](https://gist.github.com/jlwatson/a3ceff5f7c7dffe41cca71e70c5de30d)
+//! (current as of 01/28/18). In general, given a radio driver `RF233Device`,
+//! a `kernel::hil::time::Alarm`, and a `kernel::hil::rng::RNG` device, the
+//! necessary modifications to the board configuration are shown below for `imix`s:
+//!
+//! ```rust
+//! // Xargo.toml
+//! ...
+//! features = ["c", "mem"]
+//! ```
+//!
+//! ```rust
+//! // main.rs
+//!
+//! use capsules::ieee802154::mac::Mac;
+//! use capsules::ieee802154::xmac;
+//! type XMacDevice = capsules::ieee802154::xmac::XMac<'static, RF233Device, Alarm>;
+//!
+//! // ...
+//! // XMac needs one buffer in addition to those provided to the RF233 driver.
+//! //   1. stores actual packet contents to free the SPI buffers used by the
+//! //      radio for transmitting preamble packets
+//! static mut MAC_BUF: [u8; radio::MAX_BUF_SIZE] = [0x00; radio::MAX_BUF_SIZE];
+//! // ...
+//! let xmac: &XMacDevice = static_init!(XMacDevice, xmac::XMac::new(rf233, alarm, rng));
+//! rng.set_client(xmac);
+//! alarm.set_client(xmac);
+//!
+//! // Hook up the radio to the XMAC implementation.
+//! rf233.set_transmit_client(xmac);
+//! rf233.set_receive_client(xmac, &mut RF233_RX_BUF);
+//! rf233.set_power_client(xmac);
+//!
+//! xmac.initialize(&mut MAC_BUF);
+//!
+//! // We can now use the XMac driver to instantiate a MacDevice like a Framer
+//! let mac_device = static_init!(
+//!     capsules::ieee802154::framer::Framer<'static, XMacDevice>,
+//!     capsules::ieee802154::framer::Framer::new(xmac));
+//! xmac.set_transmit_client(mac_device);
+//! xmac.set_receive_client(mac_device);
+//! xmac.set_config_client(mac_device);
+//! ```
+
+//
+// TODO: Test no-preamble transmission with randomized backoff, requires 3
+//       devices.
+// TODO: Modifying sleep time with traffic load to optimize energy usage.
+// TODO: Remove expectation that radios cancel pending sleeps when receiving a
+//       new packet (see line 652).
+//
+// Author: Jean-Luc Watson
+// Date: Nov 21 2017
+//
+
+use core::cell::Cell;
+use ieee802154::mac::Mac;
+use kernel::ReturnCode;
+use kernel::common::take_cell::TakeCell;
+use kernel::hil::radio;
+use kernel::hil::rng::{self, RNG};
+use kernel::hil::time::{self, Alarm, Frequency, Time};
+use net::ieee802154::*;
+
+// Time the radio will remain awake listening for packets before sleeping.
+// Observing the RF233, receive callbacks for preambles are generated only after
+// having been awake for more than 4-6 ms; 10 ms is a safe amount of time where
+// we are very likely to pick up any incoming preambles, and is half as much
+// as the 20 ms lower bound in Buettner et al.
+const WAKE_TIME_MS: u32 = 10;
+// Time the radio will sleep between wakes. Configurable to any desired value
+// less than or equal to the max time the transmitter sends preambles before
+// abandoning the transmission.
+const SLEEP_TIME_MS: u32 = 250;
+// Time the radio will continue to send preamble packets before aborting the
+// transmission and returning ENOACK. Should be at least as large as the maximum
+// sleep time for any node in the network.
+const PREAMBLE_TX_MS: u32 = 251;
+
+// Maximum backoff for a transmitter attempting to send a data packet, when the
+// node has detected a data packet sent to the same destination from another
+// transmitter. This is an optimization that eliminates the need for any
+// preambles when the receiving node is shown to already be awake.
+const MAX_TX_BACKOFF_MS: u32 = 10;
+// After receiving a data packet, maximum time a node will stay awake to receive
+// any additional incoming packets before going to sleep.
+const MAX_RX_SLEEP_DELAY_MS: u32 = MAX_TX_BACKOFF_MS;
+
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, PartialEq)]
+enum XMacState {
+    // The primary purpose of these states is to manage the timer that runs the
+    // protocol and determines the state of the radio (e.g. if in SLEEP, a fired
+    // timer indicates we should transition to AWAKE).
+    AWAKE,       // Awake and listening for incoming preambles
+    DELAY_SLEEP, // Receiving done; waiting for any other incoming data packets
+    SLEEP,       // Asleep and not receiving or transmitting
+    STARTUP,     // Radio waking up, PowerClient::on() transitions to next state
+    TX_PREAMBLE, // Transmitting preambles and waiting for an ACK
+    TX,          // Transmitting data packet to the destination node
+    TX_DELAY,    // Backing off to send data directly without preamble
+}
+
+// Information extracted for each packet from the data buffer provided to
+// transmit(), used to generate preamble packets and detect when a delayed
+// direct transmission (described above) is appropriate.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct XMacHeaderInfo {
+    pub dst_pan: Option<PanID>,
+    pub dst_addr: Option<MacAddress>,
+    pub src_pan: Option<PanID>,
+    pub src_addr: Option<MacAddress>,
+}
+
+// The X-MAC `driver` consists primarily of a backend radio driver, an alarm for
+// transitioning between different portions of the protocol, and a source of
+// randomness for transmit backoffs. In addition, we maintain two packet buffers
+// (one for transmit, one for receive) that cycle without copying between XMAC,
+// the tx/rx client, and the underlying radio driver. The transmit buffer can
+// also hold the actual data packet contents while preambles are being
+// transmitted.
+pub struct XMac<'a, R: radio::Radio + 'a, A: Alarm + 'a> {
+    radio: &'a R,
+    alarm: &'a A,
+    rng: &'a RNG,
+    tx_client: Cell<Option<&'static radio::TxClient>>,
+    rx_client: Cell<Option<&'static radio::RxClient>>,
+    state: Cell<XMacState>,
+    delay_sleep: Cell<bool>,
+
+    tx_header: Cell<Option<XMacHeaderInfo>>,
+    tx_payload: TakeCell<'static, [u8]>,
+    tx_len: Cell<usize>,
+
+    tx_preamble_pending: Cell<bool>,
+    tx_preamble_seq_num: Cell<u8>,
+    tx_preamble_buf: TakeCell<'static, [u8]>,
+
+    rx_pending: Cell<bool>,
+}
+
+impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> XMac<'a, R, A> {
+    pub fn new(radio: &'a R, alarm: &'a A, rng: &'a RNG) -> XMac<'a, R, A> {
+        XMac {
+            radio: radio,
+            alarm: alarm,
+            rng: rng,
+            tx_client: Cell::new(None),
+            rx_client: Cell::new(None),
+            state: Cell::new(XMacState::STARTUP),
+            delay_sleep: Cell::new(false),
+            tx_header: Cell::new(None),
+            tx_payload: TakeCell::empty(),
+            tx_len: Cell::new(0),
+            tx_preamble_pending: Cell::new(false),
+            tx_preamble_seq_num: Cell::new(0),
+            tx_preamble_buf: TakeCell::empty(),
+            rx_pending: Cell::new(false),
+        }
+    }
+
+    fn sleep_time(&self) -> u32 {
+        // TODO (ongoing) modify based on traffic load to efficiently schedule
+        // sleep. Currently sleeps for a constant amount of time.
+        SLEEP_TIME_MS
+    }
+
+    fn sleep(&self) {
+        // If transmitting/delaying sleep, we don't want to try to sleep (again)
+        if self.state.get() == XMacState::AWAKE {
+            // If we should delay sleep (completed RX), set timer accordingly
+            if self.delay_sleep.get() {
+                self.state.set(XMacState::DELAY_SLEEP);
+                self.set_timer_ms::<A>(MAX_RX_SLEEP_DELAY_MS);
+
+            // Otherwise, don't sleep if expecting a data packet or transmitting
+            } else if !self.rx_pending.get() {
+                self.radio.stop();
+                self.state.set(XMacState::SLEEP);
+                self.set_timer_ms::<A>(self.sleep_time());
+            }
+        }
+    }
+
+    // Sets the timer to fire a set number of milliseconds in the future based
+    // on the current tick value.
+    fn set_timer_ms<T: Time>(&self, ms: u32) {
+        self.alarm.set_alarm(
+            self.alarm
+                .now()
+                .wrapping_add(((ms as f32 / 1000.0) * <T::Frequency>::frequency() as f32) as u32),
+        );
+    }
+
+    fn transmit_preamble(&self) {
+        let mut result: (ReturnCode, Option<&'static mut [u8]>) = (ReturnCode::SUCCESS, None);
+        let buf = self.tx_preamble_buf.take().unwrap();
+        let tx_header = self.tx_header.get().unwrap();
+
+        // If we're not currently sending preambles, skip transmission
+        if let XMacState::TX_PREAMBLE = self.state.get() {
+            // Generate preamble frame. We use a reserved frame type (0b101) to
+            // distinguish from regular data frames, increment a sequence
+            // number for each consecutive packet sent, and send with no
+            // security.
+            let header = Header {
+                frame_type: FrameType::Multipurpose,
+                frame_pending: false,
+                ack_requested: true,
+                version: FrameVersion::V2015,
+                seq: Some(self.tx_preamble_seq_num.get()),
+                dst_pan: tx_header.dst_pan,
+                dst_addr: tx_header.dst_addr,
+                src_pan: tx_header.src_pan,
+                src_addr: tx_header.src_addr,
+                security: None,
+                header_ies: Default::default(),
+                header_ies_len: 0,
+                payload_ies: Default::default(),
+                payload_ies_len: 0,
+            };
+
+            self.tx_preamble_seq_num
+                .set(self.tx_preamble_seq_num.get() + 1);
+
+            match header.encode(&mut buf[radio::PSDU_OFFSET..], true).done() {
+                // If we can successfully encode the preamble, transmit.
+                Some((data_offset, _)) => {
+                    result = self.radio.transmit(buf, data_offset + radio::PSDU_OFFSET);
+                }
+                None => {
+                    self.tx_preamble_buf.replace(buf);
+                    self.call_tx_client(self.tx_payload.take().unwrap(), false, ReturnCode::FAIL);
+                    return;
+                }
+            }
+        }
+
+        // If the transmission fails, callback directly back into the client
+        if result.0 != ReturnCode::SUCCESS {
+            self.call_tx_client(result.1.unwrap(), false, result.0);
+        }
+    }
+
+    fn transmit_packet(&self) {
+        // If we have actual data to transmit, send it and report errors to
+        // client.
+        if self.tx_payload.is_some() {
+            let result: (ReturnCode, Option<&'static mut [u8]>);
+            let tx_buf = self.tx_payload.take().unwrap();
+
+            result = self.radio.transmit(tx_buf, self.tx_len.get());
+
+            if result.0 != ReturnCode::SUCCESS {
+                self.call_tx_client(result.1.unwrap(), false, result.0);
+            }
+        }
+    }
+
+    // Reports back to client that transmission is complete, radio can turn off
+    // if not kept awake by other portions of the protocol.
+    fn call_tx_client(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
+        self.state.set(XMacState::AWAKE);
+        self.sleep();
+        self.tx_client.get().map(move |c| {
+            c.send_done(buf, acked, result);
+        });
+    }
+
+    // Reports any received packet back to the client and starts going to sleep.
+    // Does not propagate preamble packets up to the RxClient.
+    fn call_rx_client(
+        &self,
+        buf: &'static mut [u8],
+        len: usize,
+        crc_valid: bool,
+        result: ReturnCode,
+    ) {
+        self.delay_sleep.set(true);
+        self.sleep();
+
+        self.rx_client.get().map(move |c| {
+            c.receive(buf, len, crc_valid, result);
+        });
+    }
+}
+
+impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> rng::Client for XMac<'a, R, A> {
+    fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> rng::Continue {
+        match randomness.next() {
+            Some(random) => {
+                if self.state.get() == XMacState::TX_DELAY {
+                    // When another data packet to our desired destination is
+                    // detected, we backoff a random amount before sending our
+                    // own data with no preamble. This assumes that the reciever
+                    // will remain awake long enough to receive our transmission,
+                    // as it should with this implementation. Since RNG is
+                    // asynchronous, we account for the time spent waiting for
+                    // the callback and randomly determine the remaining time
+                    // spent backing off.
+                    let time_remaining_ms =
+                        (((self.alarm.get_alarm().wrapping_sub(self.alarm.now())) as f32
+                            / <A::Frequency>::frequency() as f32) * 1000.0)
+                            as u32;
+                    self.set_timer_ms::<A>(random % time_remaining_ms);
+                }
+                rng::Continue::Done
+            }
+            None => rng::Continue::More,
+        }
+    }
+}
+
+// The vast majority of these calls pass through to the underlying radio driver.
+impl<'a, R: radio::Radio + 'a, A: Alarm> Mac for XMac<'a, R, A> {
+    fn initialize(&self, mac_buf: &'static mut [u8]) -> ReturnCode {
+        self.tx_preamble_buf.replace(mac_buf);
+        self.state.set(XMacState::STARTUP);
+        ReturnCode::SUCCESS
+    }
+
+    // Always lie and say the radio is on when sleeping, as XMAC will wake up
+    // itself to send preambles if necessary.
+    fn is_on(&self) -> bool {
+        if self.state.get() == XMacState::SLEEP {
+            return true;
+        }
+        self.radio.is_on()
+    }
+
+    fn set_config_client(&self, client: &'static radio::ConfigClient) {
+        self.radio.set_config_client(client)
+    }
+
+    fn set_address(&self, addr: u16) {
+        self.radio.set_address(addr)
+    }
+
+    fn set_address_long(&self, addr: [u8; 8]) {
+        self.radio.set_address_long(addr)
+    }
+
+    fn set_pan(&self, id: u16) {
+        self.radio.set_pan(id)
+    }
+
+    fn get_address(&self) -> u16 {
+        self.radio.get_address()
+    }
+
+    fn get_address_long(&self) -> [u8; 8] {
+        self.radio.get_address_long()
+    }
+
+    fn get_pan(&self) -> u16 {
+        self.radio.get_pan()
+    }
+
+    fn config_commit(&self) {
+        self.radio.config_commit()
+    }
+
+    fn set_transmit_client(&self, client: &'static radio::TxClient) {
+        self.tx_client.set(Some(client));
+    }
+
+    fn set_receive_client(&self, client: &'static radio::RxClient) {
+        self.rx_client.set(Some(client));
+    }
+
+    fn set_receive_buffer(&self, buffer: &'static mut [u8]) {
+        self.radio.set_receive_buffer(buffer);
+    }
+
+    fn transmit(
+        &self,
+        full_mac_frame: &'static mut [u8],
+        frame_len: usize,
+    ) -> (ReturnCode, Option<&'static mut [u8]>) {
+        // If the radio is busy, we already have data to transmit, or the buffer
+        // size is wrong, fail before attempting to send any preamble packets
+        // (and waking up the radio).
+        let frame_len = frame_len + radio::MFR_SIZE;
+        if self.radio.busy() || self.tx_payload.is_some() {
+            return (ReturnCode::EBUSY, Some(full_mac_frame));
+        } else if radio::PSDU_OFFSET + frame_len >= full_mac_frame.len() {
+            return (ReturnCode::ESIZE, Some(full_mac_frame));
+        }
+
+        match Header::decode(&full_mac_frame[radio::PSDU_OFFSET..], false).done() {
+            Some((_, (header, _))) => {
+                self.tx_len.set(frame_len - radio::PSDU_OFFSET);
+                self.tx_header.set(Some(XMacHeaderInfo {
+                    dst_addr: header.dst_addr,
+                    dst_pan: header.dst_pan,
+                    src_addr: header.src_addr,
+                    src_pan: header.src_pan,
+                }));
+            }
+            None => {
+                self.tx_header.set(None);
+            }
+        }
+
+        match self.tx_header.get() {
+            Some(_) => {
+                self.tx_payload.replace(full_mac_frame);
+            }
+            None => {
+                return (ReturnCode::FAIL, Some(full_mac_frame));
+            }
+        }
+
+        self.tx_preamble_seq_num.set(0);
+
+        // If the radio is on, start the preamble timer and start transmitting
+        if self.radio.is_on() {
+            self.state.set(XMacState::TX_PREAMBLE);
+            self.set_timer_ms::<A>(PREAMBLE_TX_MS);
+            self.transmit_preamble();
+
+        // If the radio is currently sleeping, wake it and indicate that when
+        // ready, it should begin transmitting preambles
+        } else {
+            self.state.set(XMacState::STARTUP);
+            self.tx_preamble_pending.set(true);
+            self.radio.start();
+        }
+
+        (ReturnCode::SUCCESS, None)
+    }
+}
+
+// Core of the XMAC protocol - when the timer fires, the protocol state
+// indicates the next state/action to take.
+impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> time::Client for XMac<'a, R, A> {
+    fn fired(&self) {
+        match self.state.get() {
+            XMacState::SLEEP => {
+                // If asleep, start the radio and wait for the PowerClient to
+                // indicate that the radio is ready
+                if !self.radio.is_on() {
+                    self.state.set(XMacState::STARTUP);
+                    self.radio.start();
+                } else {
+                    self.set_timer_ms::<A>(WAKE_TIME_MS);
+                    self.state.set(XMacState::AWAKE);
+                }
+            }
+            // If we've been delaying sleep or haven't heard any incoming
+            // preambles, turn the radio off.
+            XMacState::AWAKE => {
+                self.sleep();
+            }
+            XMacState::DELAY_SLEEP => {
+                self.delay_sleep.set(false);
+                self.state.set(XMacState::AWAKE);
+                self.sleep();
+            }
+            // If we've sent preambles for longer than the maximum sleep time of
+            // any node in the network, then our destination is non-responsive;
+            // return ENOACK to the client.
+            XMacState::TX_PREAMBLE => {
+                self.call_tx_client(self.tx_payload.take().unwrap(), false, ReturnCode::ENOACK);
+            }
+            // After a randomized backoff period, transmit the data directly.
+            XMacState::TX_DELAY => {
+                self.state.set(XMacState::TX);
+                self.transmit_packet();
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> radio::PowerClient for XMac<'a, R, A> {
+    fn changed(&self, on: bool) {
+        // If the radio turns on and we're in STARTUP, then either transition to
+        // listening for incoming preambles or start transmitting preambles if
+        // the radio was turned on for a transmission.
+        if on {
+            if let XMacState::STARTUP = self.state.get() {
+                if self.tx_preamble_pending.get() {
+                    self.tx_preamble_pending.set(false);
+                    self.state.set(XMacState::TX_PREAMBLE);
+                    self.set_timer_ms::<A>(PREAMBLE_TX_MS);
+                    self.transmit_preamble();
+                } else {
+                    self.state.set(XMacState::AWAKE);
+                    self.set_timer_ms::<A>(WAKE_TIME_MS);
+                }
+            }
+        }
+    }
+}
+
+impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> radio::TxClient for XMac<'a, R, A> {
+    fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
+        match self.state.get() {
+            // Completed a data transmission to the destination node
+            XMacState::TX => {
+                self.call_tx_client(buf, acked, result);
+            }
+            // Completed a preamble transmission
+            XMacState::TX_PREAMBLE => {
+                self.tx_preamble_buf.replace(buf);
+                if acked {
+                    // Destination signals ready to receive data
+                    self.state.set(XMacState::TX);
+                    self.transmit_packet();
+                } else {
+                    // Continue resending preambles
+                    self.transmit_preamble();
+                }
+            }
+            XMacState::TX_DELAY | XMacState::SLEEP => {
+                // If, while sending preambles, we switch to TX_DELAY mode, the
+                // last preamble sent will complete afterwards. If no ACK, the
+                // radio may have fallen sleep before the callback is processed.
+                self.tx_preamble_buf.replace(buf);
+            }
+            _ => {}
+        }
+    }
+}
+
+// The receive callback is complicated by the fact that, to determine when a
+// destination node is receiving packets/awake while we are attempting a
+// transmission, we put the radio in promiscuous mode. Not a huge issue, but
+// we need to be wary of incoming packets not actually addressed to our node.
+impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> radio::RxClient for XMac<'a, R, A> {
+    fn receive(
+        &self,
+        buf: &'static mut [u8],
+        frame_len: usize,
+        crc_valid: bool,
+        result: ReturnCode,
+    ) {
+        let mut data_received: bool = false;
+        let mut continue_sleep: bool = true;
+
+        // First, check to make sure we can decode the MAC header (especially
+        // the destination address) to see if we can backoff/send pending
+        // transmission.
+        if let Some((_, (header, _))) = Header::decode(&buf[radio::PSDU_OFFSET..], false).done() {
+            if let Some(dst_addr) = header.dst_addr {
+                let addr_match = match dst_addr {
+                    MacAddress::Short(addr) => addr == self.radio.get_address(),
+                    MacAddress::Long(long_addr) => long_addr == self.radio.get_address_long(),
+                };
+                // The destination doesn't match our address, check to see if we
+                // can backoff a pending transmission if it exists rather than
+                // continue sending preambles.
+                if !addr_match {
+                    if self.state.get() == XMacState::TX_PREAMBLE {
+                        if let Some(tx_dst_addr) = self.tx_header.get().and_then(|hdr| hdr.dst_addr)
+                        {
+                            if tx_dst_addr == dst_addr {
+                                // Randomize backoff - since the callback is asynchronous, set the
+                                // timer for the max and adjust later. As a result, we can't
+                                // backoff for more than the RNG generation time.
+                                self.state.set(XMacState::TX_DELAY);
+                                self.rng.get();
+                                self.set_timer_ms::<A>(MAX_TX_BACKOFF_MS);
+                                continue_sleep = false;
+                            }
+                        }
+                    }
+                } else {
+                    // We've received either a preamble or data packet
+                    match header.frame_type {
+                        FrameType::Multipurpose => {
+                            continue_sleep = false;
+                            self.rx_pending.set(true);
+                        }
+                        FrameType::Data => {
+                            continue_sleep = false;
+                            data_received = true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // TODO: this currently assumes that upon receiving a packet, the radio
+        // will cancel a pending sleep, and an additional call to Radio::stop()
+        // is required to shut down the radio. This works specifically for the
+        // RF233 with the added line at rf233.rs:744. In progress: it might be
+        // possible to remove this requirement.
+        if self.state.get() == XMacState::SLEEP {
+            self.state.set(XMacState::AWAKE);
+        }
+
+        if data_received {
+            self.rx_pending.set(false);
+            self.call_rx_client(buf, frame_len, crc_valid, result);
+        } else {
+            self.radio.set_receive_buffer(buf);
+        }
+
+        // If we should go to sleep (i.e. not waiting up for any additional data
+        // packets), shut the radio down. If a prior sleep was pending, it was
+        // cancelled as the result of the RX (see above).
+        if continue_sleep {
+            self.sleep();
+        }
+    }
+}

--- a/capsules/src/net/sixlowpan.rs
+++ b/capsules/src/net/sixlowpan.rs
@@ -224,7 +224,8 @@
 //
 
 use core::cell::Cell;
-use ieee802154::mac::{Frame, Mac, RxClient, TxClient};
+use ieee802154::device::{MacDevice, RxClient, TxClient};
+use ieee802154::framer::Frame;
 use kernel::ReturnCode;
 use kernel::common::list::{List, ListLink, ListNode};
 use kernel::common::take_cell::{MapCell, TakeCell};
@@ -365,7 +366,7 @@ impl TxState {
         &self,
         dgram_tag: u16,
         frag_buf: &'static mut [u8],
-        radio: &Mac,
+        radio: &MacDevice,
         ctx_store: &ContextStore,
     ) -> Result<(), (ReturnCode, &'static mut [u8])> {
         self.dgram_tag.set(dgram_tag);
@@ -397,7 +398,7 @@ impl TxState {
         &self,
         ip6_packet: &[u8],
         mut frame: Frame,
-        radio: &Mac,
+        radio: &MacDevice,
         ctx_store: &ContextStore,
     ) -> Result<(), (ReturnCode, &'static mut [u8])> {
         // Here, we assume that the compressed headers fit in the first MTU
@@ -462,7 +463,7 @@ impl TxState {
     fn prepare_transmit_next_fragment(
         &self,
         frag_buf: &'static mut [u8],
-        radio: &Mac,
+        radio: &MacDevice,
     ) -> Result<(), (ReturnCode, &'static mut [u8])> {
         match radio.prepare_data_frame(
             frag_buf,
@@ -703,7 +704,7 @@ impl<'a> RxState<'a> {
 /// Finally, `set_client` controls the client that will receive transmission
 /// completion and reception callbacks.
 pub struct Sixlowpan<'a, A: time::Alarm + 'a, C: ContextStore> {
-    pub radio: &'a Mac<'a>,
+    pub radio: &'a MacDevice<'a>,
     ctx_store: C,
     clock: &'a A,
     client: Cell<Option<&'a SixlowpanClient>>,
@@ -763,7 +764,7 @@ impl<'a, A: time::Alarm, C: ContextStore> Sixlowpan<'a, A, C> {
     ///
     /// # Arguments
     ///
-    /// * `radio` - An implementation of the `Mac` trait that manages the timing
+    /// * `radio` - An implementation of the `MacDevice` trait that manages the timing
     /// and frequency of sending a receiving 802.15.4 frames
     ///
     /// * `ctx_store` - Stores IPv6 address nextwork context mappings
@@ -776,7 +777,7 @@ impl<'a, A: time::Alarm, C: ContextStore> Sixlowpan<'a, A, C> {
     /// frame arrival. The clock should be continue running during sleep and
     /// have an accuracy of at least 60 seconds.
     pub fn new(
-        radio: &'a Mac<'a>,
+        radio: &'a MacDevice<'a>,
         ctx_store: C,
         tx_buf: &'static mut [u8],
         clock: &'a A,


### PR DESCRIPTION
Hi everyone,

### Pull Request Overview

This pull request adds a low power MAC protocol as a capsule wrapper for drivers implementing the `kernel::hil::radio::Radio` interface. Specifically, this is an implementation of **X-MAC**, heavily based on the original work for the protocol that you can read all about [here](http://www.cs.cmu.edu/~andersoe/papers/xmac-sensys.pdf). In addition, support for putting the RF233 radio to sleep has been added.

The overall goal is to trade latency for decreased energy usage. X-MAC nodes put their radios to sleep for the vast majority of the time and wake intermittently to detect incoming data. Transmitters wake and begin sending a stream of small, strobed 'preamble' packets (currently implemented using reserved frame types). When the receiving node wakes and both receives and ACKs a preamble frame, the transmitter can immediately send the desired data frame and go back to sleep.

A couple of notes: as a result of the protocol, the radio is at full power only for a small time slice (given the current sleep/wake period values, 3.8% of the time), but transmission is slower. If the sleep period were set to, say, 60 seconds, it could take up to a minute to successfully transfer a data packet. Additionally, if a destination node is unresponsive to preambles, a `ReturnCode::ENOACK` is generated, which may need to be handled by the application. Finally, since nodes using X-MAC expect other nodes in the network to exhibit the same behavior (maximum sleep period, preamble ACKs, etc.), it cannot be used to communicate with non-XMAC-wrapped radios.

### Testing Strategy

Ran the `ip_sense` and `tests/ieee802154/radio_rx` clients on two Imix boards and checked for good packet reception.

Since X-MAC doesn't work with non-XMAC-enabled nodes (as noted above), and likely no one currently wants to endure higher latency while testing the radio for their own uses, I haven't submitted changes to the `imix` board configuration. If someone wants to try this out, I've provided the necessary configuration [here](https://gist.github.com/jlwatson/a3ceff5f7c7dffe41cca71e70c5de30d) and described the necessary changes in `capsules/src/xmac.rs`. The timer delay calculations require floating point ops and a matching change to `Xargo.toml` (included in the gist).

### TODO

- [ ] More rigorous testing of the 'no-preamble-random-backoff' transmission optimization. That's still pending because I'll have to grab a third `imix` to test with simultaneous traffic from multiple nodes.
- [ ] There's currently an expectation in the `XMAC` receive handler that if a packet is received immediately before `radio::Radio::stop()` is called (i.e the radio has a pending sleep directly following the completion of the reception), it will cancel the pending sleep in favor of remaining awake for incoming (data) packets. Obviously, that's *slightly* not what one might expect from trying to stop the radio, so I'll explore getting around this somehow.
- [ ] Changing the current, static sleep period to a dynamic value adjusted to traffic load. This is a major part of the [original X-MAC analysis](http://www.cs.cmu.edu/~andersoe/papers/xmac-sensys.pdf) that would make the protocol more optimally energy efficient.

### Documentation Updated

- [X] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [X] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [X] `make formatall` has been run.