### PR TITLE
NRF5X [Radio Configuration, BLE driver, Libtock, BLE Tests]

### DIFF
--- a/chips/nrf51/src/lib.rs
+++ b/chips/nrf51/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm, concat_idents, const_fn, const_cell_new)]
+#![feature(asm, concat_idents, const_fn, const_cell_new, try_from)]
 #![no_std]
 #![crate_name = "nrf51"]
 #![crate_type = "rlib"]

--- a/chips/nrf51/src/radio.rs
+++ b/chips/nrf51/src/radio.rs
@@ -40,7 +40,6 @@ impl Radio {
         }
     }
 
-
     fn ble_initialize(&self, channel: RadioChannel) {
         let regs = unsafe { &*self.regs };
 
@@ -255,11 +254,12 @@ impl Radio {
 }
 
 impl nrf5x::ble_advertising_hil::BleAdvertisementDriver for Radio {
-    fn transmit_advertisement(&self,
-                              buf: &'static mut [u8],
-                              len: usize,
-                              channel: RadioChannel)
-                              -> &'static mut [u8] {
+    fn transmit_advertisement(
+        &self,
+        buf: &'static mut [u8],
+        len: usize,
+        channel: RadioChannel,
+    ) -> &'static mut [u8] {
         let res = self.replace_radio_buffer(buf, len);
         self.ble_initialize(channel);
         self.tx();
@@ -292,15 +292,15 @@ impl nrf5x::ble_advertising_hil::BleConfig for Radio {
             // Invalid transmitting power, propogate error
             TxPower::Error => kernel::ReturnCode::ENOSUPPORT,
             // Valid transmitting power, propogate success
-            e @ TxPower::Positive4dBM |
-            e @ TxPower::Positive3dBM |
-            e @ TxPower::ZerodBm |
-            e @ TxPower::Negative4dBm |
-            e @ TxPower::Negative8dBm |
-            e @ TxPower::Negative12dBm |
-            e @ TxPower::Negative16dBm |
-            e @ TxPower::Negative20dBm |
-            e @ TxPower::Negative40dBm => {
+            e @ TxPower::Positive4dBM
+            | e @ TxPower::Positive3dBM
+            | e @ TxPower::ZerodBm
+            | e @ TxPower::Negative4dBm
+            | e @ TxPower::Negative8dBm
+            | e @ TxPower::Negative12dBm
+            | e @ TxPower::Negative16dBm
+            | e @ TxPower::Negative20dBm
+            | e @ TxPower::Negative40dBm => {
                 self.tx_power.set(e);
                 kernel::ReturnCode::SUCCESS
             }

--- a/chips/nrf51/src/radio.rs
+++ b/chips/nrf51/src/radio.rs
@@ -11,6 +11,7 @@
 //! * Date: June 22, 2017
 
 use core::cell::Cell;
+use core::convert::TryFrom;
 use kernel;
 use kernel::ReturnCode;
 use nrf5x;
@@ -282,26 +283,17 @@ impl nrf5x::ble_advertising_hil::BleAdvertisementDriver for Radio {
     }
 }
 
-// The BLE Advertising Driver validates that the `tx_power` is between -20 to 10 dBm but then
-// underlying chip must validate if the current `tx_power` is supported as well
 impl nrf5x::ble_advertising_hil::BleConfig for Radio {
+    // The BLE Advertising Driver validates that the `tx_power` is between -20 to 10 dBm but then
+    // underlying chip must validate if the current `tx_power` is supported as well
     fn set_tx_power(&self, tx_power: u8) -> kernel::ReturnCode {
         // Convert u8 to TxPower
-        // similiar functionlity as the FromPrimitive trait
-        match nrf5x::constants::TxPower::from_u8(tx_power) {
+        match nrf5x::constants::TxPower::try_from(tx_power) {
             // Invalid transmitting power, propogate error
-            TxPower::Error => kernel::ReturnCode::ENOSUPPORT,
+            Err(_) => kernel::ReturnCode::ENOSUPPORT,
             // Valid transmitting power, propogate success
-            e @ TxPower::Positive4dBM
-            | e @ TxPower::Positive3dBM
-            | e @ TxPower::ZerodBm
-            | e @ TxPower::Negative4dBm
-            | e @ TxPower::Negative8dBm
-            | e @ TxPower::Negative12dBm
-            | e @ TxPower::Negative16dBm
-            | e @ TxPower::Negative20dBm
-            | e @ TxPower::Negative40dBm => {
-                self.tx_power.set(e);
+            Ok(res) => {
+                self.tx_power.set(res);
                 kernel::ReturnCode::SUCCESS
             }
         }

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm, concat_idents, const_fn, const_cell_new)]
+#![feature(asm, concat_idents, const_fn, const_cell_new, try_from)]
 #![no_std]
 #![crate_name = "nrf52"]
 #![crate_type = "rlib"]

--- a/chips/nrf52/src/radio.rs
+++ b/chips/nrf52/src/radio.rs
@@ -91,7 +91,6 @@ impl Radio {
         regs.txaddress.set(0x00);
     }
 
-
     fn radio_on(&self) {
         let regs = unsafe { &*self.regs };
         // reset and enable power
@@ -231,13 +230,13 @@ impl Radio {
     // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 3.1.1 CRC Generation
     fn ble_set_crc_config(&self) {
         let regs = unsafe { &*self.regs };
-        regs.crccnf.set(nrf5x::constants::RADIO_CRCCNF_SKIPADDR <<
-                        nrf5x::constants::RADIO_CRCCNF_SKIPADDR_POS |
-                        nrf5x::constants::RADIO_CRCCNF_LEN_3BYTES);
+        regs.crccnf.set(
+            nrf5x::constants::RADIO_CRCCNF_SKIPADDR << nrf5x::constants::RADIO_CRCCNF_SKIPADDR_POS
+                | nrf5x::constants::RADIO_CRCCNF_LEN_3BYTES,
+        );
         regs.crcinit.set(nrf5x::constants::RADIO_CRCINIT_BLE);
         regs.crcpoly.set(nrf5x::constants::RADIO_CRCPOLY_BLE);
     }
-
 
     // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 2.1.2 Access Address
     // Set access address to 0x8E89BED6
@@ -261,25 +260,27 @@ impl Radio {
 
         // sets the header of PDU TYPE to 1 byte
         // sets the header length to 1 byte
-        regs.pcnf0.set((nrf5x::constants::RADIO_PCNF0_LFLEN_1BYTE <<
-                        nrf5x::constants::RADIO_PCNF0_LFLEN_POS) |
-                       (nrf5x::constants::RADIO_PCNF0_S0_LEN_1BYTE <<
-                        nrf5x::constants::RADIO_PCNF0_S0LEN_POS) |
-                       (nrf5x::constants::RADIO_PCNF0_S1_ZERO <<
-                        nrf5x::constants::RADIO_PCNF0_S1LEN_POS) |
-                       (NRF52_RADIO_PCNF0_S1INCL_MSK << NRF52_RADIO_PCNFO_S1INCL_POS) |
-                       (NRF52_RADIO_PCNF0_PLEN_8BITS << NRF52_RADIO_PCNF0_PLEN_POS));
+        regs.pcnf0.set(
+            (nrf5x::constants::RADIO_PCNF0_LFLEN_1BYTE << nrf5x::constants::RADIO_PCNF0_LFLEN_POS)
+                | (nrf5x::constants::RADIO_PCNF0_S0_LEN_1BYTE
+                    << nrf5x::constants::RADIO_PCNF0_S0LEN_POS)
+                | (nrf5x::constants::RADIO_PCNF0_S1_ZERO << nrf5x::constants::RADIO_PCNF0_S1LEN_POS)
+                | (NRF52_RADIO_PCNF0_S1INCL_MSK << NRF52_RADIO_PCNFO_S1INCL_POS)
+                | (NRF52_RADIO_PCNF0_PLEN_8BITS << NRF52_RADIO_PCNF0_PLEN_POS),
+        );
 
-        regs.pcnf1.set((nrf5x::constants::RADIO_PCNF1_WHITEEN_ENABLED <<
-                        nrf5x::constants::RADIO_PCNF1_WHITEEN_POS) |
-                       (nrf5x::constants::RADIO_PCNF1_ENDIAN_LITTLE <<
-                        nrf5x::constants::RADIO_PCNF1_ENDIAN_POS) |
-                       (nrf5x::constants::RADIO_PCNF1_BALEN_3BYTES <<
-                        nrf5x::constants::RADIO_PCNF1_BALEN_POS) |
-                       (nrf5x::constants::RADIO_PCNF1_STATLEN_DONT_EXTEND <<
-                        nrf5x::constants::RADIO_PCNF1_STATLEN_POS) |
-                       (nrf5x::constants::RADIO_PCNF1_MAXLEN_255BYTES <<
-                        nrf5x::constants::RADIO_PCNF1_MAXLEN_POS));
+        regs.pcnf1.set(
+            (nrf5x::constants::RADIO_PCNF1_WHITEEN_ENABLED
+                << nrf5x::constants::RADIO_PCNF1_WHITEEN_POS)
+                | (nrf5x::constants::RADIO_PCNF1_ENDIAN_LITTLE
+                    << nrf5x::constants::RADIO_PCNF1_ENDIAN_POS)
+                | (nrf5x::constants::RADIO_PCNF1_BALEN_3BYTES
+                    << nrf5x::constants::RADIO_PCNF1_BALEN_POS)
+                | (nrf5x::constants::RADIO_PCNF1_STATLEN_DONT_EXTEND
+                    << nrf5x::constants::RADIO_PCNF1_STATLEN_POS)
+                | (nrf5x::constants::RADIO_PCNF1_MAXLEN_255BYTES
+                    << nrf5x::constants::RADIO_PCNF1_MAXLEN_POS),
+        );
     }
 
     // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part A], 4.6 REFERENCE SIGNAL DEFINITION
@@ -305,7 +306,6 @@ impl Radio {
         regs.frequency.set(channel as u32);
     }
 
-
     // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 3 TRANSMITTER CHARACTERISTICS
     // Minimum Output Power : -20dBm
     // Maximum Output Power : +10dBm
@@ -318,11 +318,12 @@ impl Radio {
 }
 
 impl nrf5x::ble_advertising_hil::BleAdvertisementDriver for Radio {
-    fn transmit_advertisement(&self,
-                              buf: &'static mut [u8],
-                              len: usize,
-                              channel: RadioChannel)
-                              -> &'static mut [u8] {
+    fn transmit_advertisement(
+        &self,
+        buf: &'static mut [u8],
+        len: usize,
+        channel: RadioChannel,
+    ) -> &'static mut [u8] {
         let res = self.replace_radio_buffer(buf, len);
         self.ble_initialize(channel);
         self.tx();
@@ -355,15 +356,15 @@ impl nrf5x::ble_advertising_hil::BleConfig for Radio {
             // Invalid transmitting power, propogate error
             TxPower::Error => kernel::ReturnCode::ENOSUPPORT,
             // Valid transmitting power, propogate success
-            e @ TxPower::Positive4dBM |
-            e @ TxPower::Positive3dBM |
-            e @ TxPower::ZerodBm |
-            e @ TxPower::Negative4dBm |
-            e @ TxPower::Negative8dBm |
-            e @ TxPower::Negative12dBm |
-            e @ TxPower::Negative16dBm |
-            e @ TxPower::Negative20dBm |
-            e @ TxPower::Negative40dBm => {
+            e @ TxPower::Positive4dBM
+            | e @ TxPower::Positive3dBM
+            | e @ TxPower::ZerodBm
+            | e @ TxPower::Negative4dBm
+            | e @ TxPower::Negative8dBm
+            | e @ TxPower::Negative12dBm
+            | e @ TxPower::Negative16dBm
+            | e @ TxPower::Negative20dBm
+            | e @ TxPower::Negative40dBm => {
                 self.tx_power.set(e);
                 kernel::ReturnCode::SUCCESS
             }

--- a/chips/nrf52/src/radio.rs
+++ b/chips/nrf52/src/radio.rs
@@ -1,19 +1,44 @@
-//! Radio driver, Bluetooth Low Energy, nRF52
+//! Radio driver, Bluetooth Low Energy, NRF52
 //!
-//! Sending Bluetooth Low Energy advertisement packets with payloads up to 31 bytes
+//! The generic radio configuration i.e., not specific to Bluetooth are functions and similar which
+//! do not start with `ble`. Moreover, Bluetooth Low Energy specific radio configuration
+//! starts with `ble.
 //!
-//! Currently all fields in PAYLOAD array are configurable from user-space
-//! except the PDU_TYPE.
+//! For more readabilility the Bluetooth specific configuration may be moved to separate trait
 //!
 //! ### Author
 //! * Niklas Adolfsson <niklasadolfsson1@gmail.com>
 //! * Date: July 18, 2017
+//!
+//! ### Packet Configuration
+//! ```
+//! +----------+------+--------+----+--------+----+---------+-----+
+//! | Preamble | Base | Prefix | S0 | Length | S1 | Payload | CRC |
+//! +----------+------+--------+----+--------+----+---------+-----+
+//! ```
+//!
+//! * Premable - 1 byte
+//!
+//! * Base and prefix forms together the access address
+//!
+//! * S0, an optional parameter that is configured to indicate how many bytes of
+//! the payload is the PDU Type. Configured as 1 byte!
+//!
+//! * Length, an optional parameter that is configured to indicate how many bits of the
+//! payload is the length field. Configured as 8 bits!
+//!
+//! * S1, Not used
+//!
+//! * Payload - 2 to 255 bytes
+//!
+//! * CRC - 3 bytes
 
 use core::cell::Cell;
 use kernel;
 use kernel::ReturnCode;
 use nrf5x;
-use nrf5x::ble_advertising_hil::RadioChannel;
+use nrf5x::ble_advertising_hil::RadioFrequency;
+use nrf5x::constants::TxPower;
 use peripheral_registers;
 
 // NRF52 Specific Radio Constants
@@ -27,7 +52,7 @@ static mut PAYLOAD: [u8; nrf5x::constants::RADIO_PAYLOAD_LENGTH] =
 
 pub struct Radio {
     regs: *const peripheral_registers::RADIO,
-    txpower: Cell<usize>,
+    tx_power: Cell<TxPower>,
     rx_client: Cell<Option<&'static nrf5x::ble_advertising_hil::RxClient>>,
     tx_client: Cell<Option<&'static nrf5x::ble_advertising_hil::TxClient>>,
 }
@@ -38,36 +63,10 @@ impl Radio {
     pub const fn new() -> Radio {
         Radio {
             regs: peripheral_registers::RADIO_BASE as *const peripheral_registers::RADIO,
-            txpower: Cell::new(0),
+            tx_power: Cell::new(TxPower::ZerodBm),
             rx_client: Cell::new(None),
             tx_client: Cell::new(None),
         }
-    }
-
-    fn ble_init(&self, channel: RadioChannel) {
-        self.radio_on();
-
-        // TX Power acc. to twpower variable in the struct
-        self.set_txpower();
-
-        // BLE MODE
-        self.set_channel_rate(nrf5x::constants::RadioMode::Ble1Mbit as u32);
-
-        self.set_channel_freq(channel as u32);
-        self.set_datawhiteiv(channel as u32);
-
-        self.set_tx_address();
-        self.set_rx_address();
-
-        // Set Packet Config
-        self.set_packet_config();
-        self.set_access_address_ble();
-
-        // CRC Config
-        self.set_crc_config();
-
-        // Buffer configuration
-        self.set_buffer();
     }
 
     fn tx(&self) {
@@ -82,54 +81,6 @@ impl Radio {
         regs.task_rxen.set(1);
     }
 
-    fn set_crc_config(&self) {
-        let regs = unsafe { &*self.regs };
-        regs.crccnf.set(
-            nrf5x::constants::RADIO_CRCCNF_SKIPADDR << nrf5x::constants::RADIO_CRCCNF_SKIPADDR_POS
-                | nrf5x::constants::RADIO_CRCCNF_LEN_3BYTES,
-        );
-        regs.crcinit.set(nrf5x::constants::RADIO_CRCINIT_BLE);
-        regs.crcpoly.set(nrf5x::constants::RADIO_CRCPOLY_BLE);
-    }
-
-    // Set access address to 0x8E89BED6
-    fn set_access_address_ble(&self) {
-        let regs = unsafe { &*self.regs };
-        // Set PREFIX | BASE Address
-        regs.prefix0.set(0x0000008e);
-        regs.base0.set(0x89bed600);
-    }
-
-    // Packet configuration
-    // Configured  as little endian with max size 37 bytes
-    fn set_packet_config(&self) {
-        let regs = unsafe { &*self.regs };
-
-        // sets the header of PDU TYPE to 1 byte
-        // sets the header length to 1 byte
-        regs.pcnf0.set(
-            (nrf5x::constants::RADIO_PCNF0_LFLEN_1BYTE << nrf5x::constants::RADIO_PCNF0_LFLEN_POS)
-                | (nrf5x::constants::RADIO_PCNF0_S0_LEN_1BYTE
-                    << nrf5x::constants::RADIO_PCNF0_S0LEN_POS)
-                | (nrf5x::constants::RADIO_PCNF0_S1_ZERO << nrf5x::constants::RADIO_PCNF0_S1LEN_POS)
-                | (NRF52_RADIO_PCNF0_S1INCL_MSK << NRF52_RADIO_PCNFO_S1INCL_POS)
-                | (NRF52_RADIO_PCNF0_PLEN_8BITS << NRF52_RADIO_PCNF0_PLEN_POS),
-        );
-
-        regs.pcnf1.set(
-            (nrf5x::constants::RADIO_PCNF1_WHITEEN_ENABLED
-                << nrf5x::constants::RADIO_PCNF1_WHITEEN_POS)
-                | (nrf5x::constants::RADIO_PCNF1_ENDIAN_LITTLE
-                    << nrf5x::constants::RADIO_PCNF1_ENDIAN_POS)
-                | (nrf5x::constants::RADIO_PCNF1_BALEN_3BYTES
-                    << nrf5x::constants::RADIO_PCNF1_BALEN_POS)
-                | (nrf5x::constants::RADIO_PCNF1_STATLEN_DONT_EXTEND
-                    << nrf5x::constants::RADIO_PCNF1_STATLEN_POS)
-                | (nrf5x::constants::RADIO_PCNF1_MAXLEN_37BYTES
-                    << nrf5x::constants::RADIO_PCNF1_MAXLEN_POS),
-        );
-    }
-
     fn set_rx_address(&self) {
         let regs = unsafe { &*self.regs };
         regs.rxaddresses.set(0x01);
@@ -140,29 +91,6 @@ impl Radio {
         regs.txaddress.set(0x00);
     }
 
-    // should not be configured from the capsule i.e.
-    // assume always BLE
-    fn set_channel_rate(&self, rate: u32) {
-        let regs = unsafe { &*self.regs };
-        // set channel rate,  3 - BLE 1MBIT/s
-        regs.mode.set(rate);
-    }
-
-    fn set_datawhiteiv(&self, val: u32) {
-        let regs = unsafe { &*self.regs };
-        regs.datawhiteiv.set(val);
-    }
-
-    fn set_channel_freq(&self, val: u32) {
-        let regs = unsafe { &*self.regs };
-        //37, 38 and 39 for adv.
-        match val {
-            37 => regs.frequency.set(nrf5x::constants::RADIO_FREQ_CH_37),
-            38 => regs.frequency.set(nrf5x::constants::RADIO_FREQ_CH_38),
-            39 => regs.frequency.set(nrf5x::constants::RADIO_FREQ_CH_39),
-            _ => regs.frequency.set(nrf5x::constants::RADIO_FREQ_CH_37),
-        }
-    }
 
     fn radio_on(&self) {
         let regs = unsafe { &*self.regs };
@@ -176,13 +104,12 @@ impl Radio {
         regs.power.set(0);
     }
 
-    // pre-condition validated by the capsule before arriving here
-    fn set_txpower(&self) {
+    fn set_tx_power(&self) {
         let regs = unsafe { &*self.regs };
-        regs.txpower.set(self.txpower.get() as u32);
+        regs.txpower.set(self.tx_power.get() as u32);
     }
 
-    fn set_buffer(&self) {
+    fn set_dma_ptr(&self) {
         let regs = unsafe { &*self.regs };
         unsafe {
             regs.packetptr.set((&PAYLOAD as *const u8) as u32);
@@ -207,10 +134,9 @@ impl Radio {
             regs.event_payload.set(0);
         }
 
+        // tx or rx finished!
         if regs.event_end.get() == 1 {
             regs.event_end.set(0);
-            // this state only verifies that END is received in TX-mode
-            // which means that the transmission is finished
 
             let result = if regs.crcstatus.get() == 1 {
                 ReturnCode::SUCCESS
@@ -280,35 +206,132 @@ impl Radio {
         }
         buf
     }
+
+    fn ble_initialize(&self, channel: RadioFrequency) {
+        self.radio_on();
+
+        self.ble_set_tx_power();
+
+        self.ble_set_channel_rate();
+
+        self.ble_set_channel_freq(channel);
+        self.ble_set_data_whitening(channel);
+
+        self.set_tx_address();
+        self.set_rx_address();
+
+        self.ble_set_packet_config();
+        self.ble_set_advertising_access_address();
+
+        self.ble_set_crc_config();
+
+        self.set_dma_ptr();
+    }
+
+    // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 3.1.1 CRC Generation
+    fn ble_set_crc_config(&self) {
+        let regs = unsafe { &*self.regs };
+        regs.crccnf.set(nrf5x::constants::RADIO_CRCCNF_SKIPADDR <<
+                        nrf5x::constants::RADIO_CRCCNF_SKIPADDR_POS |
+                        nrf5x::constants::RADIO_CRCCNF_LEN_3BYTES);
+        regs.crcinit.set(nrf5x::constants::RADIO_CRCINIT_BLE);
+        regs.crcpoly.set(nrf5x::constants::RADIO_CRCPOLY_BLE);
+    }
+
+
+    // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 2.1.2 Access Address
+    // Set access address to 0x8E89BED6
+    fn ble_set_advertising_access_address(&self) {
+        let regs = unsafe { &*self.regs };
+        regs.prefix0.set(0x0000008e);
+        regs.base0.set(0x89bed600);
+    }
+
+    // Packet configuration
+    // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 2.1 Packet Format
+    //
+    // LSB                                                      MSB
+    // +----------+   +----------------+   +---------------+   +------------+
+    // | Preamble | - | Access Address | - | PDU           | - | CRC        |
+    // | (1 byte) |   | (4 bytes)      |   | (2-255 bytes) |   | (3 bytes)  |
+    // +----------+   +----------------+   +---------------+   +------------+
+    //
+    fn ble_set_packet_config(&self) {
+        let regs = unsafe { &*self.regs };
+
+        // sets the header of PDU TYPE to 1 byte
+        // sets the header length to 1 byte
+        regs.pcnf0.set((nrf5x::constants::RADIO_PCNF0_LFLEN_1BYTE <<
+                        nrf5x::constants::RADIO_PCNF0_LFLEN_POS) |
+                       (nrf5x::constants::RADIO_PCNF0_S0_LEN_1BYTE <<
+                        nrf5x::constants::RADIO_PCNF0_S0LEN_POS) |
+                       (nrf5x::constants::RADIO_PCNF0_S1_ZERO <<
+                        nrf5x::constants::RADIO_PCNF0_S1LEN_POS) |
+                       (NRF52_RADIO_PCNF0_S1INCL_MSK << NRF52_RADIO_PCNFO_S1INCL_POS) |
+                       (NRF52_RADIO_PCNF0_PLEN_8BITS << NRF52_RADIO_PCNF0_PLEN_POS));
+
+        regs.pcnf1.set((nrf5x::constants::RADIO_PCNF1_WHITEEN_ENABLED <<
+                        nrf5x::constants::RADIO_PCNF1_WHITEEN_POS) |
+                       (nrf5x::constants::RADIO_PCNF1_ENDIAN_LITTLE <<
+                        nrf5x::constants::RADIO_PCNF1_ENDIAN_POS) |
+                       (nrf5x::constants::RADIO_PCNF1_BALEN_3BYTES <<
+                        nrf5x::constants::RADIO_PCNF1_BALEN_POS) |
+                       (nrf5x::constants::RADIO_PCNF1_STATLEN_DONT_EXTEND <<
+                        nrf5x::constants::RADIO_PCNF1_STATLEN_POS) |
+                       (nrf5x::constants::RADIO_PCNF1_MAXLEN_255BYTES <<
+                        nrf5x::constants::RADIO_PCNF1_MAXLEN_POS));
+    }
+
+    // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part A], 4.6 REFERENCE SIGNAL DEFINITION
+    // Bit Rate = 1 Mb/s ±1 ppm
+    fn ble_set_channel_rate(&self) {
+        let regs = unsafe { &*self.regs };
+        regs.mode.set(nrf5x::constants::RadioMode::Ble1Mbit as u32);
+    }
+
+    // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 3.2 Data Whitening
+    // Configure channel index to the LFSR and the hardware solves the rest
+    fn ble_set_data_whitening(&self, channel: RadioFrequency) {
+        let regs = unsafe { &*self.regs };
+        regs.datawhiteiv.set(channel.get_channel_index());
+    }
+
+    // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 1.4.1
+    // RF Channels:     0 - 39
+    // Data:            0 - 36
+    // Advertising:     37, 38, 39
+    fn ble_set_channel_freq(&self, channel: RadioFrequency) {
+        let regs = unsafe { &*self.regs };
+        regs.frequency.set(channel as u32);
+    }
+
+
+    // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 3 TRANSMITTER CHARACTERISTICS
+    // Minimum Output Power : -20dBm
+    // Maximum Output Power : +10dBm
+    //
+    // no check is required because the BleConfig::set_tx_power() method ensures that only
+    // valid tranmitting power is configured!
+    fn ble_set_tx_power(&self) {
+        self.set_tx_power();
+    }
 }
 
 impl nrf5x::ble_advertising_hil::BleAdvertisementDriver for Radio {
-    fn set_tx_power(&self, power: usize) -> kernel::ReturnCode {
-        match power {
-            // +4 dBm, 0 dBm, -4 dBm, -8 dBm, -12 dBm, -16 dBm, -20 dBm, -30 dBm
-            0x04 | 0x00 | 0xF4 | 0xFC | 0xF8 | 0xF0 | 0xEC | 0xD8 => {
-                self.txpower.set(power);
-                kernel::ReturnCode::SUCCESS
-            }
-            _ => kernel::ReturnCode::ENOSUPPORT,
-        }
-    }
-
-    fn transmit_advertisement(
-        &self,
-        buf: &'static mut [u8],
-        len: usize,
-        channel: RadioChannel,
-    ) -> &'static mut [u8] {
+    fn transmit_advertisement(&self,
+                              buf: &'static mut [u8],
+                              len: usize,
+                              channel: RadioFrequency)
+                              -> &'static mut [u8] {
         let res = self.replace_radio_buffer(buf, len);
-        self.ble_init(channel);
+        self.ble_initialize(channel);
         self.tx();
         self.enable_interrupts();
         res
     }
 
-    fn receive_advertisement(&self, channel: RadioChannel) {
-        self.ble_init(channel);
+    fn receive_advertisement(&self, channel: RadioFrequency) {
+        self.ble_initialize(channel);
         self.rx();
         self.enable_interrupts();
     }
@@ -319,5 +342,19 @@ impl nrf5x::ble_advertising_hil::BleAdvertisementDriver for Radio {
 
     fn set_transmit_client(&self, client: &'static nrf5x::ble_advertising_hil::TxClient) {
         self.tx_client.set(Some(client));
+    }
+}
+
+// The capsule validates that the `tx_power` is between -20 to 10 dBm but then
+// chip must validate if the current `tx_power` is supported as well
+impl nrf5x::ble_advertising_hil::BleConfig for Radio {
+    fn set_tx_power(&self, power: u8) -> kernel::ReturnCode {
+        match nrf5x::constants::TxPower::from_u8(power) {
+            TxPower::Error => kernel::ReturnCode::ENOSUPPORT,
+            e @ _ => {
+                self.tx_power.set(e);
+                kernel::ReturnCode::SUCCESS
+            }
+        }
     }
 }

--- a/chips/nrf5x/src/ble_advertising_driver.rs
+++ b/chips/nrf5x/src/ble_advertising_driver.rs
@@ -196,7 +196,7 @@
 //! * Date: June 22, 2017
 
 use ble_advertising_hil;
-use ble_advertising_hil::RadioChannel;
+use ble_advertising_hil::RadioFrequency;
 use core::cell::Cell;
 use core::cmp;
 use kernel;
@@ -216,6 +216,36 @@ enum AllowType {
     PassiveScanning,
     InitAdvertisementBuffer,
 }
+
+impl AllowType {
+    fn from_usize(n: usize) -> Option<AllowType> {
+        match n {
+            0x01 => Some(AllowType::BLEGap(BLEGapType::Flags)),
+            0x02 => Some(AllowType::BLEGap(BLEGapType::IncompleteList16BitServiceIDs)),
+            0x03 => Some(AllowType::BLEGap(BLEGapType::CompleteList16BitServiceIDs)),
+            0x04 => Some(AllowType::BLEGap(BLEGapType::IncompleteList32BitServiceIDs)),
+            0x05 => Some(AllowType::BLEGap(BLEGapType::CompleteList32BitServiceIDs)),
+            0x06 => Some(AllowType::BLEGap(BLEGapType::IncompleteList128BitServiceIDs)),
+            0x07 => Some(AllowType::BLEGap(BLEGapType::CompleteList128BitServiceIDs)),
+            0x08 => Some(AllowType::BLEGap(BLEGapType::ShortedLocalName)),
+            0x09 => Some(AllowType::BLEGap(BLEGapType::CompleteLocalName)),
+            0x0A => Some(AllowType::BLEGap(BLEGapType::TxPowerLevel)),
+            0x10 => Some(AllowType::BLEGap(BLEGapType::DeviceId)),
+            0x12 => Some(AllowType::BLEGap(BLEGapType::SlaveConnectionIntervalRange)),
+            0x14 => Some(AllowType::BLEGap(BLEGapType::List16BitSolicitationIDs)),
+            0x15 => Some(AllowType::BLEGap(BLEGapType::List128BitSolicitationIDs)),
+            0x16 => Some(AllowType::BLEGap(BLEGapType::ServiceData)),
+            0x19 => Some(AllowType::BLEGap(BLEGapType::Appearance)),
+            0x1A => Some(AllowType::BLEGap(BLEGapType::AdvertisingInterval)),
+            0x31 => Some(AllowType::PassiveScanning),
+            0x32 => Some(AllowType::InitAdvertisementBuffer),
+            0xFF => Some(AllowType::BLEGap(BLEGapType::ManufacturerSpecificData)),
+            _ => None,
+        }
+    }
+}
+
+
 
 // Gap Types only the ones that are defined in libtock are defined here
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -241,45 +271,63 @@ enum BLEGapType {
     ManufacturerSpecificData = 0xFF,
 }
 
-// dummy thing to convert usize to enum, FromPrimitive trait don't work
-// because they have dependices to std
-// if this is good idea, better to create a generic trait for this
-fn from_usize(n: usize) -> Option<AllowType> {
-    match n {
-        0x01 => Some(AllowType::BLEGap(BLEGapType::Flags)),
-        0x02 => Some(AllowType::BLEGap(BLEGapType::IncompleteList16BitServiceIDs)),
-        0x03 => Some(AllowType::BLEGap(BLEGapType::CompleteList16BitServiceIDs)),
-        0x04 => Some(AllowType::BLEGap(BLEGapType::IncompleteList32BitServiceIDs)),
-        0x05 => Some(AllowType::BLEGap(BLEGapType::CompleteList32BitServiceIDs)),
-        0x06 => Some(AllowType::BLEGap(
-            BLEGapType::IncompleteList128BitServiceIDs,
-        )),
-        0x07 => Some(AllowType::BLEGap(BLEGapType::CompleteList128BitServiceIDs)),
-        0x08 => Some(AllowType::BLEGap(BLEGapType::ShortedLocalName)),
-        0x09 => Some(AllowType::BLEGap(BLEGapType::CompleteLocalName)),
-        0x0A => Some(AllowType::BLEGap(BLEGapType::TxPowerLevel)),
-        0x10 => Some(AllowType::BLEGap(BLEGapType::DeviceId)),
-        0x12 => Some(AllowType::BLEGap(BLEGapType::SlaveConnectionIntervalRange)),
-        0x14 => Some(AllowType::BLEGap(BLEGapType::List16BitSolicitationIDs)),
-        0x15 => Some(AllowType::BLEGap(BLEGapType::List128BitSolicitationIDs)),
-        0x16 => Some(AllowType::BLEGap(BLEGapType::ServiceData)),
-        0x19 => Some(AllowType::BLEGap(BLEGapType::Appearance)),
-        0x1A => Some(AllowType::BLEGap(BLEGapType::AdvertisingInterval)),
-        0x31 => Some(AllowType::PassiveScanning),
-        0x32 => Some(AllowType::InitAdvertisementBuffer),
-        0xFF => Some(AllowType::BLEGap(BLEGapType::ManufacturerSpecificData)),
-        _ => None,
-    }
-}
-
-// Advertising Name                         Connectable     Scannable       Directed
-// ConnectUndirected    (ADV_IND)           Yes             Yes             No
-// ConnectDirected      (ADV_DIRECT_IND)    Yes             No              Yes
-// NonConnectUndirected (ADV_NONCONN_IND)   No              No              No
-// ScanRequest          (SCAN_REQ)          -               -               -
-// ScanResponse         (SCAN_RSP)          -               -               -
-// ConnectRequest       (CON_REQ)           -               -               -
-// ScanUndirected       (ADV_SCAN_IND)      No              Yes             No
+// ConnectUndirected (ADV_IND): connectable undirected advertising event
+// BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 2.3.1.1
+//
+//   PDU     +-----------+      +--------------+
+//           | AdvA      |  -   | AdvData      |
+//           | (6 bytes) |      | (0-31 bytes) |
+//           +-----------+      +--------------+
+//
+// ConnectDirected (ADV_DIRECT_IND): connectable directed advertising event
+// BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 2.3.1.2
+//
+//   PDU     +-----------+      +--------------+
+//           | AdvA      |  -   | InitA        |
+//           | (6 bytes) |      | (6 bytes)    |
+//           +-----------+      +--------------+
+//
+// NonConnectDirected (ADV_NONCONN_IND): non-connectable undirected advertising event
+// BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 2.3.1.3
+//
+//   PDU     +-----------+      +--------------+
+//           | AdvA      |  -   | AdvData      |
+//           | (6 bytes) |      | (0-31 bytes) |
+//           +-----------+      +--------------+
+//
+//
+// ScanUndirected (ADV_NONCONN_IND): scannable undirected advertising event
+// BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 2.3.1.4
+//
+//   PDU     +-----------+      +--------------+
+//           | AdvA      |  -   | AdvData      |
+//           | (6 bytes) |      | (0-31 bytes) |
+//           +-----------+      +--------------+
+//
+// ScanRequest (SCAN_REQ)
+// BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 2.3.2.1
+//
+//   PDU     +-----------+      +--------------+
+//           | ScanA     |  -   | AdvA        |
+//           | (6 bytes) |      | (6 bytes) |
+//           +-----------+      +--------------+
+//
+// ScanResponse (SCAN_RSP)
+// BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 2.3.2.2
+//
+//   PDU     +-----------+      +--------------+
+//           | AdvA      |  -   | ScanRspData  |
+//           | (6 bytes) |      | (0-31 bytes) |
+//           +-----------+      +--------------+
+//
+// ConnectRequest (CON_REQ)
+// BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 2.3.3.1
+//
+//   PDU     +-----------+      +--------------+     +--------------+
+//           | InitA     |  -   | AdvA         |  -  | LLData       |
+//           | (6 bytes) |      | 6 bytes      |     | 22 bytes     |
+//           +-----------+      +--------------+     +--------------+
+//
 #[allow(unused)]
 #[repr(u8)]
 enum BLEAdvertisementType {
@@ -305,9 +353,9 @@ enum BLEState {
     NotInitialized,
     Initialized,
     ScanningIdle,
-    Scanning(RadioChannel),
+    Scanning(RadioFrequency),
     AdvertisingIdle,
-    Advertising(RadioChannel),
+    Advertising(RadioFrequency),
 }
 
 #[derive(Copy, Clone)]
@@ -380,7 +428,8 @@ impl App {
             .unwrap_or_else(|| ReturnCode::EINVAL)
     }
 
-    // Vol 6, Part B 1.3.2.1 Static Device Address
+    // Bluetooth Core Specification:Vol. 6, Part B, section 1.3.2.1 Static Device Address
+    //
     // A static address is a 48-bit randomly generated address and shall meet the following
     // requirements:
     // • The two most significant bits of the address shall be equal to 1
@@ -485,10 +534,12 @@ impl App {
             .unwrap_or_else(|| ReturnCode::EINVAL)
     }
 
-    fn send_advertisement<'a, B, A>(&self, ble: &BLE<'a, B, A>, channel: RadioChannel) -> ReturnCode
-    where
-        A: kernel::hil::time::Alarm + 'a,
-        B: ble_advertising_hil::BleAdvertisementDriver + 'a,
+    fn send_advertisement<'a, B, A>(&self,
+                                    ble: &BLE<'a, B, A>,
+                                    channel: RadioFrequency)
+                                    -> ReturnCode
+        where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+              A: kernel::hil::time::Alarm + 'a
     {
         self.advertisement_buf
             .as_ref()
@@ -537,9 +588,8 @@ impl App {
 }
 
 pub struct BLE<'a, B, A>
-where
-    B: ble_advertising_hil::BleAdvertisementDriver + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+          A: kernel::hil::time::Alarm + 'a
 {
     radio: &'a B,
     busy: Cell<bool>,
@@ -551,9 +601,8 @@ where
 }
 
 impl<'a, B, A> BLE<'a, B, A>
-where
-    B: ble_advertising_hil::BleAdvertisementDriver + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+          A: kernel::hil::time::Alarm + 'a
 {
     pub fn new(
         radio: &'a B,
@@ -603,9 +652,8 @@ where
 
 // Timer alarm
 impl<'a, B, A> kernel::hil::time::Client for BLE<'a, B, A>
-where
-    B: ble_advertising_hil::BleAdvertisementDriver + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+          A: kernel::hil::time::Alarm + 'a
 {
     // When an alarm is fired, we find which apps have expired timers. Expired
     // timers indicate a desire to perform some operation (e.g. start an
@@ -640,15 +688,19 @@ where
                     match app.process_status {
                         Some(BLEState::AdvertisingIdle) => {
                             self.busy.set(true);
-                            app.process_status = Some(BLEState::Advertising(RadioChannel::Freq37));
+                            app.process_status =
+                                Some(BLEState::Advertising(RadioFrequency::AdvertisingChannel37));
                             self.sending_app.set(Some(app.appid()));
-                            app.send_advertisement(&self, RadioChannel::Freq37);
+                            self.radio.set_tx_power(app.tx_power);
+                            app.send_advertisement(&self, RadioFrequency::AdvertisingChannel37);
                         }
                         Some(BLEState::ScanningIdle) => {
                             self.busy.set(true);
-                            app.process_status = Some(BLEState::Scanning(RadioChannel::Freq37));
+                            app.process_status =
+                                Some(BLEState::Scanning(RadioFrequency::AdvertisingChannel37));
                             self.receiving_app.set(Some(app.appid()));
-                            self.radio.receive_advertisement(RadioChannel::Freq37);
+                            self.radio.set_tx_power(app.tx_power);
+                            self.radio.receive_advertisement(RadioFrequency::AdvertisingChannel37);
                         }
                         _ => debug!(
                             "app: {:?} \t invalid state {:?}",
@@ -665,9 +717,8 @@ where
 
 // Callback from the radio once a RX event occur
 impl<'a, B, A> ble_advertising_hil::RxClient for BLE<'a, B, A>
-where
-    B: ble_advertising_hil::BleAdvertisementDriver + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+          A: kernel::hil::time::Alarm + 'a
 {
     fn receive_event(&self, buf: &'static mut [u8], len: u8, result: ReturnCode) {
         if let Some(appid) = self.receiving_app.get() {
@@ -679,7 +730,7 @@ where
                 // Therefore, we ignore payloads with a header size bigger than 39 because the
                 // channels 37, 38 and 39 should only be used for advertisements!
                 // Packets that are bigger than 39 bytes are likely "Channel PDUs" which should
-                // only be sent on the other 37 RF channels.
+                // only be sent on the other 37 RadioFrequency channels.
 
                 let notify_userland = if len <= PACKET_LENGTH as u8 && app.app_read.is_some()
                     && result == ReturnCode::SUCCESS
@@ -702,18 +753,21 @@ where
                 }
 
                 match app.process_status {
-                    Some(BLEState::Scanning(RadioChannel::Freq37)) => {
-                        app.process_status = Some(BLEState::Scanning(RadioChannel::Freq38));
+                    Some(BLEState::Scanning(RadioFrequency::AdvertisingChannel37)) => {
+                        app.process_status =
+                            Some(BLEState::Scanning(RadioFrequency::AdvertisingChannel38));
                         app.alarm_data.expiration = Expiration::Disabled;
                         self.receiving_app.set(Some(app.appid()));
-                        self.radio.receive_advertisement(RadioChannel::Freq38);
+                        self.radio.set_tx_power(app.tx_power);
+                        self.radio.receive_advertisement(RadioFrequency::AdvertisingChannel38);
                     }
-                    Some(BLEState::Scanning(RadioChannel::Freq38)) => {
-                        app.process_status = Some(BLEState::Scanning(RadioChannel::Freq39));
+                    Some(BLEState::Scanning(RadioFrequency::AdvertisingChannel38)) => {
+                        app.process_status =
+                            Some(BLEState::Scanning(RadioFrequency::AdvertisingChannel39));
                         self.receiving_app.set(Some(app.appid()));
-                        self.radio.receive_advertisement(RadioChannel::Freq38);
+                        self.radio.receive_advertisement(RadioFrequency::AdvertisingChannel39);
                     }
-                    Some(BLEState::Scanning(RadioChannel::Freq39)) => {
+                    Some(BLEState::Scanning(RadioFrequency::AdvertisingChannel39)) => {
                         self.busy.set(false);
                         app.process_status = Some(BLEState::ScanningIdle);
                         app.set_next_alarm::<A::Frequency>(self.alarm.now());
@@ -729,9 +783,8 @@ where
 
 // Callback from the radio once a TX event occur
 impl<'a, B, A> ble_advertising_hil::TxClient for BLE<'a, B, A>
-where
-    B: ble_advertising_hil::BleAdvertisementDriver + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+          A: kernel::hil::time::Alarm + 'a
 {
     // The ReturnCode indicates valid CRC or not, not used yet but could be used for
     // re-tranmissions for invalid CRCs
@@ -739,20 +792,23 @@ where
         if let Some(appid) = self.sending_app.get() {
             let _ = self.app.enter(appid, |app, _| {
                 match app.process_status {
-                    Some(BLEState::Advertising(RadioChannel::Freq37)) => {
-                        app.process_status = Some(BLEState::Advertising(RadioChannel::Freq38));
+                    Some(BLEState::Advertising(RadioFrequency::AdvertisingChannel37)) => {
+                        app.process_status =
+                            Some(BLEState::Advertising(RadioFrequency::AdvertisingChannel38));
                         app.alarm_data.expiration = Expiration::Disabled;
                         self.sending_app.set(Some(app.appid()));
-                        app.send_advertisement(&self, RadioChannel::Freq38);
+                        self.radio.set_tx_power(app.tx_power);
+                        app.send_advertisement(&self, RadioFrequency::AdvertisingChannel38);
                     }
 
-                    Some(BLEState::Advertising(RadioChannel::Freq38)) => {
-                        app.process_status = Some(BLEState::Advertising(RadioChannel::Freq39));
+                    Some(BLEState::Advertising(RadioFrequency::AdvertisingChannel38)) => {
+                        app.process_status =
+                            Some(BLEState::Advertising(RadioFrequency::AdvertisingChannel39));
                         self.sending_app.set(Some(app.appid()));
-                        app.send_advertisement(&self, RadioChannel::Freq39);
+                        app.send_advertisement(&self, RadioFrequency::AdvertisingChannel39);
                     }
 
-                    Some(BLEState::Advertising(RadioChannel::Freq39)) => {
+                    Some(BLEState::Advertising(RadioFrequency::AdvertisingChannel39)) => {
                         self.busy.set(false);
                         app.process_status = Some(BLEState::AdvertisingIdle);
                         app.set_next_alarm::<A::Frequency>(self.alarm.now());
@@ -768,9 +824,8 @@ where
 
 // System Call implementation
 impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
-where
-    B: ble_advertising_hil::BleAdvertisementDriver + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+          A: kernel::hil::time::Alarm + 'a
 {
     fn command(
         &self,
@@ -782,20 +837,18 @@ where
         match command_num {
             // Start periodic advertisments
             0 => {
-                let res = self.app
-                    .enter(appid, |app, _| {
-                        if app.process_status == Some(BLEState::Initialized) {
-                            app.process_status = Some(BLEState::AdvertisingIdle);
-                            app.random_nonce = self.alarm.now();
-                            app.set_next_alarm::<A::Frequency>(self.alarm.now());
-                            ReturnCode::SUCCESS
-                        } else {
-                            ReturnCode::EBUSY
-                        }
-                    })
-                    .unwrap_or_else(|err| err.into());
-                self.reset_active_alarm();
-                res
+                self.app
+                    .enter(appid,
+                           |app, _| if let Some(BLEState::Initialized) = app.process_status {
+                               app.process_status = Some(BLEState::AdvertisingIdle);
+                               app.random_nonce = self.alarm.now();
+                               app.set_next_alarm::<A::Frequency>(self.alarm.now());
+                               self.reset_active_alarm();
+                               ReturnCode::SUCCESS
+                           } else {
+                               ReturnCode::EBUSY
+                           })
+                    .unwrap_or_else(|err| err.into())
             }
 
             // Stop periodic advertisements or passive scanning
@@ -810,34 +863,34 @@ where
                 .unwrap_or_else(|err| err.into()),
 
             // Configure transmitted power
+            // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part A], section 3
             //
-            // This is not supported by the user-space interface anymore
+            // Minimum Output Power:    0.01 mW (-20 dBm)
+            // Maximum Output Power:    10 mW (+10 dBm)
+            //
+            // data - Transmitting power in dBm
             2 => {
                 self.app
-                    .enter(appid, |app, _| {
-                        if app.process_status != Some(BLEState::ScanningIdle)
-                            && app.process_status != Some(BLEState::AdvertisingIdle)
-                        {
-                            match data as u8 {
-                                // this what nRF5X support at moment
-                                // two complement
-                                // 0x04 = 4 dBm, 0x00 = 0 dBm, 0xFC = -4 dBm, 0xF8 = -8 dBm
-                                // 0xF4 = -12 dBm, 0xF0 = -16 dBm, 0xEC = -20 dBm, 0xD8 = -40 dBm
-                                0x04 | 0x00 | 0xFC | 0xF8 | 0xF4 | 0xF0 | 0xEC | 0xD8 => {
-                                    app.tx_power = data as u8;
-                                    ReturnCode::SUCCESS
-                                }
-                                _ => ReturnCode::EINVAL,
-                            }
-                        } else {
-                            ReturnCode::EBUSY
-                        }
-                    })
+                    .enter(appid,
+                           |app, _| if app.process_status != Some(BLEState::ScanningIdle) &&
+                                       app.process_status != Some(BLEState::AdvertisingIdle) {
+                               match data as u8 {
+                                   e @ 0...10 | e @ 0xec...0xff => {
+                                       app.tx_power = e;
+                                       // ask chip if the power level is supported
+                                       self.radio.set_tx_power(e)
+                                   }
+                                   _ => ReturnCode::EINVAL,
+                               }
+                           } else {
+                               ReturnCode::EBUSY
+                           })
                     .unwrap_or_else(|err| err.into())
             }
 
             // Configure advertisement interval
-            // Vol 6, Part B 4.4.2.2
+            // BLUETOOTH SPECIFICATION Version 4.2 [Vol 6, Part B], section 4.4.2.2
+            //
             // The advertisment interval shall an integer multiple of 0.625ms in the range of
             // 20ms to 10240 ms!
             //
@@ -858,24 +911,25 @@ where
             // Reset payload when the kernel is not actively advertising
             // reset_payload checks whether the current app is correct state or not
             // i.e. if it's ok to reset the payload or not
-            4 => self.app
-                .enter(appid, |app, _| app.reset_payload())
-                .unwrap_or_else(|err| err.into()),
+            4 => {
+                self.app
+                    .enter(appid, |app, _| app.reset_payload())
+                    .unwrap_or_else(|err| err.into())
+            }
+
             // Passive scanning mode
             5 => {
-                let res = self.app
-                    .enter(appid, |app, _| {
-                        if app.process_status == Some(BLEState::Initialized) {
-                            app.process_status = Some(BLEState::ScanningIdle);
-                            app.set_next_alarm::<A::Frequency>(self.alarm.now());
-                            ReturnCode::SUCCESS
-                        } else {
-                            ReturnCode::EBUSY
-                        }
-                    })
-                    .unwrap_or_else(|err| err.into());
-                self.reset_active_alarm();
-                res
+                self.app
+                    .enter(appid,
+                           |app, _| if let Some(BLEState::Initialized) = app.process_status {
+                               app.process_status = Some(BLEState::ScanningIdle);
+                               app.set_next_alarm::<A::Frequency>(self.alarm.now());
+                               self.reset_active_alarm();
+                               ReturnCode::SUCCESS
+                           } else {
+                               ReturnCode::EBUSY
+                           })
+                    .unwrap_or_else(|err| err.into())
             }
 
             // Initilize BLE Driver
@@ -901,48 +955,54 @@ where
         }
     }
 
-    fn allow(
-        &self,
-        appid: kernel::AppId,
-        allow_num: usize,
-        slice: kernel::AppSlice<kernel::Shared, u8>,
-    ) -> ReturnCode {
-        match from_usize(allow_num) {
-            Some(AllowType::BLEGap(gap_type)) => self.app
-                .enter(appid, |app, _| {
-                    if app.process_status != Some(BLEState::NotInitialized) {
-                        app.app_write = Some(slice);
-                        app.set_gap_data(gap_type);
-                        ReturnCode::SUCCESS
-                    } else {
-                        ReturnCode::EINVAL
-                    }
-                })
-                .unwrap_or_else(|err| err.into()),
+    fn allow(&self,
+             appid: kernel::AppId,
+             allow_num: usize,
+             slice: kernel::AppSlice<kernel::Shared, u8>)
+             -> ReturnCode {
 
-            Some(AllowType::PassiveScanning) => self.app
-                .enter(appid, |app, _| {
-                    if app.process_status == Some(BLEState::Initialized) {
-                        app.app_read = Some(slice);
-                        ReturnCode::SUCCESS
-                    } else {
-                        ReturnCode::EINVAL
-                    }
-                })
-                .unwrap_or_else(|err| err.into()),
+        match AllowType::from_usize(allow_num) {
 
-            Some(AllowType::InitAdvertisementBuffer) => self.app
-                .enter(appid, |app, _| {
-                    if let Some(BLEState::NotInitialized) = app.process_status {
-                        app.advertisement_buf = Some(slice);
-                        app.process_status = Some(BLEState::Initialized);
-                        app.initialize_advertisement_buffer();
-                        ReturnCode::SUCCESS
-                    } else {
-                        ReturnCode::EINVAL
-                    }
-                })
-                .unwrap_or_else(|err| err.into()),
+            Some(AllowType::BLEGap(gap_type)) => {
+                self.app
+                    .enter(appid,
+                           |app, _| if app.process_status != Some(BLEState::NotInitialized) {
+                               app.app_write = Some(slice);
+                               app.set_gap_data(gap_type);
+                               ReturnCode::SUCCESS
+                           } else {
+                               ReturnCode::EINVAL
+                           })
+                    .unwrap_or_else(|err| err.into())
+            }
+
+            Some(AllowType::PassiveScanning) => {
+                self.app
+                    .enter(appid, |app, _| match app.process_status {
+                        Some(BLEState::NotInitialized) |
+                        Some(BLEState::Initialized) => {
+                            app.app_read = Some(slice);
+                            app.process_status = Some(BLEState::Initialized);
+                            ReturnCode::SUCCESS
+                        }
+                        _ => ReturnCode::EINVAL,
+                    })
+                    .unwrap_or_else(|err| err.into())
+            }
+
+            Some(AllowType::InitAdvertisementBuffer) => {
+                self.app
+                    .enter(appid,
+                           |app, _| if let Some(BLEState::NotInitialized) = app.process_status {
+                               app.advertisement_buf = Some(slice);
+                               app.process_status = Some(BLEState::Initialized);
+                               app.initialize_advertisement_buffer();
+                               ReturnCode::SUCCESS
+                           } else {
+                               ReturnCode::EINVAL
+                           })
+                    .unwrap_or_else(|err| err.into())
+            }
             _ => ReturnCode::ENOSUPPORT,
         }
     }
@@ -950,12 +1010,19 @@ where
     fn subscribe(&self, subscribe_num: usize, callback: kernel::Callback) -> ReturnCode {
         match subscribe_num {
             // Callback for scanning
-            0 => self.app
-                .enter(callback.app_id(), |app, _| {
-                    app.scan_callback = Some(callback);
-                    ReturnCode::SUCCESS
-                })
-                .unwrap_or_else(|err| err.into()),
+            0 => {
+                self.app
+                    .enter(callback.app_id(), |app, _| match app.process_status {
+                        Some(BLEState::NotInitialized) |
+                        Some(BLEState::Initialized) => {
+                            app.scan_callback = Some(callback);
+                            ReturnCode::SUCCESS
+                        }
+                        _ => ReturnCode::EINVAL,
+
+                    })
+                    .unwrap_or_else(|err| err.into())
+            }
             _ => ReturnCode::ENOSUPPORT,
         }
     }

--- a/chips/nrf5x/src/ble_advertising_driver.rs
+++ b/chips/nrf5x/src/ble_advertising_driver.rs
@@ -225,7 +225,9 @@ impl AllowType {
             0x03 => Some(AllowType::BLEGap(BLEGapType::CompleteList16BitServiceIDs)),
             0x04 => Some(AllowType::BLEGap(BLEGapType::IncompleteList32BitServiceIDs)),
             0x05 => Some(AllowType::BLEGap(BLEGapType::CompleteList32BitServiceIDs)),
-            0x06 => Some(AllowType::BLEGap(BLEGapType::IncompleteList128BitServiceIDs)),
+            0x06 => Some(AllowType::BLEGap(
+                BLEGapType::IncompleteList128BitServiceIDs,
+            )),
             0x07 => Some(AllowType::BLEGap(BLEGapType::CompleteList128BitServiceIDs)),
             0x08 => Some(AllowType::BLEGap(BLEGapType::ShortedLocalName)),
             0x09 => Some(AllowType::BLEGap(BLEGapType::CompleteLocalName)),
@@ -244,8 +246,6 @@ impl AllowType {
         }
     }
 }
-
-
 
 // Gap Types only the ones that are defined in libtock are defined here
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -535,8 +535,9 @@ impl App {
     }
 
     fn send_advertisement<'a, B, A>(&self, ble: &BLE<'a, B, A>, channel: RadioChannel) -> ReturnCode
-        where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
-              A: kernel::hil::time::Alarm + 'a
+    where
+        B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+        A: kernel::hil::time::Alarm + 'a,
     {
         self.advertisement_buf
             .as_ref()
@@ -585,8 +586,9 @@ impl App {
 }
 
 pub struct BLE<'a, B, A>
-    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
-          A: kernel::hil::time::Alarm + 'a
+where
+    B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+    A: kernel::hil::time::Alarm + 'a,
 {
     radio: &'a B,
     busy: Cell<bool>,
@@ -598,8 +600,9 @@ pub struct BLE<'a, B, A>
 }
 
 impl<'a, B, A> BLE<'a, B, A>
-    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
-          A: kernel::hil::time::Alarm + 'a
+where
+    B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+    A: kernel::hil::time::Alarm + 'a,
 {
     pub fn new(
         radio: &'a B,
@@ -649,8 +652,9 @@ impl<'a, B, A> BLE<'a, B, A>
 
 // Timer alarm
 impl<'a, B, A> kernel::hil::time::Client for BLE<'a, B, A>
-    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
-          A: kernel::hil::time::Alarm + 'a
+where
+    B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+    A: kernel::hil::time::Alarm + 'a,
 {
     // When an alarm is fired, we find which apps have expired timers. Expired
     // timers indicate a desire to perform some operation (e.g. start an
@@ -697,7 +701,8 @@ impl<'a, B, A> kernel::hil::time::Client for BLE<'a, B, A>
                                 Some(BLEState::Scanning(RadioChannel::AdvertisingChannel37));
                             self.receiving_app.set(Some(app.appid()));
                             self.radio.set_tx_power(app.tx_power);
-                            self.radio.receive_advertisement(RadioChannel::AdvertisingChannel37);
+                            self.radio
+                                .receive_advertisement(RadioChannel::AdvertisingChannel37);
                         }
                         _ => debug!(
                             "app: {:?} \t invalid state {:?}",
@@ -714,8 +719,9 @@ impl<'a, B, A> kernel::hil::time::Client for BLE<'a, B, A>
 
 // Callback from the radio once a RX event occur
 impl<'a, B, A> ble_advertising_hil::RxClient for BLE<'a, B, A>
-    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
-          A: kernel::hil::time::Alarm + 'a
+where
+    B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+    A: kernel::hil::time::Alarm + 'a,
 {
     fn receive_event(&self, buf: &'static mut [u8], len: u8, result: ReturnCode) {
         if let Some(appid) = self.receiving_app.get() {
@@ -756,13 +762,15 @@ impl<'a, B, A> ble_advertising_hil::RxClient for BLE<'a, B, A>
                         app.alarm_data.expiration = Expiration::Disabled;
                         self.receiving_app.set(Some(app.appid()));
                         self.radio.set_tx_power(app.tx_power);
-                        self.radio.receive_advertisement(RadioChannel::AdvertisingChannel38);
+                        self.radio
+                            .receive_advertisement(RadioChannel::AdvertisingChannel38);
                     }
                     Some(BLEState::Scanning(RadioChannel::AdvertisingChannel38)) => {
                         app.process_status =
                             Some(BLEState::Scanning(RadioChannel::AdvertisingChannel39));
                         self.receiving_app.set(Some(app.appid()));
-                        self.radio.receive_advertisement(RadioChannel::AdvertisingChannel39);
+                        self.radio
+                            .receive_advertisement(RadioChannel::AdvertisingChannel39);
                     }
                     Some(BLEState::Scanning(RadioChannel::AdvertisingChannel39)) => {
                         self.busy.set(false);
@@ -780,8 +788,9 @@ impl<'a, B, A> ble_advertising_hil::RxClient for BLE<'a, B, A>
 
 // Callback from the radio once a TX event occur
 impl<'a, B, A> ble_advertising_hil::TxClient for BLE<'a, B, A>
-    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
-          A: kernel::hil::time::Alarm + 'a
+where
+    B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+    A: kernel::hil::time::Alarm + 'a,
 {
     // The ReturnCode indicates valid CRC or not, not used yet but could be used for
     // re-tranmissions for invalid CRCs
@@ -821,8 +830,9 @@ impl<'a, B, A> ble_advertising_hil::TxClient for BLE<'a, B, A>
 
 // System Call implementation
 impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
-    where B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
-          A: kernel::hil::time::Alarm + 'a
+where
+    B: ble_advertising_hil::BleAdvertisementDriver + ble_advertising_hil::BleConfig + 'a,
+    A: kernel::hil::time::Alarm + 'a,
 {
     fn command(
         &self,
@@ -833,20 +843,19 @@ impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
     ) -> ReturnCode {
         match command_num {
             // Start periodic advertisments
-            0 => {
-                self.app
-                    .enter(appid,
-                           |app, _| if let Some(BLEState::Initialized) = app.process_status {
-                               app.process_status = Some(BLEState::AdvertisingIdle);
-                               app.random_nonce = self.alarm.now();
-                               app.set_next_alarm::<A::Frequency>(self.alarm.now());
-                               self.reset_active_alarm();
-                               ReturnCode::SUCCESS
-                           } else {
-                               ReturnCode::EBUSY
-                           })
-                    .unwrap_or_else(|err| err.into())
-            }
+            0 => self.app
+                .enter(appid, |app, _| {
+                    if let Some(BLEState::Initialized) = app.process_status {
+                        app.process_status = Some(BLEState::AdvertisingIdle);
+                        app.random_nonce = self.alarm.now();
+                        app.set_next_alarm::<A::Frequency>(self.alarm.now());
+                        self.reset_active_alarm();
+                        ReturnCode::SUCCESS
+                    } else {
+                        ReturnCode::EBUSY
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
 
             // Stop periodic advertisements or passive scanning
             1 => self.app
@@ -868,20 +877,22 @@ impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
             // data - Transmitting power in dBm
             2 => {
                 self.app
-                    .enter(appid,
-                           |app, _| if app.process_status != Some(BLEState::ScanningIdle) &&
-                                       app.process_status != Some(BLEState::AdvertisingIdle) {
-                               match data as u8 {
-                                   e @ 0...10 | e @ 0xec...0xff => {
-                                       app.tx_power = e;
-                                       // ask chip if the power level is supported
-                                       self.radio.set_tx_power(e)
-                                   }
-                                   _ => ReturnCode::EINVAL,
-                               }
-                           } else {
-                               ReturnCode::EBUSY
-                           })
+                    .enter(appid, |app, _| {
+                        if app.process_status != Some(BLEState::ScanningIdle)
+                            && app.process_status != Some(BLEState::AdvertisingIdle)
+                        {
+                            match data as u8 {
+                                e @ 0...10 | e @ 0xec...0xff => {
+                                    app.tx_power = e;
+                                    // ask chip if the power level is supported
+                                    self.radio.set_tx_power(e)
+                                }
+                                _ => ReturnCode::EINVAL,
+                            }
+                        } else {
+                            ReturnCode::EBUSY
+                        }
+                    })
                     .unwrap_or_else(|err| err.into())
             }
 
@@ -908,26 +919,23 @@ impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
             // Reset payload when the kernel is not actively advertising
             // reset_payload checks whether the current app is correct state or not
             // i.e. if it's ok to reset the payload or not
-            4 => {
-                self.app
-                    .enter(appid, |app, _| app.reset_payload())
-                    .unwrap_or_else(|err| err.into())
-            }
+            4 => self.app
+                .enter(appid, |app, _| app.reset_payload())
+                .unwrap_or_else(|err| err.into()),
 
             // Passive scanning mode
-            5 => {
-                self.app
-                    .enter(appid,
-                           |app, _| if let Some(BLEState::Initialized) = app.process_status {
-                               app.process_status = Some(BLEState::ScanningIdle);
-                               app.set_next_alarm::<A::Frequency>(self.alarm.now());
-                               self.reset_active_alarm();
-                               ReturnCode::SUCCESS
-                           } else {
-                               ReturnCode::EBUSY
-                           })
-                    .unwrap_or_else(|err| err.into())
-            }
+            5 => self.app
+                .enter(appid, |app, _| {
+                    if let Some(BLEState::Initialized) = app.process_status {
+                        app.process_status = Some(BLEState::ScanningIdle);
+                        app.set_next_alarm::<A::Frequency>(self.alarm.now());
+                        self.reset_active_alarm();
+                        ReturnCode::SUCCESS
+                    } else {
+                        ReturnCode::EBUSY
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
 
             // Initilize BLE Driver
             // Allow call to allocate the advertisement buffer must be
@@ -952,54 +960,48 @@ impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
         }
     }
 
-    fn allow(&self,
-             appid: kernel::AppId,
-             allow_num: usize,
-             slice: kernel::AppSlice<kernel::Shared, u8>)
-             -> ReturnCode {
-
+    fn allow(
+        &self,
+        appid: kernel::AppId,
+        allow_num: usize,
+        slice: kernel::AppSlice<kernel::Shared, u8>,
+    ) -> ReturnCode {
         match AllowType::from_usize(allow_num) {
+            Some(AllowType::BLEGap(gap_type)) => self.app
+                .enter(appid, |app, _| {
+                    if app.process_status != Some(BLEState::NotInitialized) {
+                        app.app_write = Some(slice);
+                        app.set_gap_data(gap_type);
+                        ReturnCode::SUCCESS
+                    } else {
+                        ReturnCode::EINVAL
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
 
-            Some(AllowType::BLEGap(gap_type)) => {
-                self.app
-                    .enter(appid,
-                           |app, _| if app.process_status != Some(BLEState::NotInitialized) {
-                               app.app_write = Some(slice);
-                               app.set_gap_data(gap_type);
-                               ReturnCode::SUCCESS
-                           } else {
-                               ReturnCode::EINVAL
-                           })
-                    .unwrap_or_else(|err| err.into())
-            }
+            Some(AllowType::PassiveScanning) => self.app
+                .enter(appid, |app, _| match app.process_status {
+                    Some(BLEState::NotInitialized) | Some(BLEState::Initialized) => {
+                        app.app_read = Some(slice);
+                        app.process_status = Some(BLEState::Initialized);
+                        ReturnCode::SUCCESS
+                    }
+                    _ => ReturnCode::EINVAL,
+                })
+                .unwrap_or_else(|err| err.into()),
 
-            Some(AllowType::PassiveScanning) => {
-                self.app
-                    .enter(appid, |app, _| match app.process_status {
-                        Some(BLEState::NotInitialized) |
-                        Some(BLEState::Initialized) => {
-                            app.app_read = Some(slice);
-                            app.process_status = Some(BLEState::Initialized);
-                            ReturnCode::SUCCESS
-                        }
-                        _ => ReturnCode::EINVAL,
-                    })
-                    .unwrap_or_else(|err| err.into())
-            }
-
-            Some(AllowType::InitAdvertisementBuffer) => {
-                self.app
-                    .enter(appid,
-                           |app, _| if let Some(BLEState::NotInitialized) = app.process_status {
-                               app.advertisement_buf = Some(slice);
-                               app.process_status = Some(BLEState::Initialized);
-                               app.initialize_advertisement_buffer();
-                               ReturnCode::SUCCESS
-                           } else {
-                               ReturnCode::EINVAL
-                           })
-                    .unwrap_or_else(|err| err.into())
-            }
+            Some(AllowType::InitAdvertisementBuffer) => self.app
+                .enter(appid, |app, _| {
+                    if let Some(BLEState::NotInitialized) = app.process_status {
+                        app.advertisement_buf = Some(slice);
+                        app.process_status = Some(BLEState::Initialized);
+                        app.initialize_advertisement_buffer();
+                        ReturnCode::SUCCESS
+                    } else {
+                        ReturnCode::EINVAL
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
             _ => ReturnCode::ENOSUPPORT,
         }
     }
@@ -1007,19 +1009,15 @@ impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
     fn subscribe(&self, subscribe_num: usize, callback: kernel::Callback) -> ReturnCode {
         match subscribe_num {
             // Callback for scanning
-            0 => {
-                self.app
-                    .enter(callback.app_id(), |app, _| match app.process_status {
-                        Some(BLEState::NotInitialized) |
-                        Some(BLEState::Initialized) => {
-                            app.scan_callback = Some(callback);
-                            ReturnCode::SUCCESS
-                        }
-                        _ => ReturnCode::EINVAL,
-
-                    })
-                    .unwrap_or_else(|err| err.into())
-            }
+            0 => self.app
+                .enter(callback.app_id(), |app, _| match app.process_status {
+                    Some(BLEState::NotInitialized) | Some(BLEState::Initialized) => {
+                        app.scan_callback = Some(callback);
+                        ReturnCode::SUCCESS
+                    }
+                    _ => ReturnCode::EINVAL,
+                })
+                .unwrap_or_else(|err| err.into()),
             _ => ReturnCode::ENOSUPPORT,
         }
     }

--- a/chips/nrf5x/src/ble_advertising_hil.rs
+++ b/chips/nrf5x/src/ble_advertising_hil.rs
@@ -52,9 +52,9 @@ pub trait BleAdvertisementDriver {
     fn transmit_advertisement(&self,
                               buf: &'static mut [u8],
                               len: usize,
-                              channel: RadioFrequency)
+                              channel: RadioChannel)
                               -> &'static mut [u8];
-    fn receive_advertisement(&self, channel: RadioFrequency);
+    fn receive_advertisement(&self, channel: RadioChannel);
     fn set_receive_client(&self, client: &'static RxClient);
     fn set_transmit_client(&self, client: &'static TxClient);
 }
@@ -73,7 +73,7 @@ pub trait TxClient {
 
 // Bluetooth Core Specification:Vol. 6. Part B, section 1.4.1 Advertising and Data Channel Indices
 #[derive(PartialEq, Debug, Copy, Clone)]
-pub enum RadioFrequency {
+pub enum RadioChannel {
     DataChannel0 = 4,
     DataChannel1 = 6,
     DataChannel2 = 8,
@@ -116,49 +116,49 @@ pub enum RadioFrequency {
     AdvertisingChannel39 = 80,
 }
 
-impl RadioFrequency {
+impl RadioChannel {
     pub fn get_channel_index(&self) -> u32 {
         match *self {
-            RadioFrequency::DataChannel0 => 0,
-            RadioFrequency::DataChannel1 => 1,
-            RadioFrequency::DataChannel2 => 2,
-            RadioFrequency::DataChannel3 => 3,
-            RadioFrequency::DataChannel4 => 4,
-            RadioFrequency::DataChannel5 => 5,
-            RadioFrequency::DataChannel6 => 6,
-            RadioFrequency::DataChannel7 => 7,
-            RadioFrequency::DataChannel8 => 8,
-            RadioFrequency::DataChannel9 => 9,
-            RadioFrequency::DataChannel10 => 10,
-            RadioFrequency::DataChannel11 => 11,
-            RadioFrequency::DataChannel12 => 12,
-            RadioFrequency::DataChannel13 => 13,
-            RadioFrequency::DataChannel14 => 14,
-            RadioFrequency::DataChannel15 => 15,
-            RadioFrequency::DataChannel16 => 16,
-            RadioFrequency::DataChannel17 => 17,
-            RadioFrequency::DataChannel18 => 18,
-            RadioFrequency::DataChannel19 => 19,
-            RadioFrequency::DataChannel20 => 20,
-            RadioFrequency::DataChannel21 => 21,
-            RadioFrequency::DataChannel22 => 22,
-            RadioFrequency::DataChannel23 => 23,
-            RadioFrequency::DataChannel24 => 24,
-            RadioFrequency::DataChannel25 => 25,
-            RadioFrequency::DataChannel26 => 26,
-            RadioFrequency::DataChannel27 => 27,
-            RadioFrequency::DataChannel28 => 28,
-            RadioFrequency::DataChannel29 => 29,
-            RadioFrequency::DataChannel30 => 30,
-            RadioFrequency::DataChannel31 => 31,
-            RadioFrequency::DataChannel32 => 32,
-            RadioFrequency::DataChannel33 => 33,
-            RadioFrequency::DataChannel34 => 34,
-            RadioFrequency::DataChannel35 => 35,
-            RadioFrequency::DataChannel36 => 36,
-            RadioFrequency::AdvertisingChannel37 => 37,
-            RadioFrequency::AdvertisingChannel38 => 38,
-            RadioFrequency::AdvertisingChannel39 => 39,
+            RadioChannel::DataChannel0 => 0,
+            RadioChannel::DataChannel1 => 1,
+            RadioChannel::DataChannel2 => 2,
+            RadioChannel::DataChannel3 => 3,
+            RadioChannel::DataChannel4 => 4,
+            RadioChannel::DataChannel5 => 5,
+            RadioChannel::DataChannel6 => 6,
+            RadioChannel::DataChannel7 => 7,
+            RadioChannel::DataChannel8 => 8,
+            RadioChannel::DataChannel9 => 9,
+            RadioChannel::DataChannel10 => 10,
+            RadioChannel::DataChannel11 => 11,
+            RadioChannel::DataChannel12 => 12,
+            RadioChannel::DataChannel13 => 13,
+            RadioChannel::DataChannel14 => 14,
+            RadioChannel::DataChannel15 => 15,
+            RadioChannel::DataChannel16 => 16,
+            RadioChannel::DataChannel17 => 17,
+            RadioChannel::DataChannel18 => 18,
+            RadioChannel::DataChannel19 => 19,
+            RadioChannel::DataChannel20 => 20,
+            RadioChannel::DataChannel21 => 21,
+            RadioChannel::DataChannel22 => 22,
+            RadioChannel::DataChannel23 => 23,
+            RadioChannel::DataChannel24 => 24,
+            RadioChannel::DataChannel25 => 25,
+            RadioChannel::DataChannel26 => 26,
+            RadioChannel::DataChannel27 => 27,
+            RadioChannel::DataChannel28 => 28,
+            RadioChannel::DataChannel29 => 29,
+            RadioChannel::DataChannel30 => 30,
+            RadioChannel::DataChannel31 => 31,
+            RadioChannel::DataChannel32 => 32,
+            RadioChannel::DataChannel33 => 33,
+            RadioChannel::DataChannel34 => 34,
+            RadioChannel::DataChannel35 => 35,
+            RadioChannel::DataChannel36 => 36,
+            RadioChannel::AdvertisingChannel37 => 37,
+            RadioChannel::AdvertisingChannel38 => 38,
+            RadioChannel::AdvertisingChannel39 => 39,
         }
     }
 }

--- a/chips/nrf5x/src/ble_advertising_hil.rs
+++ b/chips/nrf5x/src/ble_advertising_hil.rs
@@ -1,18 +1,66 @@
 //! Bluetooth Low Energy HIL
 
+
+//! ```
+//! Application
+//!
+//!           +------------------------------------------------+
+//!           | Applications                                   |
+//!           +------------------------------------------------+
+//!
+//! ```
+//! Host
+//!
+//!           +------------------------------------------------+
+//!           | Generic Access Profile                         |
+//!           +------------------------------------------------+
+//!
+//!           +------------------------------------------------+
+//!           | Generic Attribute Profile                      |
+//!           +------------------------------------------------+
+//!
+//!           +--------------------+      +-------------------+
+//!           | Attribute Protocol |      | Security Mananger |
+//!           +--------------------+      +-------------------+
+//!
+//!           +-----------------------------------------------+
+//!           | Logical Link and Adaptation Protocol          |
+//!           +-----------------------------------------------+
+//!
+//! ```
+//!
+//! ```
+//! Controller
+//!
+//!           +--------------------------------------------+
+//!           | Host Controller Interface                  |
+//!           +--------------------------------------------+
+//!
+//!           +------------------+      +------------------+
+//!           | Link Layer       |      | Direct Test Mode |
+//!           +------------------+      +------------------+
+//!
+//!           +--------------------------------------------+
+//!           | Physical Layer                             |
+//!           +--------------------------------------------+
+//!
+//! ```
+
 use kernel::ReturnCode;
 
 pub trait BleAdvertisementDriver {
-    fn set_tx_power(&self, power: usize) -> ReturnCode;
-    fn transmit_advertisement(
-        &self,
-        buf: &'static mut [u8],
-        len: usize,
-        freq: RadioChannel,
-    ) -> &'static mut [u8];
-    fn receive_advertisement(&self, freq: RadioChannel);
+    fn transmit_advertisement(&self,
+                              buf: &'static mut [u8],
+                              len: usize,
+                              channel: RadioFrequency)
+                              -> &'static mut [u8];
+    fn receive_advertisement(&self, channel: RadioFrequency);
     fn set_receive_client(&self, client: &'static RxClient);
     fn set_transmit_client(&self, client: &'static TxClient);
+}
+
+pub trait BleConfig {
+    fn set_tx_power(&self, power: u8) -> ReturnCode;
 }
 
 pub trait RxClient {
@@ -23,9 +71,94 @@ pub trait TxClient {
     fn transmit_event(&self, result: ReturnCode);
 }
 
+// Bluetooth Core Specification:Vol. 6. Part B, section 1.4.1 Advertising and Data Channel Indices
 #[derive(PartialEq, Debug, Copy, Clone)]
-pub enum RadioChannel {
-    Freq37 = 37,
-    Freq38 = 38,
-    Freq39 = 39,
+pub enum RadioFrequency {
+    DataChannel0 = 4,
+    DataChannel1 = 6,
+    DataChannel2 = 8,
+    DataChannel3 = 10,
+    DataChannel4 = 12,
+    DataChannel5 = 14,
+    DataChannel6 = 16,
+    DataChannel7 = 18,
+    DataChannel8 = 20,
+    DataChannel9 = 22,
+    DataChannel10 = 24,
+    DataChannel11 = 28,
+    DataChannel12 = 30,
+    DataChannel13 = 32,
+    DataChannel14 = 34,
+    DataChannel15 = 36,
+    DataChannel16 = 38,
+    DataChannel17 = 40,
+    DataChannel18 = 42,
+    DataChannel19 = 44,
+    DataChannel20 = 46,
+    DataChannel21 = 48,
+    DataChannel22 = 50,
+    DataChannel23 = 52,
+    DataChannel24 = 54,
+    DataChannel25 = 56,
+    DataChannel26 = 58,
+    DataChannel27 = 60,
+    DataChannel28 = 62,
+    DataChannel29 = 64,
+    DataChannel30 = 66,
+    DataChannel31 = 68,
+    DataChannel32 = 70,
+    DataChannel33 = 72,
+    DataChannel34 = 74,
+    DataChannel35 = 76,
+    DataChannel36 = 78,
+    AdvertisingChannel37 = 2,
+    AdvertisingChannel38 = 26,
+    AdvertisingChannel39 = 80,
+}
+
+impl RadioFrequency {
+    pub fn get_channel_index(&self) -> u32 {
+        match *self {
+            RadioFrequency::DataChannel0 => 0,
+            RadioFrequency::DataChannel1 => 1,
+            RadioFrequency::DataChannel2 => 2,
+            RadioFrequency::DataChannel3 => 3,
+            RadioFrequency::DataChannel4 => 4,
+            RadioFrequency::DataChannel5 => 5,
+            RadioFrequency::DataChannel6 => 6,
+            RadioFrequency::DataChannel7 => 7,
+            RadioFrequency::DataChannel8 => 8,
+            RadioFrequency::DataChannel9 => 9,
+            RadioFrequency::DataChannel10 => 10,
+            RadioFrequency::DataChannel11 => 11,
+            RadioFrequency::DataChannel12 => 12,
+            RadioFrequency::DataChannel13 => 13,
+            RadioFrequency::DataChannel14 => 14,
+            RadioFrequency::DataChannel15 => 15,
+            RadioFrequency::DataChannel16 => 16,
+            RadioFrequency::DataChannel17 => 17,
+            RadioFrequency::DataChannel18 => 18,
+            RadioFrequency::DataChannel19 => 19,
+            RadioFrequency::DataChannel20 => 20,
+            RadioFrequency::DataChannel21 => 21,
+            RadioFrequency::DataChannel22 => 22,
+            RadioFrequency::DataChannel23 => 23,
+            RadioFrequency::DataChannel24 => 24,
+            RadioFrequency::DataChannel25 => 25,
+            RadioFrequency::DataChannel26 => 26,
+            RadioFrequency::DataChannel27 => 27,
+            RadioFrequency::DataChannel28 => 28,
+            RadioFrequency::DataChannel29 => 29,
+            RadioFrequency::DataChannel30 => 30,
+            RadioFrequency::DataChannel31 => 31,
+            RadioFrequency::DataChannel32 => 32,
+            RadioFrequency::DataChannel33 => 33,
+            RadioFrequency::DataChannel34 => 34,
+            RadioFrequency::DataChannel35 => 35,
+            RadioFrequency::DataChannel36 => 36,
+            RadioFrequency::AdvertisingChannel37 => 37,
+            RadioFrequency::AdvertisingChannel38 => 38,
+            RadioFrequency::AdvertisingChannel39 => 39,
+        }
+    }
 }

--- a/chips/nrf5x/src/ble_advertising_hil.rs
+++ b/chips/nrf5x/src/ble_advertising_hil.rs
@@ -1,6 +1,5 @@
 //! Bluetooth Low Energy HIL
 
-
 //! ```
 //! Application
 //!
@@ -49,11 +48,12 @@
 use kernel::ReturnCode;
 
 pub trait BleAdvertisementDriver {
-    fn transmit_advertisement(&self,
-                              buf: &'static mut [u8],
-                              len: usize,
-                              channel: RadioChannel)
-                              -> &'static mut [u8];
+    fn transmit_advertisement(
+        &self,
+        buf: &'static mut [u8],
+        len: usize,
+        channel: RadioChannel,
+    ) -> &'static mut [u8];
     fn receive_advertisement(&self, channel: RadioChannel);
     fn set_receive_client(&self, client: &'static RxClient);
     fn set_transmit_client(&self, client: &'static TxClient);

--- a/chips/nrf5x/src/constants.rs
+++ b/chips/nrf5x/src/constants.rs
@@ -17,6 +17,7 @@ pub const RADIO_PCNF1_ENDIAN_POS: u32 = 24;
 pub const RADIO_PCNF1_ENDIAN_BIG: u32 = 1;
 pub const RADIO_PCNF1_ENDIAN_LITTLE: u32 = 0;
 pub const RADIO_PCNF1_MAXLEN_37BYTES: u32 = 37;
+pub const RADIO_PCNF1_MAXLEN_255BYTES: u32 = 255;
 pub const RADIO_PCNF1_STATLEN_DONT_EXTEND: u32 = 0;
 pub const RADIO_PCNF1_BALEN_3BYTES: u32 = 3;
 
@@ -55,11 +56,42 @@ pub const RADIO_STATE_TX: u32 = 11;
 pub const RADIO_STATE_TXDISABLE: u32 = 12;
 
 // BUFFER SIZE
-pub const RADIO_PAYLOAD_LENGTH: usize = 39;
+pub const RADIO_PAYLOAD_LENGTH: usize = 255;
 
 pub enum RadioMode {
     Nrf1Mbit = 0,
     Nrf2Mbit = 1,
     Nrt250Kbit = 2,
     Ble1Mbit = 3,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum TxPower {
+    Positive4dBM = 0x04,
+    Positive3dBM = 0x03,
+    ZerodBm = 0x00,
+    Negative4dBm = 0xFC,
+    Negative8dBm = 0xF8,
+    Negative12dBm = 0xF4,
+    Negative16dBm = 0xF0,
+    Negative20dBm = 0xEC,
+    Negative40dBm = 0xD8,
+    Error,
+}
+
+impl TxPower {
+    pub fn from_u8(val: u8) -> TxPower {
+        match val {
+            4 => TxPower::Positive4dBM,
+            3 => TxPower::Positive3dBM,
+            0 => TxPower::ZerodBm,
+            0xFC => TxPower::Negative4dBm,
+            0xF8 => TxPower::Negative8dBm,
+            0xF4 => TxPower::Negative12dBm,
+            0xF0 => TxPower::Negative16dBm,
+            0xEC => TxPower::Negative20dBm,
+            0xD8 => TxPower::Negative40dBm,
+            _ => TxPower::Error,
+        }
+    }
 }

--- a/chips/nrf5x/src/constants.rs
+++ b/chips/nrf5x/src/constants.rs
@@ -1,3 +1,5 @@
+use core::convert::TryFrom;
+
 // PCNF0
 pub const RADIO_PCNF0_LFLEN_POS: u32 = 0;
 pub const RADIO_PCNF0_S0LEN_POS: u32 = 8;
@@ -76,22 +78,24 @@ pub enum TxPower {
     Negative16dBm = 0xF0,
     Negative20dBm = 0xEC,
     Negative40dBm = 0xD8,
-    Error,
 }
 
-impl TxPower {
-    pub fn from_u8(val: u8) -> TxPower {
+//FIXME: use enum-tryfrom-derive, https://docs.rs/crate/enum-tryfrom-derive/0.1.2
+impl TryFrom<u8> for TxPower {
+    type Error = ();
+
+    fn try_from(val: u8) -> Result<TxPower, ()> {
         match val {
-            4 => TxPower::Positive4dBM,
-            3 => TxPower::Positive3dBM,
-            0 => TxPower::ZerodBm,
-            0xFC => TxPower::Negative4dBm,
-            0xF8 => TxPower::Negative8dBm,
-            0xF4 => TxPower::Negative12dBm,
-            0xF0 => TxPower::Negative16dBm,
-            0xEC => TxPower::Negative20dBm,
-            0xD8 => TxPower::Negative40dBm,
-            _ => TxPower::Error,
+            4 => Ok(TxPower::Positive4dBM),
+            3 => Ok(TxPower::Positive3dBM),
+            0 => Ok(TxPower::ZerodBm),
+            0xFC => Ok(TxPower::Negative4dBm),
+            0xF8 => Ok(TxPower::Negative8dBm),
+            0xF4 => Ok(TxPower::Negative12dBm),
+            0xF0 => Ok(TxPower::Negative16dBm),
+            0xEC => Ok(TxPower::Negative20dBm),
+            0xD8 => Ok(TxPower::Negative40dBm),
+            _ => Err(()),
         }
     }
 }

--- a/chips/nrf5x/src/lib.rs
+++ b/chips/nrf5x/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm, concat_idents, const_fn, const_cell_new)]
+#![feature(asm, concat_idents, const_fn, const_cell_new, try_from)]
 #![no_std]
 
 #[allow(unused_imports)]

--- a/userland/examples/tests/ble/ble_advertising_dynamic/Makefile
+++ b/userland/examples/tests/ble/ble_advertising_dynamic/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/ble/ble_advertising_dynamic/README.md
+++ b/userland/examples/tests/ble/ble_advertising_dynamic/README.md
@@ -1,0 +1,10 @@
+Bluetooth Low Energy Dynamic Test
+======================================
+
+A test application that changes advertisement name, advertisement interval and
+tx power every second.
+
+Supported Boards
+-----------------
+nRF51-DK
+nRF52-DK

--- a/userland/examples/tests/ble/ble_advertising_dynamic/main.c
+++ b/userland/examples/tests/ble/ble_advertising_dynamic/main.c
@@ -1,0 +1,93 @@
+#include <rng.h>
+#include <simple_ble.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <timer.h>
+#include <tock.h>
+
+// Sizes in bytes
+#define DEVICE_NAME_SIZE 6
+#define MANUFACTURER_DATA_SIZE 2
+
+/*******************************************************************************
+ * MAIN
+ ******************************************************************************/
+
+int main(void) {
+  int err;
+  printf("[Test] BLE Dynamic Advertising\r\n");
+
+  uint16_t advertising_interval_ms = 500;
+  uint8_t device_name[]            = "TockOS";
+  uint8_t rand[1];
+  uint8_t manufacturer_data[] = {0x13, 0x37};
+  uint8_t device_name2[]      = "CoolOS";
+
+  printf(" - Initializing BLE...\r\n");
+  err = ble_initialize(advertising_interval_ms, true);
+  if (err < TOCK_SUCCESS)
+    printf("ble_initialize, error: %s\r\n", tock_strerror(err));
+
+  printf(" - Configure Tx Power: %d dBm ...\r\n", (int8_t)NEGATIVE_20_DBM);
+  err = ble_set_tx_power(NEGATIVE_20_DBM);
+  if (err < TOCK_SUCCESS)
+    printf("ble_set_tx_power, error: %s\r\n", tock_strerror(err));
+
+
+  // start advertising
+  printf(" - Begin advertising! %s\r\n", device_name);
+  err = ble_start_advertising();
+  if (err < TOCK_SUCCESS)
+    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+
+  // configuration complete
+  printf("Now advertising every %d ms as '%s'\r\n", advertising_interval_ms,
+         device_name);
+
+  bool toggle = true;
+
+  for ( ; ; ) {
+    // this should always return error if the logic is correct 
+    if (ble_start_advertising() >= TOCK_SUCCESS) {
+      printf("TEST FAILED\r\n");
+      return TOCK_FAIL;
+    }
+
+    // Reset advertisement buffer
+    // Use a while loop because the driver may be busy and we don't know that */
+    while (ble_reset_advertisement() != TOCK_SUCCESS) ;
+
+    // configure advertisement name the buffer should have an offset of 16 at
+    // this point
+    if (toggle == true) {
+      while (ble_advertise_name(device_name2, DEVICE_NAME_SIZE) != TOCK_SUCCESS) ;
+      while (ble_set_tx_power(ZERO_DBM) != TOCK_SUCCESS) ;
+      while (ble_set_advertisement_interval(100) != TOCK_SUCCESS) ;
+      printf("ble_dynamic_update: \r\ndevice_name: %s\t power_level: %d dBm\t advertising_interval_ms: %d\r\n", device_name2, ZERO_DBM, 100);
+      
+    }else {
+      while (ble_advertise_name(device_name, DEVICE_NAME_SIZE) != TOCK_SUCCESS) ;
+      while (ble_set_tx_power(POSITIVE_4_DBM) != TOCK_SUCCESS) ;
+      while (ble_set_advertisement_interval(300) != TOCK_SUCCESS) ;
+      printf("ble_dynamic_update: \r\ndevice_name: %s\t power_level: %d dBm \t, advertising_interval_ms: %d\r\n", device_name, POSITIVE_4_DBM, 300);
+    }
+
+    // generate a random value between 0 - 20
+    rng_sync(rand, 4, 4);
+    int r = rand[0] % 20;
+
+    // Each iteration will the advertisement buffer with 4 bytes
+    // Len | 0xff | 0x13 | 0x37
+    // So, 39 - 16 = 23
+    // r >= 8 could create a buffer overflow in the kernel if the logic is
+    // broken, thus if the kernel crashes => test failed
+    for (int i = 0; i < r; i++) {
+      while (ble_advertise_manufacturer_specific_data(manufacturer_data, MANUFACTURER_DATA_SIZE) != TOCK_SUCCESS) ;
+    }
+
+    toggle = !toggle;
+    delay_ms(1000);
+  }
+
+  return 0;
+}

--- a/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser1/Makefile
+++ b/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser1/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../../../
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser1/main.c
+++ b/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser1/main.c
@@ -1,0 +1,40 @@
+#include <simple_ble.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <tock.h>
+
+// Sizes in bytes
+#define DEVICE_NAME_SIZE 7
+
+int main(void) {
+  int err;
+  
+  // declarations of variables to be used in this BLE example application
+  uint16_t advertising_interval_ms = 100;
+  uint8_t device_name[]            = "TockOS1";
+
+  // configure advertisement interval to 100ms
+  // configure LE only and discoverable
+  printf(" - Initializing BLE... %s\n", device_name);
+  err = ble_initialize(advertising_interval_ms, true);
+  if (err < TOCK_SUCCESS)
+    printf("ble_initialize, error: %s\r\n", tock_strerror(err));
+
+  // configure device name as Advertiser1
+  printf(" - Setting the device name... %s\n", device_name);
+  err = ble_advertise_name(device_name, DEVICE_NAME_SIZE);
+  if (err < TOCK_SUCCESS)
+    printf("ble_advertise_name, error: %s\r\n", tock_strerror(err));
+
+  // start advertising
+  printf(" - Begin advertising! %s\n", device_name);
+  err = ble_start_advertising();
+  if (err < TOCK_SUCCESS)
+    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+
+  // configuration complete
+  printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,
+         device_name);
+  
+  return 0;
+}

--- a/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser2/Makefile
+++ b/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser2/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../../../
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser2/main.c
+++ b/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser2/main.c
@@ -1,0 +1,69 @@
+#include <simple_ble.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <tock.h>
+
+// Sizes in bytes
+#define DEVICE_NAME_SIZE 11
+#define UUIDS_SIZE 4
+#define MANUFACTURER_DATA_SIZE 2
+#define FAKE_TEMPERATURE_DATA_SIZE 2
+
+/*******************************************************************************
+ * MAIN
+ ******************************************************************************/
+
+int main(void) {
+  int err;
+
+  // declarations of variables to be used in this BLE example application
+  uint16_t advertising_interval_ms = 300;
+  uint8_t device_name[]            = "TockOS2";
+  uint16_t uuids[]                 = {0x1800, 0x1809};
+  uint8_t manufacturer_data[]      = {0x13, 0x37};
+  uint8_t fake_temperature_data[]  = {0x00, 0x00};
+
+  // configure advertisement interval to 300ms
+  // configure LE only and discoverable
+  printf(" - Initializing BLE... %s\n", device_name);
+  err = ble_initialize(advertising_interval_ms, true);
+  if (err < TOCK_SUCCESS)
+    printf("ble_initialize, error: %s\r\n", tock_strerror(err));
+
+  printf(" - Setting the device name... %s\n", device_name);
+  err = ble_advertise_name(device_name, DEVICE_NAME_SIZE);
+  if (err < TOCK_SUCCESS)
+    printf("ble_advertise_name, error: %s\r\n", tock_strerror(err));
+
+  // configure list of UUIDs */
+  printf(" - Setting the device UUID...\n");
+  err = ble_advertise_uuid16(uuids, UUIDS_SIZE);
+  if (err < TOCK_SUCCESS)
+    printf("ble_advertise_uuid16, error: %s\r\n", tock_strerror(err));
+
+  // configure manufacturer data
+  printf(" - Setting manufacturer data...\n");
+  err = ble_advertise_manufacturer_specific_data(manufacturer_data,
+                                                 MANUFACTURER_DATA_SIZE);
+  if (err < TOCK_SUCCESS)
+    printf("ble_advertise_manufacturer_specific_data, error: %s\r\n",
+           tock_strerror(err));
+
+  // configure service data
+  printf(" - Setting service data...\n");
+  err = ble_advertise_service_data(uuids[1], fake_temperature_data,
+                                   FAKE_TEMPERATURE_DATA_SIZE);
+  if (err < TOCK_SUCCESS)
+    printf("ble_advertise_service_data, error: %s\r\n", tock_strerror(err));
+
+  // start advertising
+  printf(" - Begin advertising! %s\n", device_name);
+  err = ble_start_advertising();
+  if (err < TOCK_SUCCESS)
+    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+
+  // configuration complete
+  printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,
+         device_name);
+  return 0;
+}

--- a/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser3/Makefile
+++ b/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser3/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../../../
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser3/main.c
+++ b/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser3/main.c
@@ -1,0 +1,36 @@
+#include <simple_ble.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <tock.h>
+
+// Sizes in bytes
+#define DEVICE_NAME_SIZE 7
+
+int main(void) {
+  int err;
+
+  uint16_t advertising_interval_ms = 20;
+  uint8_t device_name[]            = "TockOS3";
+
+  // configure LE only and discoverable
+  printf(" - Initializing BLE... %s\n", device_name);
+  err = ble_initialize(advertising_interval_ms, true);
+  if (err < TOCK_SUCCESS)
+    printf("ble_initialize, error: %s\r\n", tock_strerror(err));
+
+  printf(" - Setting the device name... %s\n", device_name);
+  err = ble_advertise_name(device_name, DEVICE_NAME_SIZE);
+  if (err < TOCK_SUCCESS)
+    printf("ble_advertise_name, error: %s\r\n", tock_strerror(err));
+
+  // start advertising
+  printf(" - Begin advertising! %s\n", device_name);
+  err = ble_start_advertising();
+  if (err < TOCK_SUCCESS)
+    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+
+  // configuration complete
+  printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,
+         device_name);
+  return 0;
+}

--- a/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser4/Makefile
+++ b/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser4/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../../../
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser4/main.c
+++ b/userland/examples/tests/ble/ble_nrf5x_concurrency/Advertiser4/main.c
@@ -1,0 +1,37 @@
+#include <simple_ble.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <tock.h>
+
+// Sizes in bytes
+#define DEVICE_NAME_SIZE 7
+
+int main(void) {
+  int err;
+
+  uint16_t advertising_interval_ms = 1000;
+  uint8_t device_name[]            = "TockOS4";
+
+  // configure advertisement interval to 1000ms
+  // configure LE only and discoverable
+  printf(" - Initializing BLE... %s\n", device_name);
+  err = ble_initialize(advertising_interval_ms, true);
+  if (err < TOCK_SUCCESS)
+    printf("ble_initialize, error: %s\r\n", tock_strerror(err));
+
+  printf(" - Setting the device name... %s\n", device_name);
+  err = ble_advertise_name(device_name, DEVICE_NAME_SIZE);
+  if (err < TOCK_SUCCESS)
+    printf("ble_advertise_name, error: %s\r\n", tock_strerror(err));
+
+  // start advertising
+  printf(" - Begin advertising! %s\n", device_name);
+  err = ble_start_advertising();
+  if (err < TOCK_SUCCESS)
+    printf("ble_start_advertising, error: %s\r\n", tock_strerror(err));
+
+  // configuration complete
+  printf("Now advertising every %d ms as '%s'\n", advertising_interval_ms,
+         device_name);
+  return 0;
+}

--- a/userland/examples/tests/ble/ble_nrf5x_concurrency/README.md
+++ b/userland/examples/tests/ble/ble_nrf5x_concurrency/README.md
@@ -1,0 +1,21 @@
+Bluetooth Low Energy Concurrency Test
+======================================
+
+The test launches four applications that are transmitting Bluetooth Low Energy
+advertisements periodically with different intervals.
+
+A bash script named `run.sh` builds and flashes the applications via tockloader
+then verify that all applications are found in your phone or Bluetooth Sniffer
+
+Note, that this only tests the functionality roughly and don't ensure free
+from deadlock, race-conditions and similar difficult problems.
+
+Usage
+-----------------
+```
+$ ./run.sh
+```
+
+Supported Boards
+-----------------
+nRF52-DK

--- a/userland/examples/tests/ble/ble_nrf5x_concurrency/run.sh
+++ b/userland/examples/tests/ble/ble_nrf5x_concurrency/run.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Apps
+APP1=Advertiser1
+APP1_TAB=$APP1/build/$APP1.tab
+
+APP2=Advertiser2
+APP2_TAB=$APP2/build/$APP2.tab
+
+APP3=Advertiser3
+APP3_TAB=$APP3/build/$APP3.tab
+
+APP4=Advertiser4
+APP4_TAB=$APP4/build/$APP4.tab
+
+# erase apps
+tockloader erase-apps --jtag --board nrf52dk --arch cortex-m4 --app-address 0x20000 --jtag-device nrf52
+
+# build apps
+make -C $APP1
+make -C $APP2
+make -C $APP3
+make -C $APP4
+
+# flash apps
+tockloader install --jtag --board nrf52dk --arch cortex-m4 \
+--app-address 0x20000 --jtag-device nrf52 $APP1_TAB
+tockloader install --jtag --board nrf52dk --arch cortex-m4 \
+--app-address 0x20000 --jtag-device nrf52 $APP2_TAB
+tockloader install --jtag --board nrf52dk --arch cortex-m4 \
+--app-address 0x20000 --jtag-device nrf52 $APP3_TAB
+tockloader install --jtag --board nrf52dk --arch cortex-m4 \
+--app-address 0x20000 --jtag-device nrf52 $APP4_TAB

--- a/userland/examples/tests/ble/ble_test_faulty_states/Makefile
+++ b/userland/examples/tests/ble/ble_test_faulty_states/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/ble/ble_test_faulty_states/README.md
+++ b/userland/examples/tests/ble/ble_test_faulty_states/README.md
@@ -1,0 +1,9 @@
+Bluetooth Low Energy Faulty States
+======================================
+A few very basic tests that verify that the kernel don't accept faulty state
+transitions. 
+
+Supported Boards
+-----------------
+nRF51-DK
+nRF52-DK

--- a/userland/examples/tests/ble/ble_test_faulty_states/main.c
+++ b/userland/examples/tests/ble/ble_test_faulty_states/main.c
@@ -1,0 +1,120 @@
+#include <rng.h>
+#include <simple_ble.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <timer.h>
+#include <tock.h>
+
+#define BUF_SIZE 39
+
+int test_not_initialized(void);
+int test_scan_advertise_concurrently(void);
+
+// not used
+static void callback(__attribute__((unused)) int a, __attribute__((unused)) int b, __attribute__((unused)) int c,
+                     __attribute__((unused)) void *d) {
+  return;
+}
+
+static unsigned char scan[BUF_SIZE];
+
+
+/*******************************************************************************
+ * MAIN
+ ******************************************************************************/
+int main(void) {
+  int err;
+  printf("[Test] BLE States\n");
+
+  err = test_not_initialized();
+  if (err < TOCK_SUCCESS) {
+    printf("test_not_initialized: %s\r\n", tock_strerror(err));
+    return err;
+  }
+
+  err = test_scan_advertise();
+  if (err < TOCK_SUCCESS) {
+    printf("test_scan_advertise: %s\r\n", tock_strerror(err));
+    return err;
+  }
+  printf("TEST PASSED\r\n");
+  return 0;
+}
+
+/*******************************************************************************
+ * TESTS
+ ******************************************************************************/
+int test_not_initialized(void) {
+  int err = ble_start_advertising();
+  if (err >= TOCK_SUCCESS) {
+    return err;
+  }
+
+  err = ble_stop_advertising();
+  if (err >= TOCK_SUCCESS) {
+    return err;
+  }
+
+  err = ble_start_passive_scan(0, 0, 0);
+  if (err >= TOCK_SUCCESS) {
+    return err;
+  }
+
+  err = ble_stop_passive_scan();
+  if (err >= TOCK_SUCCESS) {
+    return err;
+  }
+
+  err = ble_advertise_name(0, 0);
+  if (err >= TOCK_SUCCESS) {
+    return err;
+  }
+  return TOCK_SUCCESS;
+}
+
+int test_scan_advertise(void) {
+  int advertising_interval_ms = 20;
+  // valid
+  int err = ble_initialize(advertising_interval_ms, true);
+  if (err < TOCK_SUCCESS) {
+    return err;
+  }
+
+  // valid
+  err = ble_start_advertising();
+  if (err < TOCK_SUCCESS) {
+    return err;
+  }
+
+  // invalid, the app can't advertise and scan at the same time
+  err = ble_start_passive_scan(scan, BUF_SIZE, callback);
+  if (err >= TOCK_SUCCESS) {
+    return err;
+  }
+
+  // valid stop advertise
+  err = ble_stop_advertising();
+  if (err < TOCK_SUCCESS) {
+    return err;
+  }
+
+  // valid
+  err = ble_start_passive_scan(scan, BUF_SIZE, callback);
+  if (err < TOCK_SUCCESS) {
+    return err;
+  }
+
+  // invalid, the app can't advertise and scan at the same time
+  err = ble_start_advertising();
+  if (err >= TOCK_SUCCESS) {
+    return err;
+  }
+
+  // valid stop scanning
+  err = ble_stop_passive_scan();
+  if (err < TOCK_SUCCESS) {
+    return err;
+  }
+
+  return TOCK_SUCCESS;
+}

--- a/userland/examples/tests/ble/ble_test_tx_power/Makefile
+++ b/userland/examples/tests/ble/ble_test_tx_power/Makefile
@@ -1,0 +1,11 @@
+# Makefile for user application
+
+# Specify this directory relative to the current application.
+TOCK_USERLAND_BASE_DIR = ../../../..
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk

--- a/userland/examples/tests/ble/ble_test_tx_power/README.md
+++ b/userland/examples/tests/ble/ble_test_tx_power/README.md
@@ -1,0 +1,10 @@
+Bluetooth Low Energy Transmitting Power
+======================================
+
+A test that verifies that the kernel only accepts valid Bluetooth transmitting
+power levels which are supported by NRF5X.
+
+Supported Boards
+-----------------
+nRF51-DK
+nRF52-DK

--- a/userland/examples/tests/ble/ble_test_tx_power/main.c
+++ b/userland/examples/tests/ble/ble_test_tx_power/main.c
@@ -1,0 +1,68 @@
+#include <rng.h>
+#include <simple_ble.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <timer.h>
+#include <tock.h>
+
+#define NRF5X_POS_4_DBM   0x04
+#define NRF5X_POS_3_DBM   0x03
+#define NRF5X_0_DBM       0x00 
+#define NRF5X_NEG_4_DBM   0xfc
+#define NRF5X_NEG_8_DBM   0xf8
+#define NRF5X_NEG_12_DBM  0xf4
+#define NRF5X_NEG_16_DBM  0xf0
+#define NRF5X_NEG_20_DBM  0xec
+
+bool is_valid_power(uint8_t power);
+
+int main(void) {
+  int err;
+  printf("[NRF5X Test] BLE TxPower\n");
+
+  for (uint16_t i = 0; i <= 0xff; ++i) {
+    bool is_valid = is_valid_power(i);
+
+    if (is_valid) {
+      err = ble_set_tx_power(i);
+      if (err < TOCK_SUCCESS) {
+        printf("Test failed \t power_level %d could not be configured\r\n", i);
+        return 0;
+      }
+    }
+
+    else {
+      err = ble_set_tx_power(i);
+      if (err >= TOCK_SUCCESS) {
+        printf("Test failed \t power_level %d is configured faulty\r\n", i);
+        return 0;
+      }
+    }
+  }
+
+  printf("Test passed!!\r\n");
+  return 0;
+}
+
+bool is_valid_power(uint8_t power) { 
+  switch (power) {
+    case NRF5X_POS_4_DBM: 
+      return true;
+    case NRF5X_POS_3_DBM:
+      return true;
+    case NRF5X_0_DBM: 
+      return true;
+    case NRF5X_NEG_4_DBM:
+      return true;
+    case NRF5X_NEG_8_DBM:
+      return true;
+    case NRF5X_NEG_12_DBM:
+      return true;
+    case NRF5X_NEG_16_DBM:
+      return true;
+    case NRF5X_NEG_20_DBM:
+      return true;
+    default:
+      return false;
+  }
+}

--- a/userland/libtock/simple_ble.c
+++ b/userland/libtock/simple_ble.c
@@ -27,13 +27,6 @@ static int s_ble_configure_flags(uint8_t flags) {
   return allow(BLE_DRIVER_NUMBER, GAP_FLAGS, &flags, 1);
 }
 
-// internal helper to configure advertisement interval
-//
-// advertising_iterval_ms - advertisment intervall in millisecons
-static int s_ble_configure_advertisement_interval(uint16_t advertising_itv_ms) {
-  return command(BLE_DRIVER_NUMBER, BLE_CFG_ADV_ITV_CMD, advertising_itv_ms, 0);
-}
-
 // internal helper to configure gap data in the advertisement
 //
 // header - gap data header
@@ -72,7 +65,7 @@ int ble_initialize(uint16_t advertising_itv_ms, bool discoverable) {
   // configure advertisement interval
   // if the interval is less than 20 or bigger than 10240 to kernel
   // will use default value
-  err = s_ble_configure_advertisement_interval(advertising_itv_ms);
+  err = ble_set_advertisement_interval(advertising_itv_ms);
   if (err < TOCK_SUCCESS)
     return err;
 
@@ -149,10 +142,6 @@ int ble_start_passive_scan(uint8_t *data, uint8_t max_len,
     if (err < TOCK_SUCCESS)
       return err;
 
-    err = s_initialize_advertisement_buffer();
-    if (err < TOCK_SUCCESS)
-      return err;
-
     err =
       allow(BLE_DRIVER_NUMBER, BLE_CFG_SCAN_BUF_ALLOW, (void *)data, max_len);
     if (err < TOCK_SUCCESS)
@@ -164,4 +153,12 @@ int ble_start_passive_scan(uint8_t *data, uint8_t max_len,
 
 int ble_stop_passive_scan(void) {
   return command(BLE_DRIVER_NUMBER, BLE_ADV_STOP_CMD, 1, 0);
+}
+
+int ble_set_tx_power(TxPower_t power_level) {
+  return command(BLE_DRIVER_NUMBER, BLE_CFG_TX_POWER_CMD, power_level, 0);
+}
+
+int ble_set_advertisement_interval(uint16_t advertising_itv_ms) {
+  return command(BLE_DRIVER_NUMBER, BLE_CFG_ADV_ITV_CMD, advertising_itv_ms, 0);
 }

--- a/userland/libtock/simple_ble.h
+++ b/userland/libtock/simple_ble.h
@@ -69,6 +69,40 @@ enum {
   SIMULTANEOUS_LE_BREDR_H = 0x10  /* Not relevant - central mode only. */
 } GapFlags_t;
 
+typedef enum {
+  POSITIVE_10_DBM = 10,
+  POSITIVE_9_DBM = 9,
+  POSITIVE_8_DBM = 8,
+  POSITIVE_7_DBM = 7,
+  POSITIVE_6_DBM = 6,
+  POSITIVE_5_DBM = 5,
+  POSITIVE_4_DBM = 4,
+  POSITIVE_3_DBM = 3,
+  POSITIVE_2_DBM = 2,
+  POSITIVE_1_DBM = 1,
+  ZERO_DBM = 0,
+  NEGATIVE_1_DBM = 0xff,
+  NEGATIVE_2_DBM = 0xfe,
+  NEGATIVE_3_DBM = 0xfd,
+  NEGATIVE_4_DBM = 0xfc,
+  NEGATIVE_5_DBM = 0xfb,
+  NEGATIVE_6_DBM = 0xfa,
+  NEGATIVE_7_DBM = 0xf9,
+  NEGATIVE_8_DBM = 0xf8,
+  NEGATIVE_9_DBM = 0xf7,
+  NEGATIVE_10_DBM = 0xf6,
+  NEGATIVE_11_DBM = 0xf5,
+  NEGATIVE_12_DBM = 0xf4,
+  NEGATIVE_13_DBM = 0xf3,
+  NEGATIVE_14_DBM = 0xf2,
+  NEGATIVE_15_DBM = 0xf1,
+  NEGATIVE_16_DBM = 0xf0,
+  NEGATIVE_17_DBM = 0xef,
+  NEGATIVE_18_DBM = 0xee,
+  NEGATIVE_19_DBM = 0xed,
+  NEGATIVE_20_DBM = 0xec,
+} TxPower_t;
+
 /*******************************************************************************
  *   User-space API
  ******************************************************************************/
@@ -138,7 +172,21 @@ int ble_advertise_manufacturer_specific_data(uint8_t *data, uint8_t size_b);
 //
 int ble_start_passive_scan(uint8_t *data, uint8_t len, subscribe_cb callback);
 
+// stop passive scanning
 int ble_stop_passive_scan(void);
+
+// configure tx_power
+//
+// power_level          - transmitting power in dBM of the radio
+//                        according to Bluetooth 4.2 (-20 dBm to 10 dBm)
+//
+int ble_set_tx_power(TxPower_t power_level);
+
+// configure advertisment interval
+//
+// advertising_iterval_ms - advertisment interval in milliseconds
+//
+int ble_set_advertisement_interval(uint16_t advertising_itv_ms);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds/changes/fixes...
* Support Packets with payload up 255 bytes (but the BLE advertising driver is only using 39)
* Added more inline comments and references to Bluetooth Standard (makes the code more readable I hope)
* Added four simple tests for BLE
* Made the interface to control tx_power level and advertisement interval accessible to user-space
* Configure tx power before advertising/scanning in the Bluetooth Advertising Driver
* Added new enum for RadioFrequency for all BLE channels (0-39)
* `simple_ble::start_passive_scanning()` it doesn't make sense to initialize the advertisement buffer!

### Testing Strategy

This pull request was tested by:

- The new BLE tests (both on nrf51dk and nrf52dk)
- ble_advertising (both on nrf51dk and nrf52dk)
- ble_passive_scanning (both on nrf51dk and nrf52dk)


### TODO or Help Wanted


### Documentation Updated

- [X] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [X] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [X] `make formatall` has been run.

  