### PR TITLE
doc: Start on new porting guide

### DIFF
--- a/doc/Porting.md
+++ b/doc/Porting.md
@@ -1,0 +1,43 @@
+Porting Tock
+============
+
+This guide covers how to port Tock to a new platform.
+
+Overview
+--------
+
+At a high level, to port Tock to a new microcontroller, you need to write a new "chip" crate
+and a new "board" crate (porting to a new board with an already supported microcontroller
+just needs a new "board" crate). At a high level, the chip crate implements the traits found
+in `kernel/src/hil` for controllers (e.g. the UART, GPIO, alarms, etc) and the board crate
+stitches capsules together with the chip crates (e.g. assigning pins, baud rates, etc).
+
+
+`chip` Crate
+------------
+
+The `chip` crate is specific to a specific microcontroller.
+
+
+`board` Crate
+-------------
+
+The `board` crate, in `boards/src`, is specific to a physical hardware platform.
+The board file essentially configures the kernel to support the specific hardware
+setup. This includes instantiating drivers for sensors, mapping communication busses
+to those sensors, configuring GPIO pins, etc.
+
+
+### Loading Apps
+
+You can create a custom [Makefile-app](https://github.com/helena-project/tock/blob/master/boards/imix/Makefile-app)
+and include the commands needed to program an app and kernels on your board.
+
+Common Pitfalls
+---------------
+
+- Make sure you are careful when setting up the board `main.rs` file. In particular,
+it is important to ensure that all of the required `set_client` functions for capsules
+are called so that callbacks are not lost. Forgetting these often results in the platform
+looking like it doesn't do anything.
+

--- a/doc/Porting.md
+++ b/doc/Porting.md
@@ -1,7 +1,7 @@
 Porting Tock
 ============
 
-This guide covers how to port Tock to a new platform.
+_This guide covers how to port Tock to a new platform. It is a work in progress. Comments and pull requests are appreciated!_
 
 Overview
 --------

--- a/doc/Porting.md
+++ b/doc/Porting.md
@@ -1,43 +1,51 @@
 Porting Tock
 ============
 
-_This guide covers how to port Tock to a new platform. It is a work in progress. Comments and pull requests are appreciated!_
+This guide covers how to port Tock to a new platform.
+
+_It is a work in progress. Comments and pull requests are appreciated!_
 
 Overview
 --------
 
-At a high level, to port Tock to a new microcontroller, you need to write a new "chip" crate
-and a new "board" crate (porting to a new board with an already supported microcontroller
-just needs a new "board" crate). At a high level, the chip crate implements the traits found
-in `kernel/src/hil` for controllers (e.g. the UART, GPIO, alarms, etc) and the board crate
-stitches capsules together with the chip crates (e.g. assigning pins, baud rates, etc).
+At a high level, to port Tock to a new microcontroller, you need to write a new
+"chip" crate and a new "board" crate (porting to a new board with an already
+supported microcontroller just needs a new "board" crate). At a high level, the
+chip crate implements the traits found in `kernel/src/hil` for controllers (e.g.
+the UART, GPIO, alarms, etc) and the board crate stitches capsules together with
+the chip crates (e.g. assigning pins, baud rates, etc).
 
 
 `chip` Crate
 ------------
 
-The `chip` crate is specific to a specific microcontroller.
+The `chip` crate is specific to a particular microcontroller, but should attempt
+to be general towards a family of microcontrollers. For example, support for the
+`nRF58240` and `nRF58230` microcontrollers is shared in the `chips/nrf52` and
+`chips/nrf5x` crates. This helps reduce duplicated code and simplifies adding
+new specific microcontrollers.
+
+The `chip` crate contains microcontroller-specific implementations of the
+interfaces defined in `kernel/src/hil`.
 
 
 `board` Crate
 -------------
 
 The `board` crate, in `boards/src`, is specific to a physical hardware platform.
-The board file essentially configures the kernel to support the specific hardware
-setup. This includes instantiating drivers for sensors, mapping communication busses
-to those sensors, configuring GPIO pins, etc.
-
+The board file essentially configures the kernel to support the specific
+hardware setup. This includes instantiating drivers for sensors, mapping
+communication busses to those sensors, configuring GPIO pins, etc.
 
 ### Loading Apps
 
-You can create a custom [Makefile-app](https://github.com/helena-project/tock/blob/master/boards/imix/Makefile-app)
+You can create a custom
+[Makefile-app](https://github.com/helena-project/tock/blob/master/boards/imix/Makefile-app)
 and include the commands needed to program an app and kernels on your board.
 
-Common Pitfalls
----------------
+### Common Pitfalls
 
-- Make sure you are careful when setting up the board `main.rs` file. In particular,
-it is important to ensure that all of the required `set_client` functions for capsules
-are called so that callbacks are not lost. Forgetting these often results in the platform
-looking like it doesn't do anything.
-
+- Make sure you are careful when setting up the board `main.rs` file. In
+  particular, it is important to ensure that all of the required `set_client`
+  functions for capsules are called so that callbacks are not lost. Forgetting
+  these often results in the platform looking like it doesn't do anything.

--- a/doc/Porting.md
+++ b/doc/Porting.md
@@ -16,6 +16,28 @@ UART, GPIO, alarms, etc) and the board crate stitches capsules together with
 the chip crates (e.g. assigning pins, baud rates, etc).
 
 
+`arch` Crate
+------------
+
+Tock currently supports the ARM Cortex M0 and Cortex M4. There is not much
+architecture-specific code in Tock, the list is pretty much:
+
+ - Syscall entry/exit
+ - Interrupt configuration
+ - Top-half interrupt handlers
+ - MPU configuration (if appropriate)
+ - Power management configuration (if appropriate)
+
+It would likely be fairly easy to port Tock to another ARM Cortex M
+(specifically the M0+, M23, M3, or M7). It will probably be more work to port
+Tock to a non-ARM architecture. While we aim to be architecture agnostic, we
+have not exercised this path at all and there will likely be unforeseen
+challenges.
+
+If you are interested in porting Tock to a new architecture, it's likely best
+to reach out to us via email or IRC before digging in too deep.
+
+
 `chip` Crate
 ------------
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -30,6 +30,7 @@ are specified.
 
 ### Tock Setup and Usage
 - **[Getting Started](Getting_Started.md)** - Installing the Tock toolchain and programming hardware.
+- **[Porting Tock](Porting.md)** - Guide to add new platforms.
 
 ### Tutorials and Courses
 - **[Quick Tutorials](tutorials)** - Specific tutorials that walk through features of Tock.


### PR DESCRIPTION
### Pull Request Overview

This pull request starts adding docs for porting Tock to new platforms.

### TODO or Help Wanted

This is a start. We should add commits to get a little more substance, but merge soon and update it as needed.


### Documentation Updated

- [ ] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [ ] `make formatall` has been run.
