### PR TITLE
Enable remaining GPIO pins on NRF52DK

### DIFF
--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -156,42 +156,49 @@ pub unsafe fn reset_handler() {
     uicr.set_psel1_reset_pin(BUTTON_RST_PIN);
 
     // GPIOs
-    // FIXME: Test if it works and remove un-commented code!
     let gpio_pins = static_init!(
-        [&'static nrf5x::gpio::GPIOPin; 15],
+        [&'static nrf5x::gpio::GPIOPin; 23],
         [
-            &nrf5x::gpio::PORT[3],  // Bottom right header on DK board
-            &nrf5x::gpio::PORT[4],  //
-            &nrf5x::gpio::PORT[28], //
-            &nrf5x::gpio::PORT[29], //
-            &nrf5x::gpio::PORT[30], //
-            &nrf5x::gpio::PORT[31], // -----
-            &nrf5x::gpio::PORT[10], // Top right header on DK board
-            &nrf5x::gpio::PORT[9],  //
-            &nrf5x::gpio::PORT[8],  //
-            &nrf5x::gpio::PORT[7],  //
-            &nrf5x::gpio::PORT[6],  //
-            &nrf5x::gpio::PORT[5],  //
-            &nrf5x::gpio::PORT[21], //
-            &nrf5x::gpio::PORT[1],  //
-            &nrf5x::gpio::PORT[0]   // -----
-        /*&nrf52::gpio::PORT[18],  // Top mid header on DK board
-        &nrf52::gpio::PORT[17],  //
-        &nrf52::gpio::PORT[16],  //
-        &nrf52::gpio::PORT[15],  //
-        &nrf52::gpio::PORT[14],  //
-        &nrf52::gpio::PORT[13],  //
-        &nrf52::gpio::PORT[12],  //
-        &nrf52::gpio::PORT[11],  // ----
-        &nrf52::gpio::PORT[27],  // Top left header on DK board
-        &nrf52::gpio::PORT[26],  //
-        &nrf52::gpio::PORT[2],  //
-        &nrf52::gpio::PORT[25],  //
-        &nrf52::gpio::PORT[24],  //
-        &nrf52::gpio::PORT[23],  //
-        &nrf52::gpio::PORT[22],  //
-        &nrf52::gpio::PORT[20],  //
-        &nrf52::gpio::PORT[19],  // ----*/
+            // Bottom right header on DK board
+            &nrf5x::gpio::PORT[3],
+            &nrf5x::gpio::PORT[4],
+            &nrf5x::gpio::PORT[28],
+            &nrf5x::gpio::PORT[29],
+            &nrf5x::gpio::PORT[30],
+            &nrf5x::gpio::PORT[31],
+            // -----
+            // Top right header on DK board
+            // NOTE: Those are connected internally and should not be used externally
+            &nrf5x::gpio::PORT[10], // NFC1
+            &nrf5x::gpio::PORT[9],  // NFC2
+            &nrf5x::gpio::PORT[8],  // RXD
+            &nrf5x::gpio::PORT[7],  // CTS
+            &nrf5x::gpio::PORT[6],  // TXD
+            &nrf5x::gpio::PORT[5],  // RTS
+            //&nrf5x::gpio::PORT[21], // RESET
+            &nrf5x::gpio::PORT[1], // XL2
+            &nrf5x::gpio::PORT[0], // XL1
+            // -----
+            // Top mid header on DK board
+            // &nrf5x::gpio::PORT[18], // LED 2
+            // &nrf5x::gpio::PORT[17], // LED 1
+            // &nrf5x::gpio::PORT[16], // Button 4
+            // &nrf5x::gpio::PORT[15], // Button 3
+            // &nrf5x::gpio::PORT[14], // Button 2
+            // &nrf5x::gpio::PORT[13], // Button 1
+            &nrf5x::gpio::PORT[12],
+            &nrf5x::gpio::PORT[11],
+            // -----
+            // Top left header on DK board
+            &nrf5x::gpio::PORT[27],
+            &nrf5x::gpio::PORT[26],
+            &nrf5x::gpio::PORT[2],
+            &nrf5x::gpio::PORT[25],
+            &nrf5x::gpio::PORT[24],
+            &nrf5x::gpio::PORT[23],
+            &nrf5x::gpio::PORT[22] // &nrf5x::gpio::PORT[20], // LED 4
+                                   // &nrf5x::gpio::PORT[19], // LED 3
+                                   // -----
         ]
     );
 

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -157,7 +157,7 @@ pub unsafe fn reset_handler() {
 
     // GPIOs
     let gpio_pins = static_init!(
-        [&'static nrf5x::gpio::GPIOPin; 23],
+        [&'static nrf5x::gpio::GPIOPin; 15],
         [
             // Bottom right header on DK board
             &nrf5x::gpio::PORT[3],
@@ -169,15 +169,15 @@ pub unsafe fn reset_handler() {
             // -----
             // Top right header on DK board
             // NOTE: Those are connected internally and should not be used externally
-            &nrf5x::gpio::PORT[10], // NFC1
-            &nrf5x::gpio::PORT[9],  // NFC2
-            &nrf5x::gpio::PORT[8],  // RXD
-            &nrf5x::gpio::PORT[7],  // CTS
-            &nrf5x::gpio::PORT[6],  // TXD
-            &nrf5x::gpio::PORT[5],  // RTS
-            //&nrf5x::gpio::PORT[21], // RESET
-            &nrf5x::gpio::PORT[1], // XL2
-            &nrf5x::gpio::PORT[0], // XL1
+            // &nrf5x::gpio::PORT[10], // NFC1
+            // &nrf5x::gpio::PORT[9],  // NFC2
+            // &nrf5x::gpio::PORT[8],  // RXD
+            // &nrf5x::gpio::PORT[7],  // CTS
+            // &nrf5x::gpio::PORT[6],  // TXD
+            // &nrf5x::gpio::PORT[5],  // RTS
+            // &nrf5x::gpio::PORT[21], // RESET
+            // &nrf5x::gpio::PORT[1],  // XL2
+            // &nrf5x::gpio::PORT[0],  // XL1
             // -----
             // Top mid header on DK board
             // &nrf5x::gpio::PORT[18], // LED 2

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -21,8 +21,6 @@
 //! * P0.22 -> (top left header)
 //! * P0.12 -> (top mid header)
 //! * P0.11 -> (top mid header)
-//! * P0.01 -> (top right header)
-//! * P0.00 -> (top right header)
 //! * P0.03 -> (bottom right header)
 //! * P0.04 -> (bottom right header)
 //! * P0.28 -> (bottom right header)
@@ -52,6 +50,10 @@
 //! ### `NFC`
 //! * P0.09 -> NFC1
 //! * P0.10 -> NFC2
+//!
+//! ### `LFXO`
+//! * P0.01 -> XL2
+//! * P0.00 -> XL1
 //!
 //! Author
 //! -------------------
@@ -159,46 +161,21 @@ pub unsafe fn reset_handler() {
     let gpio_pins = static_init!(
         [&'static nrf5x::gpio::GPIOPin; 15],
         [
-            // Bottom right header on DK board
-            &nrf5x::gpio::PORT[3],
+            &nrf5x::gpio::PORT[3], // Bottom right header on DK board
             &nrf5x::gpio::PORT[4],
             &nrf5x::gpio::PORT[28],
             &nrf5x::gpio::PORT[29],
             &nrf5x::gpio::PORT[30],
-            &nrf5x::gpio::PORT[31],
-            // -----
-            // Top right header on DK board
-            // NOTE: Those are connected internally and should not be used externally
-            // &nrf5x::gpio::PORT[10], // NFC1
-            // &nrf5x::gpio::PORT[9],  // NFC2
-            // &nrf5x::gpio::PORT[8],  // RXD
-            // &nrf5x::gpio::PORT[7],  // CTS
-            // &nrf5x::gpio::PORT[6],  // TXD
-            // &nrf5x::gpio::PORT[5],  // RTS
-            // &nrf5x::gpio::PORT[21], // RESET
-            // &nrf5x::gpio::PORT[1],  // XL2
-            // &nrf5x::gpio::PORT[0],  // XL1
-            // -----
-            // Top mid header on DK board
-            // &nrf5x::gpio::PORT[18], // LED 2
-            // &nrf5x::gpio::PORT[17], // LED 1
-            // &nrf5x::gpio::PORT[16], // Button 4
-            // &nrf5x::gpio::PORT[15], // Button 3
-            // &nrf5x::gpio::PORT[14], // Button 2
-            // &nrf5x::gpio::PORT[13], // Button 1
-            &nrf5x::gpio::PORT[12],
-            &nrf5x::gpio::PORT[11],
-            // -----
-            // Top left header on DK board
-            &nrf5x::gpio::PORT[27],
+            &nrf5x::gpio::PORT[31], // -----
+            &nrf5x::gpio::PORT[12], // Top mid header on DK board
+            &nrf5x::gpio::PORT[11], // -----
+            &nrf5x::gpio::PORT[27], // Top left header on DK board
             &nrf5x::gpio::PORT[26],
             &nrf5x::gpio::PORT[2],
             &nrf5x::gpio::PORT[25],
             &nrf5x::gpio::PORT[24],
             &nrf5x::gpio::PORT[23],
-            &nrf5x::gpio::PORT[22] // &nrf5x::gpio::PORT[20], // LED 4
-                                   // &nrf5x::gpio::PORT[19], // LED 3
-                                   // -----
+            &nrf5x::gpio::PORT[22] // -----
         ]
     );
 


### PR DESCRIPTION
### Pull Request Overview

I tested write access to all external GPIO pins (including the commented-out ones) on the NRF52DK and updated the board setup function accordingly. The changes are:
* Test and enable P0.02, P0.11, P0.12, P0.22 to P0.27
* Test and document internal connection of P0.00, P0.01, P0.05 to P0.10
* Test and disable P0.21 (RESET)

### Testing Strategy

I did a manual test using our own fork of libtock-rs. I used https://github.com/torfmaster/libtock-rs/blob/wip/examples/gpio.rs on all (Tock-internal) pin numbers from 0 to 22. I did not verify if reading works on each port as we did not finish writing the userland support for it.

### TODO or Help Wanted

I am not sure how Tock should deal with internally connected GPIO pins. Should the userland libraries have access to them and implement, for example UART communication, or should they be abstracted by the kernel capsules?

### Documentation Updated

- [X] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [X] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [X] `make formatall` has been run.
