### PR TITLE
Prevent auto-format when using VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "editor.formatOnSave": false,
+    "editor.formatOnSave": true,
+    "rust-client.channel": "nightly-2018-01-05",
 }


### PR DESCRIPTION
### Pull Request Overview

Hi, I'm working with Tock using VSCode with global `formatOnSave` enabled and I am probably not the only one. In order to disable the formatting for Tock, I need to set a local VSCode option in the Tock workspace. Unfortunately, this setting is recognized as an untracked file in git.

My proposed solution is to check in the VSCode settings file into the repository. As an alternative we could also ignore the whole `.vscode` folder in `.gitignore`. Still, I prefer the first solution s.t. every Tock developer will work with `formatOnSave` disabled.

Cheers,
Woyten