### PR TITLE
rf233: Implement start() and stop()

### DIFF
--- a/capsules/src/rf233_const.rs
+++ b/capsules/src/rf233_const.rs
@@ -76,6 +76,9 @@ pub const IRQ_TRX_DONE: u8 = 1 << 3;
 pub const IRQ_RX_START: u8 = 1 << 2;
 pub const IRQ_PLL_LOCK: u8 = 1 << 0;
 pub const XAH_CTRL_1_AACK_PROM_MODE: u8 = 1 << 1;
+pub const XAH_CTRL_1_AACK_UPLD_RES_FT: u8 = 1 << 4;
+pub const XAH_CTRL_1_AACK_FLTR_RES_FT: u8 = 1 << 5;
+pub const AACK_FVN_MODE: u8 = 3 << 6;
 
 // Flag combinations that are used in initialization.
 pub const TRX_CTRL_1: u8 = (TRX_CTRL_1_DIG34_RXTX_INDICATOR | TRX_CTRL_1_SPI_CMD_TRX_STATUS |
@@ -85,8 +88,10 @@ pub const PHY_CC_CCA: u8 = PHY_CHANNEL | PHY_CC_CCA_MODE_CS_OR_ED;
 pub const PHY_TX_PWR: u8 = PHY_TX_PWR_4;
 pub const PHY_CHANNEL: u8 = 26;
 pub const IRQ_MASK: u8 = (IRQ_TRXBUF_ACCESS_VIOLATION | IRQ_TRX_DONE | IRQ_PLL_LOCK | IRQ_RX_START);
-pub const XAH_CTRL_1: u8 = XAH_CTRL_1_AACK_PROM_MODE;
+pub const XAH_CTRL_1: u8 = XAH_CTRL_1_AACK_UPLD_RES_FT | XAH_CTRL_1_AACK_FLTR_RES_FT |
+                           XAH_CTRL_1_AACK_PROM_MODE;
 pub const XAH_CTRL_0: u8 = 0;
+pub const CSMA_SEED_1: u8 = AACK_FVN_MODE;
 pub const TRX_RPC: u8 = 0xFF;
 pub const TRX_TRAC_MASK: u8 = 0xE0;
 pub const TRX_TRAC_SUCCESS_DATA_PENDING: u8 = 1;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds support for putting the RF233 in sleep mode. All changes taken from #692 and moved to separate PR for easier reviewing.


### Testing Strategy

See #692


### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [x] `make formatall` has been run.
