### PR TITLE
sam4l: fix RXRDY bit position

### DIFF
--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -271,7 +271,7 @@ impl USART {
             (1 <<  7) | // PARE
             (1 <<  6) | // FRAME
             (1 <<  5) | // OVRE
-            (1 << 1); //.. RXRDY
+            (1 << 0); //.. RXRDY
         regs.idr.set(idr_val);
     }
 


### PR DESCRIPTION
### Pull Request Overview

Noticed this working on other things - nothing's using RX so it shouldn't affect anything, but it was wrong.
(24.7.3 / p628)

### Testing Strategy

N/A

### Documentation Updated

- [X] Kernel: ~~The relevant files in `/docs` have been updated or no updates are required.~~
- [X] Userland: ~~The application README has been added, updated, or no updates are required.~~

### Formatting

- [x] `make formatall` has been run.
