### PR TITLE
debug: allow use of debug_gpio! in unsafe context

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -62,7 +62,8 @@ pub unsafe fn assign_gpios(gpio0: Option<&'static hil::gpio::Pin>,
 #[macro_export]
 macro_rules! debug_gpio {
     ($i:tt, $method:ident) => ({
-        $crate::debug::DEBUG_GPIOS.$i.map(|g| g.$method());
+        #[allow(unused_unsafe)]
+        unsafe { $crate::debug::DEBUG_GPIOS.$i.map(|g| g.$method()); }
     });
 }
 


### PR DESCRIPTION
### Pull Request Overview

The prior `debug_gpio!` macro required the caller to wrap it in `unsafe`, but that's really not what you want. Putting `unsafe` in the macro elicits warnings when it's called from an unsafe context. Rust added support for `allow(unused_unsafe)` in macros to address this, so use it.

### Testing Strategy

Using `debug_gpio!` in a mix of chips, kernel, and board (hail) files.

### Documentation Updated

- [x] Kernel: ~~The relevant files in `/docs` have been updated or no updates are required.~~
- [x] Userland: ~~The application README has been added, updated, or no updates are required.~~

### Formatting

- [x] `make formatall` has been run.
