### PR TITLE
Implement `debug_gpio!` macro

### DIFF
--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -6,7 +6,7 @@
 #![no_std]
 
 #[allow(unused_imports)]
-#[macro_use(debug)]
+#[macro_use(debug, debug_gpio)]
 extern crate kernel;
 
 pub mod mpu;

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -10,7 +10,7 @@
 extern crate capsules;
 extern crate compiler_builtins;
 #[allow(unused_imports)]
-#[macro_use(debug,static_init)]
+#[macro_use(debug,debug_gpio,static_init)]
 extern crate kernel;
 extern crate sam4l;
 
@@ -180,6 +180,13 @@ pub unsafe fn reset_handler() {
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);
 
     set_pin_primary_functions();
+
+    // Configure kernel debug gpios as early as possible
+    kernel::debug::assign_debug_gpios(
+        Some(&sam4l::gpio::PA[13]),
+        Some(&sam4l::gpio::PA[15]),
+        Some(&sam4l::gpio::PA[14]),
+        );
 
     let mut chip = sam4l::chip::Sam4l::new();
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -182,11 +182,9 @@ pub unsafe fn reset_handler() {
     set_pin_primary_functions();
 
     // Configure kernel debug gpios as early as possible
-    kernel::debug::assign_debug_gpios(
-        Some(&sam4l::gpio::PA[13]),
-        Some(&sam4l::gpio::PA[15]),
-        Some(&sam4l::gpio::PA[14]),
-        );
+    kernel::debug::assign_gpios(Some(&sam4l::gpio::PA[13]),
+                                Some(&sam4l::gpio::PA[15]),
+                                Some(&sam4l::gpio::PA[14]));
 
     let mut chip = sam4l::chip::Sam4l::new();
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -10,7 +10,7 @@
 extern crate capsules;
 extern crate compiler_builtins;
 #[allow(unused_imports)]
-#[macro_use(debug,debug_gpio,static_init)]
+#[macro_use(debug, debug_gpio, static_init)]
 extern crate kernel;
 extern crate sam4l;
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -4,7 +4,8 @@
 
 extern crate capsules;
 extern crate compiler_builtins;
-#[macro_use(debug, static_init)]
+#[allow(unused_imports)]
+#[macro_use(debug, debug_gpio, static_init)]
 extern crate kernel;
 extern crate sam4l;
 

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -41,7 +41,8 @@
 
 extern crate capsules;
 extern crate compiler_builtins;
-#[macro_use(debug, static_init)]
+#[allow(unused_imports)]
+#[macro_use(debug, debug_gpio, static_init)]
 extern crate kernel;
 extern crate nrf51;
 extern crate nrf5x;

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -64,7 +64,8 @@
 
 extern crate capsules;
 extern crate compiler_builtins;
-#[macro_use(debug, static_init)]
+#[allow(unused_imports)]
+#[macro_use(debug, debug_gpio, static_init)]
 extern crate kernel;
 extern crate nrf52;
 extern crate nrf5x;

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -1,4 +1,4 @@
-//! Provides a `debug!` macro for in-kernel debugging.
+//! Support for in-kernel debugging.
 //!
 //! This module uses an internal buffer to write the strings into. If you are
 //! writing and the buffer fills up, you can make the size of `output_buffer`
@@ -9,6 +9,12 @@
 //!
 //! ```rust
 //! debug!("Yes the code gets here with value {}", i);
+//! debug_verbose!("got here"); // includes message count, file, and line
+//! ```
+//!
+//! ```
+//! Yes the code gets here with value 42
+//! TOCK_DEBUG(0): /tock/capsules/src/sensys.rs:24: got here
 //! ```
 
 use callback::{AppId, Callback};

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -25,6 +25,7 @@
 //! ```rust
 //! debug!("Yes the code gets here with value {}", i);
 //! debug_verbose!("got here"); // includes message count, file, and line
+//! debug_gpio!(0, toggle); // Toggles the first debug GPIO
 //! ```
 //!
 //! ```


### PR DESCRIPTION
### Pull Request Overview

This adds a `debug_gpio!` macro that can be used anywhere in the kernel to twiddle some pins.

It intentionally doesn't make any assumptions about sole ownership of the assigned GPIO pins, as pin twiddling is a fairly low-level debugging operation and such restriction would probably be more annoying than helpful.

### Testing Strategy

Twiddling LED gpios on Hail.


### TODO or Help Wanted

It might be nice to choose some sane default pins for the nrf boards, but shouldn't be a blocker.

### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] ~~Userland: The application README has been added, updated, or no updates are required.~~

### Formatting

- [x] `make formatall` has been run.
