### PR TITLE
refactor: remove unnecessary transmute calls

### DIFF
--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -210,7 +210,7 @@ impl Adc {
 
     /// Interrupt handler for the ADC.
     pub fn handle_interrupt(&mut self) {
-        let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AdcRegisters = unsafe { &*self.registers };
         let status = regs.sr.get();
 
         if self.enabled.get() && self.active.get() {
@@ -266,7 +266,7 @@ impl Adc {
             // already configured to work on this frequency
             ReturnCode::SUCCESS
         } else {
-            let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
+            let regs: &AdcRegisters = unsafe { &*self.registers };
 
             // disabling the ADC before switching clocks is necessary to avoid leaving it
             // in undefined state
@@ -406,7 +406,7 @@ impl hil::adc::Adc for Adc {
     ///
     /// - `channel`: the ADC channel to sample
     fn sample(&self, channel: &Self::Channel) -> ReturnCode {
-        let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AdcRegisters = unsafe { &*self.registers };
 
         // always configure to 1KHz to get the slowest clock with single sampling
         let res = self.config_and_enable(1000);
@@ -461,7 +461,7 @@ impl hil::adc::Adc for Adc {
     /// - `channel`: the ADC channel to sample
     /// - `frequency`: the number of samples per second to collect
     fn sample_continuous(&self, channel: &Self::Channel, frequency: u32) -> ReturnCode {
-        let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AdcRegisters = unsafe { &*self.registers };
 
         let res = self.config_and_enable(frequency);
 
@@ -561,7 +561,7 @@ impl hil::adc::Adc for Adc {
     /// but can be called to abort any currently running operation. The buffer,
     /// if any, will be returned via the `samples_ready` callback.
     fn stop_sampling(&self) -> ReturnCode {
-        let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AdcRegisters = unsafe { &*self.registers };
 
         if !self.enabled.get() {
             ReturnCode::EOFF
@@ -634,7 +634,7 @@ impl hil::adc::AdcHighSpeed for Adc {
                         buffer2: &'static mut [u16],
                         length2: usize)
                         -> (ReturnCode, Option<&'static mut [u16]>, Option<&'static mut [u16]>) {
-        let regs: &mut AdcRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AdcRegisters = unsafe { &*self.registers };
 
         let res = self.config_and_enable(frequency);
 

--- a/chips/sam4l/src/aes.rs
+++ b/chips/sam4l/src/aes.rs
@@ -1,7 +1,6 @@
 //! Implementation of the AESA peripheral on the SAM4L.
 
 use core::cell::Cell;
-use core::mem;
 
 use kernel::common::VolatileCell;
 use kernel::common::take_cell::TakeCell;
@@ -83,21 +82,21 @@ impl Aes {
     }
 
     pub fn enable(&self) {
-        let regs: &mut AesRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AesRegisters = unsafe { &*self.registers };
 
         self.enable_clock();
         regs.ctrl.set(0x01);
     }
 
     pub fn disable(&self) {
-        let regs: &mut AesRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AesRegisters = unsafe { &*self.registers };
 
         regs.ctrl.set(0x00);
         self.disable_clock();
     }
 
     fn enable_ctr_mode(&self) {
-        let regs: &mut AesRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AesRegisters = unsafe { &*self.registers };
 
         //         encrypt    dma        mode       cmeasure
         let mode = (1 << 0) | (0 << 3) | (4 << 4) | (0xF << 16);
@@ -105,26 +104,26 @@ impl Aes {
     }
 
     fn enable_interrupts(&self) {
-        let regs: &mut AesRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AesRegisters = unsafe { &*self.registers };
 
         // We want both interrupts.
         regs.ier.set((1 << 16) | (1 << 0));
     }
 
     fn disable_interrupts(&self) {
-        let regs: &mut AesRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AesRegisters = unsafe { &*self.registers };
         regs.idr.set((1 << 16) | (1 << 0));
     }
 
     fn notify_new_message(&self) {
-        let regs: &mut AesRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AesRegisters = unsafe { &*self.registers };
 
         // Notify of a new message.
         regs.ctrl.set((1 << 2) | (1 << 0));
     }
 
     fn write_block(&self) {
-        let regs: &mut AesRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AesRegisters = unsafe { &*self.registers };
 
         self.data.map(|data| {
             let index = self.data_index.get();
@@ -141,7 +140,7 @@ impl Aes {
     }
 
     pub fn handle_interrupt(&self) {
-        let regs: &mut AesRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AesRegisters = unsafe { &*self.registers };
 
         let status = regs.sr.get();
 
@@ -192,7 +191,7 @@ impl hil::symmetric_encryption::SymmetricEncryption for Aes {
     fn init(&self) {}
 
     fn set_key(&self, key: &'static mut [u8], len: usize) -> &'static mut [u8] {
-        let regs: &mut AesRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AesRegisters = unsafe { &*self.registers };
         self.enable();
 
         if len == 16 {
@@ -215,7 +214,7 @@ impl hil::symmetric_encryption::SymmetricEncryption for Aes {
 
     fn aes128_crypt_ctr(&self, data: &'static mut [u8], init_ctr: &'static mut [u8], len: usize) {
 
-        let regs: &mut AesRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &AesRegisters = unsafe { &*self.registers };
         self.enable();
         self.enable_interrupts();
         self.enable_ctr_mode();

--- a/chips/sam4l/src/dac.rs
+++ b/chips/sam4l/src/dac.rs
@@ -6,7 +6,6 @@
 //! - Date: May 26th, 2017
 
 use core::cell::Cell;
-use core::mem;
 use kernel::ReturnCode;
 use kernel::common::VolatileCell;
 use kernel::hil;
@@ -53,7 +52,7 @@ impl Dac {
 
 impl hil::dac::DacChannel for Dac {
     fn initialize(&self) -> ReturnCode {
-        let regs: &mut DacRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &DacRegisters = unsafe { &*self.registers };
         if !self.enabled.get() {
             self.enabled.set(true);
 
@@ -80,7 +79,7 @@ impl hil::dac::DacChannel for Dac {
 
 
     fn set_value(&self, value: usize) -> ReturnCode {
-        let regs: &mut DacRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &DacRegisters = unsafe { &*self.registers };
         if !self.enabled.get() {
             ReturnCode::EOFF
         } else {

--- a/chips/sam4l/src/flashcalw.rs
+++ b/chips/sam4l/src/flashcalw.rs
@@ -22,7 +22,6 @@
 //! - Date: July 27, 2016
 
 use core::cell::Cell;
-use core::mem;
 use core::ops::{Index, IndexMut};
 use helpers::{DeferredCall, Task};
 use kernel::ReturnCode;
@@ -218,12 +217,12 @@ impl FLASHCALW {
 
     //  Flush the cache. Should be called after every write!
     fn invalidate_cache(&self) {
-        let registers: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let registers: &FlashcalwRegisters = unsafe { &*self.registers };
         registers.maint0.set(0x1);
     }
 
     pub fn enable_picocache(&self, enable: bool) {
-        let registers: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let registers: &FlashcalwRegisters = unsafe { &*self.registers };
         if enable {
             registers.ctrl.set(0x1);
         } else {
@@ -246,13 +245,13 @@ impl FLASHCALW {
     }
 
     pub fn pico_enabled(&self) -> bool {
-        let registers: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let registers: &FlashcalwRegisters = unsafe { &*self.registers };
         registers.sr.get() & 0x1 != 0
     }
 
     // Helper to read a flashcalw register (espically if your function is doing so once)
     fn read_register(&self, key: RegKey) -> u32 {
-        let registers: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let registers: &FlashcalwRegisters = unsafe { &*self.registers };
 
         match key {
             RegKey::CONTROL => registers.fcr.get(),
@@ -399,7 +398,7 @@ impl FLASHCALW {
     }
 
     fn set_wait_state(&self, wait_state: u32) {
-        let regs: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         if wait_state == 1 {
             regs.fcr.set(regs.fcr.get() | bit!(6));
         } else {
@@ -408,7 +407,7 @@ impl FLASHCALW {
     }
 
     fn enable_ws1_read_opt(&mut self, enable: bool) {
-        let regs: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         if enable {
             regs.fcr.set(regs.fcr.get() | bit!(7));
         } else {
@@ -470,7 +469,7 @@ impl FLASHCALW {
 
     /// Configure high-speed flash mode. This is taken from the ASF code
     pub fn enable_high_speed_flash(&self) {
-        let regs: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
 
         // Since we are running at a fast speed we have to set a clock delay
         // for flash, as well as enable fast flash mode.
@@ -493,7 +492,7 @@ impl FLASHCALW {
     }
 
     fn enable_ready_int(&self, enable: bool) {
-        let regs: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         if enable {
             regs.fcr.set(regs.fcr.get() | bit!(0));
         } else {
@@ -507,7 +506,7 @@ impl FLASHCALW {
     }
 
     fn enable_lock_error_int(&self, enable: bool) {
-        let regs: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         if enable {
             regs.fcr.set(regs.fcr.get() | bit!(2));
         } else {
@@ -521,7 +520,7 @@ impl FLASHCALW {
     }
 
     fn enable_prog_error_int(&self, enable: bool) {
-        let regs: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         if enable {
             regs.fcr.set(regs.fcr.get() | bit!(3));
         } else {
@@ -535,7 +534,7 @@ impl FLASHCALW {
     }
 
     fn enable_ecc_int(&self, enable: bool) {
-        let regs: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         if enable {
             regs.fcr.set(regs.fcr.get() | bit!(4));
         } else {
@@ -595,7 +594,7 @@ impl FLASHCALW {
             self.enable_ready_int(true);
         }
 
-        let cmd_regs: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let cmd_regs: &FlashcalwRegisters = unsafe { &*self.registers };
         let mut reg_val: u32 = cmd_regs.fcmd.get();
 
         let clear_cmd_mask: u32 = !(bit!(6) - 1);
@@ -668,7 +667,7 @@ impl FLASHCALW {
     }
 
     fn is_page_erased(&self) -> bool {
-        let registers: &mut FlashcalwRegisters = unsafe { mem::transmute(self.registers) };
+        let registers: &FlashcalwRegisters = unsafe { &*self.registers };
         let status = registers.fsr.get();
 
         (status & bit!(5)) != 0

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -8,7 +8,6 @@
 
 use core::cell::Cell;
 use core::cmp;
-use core::mem;
 
 use dma::DMAChannel;
 use dma::DMAClient;
@@ -176,7 +175,7 @@ impl Spi {
     }
 
     fn init_as_role(&self, role: SpiRole) {
-        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &SpiRegisters = unsafe { &*self.registers };
 
         self.role.set(role);
         self.enable_clock();
@@ -205,7 +204,7 @@ impl Spi {
     }
 
     pub fn enable(&self) {
-        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &SpiRegisters = unsafe { &*self.registers };
 
         self.enable_clock();
         regs.cr.set(spi_consts::cr::SPIEN);
@@ -216,7 +215,7 @@ impl Spi {
     }
 
     pub fn disable(&self) {
-        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &SpiRegisters = unsafe { &*self.registers };
 
         self.dma_read.get().map(|read| read.disable());
         self.dma_write.get().map(|write| write.disable());
@@ -309,7 +308,7 @@ impl Spi {
     pub fn set_active_peripheral(&self, peripheral: Peripheral) {
         // Slave cannot set active peripheral
         if self.role.get() == SpiRole::SpiMaster {
-            let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+            let regs: &SpiRegisters = unsafe { &*self.registers };
             let peripheral_number: u32 = match peripheral {
                 Peripheral::Peripheral0 => spi_consts::mr::PCS0,
                 Peripheral::Peripheral1 => spi_consts::mr::PCS1,
@@ -325,7 +324,7 @@ impl Spi {
     /// Returns the currently active peripheral
     pub fn get_active_peripheral(&self) -> Peripheral {
         if self.role.get() == SpiRole::SpiMaster {
-            let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+            let regs: &SpiRegisters = unsafe { &*self.registers };
 
             let mr = regs.mr.get();
             let peripheral_number = mr & (spi_consts::mr::PCS_MASK);
@@ -349,7 +348,7 @@ impl Spi {
     /// Returns the value of CSR0, CSR1, CSR2, or CSR3,
     /// whichever corresponds to the active peripheral
     fn read_active_csr(&self) -> u32 {
-        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &SpiRegisters = unsafe { &*self.registers };
 
         match self.get_active_peripheral() {
             Peripheral::Peripheral0 => regs.csr0.get(),
@@ -361,7 +360,7 @@ impl Spi {
     /// Sets the Chip Select Register (CSR) of the active peripheral
     /// (CSR0, CSR1, CSR2, or CSR3).
     fn write_active_csr(&self, value: u32) {
-        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &SpiRegisters = unsafe { &*self.registers };
 
         match self.get_active_peripheral() {
             Peripheral::Peripheral0 => regs.csr0.set(value),
@@ -384,7 +383,7 @@ impl Spi {
     }
 
     pub fn handle_interrupt(&self) {
-        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &SpiRegisters = unsafe { &*self.registers };
         let sr = regs.sr.get();
 
         self.slave_client.get().map(|client| {
@@ -471,7 +470,7 @@ impl spi::SpiMaster for Spi {
     /// Write a byte to the SPI and discard the read; if an
     /// asynchronous operation is outstanding, do nothing.
     fn write_byte(&self, out_byte: u8) {
-        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &SpiRegisters = unsafe { &*self.registers };
 
         let tdr = (out_byte as u32) & spi_consts::tdr::TD;
         // Wait for data to leave TDR and enter serializer, so TDR is free
@@ -489,7 +488,7 @@ impl spi::SpiMaster for Spi {
     /// Write a byte to the SPI and return the read; if an
     /// asynchronous operation is outstanding, do nothing.
     fn read_write_byte(&self, val: u8) -> u8 {
-        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &SpiRegisters = unsafe { &*self.registers };
 
         self.write_byte(val);
         // Wait for receive data register full
@@ -587,7 +586,7 @@ impl spi::SpiSlave for Spi {
     /// This sets the value in the TDR register, to be sent as soon as the
     /// chip select pin is low.
     fn set_write_byte(&self, write_byte: u8) {
-        let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &SpiRegisters = unsafe { &*self.registers };
         regs.tdr.set(write_byte as u32);
     }
 

--- a/chips/sam4l/src/wdt.rs
+++ b/chips/sam4l/src/wdt.rs
@@ -1,7 +1,6 @@
 //! Implementation of the SAM4L hardware watchdog timer.
 
 use core::cell::Cell;
-use core::mem;
 use kernel::common::VolatileCell;
 use kernel::hil;
 use pm::{self, Clock, PBDClock};
@@ -37,7 +36,7 @@ impl Wdt {
     }
 
     fn start(&self, period: usize) {
-        let regs: &mut WdtRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &WdtRegisters = unsafe { &*self.registers };
 
         self.enabled.set(true);
 
@@ -86,7 +85,7 @@ impl Wdt {
     }
 
     fn stop(&self) {
-        let regs: &mut WdtRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &WdtRegisters = unsafe { &*self.registers };
 
         // Set enable bit (bit 0) to 0 to disable
         let control = regs.cr.get() & !0x01;
@@ -103,7 +102,7 @@ impl Wdt {
     }
 
     fn tickle(&self) {
-        let regs: &mut WdtRegisters = unsafe { mem::transmute(self.registers) };
+        let regs: &WdtRegisters = unsafe { &*self.registers };
 
         // Need to write the WDTCLR bit twice for it to work
         regs.clr.set((0x55 << 24) | (1 << 0));

--- a/doc/Mutable_References.md
+++ b/doc/Mutable_References.md
@@ -131,7 +131,7 @@ call to `take`:
 
 ```rust
 pub fn abort_xfer(&self) -> Option<&'static mut [u8]> {
-    let registers: &mut DMARegisters = unsafe { mem::transmute(self.registers) };
+    let registers: &DMARegisters = unsafe { &*self.registers };
     registers.interrupt_disable.set(!0);
     // Reset counter
     registers.transfer_counter.set(0);
@@ -153,7 +153,7 @@ Here is a simple use of `map`, taken from `chips/sam4l/src/dma.rs`:
 
 ```rust
 pub fn disable(&self) {
-    let regs: &mut SpiRegisters = unsafe { mem::transmute(self.registers) };
+    let regs: &SpiRegisters = unsafe { &*self.registers };
 
     self.dma_read.map(|read| read.disable());
     self.dma_write.map(|write| write.disable());


### PR DESCRIPTION
### Pull Request Overview

The sam4l chip was using transmute as an idiom where it's not
actually needed. This shouldn't change any functionality, just
removes unneeded calls to transmute.

### Testing Strategy

Compile-tested only. But there's no logical changes here

### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] ~~Userland: The application README has been added, updated, or no updates are required.~~

### Formatting

- [x] `make formatall` has been run.
