### PR TITLE
Add support for the teensy 3.2

### DIFF
--- a/apps/MakeVariables.mk
+++ b/apps/MakeVariables.mk
@@ -1,0 +1,2 @@
+APPS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+TOCK_USERLAND_BASE_DIR := $(APPS_DIR)../tock/userland

--- a/apps/examples/blink/Makefile
+++ b/apps/examples/blink/Makefile
@@ -1,0 +1,15 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/blink/main.c
+++ b/apps/examples/blink/main.c
@@ -1,0 +1,22 @@
+#include <led.h>
+#include <timer.h>
+
+int main(void) {
+  // Ask the kernel how many LEDs are on this board.
+  int num_leds = led_count();
+
+  // Blink the LEDs in a binary count pattern and scale
+  // to the number of LEDs on the board.
+  for (int count = 0; ; count++) {
+    for (int i = 0; i < num_leds; i++) {
+      if (count & (1 << i)) {
+        led_on(i);
+      } else {
+        led_off(i);
+      }
+    }
+
+    // This delay uses an underlying timer in the kernel.
+    delay_ms(250);
+  }
+}

--- a/apps/examples/dotstar/colorwheel/Makefile
+++ b/apps/examples/dotstar/colorwheel/Makefile
@@ -1,0 +1,15 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/dotstar/colorwheel/main.c
+++ b/apps/examples/dotstar/colorwheel/main.c
@@ -1,0 +1,197 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+
+// Tock API
+#include <led.h>
+#include <timer.h>
+#include <spi.h>
+
+// Number of active pixels on the Dotstar LED strip.
+// You may need to decrease this number if your power supply is not strong
+// enough.
+#define NUM_PIXELS 150
+#define PIXEL_BUFFER_SIZE ((NUM_PIXELS*4) + 8)
+
+// Global buffer which holds all of the pixels.
+static char pixels[PIXEL_BUFFER_SIZE];
+
+// Needed for the spi_read_write call; unused.
+static char rbuf[PIXEL_BUFFER_SIZE];
+
+// Dotstar strips expect the pixel colors to be set blue first, green second,
+// and red third.
+static const uint32_t BLUE_OFFSET = 1;
+static const uint32_t GREEN_OFFSET = 2;
+static const uint32_t RED_OFFSET = 3;
+
+// Constants used when converting between a Color and its RGB components.
+#define COLOR_SHIFT(x) ((8 * (3 - x)))
+#define RED_SHIFT COLOR_SHIFT(RED_OFFSET)
+#define BLUE_SHIFT COLOR_SHIFT(BLUE_OFFSET)
+#define GREEN_SHIFT COLOR_SHIFT(GREEN_OFFSET)
+
+// Constants used when getting and setting pixel values.
+#define PIXEL_INDEX(i, c) (((i * 4) + 4 + c))
+#define RED_INDEX(i) (PIXEL_INDEX(i, RED_OFFSET))
+#define BLUE_INDEX(i) (PIXEL_INDEX(i, BLUE_OFFSET))
+#define GREEN_INDEX(i) (PIXEL_INDEX(i, GREEN_OFFSET))
+
+// A Color is a 'packed' representation of its RGB components.
+typedef uint32_t Color;
+
+/**
+ * Extract the color components from a Color.
+ * @{
+ */
+static uint8_t red(Color color) {
+    return (uint8_t)((color >> RED_SHIFT) & 0xFF);
+}
+
+static uint8_t green(Color color) {
+    return (uint8_t)((color >> GREEN_SHIFT) & 0xFF);
+}
+
+static uint8_t blue(Color color) {
+    return (uint8_t)((color >> BLUE_SHIFT) & 0xFF);
+}
+/**
+ * @}
+ */
+
+/**
+ * Create a Color from its individual components.
+ */
+static Color color(uint8_t r, uint8_t g, uint8_t b) {
+    return (r << RED_SHIFT) | (g << GREEN_SHIFT) | (b << BLUE_SHIFT);
+}
+
+/**
+ * Calculate a color along a color wheel, which cycles from red to blue to green
+ * and back.
+ *
+ * @param wheelpos A value from 0-255 representing the position along the color
+ *                 wheel.
+ * @returns The Color corresponding to the given position in the color wheel.
+ */
+static Color wheel(uint8_t wheelpos) {
+    wheelpos = 255 - wheelpos;
+    if (wheelpos < 85) return color(255 - wheelpos * 3, 0, wheelpos * 3);
+
+    if (wheelpos < 170) {
+        wheelpos -= 85;
+        return color(0, wheelpos*3, 255 - wheelpos * 3);
+    }
+
+    wheelpos -= 170;
+    return color(wheelpos*3, 255 - wheelpos * 3, 0);
+}
+
+/**
+ * Callback for the SPI write operation in update_strip().
+ */
+static void write_cb(__attribute__ ((unused)) int arg0,
+                     __attribute__ ((unused)) int arg2,
+                     __attribute__ ((unused)) int arg3,
+                     __attribute__ ((unused)) void* userdata) {
+}
+
+/**
+ * Set the color of the pixel at the given index.
+ *
+ * This does not actually update the LED strip, but instead just modifies the
+ * pixel's color in the pixel buffer. To display the new color on the strip, you
+ * must call update_strip().
+ */
+static void set_pixel(uint32_t pixel, Color color) {
+    pixels[RED_INDEX(pixel)] = red(color);
+    pixels[GREEN_INDEX(pixel)] = green(color);
+    pixels[BLUE_INDEX(pixel)] = blue(color);
+}
+
+/**
+ * Get the color of the pixel at the given index.
+ *
+ * This does not return the pixel color as it is currently displayed on the
+ * strip, but rather the color in the pixel buffer that has been set by set_pixel().
+ */
+static Color __attribute__((unused)) get_pixel(uint32_t pixel) {
+    return color(pixels[RED_INDEX(pixel)],
+                 pixels[GREEN_INDEX(pixel)],
+                 pixels[BLUE_INDEX(pixel)]);
+}
+
+/**
+ * Initialize the SPI and the pixel buffer in order to use the LED strip.
+ *
+ * This function must be called once before ever calling update_strip().
+ * All pixels in the buffer will be initially set to zero (off).
+ */
+static void initialize_strip(void) {
+    spi_set_chip_select(0);
+    spi_set_rate(12e6);
+    spi_set_polarity(false);
+    spi_set_phase(false);
+
+    int i;
+    for (i = 0; i < 4; i++) {
+        pixels[i] = 0x0;
+    }
+
+    for (i = 4; i < PIXEL_BUFFER_SIZE; i++) {
+        pixels[i] = 0xFF;
+    }
+
+    for (i = 0; i < NUM_PIXELS; i++) {
+        set_pixel(i, 0);
+    }
+}
+
+/**
+ * Write all pixel values to the Dotstar LED strip.
+ *
+ * This function is what actually displays the new pixel colors onto the strip.
+ * Before using this function, you must first have called initialize_strip().
+ */
+static void update_strip(void) {
+    spi_read_write(pixels, rbuf, PIXEL_BUFFER_SIZE, write_cb, NULL);
+}
+
+/**
+ * Simple animation which cycles two simultaneous color wheels on the Dotstar LED strip.
+ */
+int main(void) {
+    // Needed before calling update_strip(). All pixels in the buffer are
+    // initialized to zero.
+    initialize_strip();
+
+    // Position in the forward color wheel.
+    uint8_t wf = 0;
+
+    // Position in the backward color wheel.
+    uint8_t wb = 255;
+
+    while (1) {
+        // Set the forward color wheel pixels.
+        int i;
+        for (i = 0; i < NUM_PIXELS; i+=4) {
+            set_pixel(i, wheel(wf+(i/4)));
+        }
+
+        // Set the backward color wheel pixels.
+        for (i = 2; i < NUM_PIXELS; i+=4) {
+            set_pixel(i, wheel(wb-(i/4)));
+        }
+
+        // Advance along the two wheels at different rates to make the pattern
+        // more interesting.
+        wf++;
+        wb-=2;
+
+        // Display the new pixel values.
+        update_strip();
+
+        // Wait 20 milliseconds before displaying the next update.
+        delay_ms(20);
+    }
+}

--- a/apps/examples/dotstar/cylon/Makefile
+++ b/apps/examples/dotstar/cylon/Makefile
@@ -1,0 +1,15 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/dotstar/cylon/main.c
+++ b/apps/examples/dotstar/cylon/main.c
@@ -1,0 +1,113 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <led.h>
+#include <timer.h>
+#include <spi.h>
+
+#include <stdint.h>
+
+#define NUM_PIXELS 150
+#define PIXEL_BUFFER_SIZE ((NUM_PIXELS*4) + 8)
+
+static char pixels[PIXEL_BUFFER_SIZE];
+static char rbuf[PIXEL_BUFFER_SIZE];
+static uint32_t RED_OFFSET = 3;
+static uint32_t GREEN_OFFSET = 2;
+static uint32_t BLUE_OFFSET = 1;
+
+static void initialize_strip(void) {
+    spi_set_chip_select(0);
+    spi_set_rate(12e6);
+    spi_set_polarity(false);
+    spi_set_phase(false);
+
+    int i;
+    for (i = 0; i < 4; i++) {
+        pixels[i] = 0x0;
+    }
+
+    for (i = 4; i < PIXEL_BUFFER_SIZE; i++) {
+        pixels[i] = 0xFF;
+    }
+}
+
+static uint8_t red(uint32_t color) {
+    return (uint8_t)((color >> (8*(3 - RED_OFFSET))) & 0xFF);
+}
+
+static uint8_t green(uint32_t color) {
+    return (uint8_t)((color >> (8*(3 - GREEN_OFFSET))) & 0xFF);
+}
+
+static uint8_t blue(uint32_t color) {
+    return (uint8_t)((color >> (8*(3 - BLUE_OFFSET))) & 0xFF);
+}
+
+static uint32_t color(uint8_t r, uint8_t g, uint8_t b) {
+    return 0 | (r << (8*(3 - RED_OFFSET))) | (g << (8*(3 - GREEN_OFFSET))) | (b << (8*(3 - BLUE_OFFSET)));
+}
+
+static void set_pixel(uint32_t pixel, uint32_t color) {
+    pixels[pixel*4 + 4 + RED_OFFSET] = red(color);
+    pixels[pixel*4 + 4 + BLUE_OFFSET] = blue(color);
+    pixels[pixel*4 + 4 + GREEN_OFFSET] = green(color);
+}
+
+
+static uint32_t __attribute__((unused)) get_pixel(uint32_t pixel) {
+    return color(pixels[pixel*4 + 4 + RED_OFFSET],
+                 pixels[pixel*4 + 4 + GREEN_OFFSET],
+                 pixels[pixel*4 + 4 + BLUE_OFFSET]);
+}
+
+static uint32_t wheel(uint8_t wheelpos) {
+    wheelpos = 255 - wheelpos;
+    if (wheelpos < 85) return color(255 - wheelpos * 3, 0, wheelpos * 3);
+
+    if (wheelpos < 170) {
+        wheelpos -= 85;
+        return color(0, wheelpos*3, 255 - wheelpos * 3);
+    }
+
+    wheelpos -= 170;
+    return color(wheelpos*3, 255 - wheelpos * 3, 0);
+}
+
+static void write_cb(__attribute__ ((unused)) int arg0,
+                     __attribute__ ((unused)) int arg2,
+                     __attribute__ ((unused)) int arg3,
+                     __attribute__ ((unused)) void* userdata) {
+}
+
+
+static void update_strip(void) {
+    spi_read_write(pixels, rbuf, PIXEL_BUFFER_SIZE, write_cb, NULL);
+}
+
+int main(void) {
+    initialize_strip();
+
+    int i;
+    for (i = 0; i < NUM_PIXELS; i++) {
+        set_pixel(i, 0);
+        update_strip();
+    }
+
+    uint8_t w = 0;
+    uint8_t wb = 255;
+    int which = 0;
+    int dir = 1;
+    while (1) {
+        delay_ms(20);
+        set_pixel(which, color(0, 0, 0));
+        which = which + dir;
+        set_pixel(which, color(32, 32, 32));
+        if (which == NUM_PIXELS) {
+           dir = -1;
+        } else if (which == 0) {
+           dir = 1;
+        }
+        update_strip();
+    }
+}

--- a/apps/examples/gpio/Makefile
+++ b/apps/examples/gpio/Makefile
@@ -1,0 +1,15 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/gpio/main.c
+++ b/apps/examples/gpio/main.c
@@ -1,0 +1,97 @@
+/* vim: set sw=2 expandtab tw=80: */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <console.h>
+#include <gpio.h>
+#include <led.h>
+#include <timer.h>
+#include <tock.h>
+
+// callback for timers
+static void timer_cb (__attribute__ ((unused)) int arg0,
+                      __attribute__ ((unused)) int arg1,
+                      __attribute__ ((unused)) int arg2,
+                      __attribute__ ((unused)) void* userdata) {}
+
+// **************************************************
+// GPIO output example
+// **************************************************
+static void gpio_output(void) {
+  printf("Periodically blinking LED\n");
+
+  // Start repeating timer
+  tock_timer_t timer;
+  timer_every(500, timer_cb, NULL, &timer);
+
+  while (1) {
+    led_toggle(0);
+    yield();
+  }
+}
+
+// **************************************************
+// GPIO input example
+// **************************************************
+static void gpio_input(void) {
+  printf("Periodically reading value of the GPIO 0 pin\n");
+  printf("Jump pin high to test (defaults to low)\n");
+
+  // set LED pin as input and start repeating timer
+  // pin is configured with a pull-down resistor, so it should read 0 as default
+  gpio_enable_input(0, PullDown);
+  tock_timer_t timer;
+  timer_every(500, timer_cb, NULL, &timer);
+
+  while (1) {
+    // print pin value
+    int pin_val = gpio_read(0);
+    printf("\tValue(%d)\n", pin_val);
+    yield();
+  }
+}
+
+// **************************************************
+// GPIO interrupt example
+// **************************************************
+static void gpio_cb (__attribute__ ((unused)) int pin_num,
+                     __attribute__ ((unused)) int arg2,
+                     __attribute__ ((unused)) int arg3,
+                     __attribute__ ((unused)) void* userdata) {}
+
+static void gpio_interrupt(void) {
+  printf("Print GPIO 0 pin reading whenever its value changes\n");
+  printf("Jump pin high to test\n");
+
+  // set callback for GPIO interrupts
+  gpio_interrupt_callback(gpio_cb, NULL);
+
+  // set LED as input and enable interrupts on it
+  gpio_enable_interrupt(0, PullUp, Change);
+
+  while (1) {
+    yield();
+    int pin_val = gpio_read(0);
+    printf("\tGPIO Interrupt! Value: %d\n", pin_val);
+  }
+}
+
+
+int main(void) {
+  printf("*********************\n");
+  printf("GPIO Test Application\n");
+
+  // Set mode to which test you want
+  uint8_t mode = 0;
+
+  switch (mode) {
+    case 0: gpio_interrupt(); break;
+    case 1: gpio_output(); break;
+    case 2: gpio_input(); break;
+  }
+
+  return 0;
+}

--- a/apps/examples/hello_world/Makefile
+++ b/apps/examples/hello_world/Makefile
@@ -1,0 +1,15 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/hello_world/main.c
+++ b/apps/examples/hello_world/main.c
@@ -1,0 +1,24 @@
+#include <led.h>
+#include <timer.h>
+#include <stdio.h>
+
+int main(void) {
+  // Ask the kernel how many LEDs are on this board.
+  int num_leds = led_count();
+
+  // Blink the LEDs in a binary count pattern and scale
+  // to the number of LEDs on the board.
+  for (int count = 0; ; count++) {
+    for (int i = 0; i < num_leds; i++) {
+      if (count & (1 << i)) {
+        led_on(i);
+      } else {
+        led_off(i);
+      }
+    }
+    printf("Hi there! %d\r\n", count);
+
+    // This delay uses an underlying timer in the kernel.
+    delay_ms(250);
+  }
+}

--- a/apps/examples/multi_spi_tx/Makefile
+++ b/apps/examples/multi_spi_tx/Makefile
@@ -1,0 +1,19 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include libteensy header files
+override CPPFLAGS += -I../../../libteensy
+EXTERN_LIBS += ../../../libteensy
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/multi_spi_tx/main.c
+++ b/apps/examples/multi_spi_tx/main.c
@@ -1,0 +1,69 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <led.h>
+#include <spi.h>
+
+#include <multispi.h>
+#include <timer.h>
+
+#define BUF_SIZE 200
+char rbuf[BUF_SIZE];
+char wbuf[BUF_SIZE];
+const char *msg = "Hello World!\r\n";
+bool toggle = true;
+
+static void write_cb(__attribute__ ((unused)) int arg0,
+                     __attribute__ ((unused)) int arg2,
+                     __attribute__ ((unused)) int arg3,
+                     __attribute__ ((unused)) void* userdata) {
+  led_toggle(0);
+  delay_ms(200);
+  select_spi_bus(0);
+  spi_read_write_sync(wbuf, rbuf, BUF_SIZE);
+
+  select_spi_bus(1);
+  spi_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
+}
+
+// This function can operate in one of two modes. Either
+// a periodic timer triggers an SPI operation, or SPI
+// operations are performed back-to-back (callback issues
+// the next one.) The periodic one writes 6 byte messages,
+// the back-to-back writes a 10 byte message, followed by
+// 6 byte ones.
+//
+// In both cases, the calls alternate on which of two
+// buffers is used as the write buffer. The first call
+// uses the buffer initialized to 0..199. The
+// 2n calls use the buffer initialized to 0.
+//
+// If you use back-to-back operations, the calls
+// both read and write. Periodic operations only
+// write. Therefore, if you set SPI to loopback
+// and use back-to-back // loopback, then the read buffer
+// on the first call will read in the data written.  As a
+// result, you can check if reads work properly: all writes
+// will be 0..n rather than all 0s.
+
+int main(void) {
+  int i;
+  for (i = 0; i < 200; i++) {
+    wbuf[i] = msg[i % 15];
+  }
+  select_spi_bus(0);
+  spi_set_chip_select(0);
+  spi_set_rate(10e6);
+  spi_set_polarity(true);
+  spi_set_phase(true);
+
+  spi_read_write_sync(wbuf, rbuf, BUF_SIZE);
+
+  select_spi_bus(1);
+  spi_set_chip_select(0);
+  spi_set_rate(20e6);
+  spi_set_polarity(false);
+  spi_set_phase(false);
+
+  spi_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
+}

--- a/apps/examples/serial_seven_segment/Makefile
+++ b/apps/examples/serial_seven_segment/Makefile
@@ -1,0 +1,15 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/serial_seven_segment/main.c
+++ b/apps/examples/serial_seven_segment/main.c
@@ -1,0 +1,47 @@
+#include <led.h>
+#include <timer.h>
+#include <stdio.h>
+
+static char digits[] = "0000";
+
+void update_display(char *d) {
+    printf("%c%c%c%c", d[0], d[1], d[2], d[3]);
+    fflush(stdout);
+}
+
+void reset_display() {
+    printf("\x81");
+    fflush(stdout);
+}
+
+int main(void) {
+    reset_display();
+
+    while (1) {
+        // This delay uses an underlying timer in the kernel.
+        delay_ms(50);
+
+        update_display(digits);
+
+        if (digits[3] == '9') {
+            digits[3] = '0';
+            if (digits[2] == '9') {
+                digits[2] = '0';
+                if (digits[1] == '9') {
+                    digits[1] = '0';
+                    if (digits[0] == '9') {
+                        digits[0] = '0';
+                    } else {
+                        digits[0]++;
+                    }
+                } else {
+                    digits[1]++;
+                }
+            } else {
+                digits[2]++;
+            }
+        } else {
+            digits[3]++;
+        }
+    }
+}

--- a/apps/examples/spi_rx/Makefile
+++ b/apps/examples/spi_rx/Makefile
@@ -1,0 +1,19 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include libteensy header files
+override CPPFLAGS += -I../../../libteensy
+EXTERN_LIBS += ../../../libteensy
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/spi_rx/main.c
+++ b/apps/examples/spi_rx/main.c
@@ -1,0 +1,68 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <led.h>
+#include <spi.h>
+#include <multispi.h>
+#include <timer.h>
+
+#define BUF_SIZE 200
+char rbuf[BUF_SIZE];
+char wbuf[BUF_SIZE];
+bool toggle = true;
+
+static void write_cb(__attribute__ ((unused)) int arg0,
+                     __attribute__ ((unused)) int arg2,
+                     __attribute__ ((unused)) int arg3,
+                     __attribute__ ((unused)) void* userdata) {
+  int i;
+  for (i = 0; i < BUF_SIZE; i++) {
+    if (rbuf[i] != wbuf[i]) {
+        printf("Receive failed at character %i\r\n", i);
+        led_on(0);
+        while (1) {}
+    }
+  }
+
+  for (i = 0; i < BUF_SIZE; i++) {
+    wbuf[i]++;
+  }
+
+  delay_ms(500);
+
+  spi_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
+}
+
+// This function can operate in one of two modes. Either
+// a periodic timer triggers an SPI operation, or SPI
+// operations are performed back-to-back (callback issues
+// the next one.) The periodic one writes 6 byte messages,
+// the back-to-back writes a 10 byte message, followed by
+// 6 byte ones.
+//
+// In both cases, the calls alternate on which of two
+// buffers is used as the write buffer. The first call
+// uses the buffer initialized to 0..199. The
+// 2n calls use the buffer initialized to 0.
+//
+// If you use back-to-back operations, the calls
+// both read and write. Periodic operations only
+// write. Therefore, if you set SPI to loopback
+// and use back-to-back // loopback, then the read buffer
+// on the first call will read in the data written.  As a
+// result, you can check if reads work properly: all writes
+// will be 0..n rather than all 0s.
+
+int main(void) {
+  int i;
+  for (i = 0; i < BUF_SIZE; i++) {
+    wbuf[i] = i;
+  }
+
+  select_spi_bus(0);
+  spi_set_chip_select(0);
+  spi_set_rate(20000000);
+  spi_set_polarity(false);
+  spi_set_phase(false);
+  spi_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
+}

--- a/apps/examples/spi_tx/Makefile
+++ b/apps/examples/spi_tx/Makefile
@@ -1,0 +1,15 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/spi_tx/main.c
+++ b/apps/examples/spi_tx/main.c
@@ -1,0 +1,51 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <led.h>
+#include <spi.h>
+
+#define BUF_SIZE 200
+char rbuf[BUF_SIZE];
+char wbuf[BUF_SIZE];
+bool toggle = true;
+
+static void write_cb(__attribute__ ((unused)) int arg0,
+                     __attribute__ ((unused)) int arg2,
+                     __attribute__ ((unused)) int arg3,
+                     __attribute__ ((unused)) void* userdata) {
+  // led_toggle(0);
+  // printf("Callback\r\n");
+  spi_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
+}
+
+// This function can operate in one of two modes. Either
+// a periodic timer triggers an SPI operation, or SPI
+// operations are performed back-to-back (callback issues
+// the next one.) The periodic one writes 6 byte messages,
+// the back-to-back writes a 10 byte message, followed by
+// 6 byte ones.
+//
+// In both cases, the calls alternate on which of two
+// buffers is used as the write buffer. The first call
+// uses the buffer initialized to 0..199. The
+// 2n calls use the buffer initialized to 0.
+//
+// If you use back-to-back operations, the calls
+// both read and write. Periodic operations only
+// write. Therefore, if you set SPI to loopback
+// and use back-to-back // loopback, then the read buffer
+// on the first call will read in the data written.  As a
+// result, you can check if reads work properly: all writes
+// will be 0..n rather than all 0s.
+
+int main(void) {
+  int i;
+  for (i = 0; i < 200; i++) {
+    wbuf[i] = i;
+  }
+  spi_set_chip_select(0);
+  spi_set_rate(20000000);
+  spi_set_polarity(false);
+  spi_set_phase(false);
+  spi_read_write(wbuf, rbuf, BUF_SIZE, write_cb, NULL);
+}

--- a/apps/examples/uart_echo/Makefile
+++ b/apps/examples/uart_echo/Makefile
@@ -1,0 +1,15 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/uart_echo/README
+++ b/apps/examples/uart_echo/README
@@ -1,0 +1,21 @@
+This application is a simple user-space UART echo program.
+
+It buffers 20 bytes read over UART1 and then outputs it over UART1.
+
+To test this program, connect a USB serial converter to RX1 and TX1 on
+your Teensy, the run
+
+screen <serial port> 115200
+
+e.g.
+
+screen /dev/tty.SLAB_USBtoUART 115200
+
+And type. After you type 20 characters you should see output like this:
+
+Read returned 20.
+sdabcdefghijklmnopqrRead returned 20.
+stuvwxyzabcdefghijkl
+
+- Philip Levis, pal@cs.stanford.edu, 11/15/17
+

--- a/apps/examples/uart_echo/main.c
+++ b/apps/examples/uart_echo/main.c
@@ -1,0 +1,17 @@
+#include <led.h>
+#include <timer.h>
+#include <stdio.h>
+
+int serial_read(char* buf, size_t len);
+
+char buf[128];
+
+int main(void) {
+  printf("Starting uart_echo.\r\n");
+  while (1) {
+    int rval = serial_read(buf, 20);
+    printf("Read returned %i.\r\n", rval);
+    buf[rval] = 0;
+    serial_write(buf, rval);
+  }
+}

--- a/apps/examples/uart_echo/serial.c
+++ b/apps/examples/uart_echo/serial.c
@@ -1,0 +1,59 @@
+#include <tock.h>
+
+int serial_read_short(char* buf, size_t len);
+int serial_read(char* buf, size_t len);
+int serial_write(char* buf, size_t len);
+
+int serial_read_short(char* buf, size_t len) {
+  int read_len = 0;
+  void read_callback(int rlen,
+                     __attribute__ ((unused)) int unused1,
+                     __attribute__ ((unused)) int unused2,
+                     void* ud) {
+    *((bool*)ud) = true;
+    read_len = rlen;
+  }
+
+  int ret = allow(1, 0, buf, len);
+  bool done = false;
+  if (ret < 0)  return ret;
+  ret = subscribe(1, 0, read_callback, &done);
+  if (ret < 0)  return ret;
+  ret = command(1, 2, len, 0);
+  if (ret < 0)  return ret;
+  yield_for(&done);
+  return read_len;
+}
+
+int serial_read(char* buf, size_t len) {
+  size_t index;
+  for (index = 0; index < len;) {
+    size_t left = len - index;
+    size_t count = serial_read_short(buf + index, left);
+    index += count;
+  }
+  return (int)index;
+}
+
+int serial_write(char* buf, size_t len) {
+  int write_len = 0;
+  void write_callback(int wlen,
+                     __attribute__ ((unused)) int unused1,
+                     __attribute__ ((unused)) int unused2,
+                     void* ud) {
+    *((bool*)ud) = true;
+    write_len = wlen;
+  }
+  bool done = false;
+
+  int ret = allow(1, 1, buf, len);
+  if (ret < 0) return ret;
+
+  ret = subscribe(1, 1, write_callback, &done);
+  if (ret < 0) return ret;
+
+  ret = command(1, 1, len, 0);
+  yield_for(&done);
+  return write_len;
+}
+

--- a/apps/examples/xmodem_leds/Makefile
+++ b/apps/examples/xmodem_leds/Makefile
@@ -1,0 +1,15 @@
+# Makefile for user applications
+
+# Specify this directory relative to the current application.
+# NOTE: This should be the only line, if any, that you need to change to build
+# basic C applications.
+include ../../MakeVariables.mk
+
+# Which files to compile.
+C_SRCS := $(wildcard *.c)
+
+# Include userland master makefile. Contains rules and flags for actually
+# building the application.
+include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
+
+APP=$(patsubst $(APPS_DIR),,$(CURDIR))

--- a/apps/examples/xmodem_leds/README
+++ b/apps/examples/xmodem_leds/README
@@ -1,0 +1,34 @@
+This is an example of how to use the xmodem library to upload
+images into memory. This application has a single pixel buffer
+for a dotstar LED strip, that is 150 pixels long. It registers
+the buffer with the xmodem library. You can then send it new values
+for the pixel buffer over xmodem. When the application is notified
+that the buffer has changed it outputs it to a strip connected on
+SPI1.
+
+There is a python script, xmodem_send.py, which will transfer
+a file over the serial port with xmodem. Its basic use is:
+
+xmodem_send.py <file>
+
+There are two sample pixel images, strip.bin, which makes the 
+first 63 pixels a somewhat dim purple, and dark.bin, which makes
+all 144 pixels dark. So, for example, if you plug a USB serial
+device into RX1 and TX1, install this program on your teensy, and
+run
+
+xmodem_send.py strip.bin
+
+you should see the first 63 pixels light up purple. The starting image
+has pixel 9 lit. You may need to install serial port/xmodem librarys
+for Python; Google should tell you how if you need to.
+
+The script write_file.py is a very simple python script that lets 
+you easily write new display for your strip.
+
+The xmodem functionality is implemented in xmodem.c. To use the library,
+simply copy this file to your application directory, as well as
+xmodem.h. The build system should automatically compile it with your
+main.c.
+
+- Philip Levis, pal@cs.stanford.edu 11/15/17

--- a/apps/examples/xmodem_leds/main.c
+++ b/apps/examples/xmodem_leds/main.c
@@ -1,0 +1,106 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <led.h>
+#include <timer.h>
+#include <spi.h>
+
+#include <stdint.h>
+#include "xmodem.h"
+
+#define NUM_PIXELS 150
+#define PIXEL_BUFFER_SIZE ((NUM_PIXELS*4) + 8)
+
+static char pixels[PIXEL_BUFFER_SIZE];
+static char rbuf[PIXEL_BUFFER_SIZE];
+static uint32_t RED_OFFSET = 3;
+static uint32_t GREEN_OFFSET = 2;
+static uint32_t BLUE_OFFSET = 1;
+
+void xmodem_callback(char* buf, int len, int error);
+
+static void initialize_strip(void) {
+    spi_set_chip_select(0);
+    spi_set_rate(12e6);
+    spi_set_polarity(false);
+    spi_set_phase(false);
+
+    int i;
+    for (i = 0; i < 4; i++) {
+        pixels[i] = 0x0;
+    }
+
+    for (i = 4; i < PIXEL_BUFFER_SIZE; i++) {
+        pixels[i] = 0xFF;
+    }
+}
+
+static uint8_t red(uint32_t color) {
+    return (uint8_t)((color >> (8*(3 - RED_OFFSET))) & 0xFF);
+}
+
+static uint8_t green(uint32_t color) {
+    return (uint8_t)((color >> (8*(3 - GREEN_OFFSET))) & 0xFF);
+}
+
+static uint8_t blue(uint32_t color) {
+    return (uint8_t)((color >> (8*(3 - BLUE_OFFSET))) & 0xFF);
+}
+
+static uint32_t color(uint8_t r, uint8_t g, uint8_t b) {
+    return 0 | (r << (8*(3 - RED_OFFSET))) | (g << (8*(3 - GREEN_OFFSET))) | (b << (8*(3 - BLUE_OFFSET)));
+}
+
+static void set_pixel(uint32_t pixel, uint32_t color) {
+    pixels[pixel*4 + 4 + RED_OFFSET] = red(color);
+    pixels[pixel*4 + 4 + BLUE_OFFSET] = blue(color);
+    pixels[pixel*4 + 4 + GREEN_OFFSET] = green(color);
+}
+
+
+static uint32_t __attribute__((unused)) get_pixel(uint32_t pixel) {
+    return color(pixels[pixel*4 + 4 + RED_OFFSET],
+                 pixels[pixel*4 + 4 + GREEN_OFFSET],
+                 pixels[pixel*4 + 4 + BLUE_OFFSET]);
+}
+
+static void write_cb(__attribute__ ((unused)) int arg0,
+                     __attribute__ ((unused)) int arg2,
+                     __attribute__ ((unused)) int arg3,
+                     __attribute__ ((unused)) void* userdata) {
+}
+
+
+static void update_strip(void) {
+    spi_read_write(pixels, rbuf, PIXEL_BUFFER_SIZE, write_cb, NULL);
+}
+
+bool update = false;
+void xmodem_callback(__attribute__ ((unused)) char* buf, 
+		     __attribute__ ((unused)) int len, 
+		     __attribute__ ((unused)) int error) {
+    update = true;
+}
+
+int main(void) {
+    initialize_strip();
+    xmodem_init();
+    xmodem_set_buffer(pixels, PIXEL_BUFFER_SIZE);
+    xmodem_set_callback(xmodem_callback);
+    int i;
+    for (i = 0; i < NUM_PIXELS; i++) {
+        set_pixel(i, 0);
+        update_strip();
+    }
+    set_pixel(8, color(32, 32, 32));
+    update_strip();
+    set_pixel(9, color(32, 32, 32));
+    set_pixel(11, color(32, 32, 32));
+    while (1) {
+        yield();
+	if (update) {
+            update = false;
+            update_strip();
+	}
+    }
+}

--- a/apps/examples/xmodem_leds/write_file.py
+++ b/apps/examples/xmodem_leds/write_file.py
@@ -1,0 +1,14 @@
+#!env python
+
+f = open("dark.bin", 'wb');
+f.write(b'\x00')
+f.write(b'\x00')
+f.write(b'\x00')
+f.write(b'\x00')
+for i in range(0,144):
+    f.write(b'\xff')
+    f.write(b'\x00')
+    f.write(b'\x00')
+    f.write(b'\x00')
+f.close()
+

--- a/apps/examples/xmodem_leds/xmodem.c
+++ b/apps/examples/xmodem_leds/xmodem.c
@@ -1,0 +1,286 @@
+#include <tock.h>
+#include <timer.h>
+#include <led.h>
+#include <console.h>
+
+// Set the buffer that xmodem should fill with a transfer.
+void xmodem_set_buffer(char* buf, size_t len);
+
+// The callback that indicates an xmodem transfer completed.
+// After this callback is issued, the xmodem library will wait
+// until a new buffer is set with xmodem_set_buffer  before accepting
+// a new transfer.
+typedef void xmodem_cb(char* buf, int len, int error);
+
+void xmodem_set_callback(xmodem_cb buffer_filled);
+void xmodem_restart_transfer(void);
+void xmodem_restart_block(void);
+int xmodem_write(uint8_t byte);
+int xmodem_init(void);
+
+void xmodem_read_callback(__attribute__ ((unused)) int unused0,
+                          __attribute__ ((unused)) int unused1,
+                          __attribute__ ((unused)) int unused2,
+                          __attribute__ ((unused))void* ud);
+void xmodem_write_callback(__attribute__ ((unused)) int unused0,
+                          __attribute__ ((unused)) int unused1,
+                          __attribute__ ((unused)) int unused2,
+                          __attribute__ ((unused))void* ud);
+void xmodem_timer_callback(__attribute__ ((unused)) int unused0,
+                          __attribute__ ((unused)) int unused1,
+                          __attribute__ ((unused)) int unused2,
+                          __attribute__ ((unused))void* ud);
+
+typedef enum {
+  STOP,
+  NEW_BLOCK,
+  BLOCK_NUMBER,
+  BLOCK_INVERSE,
+  DATA,
+  CHECKSUM
+} xmodem_state_t;
+
+enum {
+        SOH = 0x01,   // Start Of Header
+        ACK = 0x06,   // Acknowledge (positive)
+        NAK = 0x15,   // Acknowledge (negative)
+        EOT = 0x04,   // End of transmission
+        PAYLOAD_SIZE = 128,
+        ARMBASE = 0x8000
+};
+
+
+static xmodem_state_t xmodem_state = STOP;
+static uint8_t xmodem_write_busy = false;
+static const uint32_t XMODEM_TIMEOUT = 4000;
+static uint8_t xmodem_byte_count;
+static uint8_t xmodem_recv;
+static uint8_t xmodem_send;
+static uint8_t xmodem_block_number;
+static uint8_t xmodem_checksum;
+static tock_timer_t xmodem_timer;
+static char* xmodem_buffer = NULL;
+static size_t xmodem_buffer_len = 0;
+static xmodem_cb* xmodem_callback = NULL;
+
+void xmodem_set_buffer(char* buf, size_t len) {
+  xmodem_buffer = buf;
+  xmodem_buffer_len = len;
+  xmodem_block_number = 1;
+}
+
+void xmodem_set_callback(xmodem_cb buffer_filled) {
+  xmodem_callback = buffer_filled;
+}
+
+void xmodem_restart_transfer(void) {
+  xmodem_state = NEW_BLOCK;
+  xmodem_write(NAK);
+  xmodem_block_number = 1;
+  xmodem_byte_count = 0;
+  xmodem_checksum = 0;
+}
+
+void xmodem_restart_block(void) {
+  xmodem_state = NEW_BLOCK;
+  xmodem_write(NAK);
+  xmodem_checksum = 0;
+}
+
+void xmodem_read_callback(__attribute__ ((unused)) int unused0,
+                          __attribute__ ((unused)) int unused1,
+                          __attribute__ ((unused)) int unused2,
+                          __attribute__ ((unused))void* ud) {
+  // Restart the NAK read timeout
+  timer_cancel(&xmodem_timer);
+  timer_in(XMODEM_TIMEOUT, xmodem_timer_callback, NULL, &xmodem_timer);
+  // issue another read
+  int ret = command(DRIVER_NUM_CONSOLE, 2, sizeof(uint8_t), 0);
+  if (ret < 0 ) {
+    xmodem_restart_transfer();
+  } 
+  switch (xmodem_state) {
+  case NEW_BLOCK:
+    switch (xmodem_recv) {
+    case EOT:
+      xmodem_write(ACK);
+      if (xmodem_callback != NULL) {
+        uint32_t size = (xmodem_block_number - 1) * PAYLOAD_SIZE ;
+        xmodem_callback(xmodem_buffer, size, 0);
+      }
+      xmodem_block_number = 1;
+      break;
+    case SOH:
+      xmodem_state = BLOCK_NUMBER;
+      xmodem_checksum = 0;
+      break;
+    default:
+      xmodem_restart_block();
+      break;
+    }
+    break;
+  case BLOCK_NUMBER:
+    if (xmodem_recv == xmodem_block_number) {
+      xmodem_state = BLOCK_INVERSE;
+    } else { // Go back to beginning of block
+      xmodem_restart_transfer();
+    }
+    break;
+  case BLOCK_INVERSE:
+    if (xmodem_recv == (0xff - xmodem_block_number)) {
+      xmodem_state = DATA;
+      xmodem_byte_count = 0;
+    } else { // Go back to beginning of block
+      xmodem_restart_transfer();
+    }
+    break;
+  case DATA: {
+    unsigned pos = ((xmodem_block_number - 1) * PAYLOAD_SIZE);
+    pos += xmodem_byte_count;
+
+    if (pos >= xmodem_buffer_len) {     // Wrote past end of buffer -- abort
+      xmodem_restart_transfer();
+      xmodem_callback(xmodem_buffer, 0, -1);
+    } else {
+      if (xmodem_buffer != NULL) {
+          xmodem_buffer[pos] = xmodem_recv;
+      }
+      xmodem_checksum += xmodem_recv;
+      xmodem_byte_count++;
+      // Completed the block
+      if (xmodem_byte_count == PAYLOAD_SIZE) {
+        xmodem_state = CHECKSUM;
+      }
+    }
+    break;
+	     }
+  case CHECKSUM:
+    if (xmodem_recv != xmodem_checksum) {
+      xmodem_restart_transfer();
+    } else {
+      xmodem_write(ACK);
+      xmodem_block_number++;
+      xmodem_state = NEW_BLOCK;
+    }
+    break;
+  case STOP:
+  default:
+    xmodem_restart_transfer();
+    // Should never happen
+    break;
+  }
+}
+
+void xmodem_write_callback(__attribute__ ((unused)) int unused0,
+                           __attribute__ ((unused)) int unused1,
+                           __attribute__ ((unused)) int unused2,
+                           __attribute__ ((unused))void* ud) {
+  xmodem_write_busy = false;
+}
+
+void xmodem_timer_callback(__attribute__ ((unused)) int unused0,
+                           __attribute__ ((unused)) int unused1,
+                           __attribute__ ((unused)) int unused2,
+                           __attribute__ ((unused)) void* ud) {
+  xmodem_write(NAK);
+  led_toggle(0);
+  timer_in(XMODEM_TIMEOUT, xmodem_timer_callback, NULL, &xmodem_timer);
+}
+
+
+
+// Non-blocking write, just issues the command, protected by a
+// busy flag so a write doesn't occur while one is pending.
+int xmodem_write(uint8_t byte) {
+  if (xmodem_write_busy == false) {
+    xmodem_send = byte;
+    int ret = allow(DRIVER_NUM_CONSOLE, 1, &xmodem_send, sizeof(uint8_t));
+    if (ret < 0) return ret;
+    ret = subscribe(DRIVER_NUM_CONSOLE, 1, xmodem_write_callback, NULL);
+    if (ret < 0) return ret;
+    ret = command(DRIVER_NUM_CONSOLE, 1, sizeof(uint8_t), 0);
+    if (ret == 0) {
+      xmodem_write_busy = true;
+      return 0;
+    }
+  }
+  return -1;
+}
+
+int xmodem_init(void) {
+  xmodem_state = NEW_BLOCK;
+  xmodem_block_number = 1;
+  xmodem_byte_count = 0;
+
+  led_on(0);
+
+  // Start reading
+  int ret = allow(DRIVER_NUM_CONSOLE, 0, &xmodem_recv, sizeof(uint8_t));
+  if (ret < 0)  return ret;
+  ret = subscribe(DRIVER_NUM_CONSOLE, 0, xmodem_read_callback, NULL);
+  if (ret < 0)  return ret;
+  ret = command(DRIVER_NUM_CONSOLE, 2, sizeof(uint8_t), 0);
+  if (ret < 0)  return ret;
+
+
+  // Set the timeout
+  timer_in(XMODEM_TIMEOUT, xmodem_timer_callback, NULL, &xmodem_timer);
+  return 0;
+}
+
+//void notmain ( void ) {
+
+        /*
+         * 132 byte packet.  All fields are 1 byte except for the 128 byte data
+         * payload.
+         *              +-----+------+----------+--....----+-----+
+         *              | SOH | blk# | 255-blk# | ..data.. | cksum |
+         *              +-----+------+----------+--....----+-----+
+         * Protocol:
+         *      - first block# = 1.
+         *  - CRC is over the whole packet
+         *  - after all packets sent, sender transmits a single EOT (must ACK).
+        unsigned char block = 1;
+        unsigned addr = ARMBASE;
+        while (1) {
+                unsigned char b;
+
+                // We received an EOT, send an ACK, jump to beginning of code
+                if((b = getbyte()) == EOT) {
+                        uart_send(ACK);
+                        BRANCHTO(ARMBASE);
+                        return; // NOTREACHED
+                }
+
+         */
+                /*
+                 * if first byte is not SOH, or second byte is not the
+                 * expected block number or the third byte is not its
+                 * negation, send a nak for a resend of this block.
+                 
+                if(b != SOH
+                || getbyte() != block
+                || getbyte() != (0xFF - block)) {
+                        uart_send(NAK);
+                        continue;
+                }
+
+                // get the data bytes
+                int i;
+                unsigned char cksum;
+                for(cksum = i = 0; i < PAYLOAD_SIZE; i++) {
+                        cksum += (b = getbyte());
+                        PUT8(addr+i, b);
+                }
+
+                // Checksum failed: NAK the block
+                if(getbyte() != cksum)
+                        uart_send(NAK);
+                // Commit our addr pointer and go to next block.
+                else {
+                        uart_send(ACK);
+                        addr += PAYLOAD_SIZE;
+                        block++;
+                }
+        }
+} */

--- a/apps/examples/xmodem_leds/xmodem.h
+++ b/apps/examples/xmodem_leds/xmodem.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Initialize the XMODEM receiver and start receiving data.
+// Note that no data will be received until a buffer is installed
+// with xmodem_set_buffer.
+int xmodem_init(void);
+
+// Install a buffer to receive into, and its length. XMODEM will
+// not write past the length. If the transfer goes past the length
+// of the buffer, XMODEM will trigger reception via the callback
+// but issue NAKs to the sender. So this will appear as a successful
+// transmission of len bytes to the process but will throw an error
+// to the sender.
+//
+// Pass a buffer of NULL or size 0 to stop future receptions.
+void xmodem_set_buffer(char* buf, size_t len);
+
+// Install the callback to issue when a transfer completes. This
+// occurs either on successful reception of an EOT from the sender,
+// or if the end of the buffer is reached. EOT has an error code of
+// 0, while end of the buffer has an error code of -1.
+typedef void xmodem_cb(char* buf, int len, int error);
+void xmodem_set_callback(xmodem_cb buffer_filled);
+
+#ifdef __cplusplus
+}
+#endif

--- a/apps/examples/xmodem_leds/xmodem_send.py
+++ b/apps/examples/xmodem_leds/xmodem_send.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python
+
+"""Julie Zelenski 2017.
+Based on earlier rpi-install.py by Pat Hanrahan.
+Edited by Omar Rizwan 2017-04-23.
+
+This program was designed to be a bootloader client to upload binary 
+images to execute on a bare metal Raspberry Pi. However, it can also
+be used to just perform basic xmodem transfers, and so you can use it
+to upload new images for an embedded system controlling a bicycle light.
+
+Communicates over serial port using xmodem protocol.
+
+Should work with:
+- Python 2.7+ and Python 3
+- any version of the on-Pi bootloader
+- macOS and Linux
+
+Maybe Cygwin and Ubuntu on Windows as well.
+
+Dependencies:
+
+    # pip install {pyserial,xmodem}
+
+"""
+from __future__ import print_function
+import argparse, logging, os, serial, sys, time
+from serial.tools import list_ports
+from xmodem import XMODEM
+
+# This version updated May 30, 2017 with timeout flag.
+VERSION = 0.7
+
+# From https://stackoverflow.com/questions/287871/print-in-terminal-with-colors-using-python
+# Plus Julie's suggestion to push bold and color together.
+class bcolors:
+    RED = '\033[31m'
+    BLUE = '\033[34m'
+    GREEN = '\033[32m'
+    BOLD = '\033[1m'
+    OKBLUE = BOLD + BLUE
+    OKGREEN = BOLD + GREEN
+    FAIL = BOLD + RED
+    ENDC = '\033[0m'
+
+def error(shortmsg, msg=""):
+    sys.stderr.write("\n%s: %s\n" % (
+        sys.argv[0],
+        bcolors.FAIL + shortmsg + bcolors.ENDC + "\n" + msg
+    ))
+    sys.exit(1)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="This script sends a binary file over a serial port using xmodem. Version %s." % VERSION)
+
+    parser.add_argument("port", help="serial port", nargs="?")
+    parser.add_argument("file", help="binary file to upload",
+                        type=argparse.FileType('rb'))
+    parser.add_argument('-v', help="verbose logging of serial activity",
+                        action="store_true")
+    parser.add_argument('-q', help="do not print while uploading",
+                        action="store_true")
+    parser.add_argument('-t', help="timeout for -p",
+                        action="store", type=int, default=100)
+
+    after = parser.add_mutually_exclusive_group()
+    after.add_argument('-p', help="print output after uploading",
+                       action="store_true")
+    after.add_argument('-s', help="open `screen` on the serial port after uploading",
+                       action="store_true")
+
+
+    args = parser.parse_args()
+
+    def printq(*pos_args, **kwargs):
+        if not args.q:
+            print(*pos_args, **kwargs)
+
+    logging.getLogger().addHandler(logging.StreamHandler())
+    if args.v: logging.getLogger().setLevel(logging.DEBUG)
+
+    if args.port:
+        portname = args.port
+    else:
+        # The CP2102 units from winter 2014-15 and spring 2016-17 both have
+        # vendor ID 0x10C4 and product ID 0xEA60.
+        try:
+            # pyserial 2.6 in the VM has a bug where grep is case-sensitive.
+            # It also requires us to use [0] instead of .device on the result
+            # to get the serial device path.
+            portname = next(list_ports.grep(r'(?i)VID:PID=10C4:EA60'))[0]
+            printq('Found serial port:', bcolors.OKBLUE + portname + bcolors.ENDC)
+
+            # We used to just have a preset list --
+            # /dev/tty.SLAB_USBtoUART for macOS + Silicon Labs driver,
+            # /dev/cu.usbserial for Prolific,
+            # /dev/ttyUSB0 for Linux, etc.
+            # Hopefully the device ID-based finder is more reliable.
+
+        except StopIteration:
+            error("Couldn't find serial port", """
+I looked through the serial ports on your computer, and couldn't
+find any port associated with a CP2102 USB-to-serial adapter. Is
+your Pi plugged in?
+""")
+
+    try:
+        # timeout set at creation of Serial will be used as default for both read/write
+        port = serial.Serial(port=portname, baudrate=115200, timeout=2)
+
+    except (OSError, serial.serialutil.SerialException):
+        error("The serial port `%s` is not available" % portname, """
+Do you have a `screen` or `rpi-install.py` currently running that's
+hanging onto that port?
+""")
+
+    stream = args.file
+    printq("Sending `%s` (%d bytes): " % (stream.name, os.stat(stream.name).st_size), end='')
+
+    success = False
+    def getc(size, timeout=1):
+        ch = port.read(size)
+        # echo 'x' to report failure if read timed out/failed
+        if ch == b'':
+            if not success: printq('x', end='')
+            sys.stdout.flush()
+        return ch
+
+    def putc(data, timeout=1):
+        n = port.write(data)
+        # echo '.' to report full packet successfully sent
+        if n >= 128:
+            printq('.', end='')
+            sys.stdout.flush()
+
+    try:
+        xmodem = XMODEM(getc, putc)
+        success = xmodem.send(stream, retry=5)
+        if not success:
+            error("Send failed (bootloader not listening?)", """
+I waited a few seconds for an acknowledgement from the bootloader
+and didn't hear anything. Do you need to reset your Pi?
+
+Further help at http://cs107e.github.io/guides/bootloader/#troubleshooting
+""")
+    except serial.serialutil.SerialException as ex:
+        error(str(ex))
+    except KeyboardInterrupt:
+        error("Canceled by user pressing Ctrl-C.", """
+You should probably restart the Pi, since you interrupted it mid-load.
+""")
+
+    printq(bcolors.OKGREEN + "\nSuccessfully sent!" + bcolors.ENDC)
+    stream.close()
+
+    start = time.time()
+    if args.p:  # Print after sending.
+        try:
+            while True:
+                if time.time() - start > args.t:
+                    break
+
+                c = getc(1)
+                if c == chr(4): break # End of transmission.
+                if c is None: continue
+
+                print(c,end='')
+        except:
+            pass
+    elif args.s:  # Run `screen` after sending.
+        sys.exit(os.system('screen %s 115200' % portname))
+
+    sys.exit(0)

--- a/boards/teensy3.2/Cargo.lock
+++ b/boards/teensy3.2/Cargo.lock
@@ -1,0 +1,43 @@
+[[package]]
+name = "capsules"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "common"
+version = "0.1.0"
+
+[[package]]
+name = "cortexm4"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "kernel"
+version = "0.1.0"
+
+[[package]]
+name = "mk20"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "common 0.1.0",
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "teensy"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "common 0.1.0",
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+ "mk20 0.1.0",
+]
+

--- a/boards/teensy3.2/Cargo.toml
+++ b/boards/teensy3.2/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "teensy"
+version = "0.1.0"
+authors = ["Shane Leonard <shanel@stanford.edu>"]
+
+[profile.dev]
+panic = "abort"
+lto = true
+opt-level = 0
+debug = true
+
+[profile.release]
+panic = "abort"
+lto = true
+
+[dependencies]
+kernel = { path = "../../kernel" }
+cortexm4 = { path = "../../arch/cortex-m4" }
+capsules = { path = "../../capsules" }
+mk20 = { path = "../../chips/mk20/" }
+common = { path = "../../common" }

--- a/boards/teensy3.2/Makefile
+++ b/boards/teensy3.2/Makefile
@@ -1,0 +1,39 @@
+# Teensy 3.6
+CHIP = mk20
+MCU=mk20dx256
+
+PLATFORM=teensy
+
+TARGET = thumbv7em-none-eabi
+TEENSY_LOADER=teensy_loader_cli
+
+APP ?= examples/blink
+APP_NAME = $(shell basename $(APP))
+
+include ../Makefile.common
+
+.PHONY: program
+program: target/$(TARGET)/release/$(PLATFORM).hex
+	$(TEENSY_LOADER) -mmcu=$(MCU) -v -w $<
+
+
+.PHONY: app
+app: target/$(TARGET)/release/$(PLATFORM)-$(APP_NAME).hex
+	$(TEENSY_LOADER) -mmcu=$(MCU) -v -w $<
+
+
+.PHONY: ../../apps/$(APP)/build/$(TOCK_ARCH)/app
+../../apps/$(APP)/build/$(TOCK_ARCH)/app:
+	@make -C ../../apps/$(APP) TOCK_ARCH=$(TOCK_ARCH)
+
+
+target/$(TARGET)/release/$(PLATFORM)-$(APP_NAME): target/$(TARGET)/release/$(PLATFORM) ../../apps/$(APP)/build/$(TOCK_ARCH)/app 
+	$(Q)$(OBJCOPY) --update-section .apps=../../apps/$(APP)/build/cortex-m4/cortex-m4.bin \
+		--set-section-flags .apps=alloc,code \
+		target/$(TARGET)/release/$(PLATFORM) $@
+
+target/$(TARGET)/release/$(PLATFORM)-$(APP_NAME).elf: target/$(TARGET)/release/$(PLATFORM)-$(APP_NAME)
+	$(Q)cp $^ $@
+
+target/$(TARGET)/release/$(PLATFORM)-$(APP_NAME).hex: target/$(TARGET)/release/$(PLATFORM)-$(APP_NAME).elf
+	$(Q)$(OBJCOPY) -Oihex $^ $@

--- a/boards/teensy3.2/Readme.md
+++ b/boards/teensy3.2/Readme.md
@@ -1,0 +1,38 @@
+# TockOS port for Teensy 3.2
+
+This directory is an experimental port of the Tock embedded operating system to
+the Teensy 3.2.
+
+## Compiling
+
+To compile the kernel, simply run `make` in this directory. You must
+have the prerequiste build tools installed, as detailed in the
+[Tock getting started guide](https://github.com/helena-project/tock/blob/master/doc/Getting_Started.md).
+
+## Programming the Teensy
+
+Connect the Teensy via USB to your computer, and run `make program` from the
+root directory. You should see a prompt telling you to press the reset button on
+your board. Once you press the button, `teensy-loader-cli` will flash the kernel
+onto the board using the Teensy's builtin HalfKay bootloader.
+
+## Blink
+
+The `boards/teensy3.2/src/tests` directory contains tests which can be run instead of running
+the normal kernel main loop. To run `blink` from the kernel, edit
+`tests/mod.rs` to the following:
+
+```rust
+// Set this function to run whatever test you desire. Test functions are named XXX_test by convention.
+pub fn test() {
+    blink::blink_test();
+}
+
+// Set this to true to make the kernel run the test instead of main.
+pub const TEST: bool = true;
+```
+
+Then run `make program` and the kernel will be compiled and flashed to your
+Teensy. You should see the orange LED blinking!
+
+To get a blink with UART console output on TX0, run `print::print_test()` instead.

--- a/boards/teensy3.2/Xargo.toml
+++ b/boards/teensy3.2/Xargo.toml
@@ -1,0 +1,7 @@
+[dependencies.core]
+
+[dependencies.compiler_builtins]
+features = ["mem"]
+git = "https://github.com/rust-lang-nursery/compiler-builtins"
+stage = 1
+rev = "67e0908d7f2fd86423ec32fc4d904952fe96e7a9"

--- a/boards/teensy3.2/chip_layout.ld
+++ b/boards/teensy3.2/chip_layout.ld
@@ -1,0 +1,36 @@
+/**
+ * ROM_ORIGIN and ROM_LENGTH define the memory region given to the kernel.
+ *
+ * Teensy 3.5/3.6 boards run the HalfKay bootloader on an external Cortex-M0, so
+ * there is no need to allocate space for a bootloader unless there is a reason
+ * to specifically use tockloader.
+ *
+ * [Teensy 3.6 Schematic]
+ */
+ROM_ORIGIN  = 0x00000000;
+ROM_LENGTH  = 0x00020000;
+
+/**
+ * Program flash is 1M total.
+ *
+ * [Kinetis K66 Sub-Family Reference Manual Section 2.3]
+ * [Teensy 3.6 Schematic]
+ */
+PROG_ORIGIN = 0x00020000;
+PROG_LENGTH = 0x000E0000;
+
+/**
+ * SRAM is 256K total, split into an upper 192K chunk and a lower 64K chunk.
+ *
+ * [Kinetis K66 Sub-Family Reference Manual Section 4.10]
+ */
+RAM_ORIGIN  = 0x20000000;
+RAM_LENGTH  = 192K;
+
+/**
+ * Minimum memory protection unit alignment size.
+ * [Kinetis K66 Sub-Family Reference Manual Section 22.3.2]
+ *
+ * TODO: verify this number
+ */
+MPU_MIN_ALIGN = 8K;

--- a/boards/teensy3.2/kernel_layout.ld
+++ b/boards/teensy3.2/kernel_layout.ld
@@ -1,0 +1,237 @@
+/*
+ * This is the generic linker script for Tock. For most developers, it should
+ * be sufficient to define {ROM/PROG/RAM}_{ORIGIN/LENGTH} (6 variables, the
+ * start and length for each) and MPU_MIN_ALIGN (the minimum alignment
+ * granularity supported by the MPU).
+ *
+ * --------------------------------------------------------------------------
+ *
+ * If you wish to create your own linker script from scratch, you must define
+ * the following symbols:
+ *
+ * `_etext`, `_srelocate`, `_erelocate`
+ *    The `_etext` symbol marks the end of data stored in flash that should
+ *    stay in flash. `_srelocate` and `_erelocate` mark the address range in
+ *    SRAM that mutable program data is copied to.
+ *
+ *    Tock will copy `_erelocate` - `_srelocate` bytes of data from the
+ *    `_etext` pointer to the `_srelocate` pointer.
+ *
+ * `_szero`, `_ezero`
+ *
+ *    The `_szero` and `_ezero` symbols define the range of the BSS, SRAM that
+ *    Tock will zero on boot.
+ *
+ * `_sapps`
+ *
+ *    The `_sapps` symbol marks the beginning of application memory in flash.
+ */
+
+MEMORY
+{
+  rom (rx)  : ORIGIN =  ROM_ORIGIN, LENGTH =  ROM_LENGTH
+  prog (rx) : ORIGIN = PROG_ORIGIN, LENGTH = PROG_LENGTH
+  ram (rwx) : ORIGIN =  RAM_ORIGIN, LENGTH =  RAM_LENGTH
+}
+
+__stack_size__ = DEFINED(__stack_size__) ? __stack_size__ : 0x1000;
+
+SECTIONS
+{
+    /* STATIC ELEMENTS FOR TOCK KERNEL */
+    .text :
+    {
+        . = ALIGN(4);
+        _textstart = .;         /* Symbol expected by some MS build toolchains */
+
+        /* Place vector table at the beginning of ROM.
+         *
+         * The first 16 entries in the ARM vector table are defined by ARM and
+         * are common among all ARM chips. The remaining entries are
+         * chip-specific, which Tock defines in a separate .irqs section
+         *
+         * http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/BABIFJFG.html
+         */
+        KEEP(*(.vectors .vectors.*))
+        KEEP(*(.irqs))
+
+        . = 0x400;
+        KEEP(*(.flashconfig))
+
+        /* .text and .rodata hold most program code and immutable constants */
+        /* .gnu.linkonce hold C++ elements with vague linkage
+                https://gcc.gnu.org/onlinedocs/gcc/Vague-Linkage.html */
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+
+        /* C++ exception unwinding information */
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+
+        /* glue_7 and glue_7t hold helper functions emitted by the compiler to
+           support interworking (linking between functions in ARM and THUMB
+           mode). Note that Cortex-M's do not support ARM mode, but this is left
+           here to save someone headache if they ever attempt to port Tock to a
+           Cortex-A core.  */
+        *(.glue_7t) *(.glue_7)
+
+
+        /* Constructor and destructor sections:
+
+           - init/fini
+              Defined by ELF as sections that hold `process
+              initialization/termination code`
+           - {pre}{init/fini}_array_{start/end}
+              Symbols used by the C runtime for initialization / termination
+           - ctors/dtors
+              Symbols used by the C++ runtime for initialization / termination
+        */
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+        /* End constructor/destructor */
+    } > rom
+
+
+    /* ARM Exception support
+     *
+     * This contains compiler-generated support for unwinding the stack,
+     * consisting of key-value pairs of function addresses and information on
+     * how to unwind stack frames.
+     * https://wiki.linaro.org/KenWerner/Sandbox/libunwind?action=AttachFile&do=get&target=libunwind-LDS.pdf
+     *
+     * .ARM.exidx is sorted, so has to go in its own output section.
+     */
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+      /* (C++) Index entries for section unwinding */
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > rom
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+
+    /* Mark the end of static elements */
+    . = ALIGN(4);
+    _etext = .;
+    _textend = .;   /* alias for _etext expected by some MS toolchains */
+
+
+
+
+
+    /* STATIC ELEMENTS FOR TOCK APPLICATIONS */
+    .apps :
+    {
+        /* _sapps symbol used by tock to look for first application */
+        . = ALIGN(4);
+        _sapps = .;
+
+        /* Optional .app sections a convenience mechanism to bundle tock
+           kernel and apps into a single image */
+        KEEP (*(.app.*))
+    } > prog
+
+
+
+    /* Kernel data that must be relocated. This is program data that is
+     * exepected to live in SRAM, but is initialized with a value. This data is
+     * physically placed into flash and is copied into SRAM by Tock. The
+     * symbols here will be defined with addresses in SRAM.
+     *
+     * Tock assumes the relocation section follows all static elements and will
+     * copy (_erelocate - _srelocate) bytes from _etext to _srelocate.
+     */
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+
+        . = ALIGN(4);
+        _erelocate = .;
+    } > ram
+
+
+
+
+    .sram (NOLOAD) :
+    {
+        /* Kernel BSS section. Memory that is expected to be initialized to
+         * zero.
+         *
+         * Elements in this section do not contribute to the binary size. Tock
+         * initialization will write zeros to the memory between _szero and
+         * _ezero.
+         *
+         * Elements placed in the .bss and .COMMON sections are simply used to
+         * measure amount of memory to zero out.
+         */
+        . = ALIGN(4);
+        _szero = .;
+
+        *(.bss .bss.*)
+        *(COMMON)
+
+        . = ALIGN(4);
+        _ezero = .;
+
+
+
+        /* Kernel stack.
+         *
+         * To keep all kernel memory contiguous (eases MPU protection of kernel
+         * data), Tock next places its own stack into SRAM.
+         */
+        . = ALIGN(8);
+         _sstack = .;
+
+        . = . + __stack_size__;
+
+        . = ALIGN(8);
+        _estack = .;
+
+
+
+        /* Application Memory.
+         *
+         * Tock uses the remainder of SRAM for application memory.
+         *
+         * Currently, Tock allocates a fixed array of application memories at
+         * compile-time, and that array is simply placed here. A possible
+         * future enhancement may allow the kernel to parcel this memory space
+         * dynamically, requiring changes to this section.
+         */
+        . = ALIGN(MPU_MIN_ALIGN);
+        *(.app_memory)
+    } > ram
+}

--- a/boards/teensy3.2/layout.ld
+++ b/boards/teensy3.2/layout.ld
@@ -1,0 +1,2 @@
+INCLUDE ./chip_layout.ld
+INCLUDE ./kernel_layout.ld

--- a/boards/teensy3.2/src/components/alarm.rs
+++ b/boards/teensy3.2/src/components/alarm.rs
@@ -1,0 +1,28 @@
+use mk20;
+use kernel;
+use components::Component;
+use capsules::alarm::AlarmDriver;
+
+pub struct AlarmComponent;
+
+impl AlarmComponent {
+    pub fn new() -> Self {
+        AlarmComponent {}
+    }
+}
+
+impl Component for AlarmComponent {
+    type Output = &'static AlarmDriver<'static, mk20::pit::Pit<'static>>;
+
+    unsafe fn finalize(&mut self) -> Option<Self::Output> {
+        mk20::pit::PIT.init();
+
+        let alarm = static_init!(
+                AlarmDriver<'static, mk20::pit::Pit>,
+                AlarmDriver::new(&mk20::pit::PIT,
+                                 kernel::Grant::create())
+            );
+        mk20::pit::PIT.set_client(alarm);
+        Some(alarm)
+    }
+}

--- a/boards/teensy3.2/src/components/console.rs
+++ b/boards/teensy3.2/src/components/console.rs
@@ -1,0 +1,37 @@
+use capsules;
+use mk20;
+use kernel;
+use kernel::hil::uart::UART;
+use components::Component;
+
+pub struct UartConsoleComponent;
+
+impl UartConsoleComponent {
+    pub fn new() -> Self {
+        UartConsoleComponent {}
+    }
+}
+
+impl Component for UartConsoleComponent {
+    type Output = &'static capsules::console::Console<'static, mk20::uart::Uart>;
+
+    unsafe fn finalize(&mut self) -> Option<Self::Output> {
+        let console = static_init!(
+                capsules::console::Console<mk20::uart::Uart>,
+                capsules::console::Console::new(&mk20::uart::UART0,
+                                                115200,
+                                                &mut capsules::console::WRITE_BUF,
+                                                kernel::Grant::create())
+            );
+        mk20::uart::UART0.set_client(console);
+        console.initialize();
+
+        let kc = static_init!(
+                capsules::console::App,
+                capsules::console::App::default()
+            );
+        kernel::debug::assign_console_driver(Some(console), kc);
+
+        Some(console)
+    }
+}

--- a/boards/teensy3.2/src/components/gpio.rs
+++ b/boards/teensy3.2/src/components/gpio.rs
@@ -1,0 +1,47 @@
+use capsules;
+use mk20;
+use components::{Component, ComponentWithDependency};
+
+type PinHandle = &'static mk20::gpio::Gpio<'static>;
+
+pub struct GpioComponent {
+    pins: Option<&'static [PinHandle]>
+}
+
+impl GpioComponent {
+    pub fn new() -> Self {
+        GpioComponent {
+            pins: None
+        }
+    }
+}
+
+impl Component for GpioComponent {
+    type Output = &'static capsules::gpio::GPIO<'static, mk20::gpio::Gpio<'static>>;
+
+    unsafe fn finalize(&mut self) -> Option<Self::Output> {
+        if self.pins.is_none() {
+            return None;
+        }
+
+        let gpio = static_init!(
+                capsules::gpio::GPIO<'static, mk20::gpio::Gpio<'static>>,
+                capsules::gpio::GPIO::new(self.pins.unwrap())
+            );
+
+        for pin in self.pins.unwrap().iter() {
+            pin.set_client(gpio);
+        }
+
+        Some(gpio)
+    }
+}
+
+impl ComponentWithDependency<&'static [PinHandle]> for GpioComponent {
+    fn dependency(&mut self, pins: &'static [PinHandle]) -> &mut Self {
+        self.pins = Some(pins);
+
+        self
+    }
+}
+

--- a/boards/teensy3.2/src/components/led.rs
+++ b/boards/teensy3.2/src/components/led.rs
@@ -1,0 +1,43 @@
+use mk20;
+use capsules;
+use components::{Component, ComponentWithDependency};
+
+type PinHandle = &'static mk20::gpio::Gpio<'static>;
+
+pub struct LedComponent {
+    leds: Option<&'static [(&'static mk20::gpio::Gpio<'static>, capsules::led::ActivationMode)]>
+}
+
+impl LedComponent {
+    pub fn new() -> Self {
+        LedComponent {
+            leds: None
+        }
+    }
+}
+
+impl Component for LedComponent {
+    type Output = &'static capsules::led::LED<'static, mk20::gpio::Gpio<'static>>;
+
+    unsafe fn finalize(&mut self) -> Option<Self::Output> {
+        if self.leds.is_none() {
+            return None;
+        }
+
+        let leds = static_init!(
+                capsules::led::LED<'static, mk20::gpio::Gpio<'static>>,
+                capsules::led::LED::new(self.leds.unwrap())
+            );
+
+        Some(leds)
+    }
+}
+
+impl ComponentWithDependency<&'static [(PinHandle, capsules::led::ActivationMode)]> for LedComponent {
+    fn dependency(&mut self, leds: &'static [(PinHandle, capsules::led::ActivationMode)]) -> &mut Self {
+        self.leds = Some(leds);
+
+        self
+    }
+}
+

--- a/boards/teensy3.2/src/components/mod.rs
+++ b/boards/teensy3.2/src/components/mod.rs
@@ -1,0 +1,23 @@
+pub trait Component {
+    type Output;
+
+    unsafe fn finalize(&mut self) -> Option<Self::Output>;
+}
+
+pub trait ComponentWithDependency<D>: Component {
+    fn dependency(&mut self, _dep: D) -> &mut Self { self }
+}
+
+mod gpio;
+mod led;
+mod spi;
+mod alarm;
+mod console;
+mod xconsole;
+
+pub use self::gpio::GpioComponent;
+pub use self::led::LedComponent;
+pub use self::spi::VirtualSpiComponent;
+pub use self::alarm::AlarmComponent;
+pub use self::console::UartConsoleComponent;
+pub use self::xconsole::XConsoleComponent;

--- a/boards/teensy3.2/src/components/spi.rs
+++ b/boards/teensy3.2/src/components/spi.rs
@@ -1,0 +1,63 @@
+use mk20;
+use capsules::virtual_spi::{VirtualSpiMasterDevice, MuxSpiMaster};
+use kernel::hil::spi::SpiMaster;
+use spi::Spi;
+use components::Component;
+
+pub struct VirtualSpiComponent;
+
+impl VirtualSpiComponent {
+    pub fn new() -> Self {
+        VirtualSpiComponent {}
+    }
+}
+
+impl Component for VirtualSpiComponent {
+    type Output = &'static Spi<'static, VirtualSpiMasterDevice<'static, mk20::spi::Spi<'static>>>;
+
+    unsafe fn finalize(&mut self) -> Option<Self::Output> {
+        mk20::spi::SPI0.init();
+        mk20::spi::SPI1.init();
+        mk20::spi::SPI2.init();
+
+        let mux_spi0 = static_init!(
+                MuxSpiMaster<'static, mk20::spi::Spi<'static>>,
+                MuxSpiMaster::new(&mk20::spi::SPI0)
+            );
+        let mux_spi1 = static_init!(
+                MuxSpiMaster<'static, mk20::spi::Spi<'static>>,
+                MuxSpiMaster::new(&mk20::spi::SPI1)
+            );
+        let mux_spi2 = static_init!(
+                MuxSpiMaster<'static, mk20::spi::Spi<'static>>,
+                MuxSpiMaster::new(&mk20::spi::SPI2)
+            );
+
+        mk20::spi::SPI0.set_client(mux_spi0);
+        mk20::spi::SPI1.set_client(mux_spi1);
+        mk20::spi::SPI2.set_client(mux_spi2);
+
+        let virtual_spi = static_init!(
+                [VirtualSpiMasterDevice<'static, mk20::spi::Spi<'static>>; 3],
+                [VirtualSpiMasterDevice::new(mux_spi0, 0),
+                 VirtualSpiMasterDevice::new(mux_spi1, 0),
+                 VirtualSpiMasterDevice::new(mux_spi2, 0)]
+            );
+
+        let spi = static_init!(
+                Spi<'static, VirtualSpiMasterDevice<'static, mk20::spi::Spi<'static>>>,
+                Spi::new(virtual_spi)
+            );
+
+        static mut SPI_READ_BUF: [u8; 1024] = [0; 1024];
+        static mut SPI_WRITE_BUF: [u8; 1024] = [0; 1024];
+
+        spi.config_buffers(&mut SPI_READ_BUF, &mut SPI_WRITE_BUF);
+
+        virtual_spi[0].set_client(spi);
+        virtual_spi[1].set_client(spi);
+        virtual_spi[2].set_client(spi);
+
+        Some(spi)
+    }
+}

--- a/boards/teensy3.2/src/components/xconsole.rs
+++ b/boards/teensy3.2/src/components/xconsole.rs
@@ -1,0 +1,41 @@
+use mk20;
+use kernel;
+use xconsole;
+use kernel::hil::uart::UART;
+use components::Component;
+
+pub struct XConsoleComponent;
+
+impl XConsoleComponent {
+    pub fn new() -> Self {
+        XConsoleComponent {}
+    }
+}
+
+impl Component for XConsoleComponent {
+    type Output = &'static xconsole::XConsole<'static, mk20::uart::Uart>;
+
+    unsafe fn finalize(&mut self) -> Option<Self::Output> {
+        let xconsole = static_init!(
+                xconsole::XConsole<mk20::uart::Uart>,
+                xconsole::XConsole::new(&mk20::uart::UART0,
+                                        115200,
+                                        &mut xconsole::WRITE_BUF,
+                                        &mut xconsole::READ_BUF,
+                                        kernel::Grant::create())
+            );
+        mk20::uart::UART0.set_client(xconsole);
+        xconsole.initialize();
+
+        let kc = static_init!(
+                xconsole::App,
+                xconsole::App::default()
+            );
+        kernel::debug::assign_console_driver(Some(xconsole), kc);
+
+        mk20::uart::UART0.enable_rx();
+        mk20::uart::UART0.enable_rx_interrupts();
+
+        Some(xconsole)
+    }
+}

--- a/boards/teensy3.2/src/io.rs
+++ b/boards/teensy3.2/src/io.rs
@@ -1,0 +1,96 @@
+use core::fmt::*;
+use kernel::hil::uart::{self, UART};
+use kernel::process;
+use mk20::{self, gpio};
+
+pub struct Writer {
+    initialized: bool,
+}
+
+pub static mut WRITER: Writer = Writer { initialized: false };
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        let uart = unsafe { &mut mk20::uart::UART0 };
+        if !self.initialized {
+            self.initialized = true;
+            uart.init(uart::UARTParams {
+                baud_rate: 115200,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+            });
+            uart.enable_tx();
+        }
+
+        for c in s.bytes() {
+            uart.send_byte(c);
+        }
+        while !uart.tx_ready() {}
+
+        Ok(())
+    }
+}
+
+#[cfg(not(test))]
+#[no_mangle]
+#[allow(unused_variables)]
+#[lang="panic_fmt"]
+pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
+    let writer = &mut WRITER;
+    let _ = writer.write_fmt(format_args!("\r\n\nKernel panic at {}:{}:\r\n\t\"", file, line));
+    let _ = write(writer, args);
+    let _ = writer.write_str("\"\r\n");
+
+    // Print version of the kernel
+    let _ = writer.write_fmt(format_args!("\tKernel version {}\r\n", env!("TOCK_KERNEL_VERSION")));
+
+    // Print fault status once
+    let procs = &mut process::PROCS;
+    if procs.len() > 0 {
+        procs[0].as_mut().map(|process| { process.fault_str(writer); });
+    }
+
+    // print data about each process
+    let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
+    let procs = &mut process::PROCS;
+    for idx in 0..procs.len() {
+        procs[idx].as_mut().map(|process| { process.statistics_str(writer); });
+    }
+
+    // blink the panic signal
+    gpio::PC05.release_claim();
+    let led = gpio::PC05.claim_as_gpio(); 
+    led.enable_output();
+    loop {
+        for _ in 0..1000000 {
+            led.clear();
+        }
+        for _ in 0..100000 {
+            led.set();
+        }
+        for _ in 0..1000000 {
+            led.clear();
+        }
+        for _ in 0..500000 {
+            led.set();
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! print {
+        ($($arg:tt)*) => (
+            {
+                use core::fmt::write;
+                let writer = unsafe { &mut $crate::io::WRITER };
+                let _ = write(writer, format_args!($($arg)*));
+            }
+        );
+}
+
+#[macro_export]
+macro_rules! println {
+        ($fmt:expr) => (print!(concat!($fmt, "\n")));
+            ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+}

--- a/boards/teensy3.2/src/main.rs
+++ b/boards/teensy3.2/src/main.rs
@@ -1,0 +1,153 @@
+#![no_std]
+#![no_main]
+#![feature(asm,const_fn,lang_items,compiler_builtins_lib)]
+
+extern crate capsules;
+extern crate compiler_builtins;
+
+#[macro_use(debug, static_init)]
+extern crate kernel;
+
+#[macro_use]
+extern crate common;
+
+#[allow(dead_code)]
+extern crate mk20;
+
+#[macro_use]
+pub mod io;
+
+#[allow(dead_code)]
+mod tests;
+
+#[allow(dead_code)]
+mod spi;
+
+#[allow(dead_code)]
+mod components;
+
+pub mod xconsole;
+
+#[allow(dead_code)]
+mod pins;
+
+use components::*;
+
+#[allow(unused)]
+struct Teensy {
+    xconsole: <XConsoleComponent as Component>::Output,
+    gpio: <GpioComponent as Component>::Output,
+    led: <LedComponent as Component>::Output,
+    alarm: <AlarmComponent as Component>::Output,
+    spi: <VirtualSpiComponent as Component>::Output,
+    ipc: kernel::ipc::IPC,
+}
+
+impl kernel::Platform for Teensy {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+        where F: FnOnce(Option<&kernel::Driver>) -> R
+    {
+        match driver_num {
+            xconsole::DRIVER_NUM => f(Some(self.xconsole)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            spi::DRIVER_NUM => f(Some(self.spi)),
+
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            _ => f(None),
+        }
+    }
+}
+
+#[link_section = ".flashconfig"]
+#[no_mangle]
+pub static FLASH_CONFIG_BYTES: [u8; 16] = [
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xDE, 0xF9, 0xFF, 0xFF,
+];
+
+#[no_mangle]
+pub unsafe fn reset_handler() {
+    // Disable the watchdog.
+    mk20::wdog::stop();
+
+    // Relocate the text and data segments.
+    mk20::init();
+
+    // Configure the system clock.
+    mk20::clock::configure(120);
+
+    // Enable the Port Control and Interrupt clocks.
+    use mk20::sim::Clock;
+    mk20::sim::clocks::PORTABCDE.enable();
+
+    let (gpio_pins, led_pins) = pins::configure_all_pins();
+    let gpio = GpioComponent::new()
+                             .dependency(gpio_pins)
+                             .finalize().unwrap();
+    let led = LedComponent::new()
+                           .dependency(led_pins)
+                           .finalize().unwrap();
+    let spi = VirtualSpiComponent::new().finalize().unwrap();
+    let alarm = AlarmComponent::new().finalize().unwrap();
+    let xconsole = XConsoleComponent::new().finalize().unwrap();
+
+    let teensy = Teensy {
+        xconsole: xconsole,
+        gpio: gpio,
+        led: led,
+        alarm: alarm,
+        spi: spi,
+        ipc: kernel::ipc::IPC::new(),
+    };
+
+    let mut chip = mk20::chip::MK20::new();
+
+    if tests::TEST {
+        tests::test();
+    }
+    kernel::main(&teensy, &mut chip, load_processes(), &teensy.ipc);
+}
+
+
+unsafe fn load_processes() -> &'static mut [Option<kernel::Process<'static>>] {
+    extern "C" {
+        /// Beginning of the ROM region containing the app images.
+        static _sapps: u8;
+    }
+
+    const NUM_PROCS: usize = 1;
+
+    // Total memory allocated to the processes
+    #[link_section = ".app_memory"]
+    static mut APP_MEMORY: [u8; 1 << 17] = [0; 1 << 17];
+
+    // How the kernel responds when a process faults
+    const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultResponse::Panic;
+
+    static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None];
+
+    // Create the processes and allocate the app memory among them
+    let mut apps_in_flash_ptr = &_sapps as *const u8;
+    let mut app_memory_ptr = APP_MEMORY.as_mut_ptr();
+    let mut app_memory_size = APP_MEMORY.len();
+    for i in 0..NUM_PROCS {
+        let (process, flash_offset, memory_offset) = kernel::Process::create(apps_in_flash_ptr,
+                                                                             app_memory_ptr,
+                                                                             app_memory_size,
+                                                                             FAULT_RESPONSE);
+        if process.is_none() {
+            break;
+        }
+
+        PROCESSES[i] = process;
+        apps_in_flash_ptr = apps_in_flash_ptr.offset(flash_offset as isize);
+        app_memory_ptr = app_memory_ptr.offset(memory_offset as isize);
+        app_memory_size -= memory_offset;
+    }
+
+    &mut PROCESSES
+}

--- a/boards/teensy3.2/src/pins.rs
+++ b/boards/teensy3.2/src/pins.rs
@@ -1,0 +1,65 @@
+use capsules::led::ActivationMode;
+use mk20;
+
+type PinHandle = &'static mk20::gpio::Gpio<'static>;
+
+pub unsafe fn configure_all_pins() -> (&'static [PinHandle],
+                                       &'static [(PinHandle, ActivationMode)]) {
+    use mk20::gpio::functions::*;
+    use mk20::gpio::*;
+
+    // The index of each pin in this array corresponds to Teensy 3.6 pinout.
+    // In other words, gpio_pins[13] is Teensy pin 13, and so on.
+    let gpio_pins = static_init!(
+        [PinHandle; 58],
+        [PB16.claim_as_gpio(), PB17.claim_as_gpio(), PD00.claim_as_gpio(),
+         PA12.claim_as_gpio(), PA13.claim_as_gpio(), PD07.claim_as_gpio(),
+         PD04.claim_as_gpio(), PD02.claim_as_gpio(), PD03.claim_as_gpio(),
+         PC03.claim_as_gpio(), PC04.claim_as_gpio(), PC06.claim_as_gpio(),
+         PC07.claim_as_gpio(), PC05.claim_as_gpio(), PD01.claim_as_gpio(),
+         PC00.claim_as_gpio(), PB00.claim_as_gpio(), PB01.claim_as_gpio(),
+         PB03.claim_as_gpio(), PB02.claim_as_gpio(), PD05.claim_as_gpio(),
+         PD06.claim_as_gpio(), PC01.claim_as_gpio(), PC02.claim_as_gpio(),
+         PE26.claim_as_gpio(), PA05.claim_as_gpio(), PA14.claim_as_gpio(),
+         PA15.claim_as_gpio(), PA16.claim_as_gpio(), PB18.claim_as_gpio(),
+         PB19.claim_as_gpio(), PB10.claim_as_gpio(), PB11.claim_as_gpio(),
+         PE24.claim_as_gpio(), PE25.claim_as_gpio(), PC08.claim_as_gpio(),
+         PC09.claim_as_gpio(), PC10.claim_as_gpio(), PC11.claim_as_gpio(),
+         PA17.claim_as_gpio(), PA28.claim_as_gpio(), PA29.claim_as_gpio(),
+         PA26.claim_as_gpio(), PB20.claim_as_gpio(), PB22.claim_as_gpio(),
+         PB23.claim_as_gpio(), PB21.claim_as_gpio(), PD08.claim_as_gpio(),
+         PD09.claim_as_gpio(), PB04.claim_as_gpio(), PB05.claim_as_gpio(),
+         PD14.claim_as_gpio(), PD13.claim_as_gpio(), PD12.claim_as_gpio(),
+         PD15.claim_as_gpio(), PD11.claim_as_gpio(), PE10.claim_as_gpio(),
+         PE11.claim_as_gpio()]);
+
+    let led_pins = static_init!(
+            [(&'static mk20::gpio::Gpio<'static>, ActivationMode); 1],
+            [(gpio_pins[13], ActivationMode::ActiveHigh)]
+        );
+
+    // UART0
+    PB17.release_claim();
+    PB16.release_claim();
+    PB17.claim_as(UART0_TX);
+    PB16.claim_as(UART0_RX);
+
+    // SPI0
+    PC04.release_claim();
+    PC06.release_claim();
+    PC07.release_claim();
+    PA15.release_claim();
+    PC06.claim_as(SPI0_MOSI);
+    PC07.claim_as(SPI0_MISO);
+    PA15.claim_as(SPI0_SCK);
+    PC04.claim_as(SPI0_CS0);
+
+    // SPI1
+    PD05.release_claim();
+    PD06.release_claim();
+    PD05.claim_as(SPI1_SCK);
+    PD06.claim_as(SPI1_MOSI);
+
+    (gpio_pins, led_pins)
+}
+

--- a/boards/teensy3.2/src/spi.rs
+++ b/boards/teensy3.2/src/spi.rs
@@ -1,0 +1,525 @@
+//! Provides userspace applications with the ability to communicate over the SPI
+//! bus.
+
+use core::cell::Cell;
+use core::cmp;
+use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
+use kernel::common::take_cell::{MapCell, TakeCell};
+use kernel::hil::spi::{SpiMasterDevice, SpiSlaveDevice, SpiMasterClient, SpiSlaveClient};
+use kernel::hil::spi::ClockPhase;
+use kernel::hil::spi::ClockPolarity;
+
+/// Syscall number
+pub const DRIVER_NUM: usize = 0x20001;
+
+// SPI operations are handled by coping into a kernel buffer for
+// writes and copying out of a kernel buffer for reads.
+//
+// If the application buffer is larger than the kernel buffer,
+// the driver issues multiple HAL operations. The len field
+// of an application keeps track of the length of the desired
+// operation, while the index variable keeps track of the
+// index an ongoing operation is at in the buffers.
+
+struct App {
+    callback: Option<Callback>,
+    app_read: Option<AppSlice<Shared, u8>>,
+    app_write: Option<AppSlice<Shared, u8>>,
+    len: usize,
+    index: usize,
+    spi_hardware: Cell<usize>
+}
+
+impl Default for App {
+    fn default() -> App {
+        App {
+            callback: None,
+            app_read: None,
+            app_write: None,
+            len: 0,
+            index: 0,
+            spi_hardware: Cell::new(1)
+        }
+    }
+}
+
+// Since we provide an additional callback in slave mode for
+// when the chip is selected, we have added a "SlaveApp" struct
+// that includes this new callback field.
+struct SlaveApp {
+    callback: Option<Callback>,
+    selected_callback: Option<Callback>,
+    app_read: Option<AppSlice<Shared, u8>>,
+    app_write: Option<AppSlice<Shared, u8>>,
+    len: usize,
+    index: usize,
+}
+
+impl Default for SlaveApp {
+    fn default() -> SlaveApp {
+        SlaveApp {
+            callback: None,
+            selected_callback: None,
+            app_read: None,
+            app_write: None,
+            len: 0,
+            index: 0,
+        }
+    }
+}
+
+pub struct Spi<'a, S: SpiMasterDevice + 'a> {
+    spi_masters: &'a [S],
+    busy: Cell<bool>,
+    app: MapCell<App>,
+    kernel_read: TakeCell<'static, [u8]>,
+    kernel_write: TakeCell<'static, [u8]>,
+    kernel_len: Cell<usize>,
+}
+
+pub struct SpiSlave<'a, S: SpiSlaveDevice + 'a> {
+    spi_slave: &'a S,
+    busy: Cell<bool>,
+    app: MapCell<SlaveApp>,
+    kernel_read: TakeCell<'static, [u8]>,
+    kernel_write: TakeCell<'static, [u8]>,
+    kernel_len: Cell<usize>,
+}
+
+impl<'a, S: SpiMasterDevice> Spi<'a, S> {
+    pub fn new(spi_masters: &'a [S]) -> Spi<'a, S> {
+        Spi {
+            spi_masters: spi_masters,
+            busy: Cell::new(false),
+            app: MapCell::new(App::default()),
+            kernel_len: Cell::new(0),
+            kernel_read: TakeCell::empty(),
+            kernel_write: TakeCell::empty(),
+        }
+    }
+
+    pub fn config_buffers(&mut self, read: &'static mut [u8], write: &'static mut [u8]) {
+        let len = cmp::min(read.len(), write.len());
+        self.kernel_len.set(len);
+        self.kernel_read.replace(read);
+        self.kernel_write.replace(write);
+    }
+
+    // Assumes checks for busy/etc. already done
+    // Updates app.index to be index + length of op
+    fn do_next_read_write(&self, app: &mut App) {
+        let start = app.index;
+        let len = cmp::min(app.len - start, self.kernel_len.get());
+        let end = start + len;
+        app.index = end;
+
+        self.kernel_write.map(|kwbuf| {
+            app.app_write
+                .as_mut()
+                .map(|src| for (i, c) in src.as_ref()[start..end].iter().enumerate() {
+                    kwbuf[i] = *c;
+                });
+        });
+        self.spi_masters[app.spi_hardware.get()].read_write_bytes(self.kernel_write.take().unwrap(),
+                                                 self.kernel_read.take(),
+                                                 len);
+    }
+}
+
+impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
+    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+        match allow_num {
+            // Pass in a read buffer to receive bytes into.
+            0 => {
+                self.app.map(|app| { app.app_read = Some(slice); });
+                ReturnCode::SUCCESS
+            }
+            // Pass in a write buffer to transmit bytes from.
+            1 => {
+                self.app.map(|app| { app.app_write = Some(slice); });
+                ReturnCode::SUCCESS
+            }
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+        match subscribe_num {
+            0 /* read_write */ => {
+                self.app.map(|app| {
+                    app.callback = Some(callback);
+                });
+                ReturnCode::SUCCESS
+            },
+            _ => ReturnCode::ENOSUPPORT
+        }
+    }
+
+    // 2: read/write buffers
+    //   - requires write buffer registered with allow
+    //   - read buffer optional
+    // 3: set chip select
+    //   - selects which peripheral (CS line) the SPI should
+    //     activate
+    //   - valid values are 0-3 for SAM4L
+    //   - invalid value will result in CS 0
+    // 4: get chip select
+    //   - returns current selected peripheral
+    // 5: set rate on current peripheral
+    //   - parameter in bps
+    // 6: get rate on current peripheral
+    //   - value in bps
+    // 7: set clock phase on current peripheral
+    //   - 0 is sample leading
+    //   - non-zero is sample trailing
+    // 8: get clock phase on current peripheral
+    //   - 0 is sample leading
+    //   - non-zero is sample trailing
+    // 9: set clock polarity on current peripheral
+    //   - 0 is idle low
+    //   - non-zero is idle high
+    // 10: get clock polarity on current peripheral
+    //   - 0 is idle low
+    //   - non-zero is idle high
+    //
+    // x: lock spi
+    //   - if you perform an operation without the lock,
+    //     it implicitly acquires the lock before the
+    //     operation and releases it after
+    //   - while an app holds the lock no other app can issue
+    //     operations on SPI (they are buffered)
+    // x+1: unlock spi
+    //   - does nothing if lock not held
+    //
+    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: AppId) -> ReturnCode {
+        match cmd_num {
+            0 /* check if present */ => ReturnCode::SUCCESS,
+            // No longer supported, wrap inside a read_write_bytes
+            1 /* read_write_byte */ => ReturnCode::ENOSUPPORT,
+            2 /* read_write_bytes */ => {
+                if self.busy.get() {
+                    return ReturnCode::EBUSY;
+                }
+                self.app.map_or(ReturnCode::FAIL, |app| {
+                    let mut mlen = 0;
+                    app.app_write.as_mut().map(|w| {
+                        mlen = w.len();
+                    });
+                    app.app_read.as_mut().map(|r| {
+                        mlen = cmp::min(mlen, r.len());
+                    });
+                    if mlen >= arg1 {
+                        app.len = arg1;
+                        app.index = 0;
+                        self.busy.set(true);
+                        self.do_next_read_write(app);
+                        ReturnCode::SUCCESS
+                    } else {
+                        ReturnCode::EINVAL /* write buffer too small */
+                    }
+                })
+            }
+            3 /* set chip select */ => {
+                // XXX: TODO: do nothing, for now, until we fix interface
+                // so virtual instances can use multiple chip selects
+                ReturnCode::ENOSUPPORT
+            }
+            4 /* get chip select */ => {
+                // XXX: We don't really know what chip select is being used
+                // since we can't set it. Return error until set chip select
+                // works.
+                ReturnCode::ENOSUPPORT
+            }
+            5 /* set baud rate */ => {
+                self.app.map_or(ReturnCode::FAIL, |app| {
+                    self.spi_masters[app.spi_hardware.get()].set_rate(arg1 as u32);
+                    ReturnCode::SUCCESS
+                })
+            }
+            6 /* get baud rate */ => {
+                self.app.map_or(ReturnCode::FAIL, |app| {
+                    ReturnCode::SuccessWithValue { value: self.spi_masters[app.spi_hardware.get()].get_rate() as usize }
+                })
+            }
+            7 /* set phase */ => {
+                self.app.map_or(ReturnCode::FAIL, |app| {
+                    match arg1 {
+                        0 => self.spi_masters[app.spi_hardware.get()].set_phase(ClockPhase::SampleLeading),
+                        _ => self.spi_masters[app.spi_hardware.get()].set_phase(ClockPhase::SampleTrailing),
+                    };
+                    ReturnCode::SUCCESS
+                })
+            }
+            8 /* get phase */ => {
+                self.app.map_or(ReturnCode::FAIL, |app| {
+                    ReturnCode::SuccessWithValue { value: self.spi_masters[app.spi_hardware.get()].get_phase() as usize }
+                })
+            }
+            9 /* set polarity */ => {
+                self.app.map_or(ReturnCode::FAIL, |app| {
+                    match arg1 {
+                        0 => self.spi_masters[app.spi_hardware.get()].set_polarity(ClockPolarity::IdleLow),
+                        _ => self.spi_masters[app.spi_hardware.get()].set_polarity(ClockPolarity::IdleHigh),
+                    };
+                    ReturnCode::SUCCESS
+                })
+            }
+            10 /* get polarity */ => {
+                self.app.map_or(ReturnCode::FAIL, |app| {
+                    ReturnCode::SuccessWithValue { value: self.spi_masters[app.spi_hardware.get()].get_polarity() as usize }
+                })
+            }
+            11 /* select underlying SPI HW */ => {
+                self.app.map_or(ReturnCode::FAIL, |app| {
+                    app.spi_hardware.set(arg1);
+                    ReturnCode::SUCCESS
+                })
+            }
+            _ => ReturnCode::ENOSUPPORT
+        }
+    }
+}
+
+impl<'a, S: SpiMasterDevice> SpiMasterClient for Spi<'a, S> {
+    fn read_write_done(&self,
+                       writebuf: &'static mut [u8],
+                       readbuf: Option<&'static mut [u8]>,
+                       length: usize) {
+        self.app.map(move |app| {
+            if app.app_read.is_some() {
+                let src = readbuf.as_ref().unwrap();
+                let dest = app.app_read.as_mut().unwrap();
+                let start = app.index - length;
+                let end = start + length;
+
+                let d = &mut dest.as_mut()[start..end];
+                for (i, c) in src[0..length].iter().enumerate() {
+                    d[i] = *c;
+                }
+            }
+
+            self.kernel_read.put(readbuf);
+            self.kernel_write.replace(writebuf);
+
+            if app.index == app.len {
+                self.busy.set(false);
+                app.len = 0;
+                app.index = 0;
+                app.callback.take().map(|mut cb| { cb.schedule(app.len, 0, 0); });
+            } else {
+                self.do_next_read_write(app);
+            }
+        });
+    }
+}
+
+impl<'a, S: SpiSlaveDevice> SpiSlave<'a, S> {
+    pub fn new(spi_slave: &'a S) -> SpiSlave<'a, S> {
+        SpiSlave {
+            spi_slave: spi_slave,
+            busy: Cell::new(false),
+            app: MapCell::new(SlaveApp::default()),
+            kernel_len: Cell::new(0),
+            kernel_read: TakeCell::empty(),
+            kernel_write: TakeCell::empty(),
+        }
+    }
+
+    pub fn config_buffers(&mut self, read: &'static mut [u8], write: &'static mut [u8]) {
+        let len = cmp::min(read.len(), write.len());
+        self.kernel_len.set(len);
+        self.kernel_read.replace(read);
+        self.kernel_write.replace(write);
+    }
+
+    // Assumes checks for busy/etc. already done
+    // Updates app.index to be index + length of op
+    fn do_next_read_write(&self, app: &mut SlaveApp) {
+        let start = app.index;
+        let len = cmp::min(app.len - start, self.kernel_len.get());
+        let end = start + len;
+        app.index = end;
+
+        self.kernel_write.map(|kwbuf| {
+            app.app_write
+                .as_mut()
+                .map(|src| for (i, c) in src.as_ref()[start..end].iter().enumerate() {
+                    kwbuf[i] = *c;
+                });
+        });
+        self.spi_slave.read_write_bytes(self.kernel_write.take(), self.kernel_read.take(), len);
+    }
+}
+
+impl<'a, S: SpiSlaveDevice> Driver for SpiSlave<'a, S> {
+    /// Provide read/write buffers to SpiSlave
+    ///
+    /// allow_num 0: Provides an app_read buffer to receive transfers into.
+    ///
+    /// allow_num 1: Provides an app_write buffer to send transfers from.
+    ///
+    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+        match allow_num {
+            0 => {
+                self.app.map(|app| app.app_read = Some(slice));
+                ReturnCode::SUCCESS
+            }
+            1 => {
+                self.app.map(|app| app.app_write = Some(slice));
+                ReturnCode::SUCCESS
+            }
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Setup callbacks for SpiSlave
+    ///
+    /// subscribe_num 0: Sets up a callback for when read_write completes. This
+    ///                  is called after completing a transfer/reception with
+    ///                  the Spi master. Note that this occurs after the pending
+    ///                  DMA transfer initiated by read_write_bytes completes.
+    ///
+    /// subscribe_num 1: Sets up a callback for when the chip select line is
+    ///                  driven low, meaning that the slave was selected by
+    ///                  the Spi master. This occurs immediately before
+    ///                  a data transfer.
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+        match subscribe_num {
+            0 /* read_write */ => {
+                self.app.map(|app| app.callback = Some(callback));
+                ReturnCode::SUCCESS
+            },
+            1 /* chip selected */ => {
+                self.app.map(|app| app.selected_callback = Some(callback));
+                ReturnCode::SUCCESS
+            },
+            _ => ReturnCode::ENOSUPPORT
+        }
+    }
+
+    /// 0: check if present
+    /// 1: read/write buffers
+    ///   - read and write buffers optional
+    ///   - fails if arg1 (bytes to write) >
+    ///     write_buffer.len()
+    /// 2: get chip select
+    ///   - returns current selected peripheral
+    ///   - in slave mode, always returns 0
+    /// 3: set clock phase on current peripheral
+    ///   - 0 is sample leading
+    ///   - non-zero is sample trailing
+    /// 4: get clock phase on current peripheral
+    ///   - 0 is sample leading
+    ///   - non-zero is sample trailing
+    /// 5: set clock polarity on current peripheral
+    ///   - 0 is idle low
+    ///   - non-zero is idle high
+    /// 6: get clock polarity on current peripheral
+    ///   - 0 is idle low
+    ///   - non-zero is idle high
+    ///
+    /// x: lock spi
+    ///   - if you perform an operation without the lock,
+    ///     it implicitly acquires the lock before the
+    ///     operation and releases it after
+    ///   - while an app holds the lock no other app can issue
+    ///     operations on SPI (they are buffered)
+    ///   - not implemented or currently supported
+    /// x+1: unlock spi
+    ///   - does nothing if lock not held
+    ///   - not implemented or currently supported
+
+    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: AppId) -> ReturnCode {
+        match cmd_num {
+            0 /* check if present */ => ReturnCode::SUCCESS,
+            1 /* read_write_bytes */ => {
+                if self.busy.get() {
+                    return ReturnCode::EBUSY;
+                }
+                self.app.map_or(ReturnCode::FAIL /* XXX app is null? */, |app| {
+                    let mut mlen = 0;
+                    app.app_write.as_mut().map(|w| {
+                        mlen = w.len();
+                    });
+                    app.app_read.as_mut().map(|r| {
+                        mlen = cmp::min(mlen, r.len());
+                    });
+                    if mlen >= arg1 {
+                        app.len = arg1;
+                        app.index = 0;
+                        self.busy.set(true);
+                        self.do_next_read_write(app);
+                        ReturnCode::SUCCESS
+                    } else {
+                        ReturnCode::EINVAL /* write buffer too small */
+                    }
+                })
+            }
+            2 /* get chip select */ => {
+                // When in slave mode, the only possible chip select is 0
+                ReturnCode::SuccessWithValue { value: 0 }
+            }
+            3 /* set phase */ => {
+                match arg1 {
+                    0 => self.spi_slave.set_phase(ClockPhase::SampleLeading),
+                    _ => self.spi_slave.set_phase(ClockPhase::SampleTrailing),
+                };
+                ReturnCode::SUCCESS
+            }
+            4 /* get phase */ => {
+                ReturnCode::SuccessWithValue { value: self.spi_slave.get_phase() as usize }
+            }
+            5 /* set polarity */ => {
+                match arg1 {
+                    0 => self.spi_slave.set_polarity(ClockPolarity::IdleLow),
+                    _ => self.spi_slave.set_polarity(ClockPolarity::IdleHigh),
+                };
+                ReturnCode::SUCCESS
+            }
+            6 /* get polarity */ => {
+                ReturnCode::SuccessWithValue { value: self.spi_slave.get_polarity() as usize }
+            }
+            _ => ReturnCode::ENOSUPPORT
+        }
+    }
+}
+
+impl<'a, S: SpiSlaveDevice> SpiSlaveClient for SpiSlave<'a, S> {
+    fn read_write_done(&self,
+                       writebuf: Option<&'static mut [u8]>,
+                       readbuf: Option<&'static mut [u8]>,
+                       length: usize) {
+        self.app.map(move |app| {
+            if app.app_read.is_some() {
+                let src = readbuf.as_ref().unwrap();
+                let dest = app.app_read.as_mut().unwrap();
+                let start = app.index - length;
+                let end = start + length;
+
+                let d = &mut dest.as_mut()[start..end];
+                for (i, c) in src[0..length].iter().enumerate() {
+                    d[i] = *c;
+                }
+            }
+
+            self.kernel_read.put(readbuf);
+            self.kernel_write.put(writebuf);
+
+            if app.index == app.len {
+                self.busy.set(false);
+                app.len = 0;
+                app.index = 0;
+                app.callback.take().map(|mut cb| { cb.schedule(app.len, 0, 0); });
+            } else {
+                self.do_next_read_write(app);
+            }
+        });
+    }
+
+    // Simple callback for when chip has been selected
+    fn chip_selected(&self) {
+        self.app.map(move |app| {
+            app.selected_callback.take().map(|mut cb| { cb.schedule(app.len, 0, 0); });
+        });
+    }
+}

--- a/boards/teensy3.2/src/tests/alarm.rs
+++ b/boards/teensy3.2/src/tests/alarm.rs
@@ -1,0 +1,60 @@
+#![allow(unused)]
+
+use mk20::{gpio, clock, pit};
+use kernel::hil::time::{Time, Alarm, Frequency, Client};
+use tests::blink;
+
+static mut INTERVAL: u32 = 18_000_000;
+static mut UP: bool = false;
+
+static mut LAST_TIME: u32 = 0;
+
+struct LedClient;
+impl Client for LedClient {
+    fn fired(&self) {
+        unsafe {
+            let now = pit::PIT.now();
+            let gap = now - LAST_TIME;
+            let wasted = gap - INTERVAL;
+            blink::led_toggle();
+            if INTERVAL > 18_000_000 || INTERVAL < 4_000_000 {
+                UP = !UP;
+            }
+            INTERVAL = if UP {INTERVAL + 1_000_000} else { INTERVAL - 1_000_000 };
+            LAST_TIME = now;
+            pit::PIT.set_alarm(INTERVAL);
+            println!("Interval: {}, Time: {}, Gap: {}, Overhead: {}", INTERVAL, now, gap, wasted);
+        }
+    }
+}
+
+static LED: LedClient = LedClient;
+
+pub fn alarm_test() {
+    unsafe {
+        pit::PIT.set_client(&LED);
+        pit::PIT.set_alarm(pit::PitFrequency::frequency() / 2);
+    }
+}
+
+struct LoopClient {
+    callback: Option<fn()>
+}
+static mut LOOP: LoopClient = LoopClient { callback: None };
+
+impl Client for LoopClient {
+    fn fired(&self) {
+        unsafe {
+            self.callback.map(|cb| cb() );
+            pit::PIT.set_alarm(pit::PitFrequency::frequency() / 2);
+        }
+    }
+}
+
+pub fn loop_500ms(client: fn()) {
+    unsafe {
+        LOOP.callback = Some(client);
+        pit::PIT.set_client(&LOOP);
+        pit::PIT.set_alarm(pit::PitFrequency::frequency() / 2);
+    }
+}

--- a/boards/teensy3.2/src/tests/blink.rs
+++ b/boards/teensy3.2/src/tests/blink.rs
@@ -1,0 +1,46 @@
+#![allow(unused)]
+
+use mk20::{gpio, clock};
+use mk20::gpio::*;
+
+fn delay() {
+    unsafe {
+        for _ in 1..2000_000 {
+            asm!("nop" :::: "volatile");
+        }
+    }
+}
+
+pub fn blink_test() {
+    loop {
+        led_toggle();
+        delay();
+    }
+}
+
+pub fn led_on() {
+    unsafe {
+        PC05.release_claim();
+        let led = PC05.claim_as_gpio();
+        led.enable_output();
+        led.set();
+    }
+}
+
+pub fn led_off() {
+    unsafe {
+        PC05.release_claim();
+        let led = PC05.claim_as_gpio();
+        led.enable_output();
+        led.clear();
+    }
+}
+
+pub fn led_toggle() {
+    unsafe {
+        PC05.release_claim();
+        let led = PC05.claim_as_gpio();
+        led.enable_output();
+        led.toggle();
+    }
+}

--- a/boards/teensy3.2/src/tests/mod.rs
+++ b/boards/teensy3.2/src/tests/mod.rs
@@ -1,0 +1,23 @@
+// Test modules
+#[allow(dead_code)]
+mod blink;
+
+#[allow(dead_code)]
+mod registers;
+
+#[allow(dead_code)]
+mod print;
+
+#[allow(dead_code)]
+mod alarm;
+
+#[allow(dead_code)]
+mod spi;
+
+// Set this function to run whatever test you desire. Test functions are named XXX_test by convention.
+pub fn test() {
+    spi::spi_test();
+}
+
+// Set this to true to make the kernel run the test instead of main.
+pub const TEST: bool = false;

--- a/boards/teensy3.2/src/tests/print.rs
+++ b/boards/teensy3.2/src/tests/print.rs
@@ -1,0 +1,19 @@
+use tests::{blink, alarm};
+
+pub fn print_test() {
+    alarm::loop_500ms(|| {
+        println!("Hello World!"); 
+        blink::led_toggle(); 
+    });
+}
+
+pub fn panic_test() {
+    panic!("This is a kernel panic.");
+}
+
+pub fn debug_test() {
+    alarm::loop_500ms(|| {
+        debug!("This is a kernel debug message."); 
+        blink::led_toggle(); 
+    });
+}

--- a/boards/teensy3.2/src/tests/registers.rs
+++ b/boards/teensy3.2/src/tests/registers.rs
@@ -1,0 +1,36 @@
+#[allow(unused)]
+
+use common::regs::ReadWrite;
+
+struct Registers {
+    c1: ReadWrite<u8, Control>,
+}
+
+// Some made up register fields.
+bitfields! { u8,
+    C1 Control [
+        CLKS  (6, Mask(0b11)) [],
+        PRDIV (4, Mask(0b11)) [
+            Div32 = 2
+        ]
+    ]
+}
+
+const BASE: *mut Registers = 0x2000_0000 as *mut Registers; 
+
+#[inline(never)]
+pub fn register_test() {
+    unsafe {
+        let regs: &mut Registers = ::core::mem::transmute(BASE);
+
+        regs.c1.set(1 << 5);
+
+        regs.c1.modify(C1::CLKS.val(3) +
+                       C1::PRDIV.val(1));
+
+        regs.c1.write(C1::CLKS.val(1) +
+                      C1::PRDIV::Div32);
+
+        while regs.c1.read(C1::CLKS) != 1 {}
+    }
+}

--- a/boards/teensy3.2/src/tests/spi.rs
+++ b/boards/teensy3.2/src/tests/spi.rs
@@ -1,0 +1,43 @@
+#![allow(unused)]
+
+use mk20::{clock, spi};
+use kernel::hil::spi::*;
+use tests::{blink, alarm};
+
+static mut WBUF: [u8; 8] = ['H' as u8,
+                            'i' as u8,
+                            ' ' as u8,
+                            't' as u8,
+                            'h' as u8,
+                            'e' as u8,
+                            'r' as u8,
+                            'e' as u8];
+
+
+struct SpiClient;
+impl SpiMasterClient for SpiClient {
+    fn read_write_done(&self, write_buf: &'static mut [u8],
+                              read_buf: Option<&'static mut [u8]>,
+                              len: usize) {
+        println!("SPI transfer complete");
+        blink::led_toggle();
+    }
+}
+
+static SPI: SpiClient = SpiClient;
+
+pub fn spi_test() {
+    unsafe {
+        spi::SPI1.set_client(&SPI);
+
+        let rate = spi::SPI1.set_rate(20_000_000);
+        println!("Baud rate: {}", rate);
+        println!("Bus clock: {}", clock::bus_clock_hz());
+    }
+
+    alarm::loop_500ms(|| {
+        unsafe {
+            spi::SPI1.read_write_bytes(&mut WBUF, None, 8);
+        }
+    });
+}

--- a/boards/teensy3.2/src/xconsole.rs
+++ b/boards/teensy3.2/src/xconsole.rs
@@ -1,0 +1,377 @@
+//! Provides userspace with access to a serial interface for xmodem protocol.
+//! This is a modified version of the standard Tock console, with a simple
+//! read operation added.
+//!
+//! Setup
+//! -----
+//!
+//! You need a device that provides the `hil::uart::UART` trait.
+//!
+//! ``rust
+//! let xconsole = static_init!(
+//!     XConsole<usart::USART>,
+//!     XConsole::new(&usart::USART0,
+//!                  115200,
+//!                  &mut xconsole::WRITE_BUF,
+//!                  &mut xconsole::READ_BUF,
+//!                  kernel::Grant::create()));
+//! hil::uart::UART::set_client(&usart::USART0, console);
+//! ```
+//!
+//! Usage
+//! -----
+//!
+//! Currently, only writing buffers to the serial device is implemented.
+//!
+//! The user must perform three steps in order to write a buffer:
+//!
+//! ```c
+//! // (Optional) Set a callback to be invoked when the buffer has been written
+//! subscribe(CONSOLE_DRIVER_NUM, 1, my_callback);
+//! // Share the buffer from userspace with the driver
+//! allow(CONSOLE_DRIVER_NUM, buffer, buffer_len_in_bytes);
+//! // Initiate the transaction
+//! command(CONSOLE_DRIVER_NUM, 1, len_to_write_in_bytes)
+//! ```
+//!
+//! When the buffer has been written successfully, the buffer is released from
+//! the driver. Successive writes must call `allow` each time a buffer is to be
+//! written.
+
+use core::cell::Cell;
+use core::cmp;
+use kernel::{AppId, AppSlice, Grant, Callback, Shared, Driver, ReturnCode};
+use kernel::common::take_cell::TakeCell;
+use kernel::hil::uart::{self, UART, Client};
+use kernel::process::Error;
+
+pub const DRIVER_NUM: usize = 0x00000001;
+
+pub struct App {
+    write_callback: Option<Callback>,
+    read_callback: Option<Callback>,
+    read_buffer: Option<AppSlice<Shared, u8>>,
+    write_buffer: Option<AppSlice<Shared, u8>>,
+    write_len: usize,
+    write_remaining: usize, // How many bytes didn't fit in the buffer and still need to be printed.
+    pending_write: bool,
+    read_idx: usize,
+}
+
+impl Default for App {
+    fn default() -> App {
+        App {
+            write_callback: None,
+            read_callback: None,
+            read_buffer: None,
+            write_buffer: None,
+            write_len: 0,
+            write_remaining: 0,
+            pending_write: false,
+            read_idx: 0,
+        }
+    }
+}
+
+pub static mut WRITE_BUF: [u8; 64] = [0; 64];
+pub static mut READ_BUF: [u8; 80] = [0; 80];
+
+pub struct XConsole<'a, U: UART + 'a> {
+    uart: &'a U,
+    apps: Grant<App>,
+    in_progress_tx: Cell<Option<AppId>>,
+    tx_buffer: TakeCell<'static, [u8]>,
+    rx_buffer: TakeCell<'static, [u8]>,
+    in_progress_rx: Cell<Option<AppId>>,
+    baud_rate: u32,
+}
+
+impl<'a, U: UART> XConsole<'a, U> {
+    pub fn new(uart: &'a U,
+               baud_rate: u32,
+               tx_buffer: &'static mut [u8],
+               rx_buffer: &'static mut [u8],
+               container: Grant<App>)
+               -> XConsole<'a, U> {
+        XConsole {
+            uart: uart,
+            apps: container,
+            in_progress_tx: Cell::new(None),
+            tx_buffer: TakeCell::new(tx_buffer),
+            rx_buffer: TakeCell::new(rx_buffer),
+            baud_rate: baud_rate,
+            in_progress_rx: Cell::new(None),
+        }
+    }
+
+    pub fn initialize(&self) {
+        self.uart.init(uart::UARTParams {
+            baud_rate: self.baud_rate,
+            stop_bits: uart::StopBits::One,
+            parity: uart::Parity::None,
+            hw_flow_control: false,
+        });
+    }
+
+    /// Internal helper function for setting up a new send transaction
+    fn send_new(&self, app_id: AppId, app: &mut App, len: usize) -> ReturnCode {
+        match app.write_buffer.take() {
+            Some(slice) => {
+                app.write_len = cmp::min(len, slice.len());
+                app.write_remaining = app.write_len;
+                self.send(app_id, app, slice);
+                ReturnCode::SUCCESS
+            }
+            None => ReturnCode::EBUSY,
+        }
+    }
+
+    /// Internal helper function for continuing a previously set up transaction
+    /// Returns true if this send is still active, or false if it has completed
+    fn send_continue(&self, app_id: AppId, app: &mut App) -> Result<bool, ReturnCode> {
+        if app.write_remaining > 0 {
+            app.write_buffer.take().map_or(Err(ReturnCode::ERESERVE), |slice| {
+                self.send(app_id, app, slice);
+                Ok(true)
+            })
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Internal helper function for sending data for an existing transaction.
+    /// Cannot fail. If can't send now, it will schedule for sending later.
+    fn send(&self, app_id: AppId, app: &mut App, slice: AppSlice<Shared, u8>) {
+        if self.in_progress_tx.get().is_none() {
+            self.in_progress_tx.set(Some(app_id));
+            self.tx_buffer.take().map(|buffer| {
+                let mut transaction_len = app.write_remaining;
+                for (i, c) in slice.as_ref()[slice.len() - app.write_remaining..slice.len()]
+                    .iter()
+                    .enumerate() {
+                    if buffer.len() <= i {
+                        break;
+                    }
+                    buffer[i] = *c;
+                }
+
+                // Check if everything we wanted to print
+                // fit in the buffer.
+                if app.write_remaining > buffer.len() {
+                    transaction_len = buffer.len();
+                    app.write_remaining -= buffer.len();
+                    app.write_buffer = Some(slice);
+                } else {
+                    app.write_remaining = 0;
+                }
+
+                self.uart.transmit(buffer, transaction_len);
+            });
+        } else {
+            app.pending_write = true;
+            app.write_buffer = Some(slice);
+        }
+    }
+}
+
+impl<'a, U: UART> Driver for XConsole<'a, U> {
+    /// Setup shared buffers.
+    ///
+    /// ### `allow_num`
+    ///
+    /// - `0`: Writeable buffer for reads
+    /// - `1`: Writeable buffer for write buffer
+    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+        match allow_num {
+            0 => {
+                self.apps
+                    .enter(appid, |app, _| {
+                        app.read_buffer = Some(slice);
+                        app.read_idx = 0;
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or_else(|err| match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    })
+            }
+            1 => {
+                self.apps
+                    .enter(appid, |app, _| {
+                        app.write_buffer = Some(slice);
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or_else(|err| match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    })
+            }
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Setup callbacks.
+    ///
+    /// ### `subscribe_num`
+    ///
+    /// - `0`: Read callback
+    /// - `1`: Write buffer completed callback
+    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+        match subscribe_num {
+            0 /* read callback */ => {
+                self.apps.enter(callback.app_id(), |app, _| {
+                    app.read_callback = Some(callback);
+                    ReturnCode::SUCCESS
+                }).unwrap_or_else(|err| {
+                    match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    }
+                })
+            },
+            1 /* putstr/write_done */ => {
+                self.apps.enter(callback.app_id(), |app, _| {
+                    app.write_callback = Some(callback);
+                    ReturnCode::SUCCESS
+                }).unwrap_or_else(|err| {
+                    match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    }
+                })
+            },
+            _ => ReturnCode::ENOSUPPORT
+        }
+    }
+
+    /// Initiate serial transfers
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Driver check.
+    /// - `1`: Prints a buffer passed through `allow` up to the length passed in
+    ///        `arg1`
+    fn command(&self, cmd_num: usize, arg1: usize, _: usize, appid: AppId) -> ReturnCode {
+        match cmd_num {
+            0 /* check if present */ => ReturnCode::SUCCESS,
+            1 /* putstr */ => {
+                let len = arg1;
+                self.apps.enter(appid, |app, _| {
+                    self.send_new(appid, app, len)
+                }).unwrap_or_else(|err| {
+                    match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    }
+                })
+            },
+            2 /* raw read */ => {
+                let len = arg1;
+                self.apps.enter(appid, |_app, _| {
+                    self.rx_buffer.take().map_or(ReturnCode::ERESERVE, |buffer| {
+                        self.uart.receive(buffer, len);
+                        self.in_progress_rx.set(Some(appid));
+                        ReturnCode::SUCCESS
+                    })
+                }).unwrap_or_else(|err| {
+                    match err {
+                        Error::OutOfMemory => ReturnCode::ENOMEM,
+                        Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                        Error::NoSuchApp => ReturnCode::EINVAL,
+                    }
+                })
+            },
+            _ => ReturnCode::ENOSUPPORT
+        }
+    }
+}
+
+impl<'a, U: UART> Client for XConsole<'a, U> {
+    fn transmit_complete(&self, buffer: &'static mut [u8], _error: uart::Error) {
+        // Either print more from the AppSlice or send a callback to the
+        // application.
+        self.tx_buffer.replace(buffer);
+        self.in_progress_tx.get().map(|appid| {
+            self.in_progress_tx.set(None);
+            self.apps.enter(appid, |app, _| {
+                match self.send_continue(appid, app) {
+                    Ok(more_to_send) => {
+                        if !more_to_send {
+                            // Go ahead and signal the application
+                            let written = app.write_len;
+                            app.write_len = 0;
+                            app.write_callback.map(|mut cb| { cb.schedule(written, 0, 0); });
+                        }
+                    }
+                    Err(return_code) => {
+                        // XXX This shouldn't ever happen?
+                        app.write_len = 0;
+                        app.write_remaining = 0;
+                        app.pending_write = false;
+                        let r0 = isize::from(return_code) as usize;
+                        app.write_callback.map(|mut cb| { cb.schedule(r0, 0, 0); });
+                    }
+                }
+            })
+        });
+
+        // If we are not printing more from the current AppSlice,
+        // see if any other applications have pending messages.
+        if self.in_progress_tx.get().is_none() {
+            for cntr in self.apps.iter() {
+                let started_tx = cntr.enter(|app, _| {
+                    if app.pending_write {
+                        app.pending_write = false;
+                        match self.send_continue(app.appid(), app) {
+                            Ok(more_to_send) => more_to_send,
+                            Err(return_code) => {
+                                // XXX This shouldn't ever happen?
+                                app.write_len = 0;
+                                app.write_remaining = 0;
+                                app.pending_write = false;
+                                let r0 = isize::from(return_code) as usize;
+                                app.write_callback.map(|mut cb| { cb.schedule(r0, 0, 0); });
+                                false
+                            }
+                        }
+                    } else {
+                        false
+                    }
+                });
+                if started_tx {
+                    break;
+                }
+            }
+        }
+    }
+
+    // We don't use the return value of apps.enter since we should
+    // just fail silently and return to an idle state if the app has
+    // died.
+    #[allow(unused)]
+    fn receive_complete(&self,
+                        _rx_buffer: &'static mut [u8],
+                        _rx_len: usize,
+                        _error: uart::Error) {
+        self.in_progress_rx.get().map(|appid| {
+            self.in_progress_rx.set(None);
+            self.apps.enter(appid, |app, _| {
+                {
+                    let dest = app.read_buffer.as_mut().unwrap();
+                    let d = &mut dest.as_mut();
+                    for (i, c) in _rx_buffer[0.._rx_len].iter().enumerate() {
+                        d[i] = *c;
+                    }
+                }
+                app.read_callback.map(|mut cb| {cb.schedule(_rx_len, 0, 0); });
+            });
+        });
+        self.rx_buffer.replace(_rx_buffer);
+
+    }
+}

--- a/chips/mk20/Cargo.lock
+++ b/chips/mk20/Cargo.lock
@@ -1,0 +1,32 @@
+[[package]]
+name = "capsules"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "common"
+version = "0.1.0"
+
+[[package]]
+name = "cortexm4"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "kernel"
+version = "0.1.0"
+
+[[package]]
+name = "mk20"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "common 0.1.0",
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+]
+

--- a/chips/mk20/Cargo.toml
+++ b/chips/mk20/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mk20"
+version = "0.1.0"
+authors = ["Shane Leonard <shanel@stanford.edu>"]
+
+[profile.dev]
+panic = "abort"
+lto = true
+opt-level = 0
+debug = true
+
+[profile.release]
+panic = "abort"
+lto = true
+
+[dependencies]
+kernel = { path = "../../kernel" }
+cortexm4 = { path = "../../arch/cortex-m4" }
+capsules = { path = "../../capsules" }
+common = { path = "../../common" }

--- a/chips/mk20/src/chip.rs
+++ b/chips/mk20/src/chip.rs
@@ -1,0 +1,74 @@
+use kernel::Chip;
+use kernel::common::{RingBuffer, Queue};
+use nvic;
+use pit;
+use spi;
+use gpio;
+use uart;
+
+pub struct MK20 {
+    pub mpu: (),
+    pub systick: (),
+}
+
+// Interrupt queue allocation
+const IQ_SIZE: usize = 100;
+static mut IQ_BUF: [nvic::NvicIdx; IQ_SIZE] = [nvic::NvicIdx::DMA0; IQ_SIZE];
+pub static mut INTERRUPT_QUEUE: Option<RingBuffer<'static, nvic::NvicIdx>> = None;
+
+impl MK20 {
+    pub unsafe fn new() -> MK20 {
+        // Initialize interrupt queue
+        INTERRUPT_QUEUE = Some(RingBuffer::new(&mut IQ_BUF));
+
+        // Set up DMA channels
+        // TODO: implement
+
+        MK20 {
+            mpu: (),
+            systick: ()
+        }
+    }
+}
+
+impl Chip for MK20 {
+    type MPU = ();
+    type SysTick = ();
+
+    fn service_pending_interrupts(&mut self) {
+        use nvic::NvicIdx::*;
+        unsafe {
+            let iq = INTERRUPT_QUEUE.as_mut().unwrap();
+            while let Some(interrupt) = iq.dequeue() {
+                match interrupt {
+                    PCMA => gpio::PA.handle_interrupt(),
+                    PCMB => gpio::PB.handle_interrupt(),
+                    PCMC => gpio::PC.handle_interrupt(),
+                    PCMD => gpio::PD.handle_interrupt(),
+                    PCME => gpio::PE.handle_interrupt(),
+                    PIT2 => pit::PIT.handle_interrupt(),
+                    SPI0 => spi::SPI0.handle_interrupt(),
+                    SPI1 => spi::SPI1.handle_interrupt(),
+                    SPI2 => spi::SPI2.handle_interrupt(),
+                    UART0 => uart::UART0.handle_interrupt(),
+                    UART1 => uart::UART1.handle_interrupt(),
+                    _ => {}
+                }
+
+                nvic::enable(interrupt);
+            }
+        }
+    }
+
+    fn has_pending_interrupts(&self) -> bool {
+        unsafe { INTERRUPT_QUEUE.as_mut().unwrap().has_elements() }
+    }
+
+    fn mpu(&self) -> &Self::MPU {
+        &self.mpu
+    }
+
+    fn systick(&self) -> &Self::SysTick {
+        &self.systick
+    }
+}

--- a/chips/mk20/src/clock.rs
+++ b/chips/mk20/src/clock.rs
@@ -1,0 +1,97 @@
+// On reset, MCGOUTCLK is sourced from the 32kHz internal reference clock 
+// multiplied by the FLL, which has a default multiplier of 640.
+static mut MCGOUTCLK: u32 = 20_480_000;
+
+static mut CORECLK: u32 = 20_480_000;
+static mut BUSCLK: u32 = 20_480_000;
+static mut FLASHCLK: u32 = 10_240_000;
+
+use osc;
+use mcg;
+use sim;
+
+pub fn peripheral_clock_hz() -> u32 {
+    unsafe { BUSCLK }
+}
+
+pub fn bus_clock_hz() -> u32 {
+    unsafe { BUSCLK }
+}
+
+pub fn flash_clock_hz() -> u32 {
+    unsafe { FLASHCLK }
+}
+
+pub fn core_clock_hz() -> u32 {
+    unsafe { CORECLK }
+}
+
+#[allow(non_upper_case_globals)]
+const MHz: u32 = 1_000_000;
+
+pub fn configure(core_freq: u32) {
+    if let mcg::State::Fei(fei) = mcg::state() {
+
+        let (pll_mul, pll_div) = match core_freq {
+            16 => (16, 8),
+            20 => (20, 8),
+            24 => (24, 8),
+            28 => (28, 8),
+
+            32 => (16, 4),
+            36 => (18, 4),
+            40 => (20, 4),
+            44 => (22, 4),
+            48 => (24, 4),
+            52 => (26, 4),
+            56 => (28, 4),
+            60 => (30, 4),
+
+            64 => (16, 2),
+            68 => (17, 2),
+            72 => (18, 2),
+            76 => (19, 2),
+            80 => (20, 2),
+            84 => (21, 2),
+            88 => (22, 2),
+            92 => (23, 2),
+            96 => (24, 2),
+            100 => (25, 2),
+            104 => (26, 2),
+            108 => (27, 2),
+            112 => (28, 2),
+            116 => (29, 2),
+            120 => (30, 2),
+            _ => panic!("Invalid core frequency selected!")
+        };
+
+        let mut bus_div = 1;
+        while core_freq / bus_div > 60 {
+            bus_div += 1;
+        }
+
+        let mut flash_div = 1;
+        while core_freq / flash_div > 28 {
+            flash_div += 1;
+        }
+
+        osc::enable(mcg::xtals::Teensy16MHz);
+        sim::set_dividers(1, bus_div, flash_div);
+
+        let fbe = fei.use_xtal(mcg::xtals::Teensy16MHz);
+        let pbe = fbe.enable_pll(pll_mul, pll_div);
+        pbe.use_pll();
+
+        unsafe {
+            MCGOUTCLK = core_freq * MHz;
+            CORECLK = core_freq * MHz;
+            BUSCLK = (core_freq * MHz) / bus_div; 
+            FLASHCLK = (core_freq * MHz) / flash_div;
+        }
+
+    } else {
+        // We aren't in FEI mode, meaning that configuration has already occurred.
+        // For now, just exit without changing the existing configuration.
+        return;
+    }
+}

--- a/chips/mk20/src/gpio.rs
+++ b/chips/mk20/src/gpio.rs
@@ -12,8 +12,8 @@ use core::mem;
 use kernel::hil;
 use nvic::{self, NvicIdx};
 
-// Register map for a single Port Control and Interrupt module
-// [^1]: Section 12.5
+/// Register map for a single Port Control and Interrupt module
+/// [^1]: Section 12.5
 #[repr(C, packed)]
 pub struct PortRegisters {
     pcr: [ReadWrite<u32, PinControl>; 32],
@@ -35,24 +35,27 @@ bitfields! [ u32,
     PCR PinControl [
 
         // 31-25: reserved, read only, always value 0
-        // Interrupt Status Flag
-        // The pin interrupt configuration is valid in all digital pin muxing modes.
-        //
-        // When it in enabled:
-        //     If the pin is configured to generate a DMA request, then the
-        //	    corresponding flag will be cleared automatically at the completion of the requested DMA transfer.
-        //     Otherwise, the flag remains set until a logic one is written to the flag. If the pin is configured for a level
-        //     sensitive interrupt and the pin remains asserted, then the flag is set again immediately after it is cleared.
+        /// Interrupt Status Flag
+        ///
+        /// The pin interrupt configuration is valid in all digital pin muxing modes.
+        ///
+        /// When it in enabled:
+        ///     If the pin is configured to generate a DMA request, then the
+        ///	    corresponding flag will be cleared automatically at the completion of the requested DMA transfer.
+        ///     Otherwise, the flag remains set until a logic one is written to the flag. If the pin is configured for a level
+        ///     sensitive interrupt and the pin remains asserted, then the flag is set again immediately after it is cleared.
         InterruptStatusFlag 24 [
-            // Configured interrupt is not detected.
+            /// Configured interrupt will not be triggered
             Unactive = 0,
+            /// Configured interrupt will be triggered
             Active = 1
         ]
         ,
         // 23-20: reserved, read only, always value 0
-        // Interrupt Configuration
-        // The pin interrupt configuration is valid in all digital pin muxing modes. The corresponding pin is configured
-        // to generate interrupt/DMA request as follows:
+        /// Interrupt Configuration
+        ///
+        /// The pin interrupt configuration is valid in all digital pin muxing modes. The corresponding pin is configured
+        /// to generate interrupt/DMA request as follows:
         IRQConfiguration (16, Mask(0b1111)) [
             InterruptDisabled = 0,
             DmaRisingEdge = 1,
@@ -65,74 +68,89 @@ bitfields! [ u32,
             InterruptLogicHigh = 12
             // other values are reserved
         ],
-        // Lock the Pin Control Register fields ([15:0]) until next system reset
+        /// Lock the register fields until reset
+        ///
+        /// Lock the Pin Control Register fields ([15:0]) until next system reset
         LockRegister 15 [
             Unlocked = 0,
             Locked = 1
         ],
         // 14-11: reserved, read only, always value 0
-        // Not all pins support all pin muxing slots. Unimplemented pin muxing slots are reserved
-        // and may result in configuring the pin for a different pin muxing slot.
+        /// Mulitplex Control
+        ///
+        /// Not all pins support all pin muxing slots. Unimplemented pin muxing slots are reserved
+        /// and may result in configuring the pin for a different pin muxing slot.
         PinMuxControl (8, Mask(0b111)) [
-            // pin disabled / analog
+            /// pin disabled / analog
             PinDisabled = 0,
-            // GPIO
+            /// GPIO
             Alternative1 = 1,
-            // chip specific
+            /// chip specific
             Alternative2 = 2,
-            // chip specific
+            /// chip specific
             Alternative3 = 3,
-            // chip specific
+            /// chip specific
             Alternative4 = 4,
-            // chip specific
+            /// chip specific
             Alternative5 = 5,
-            // chip specific
+            /// chip specific
             Alternative6 = 6,
-            // chip specific
+            /// chip specific
             Alternative7 = 7
         ],
         // 7: reserved, read only, always value 0
-        // This bit is read only for pins that do not support a configurable drive strength.
-        // Drive strength configuration is valid in all digital pin muxing modes.
-        // digital pins only
+        /// Set Drive Strength
+        ///
+        /// This bit is read only for pins that do not support a configurable drive strength.
+        /// Drive strength configuration is valid in all digital pin muxing modes.
+        /// digital pins only
         DriveStrengthEnable 6 [
             Low = 0,
             High = 1
         ],
-        // This bit is read only for pins that do not support a configurable open drain output.
-        // Open drain configuration is valid in all digital pin muxing modes.
-        // digital pins only
+        /// Toggle Open Drain
+        ///
+        /// This bit is read only for pins that do not support a configurable open drain output.
+        /// Open drain configuration is valid in all digital pin muxing modes.
+        /// digital pins only
         OpenDrainEnable 5 [
             Disabled = 0,
             Enabled = 1
         ],
-        // Disable the passive input filter when high speed interfaces of more than 2 MHz are supported on the pin.
-        // digital pins only
+        /// Toggle Passive Filter
+        ///
+        /// Disable the passive input filter when high speed interfaces of more than 2 MHz are supported on the pin.
+        /// digital pins only
         PassiveFilterEnable 4 [
             Disabled = 0,
-            // A low pass filter of 10 MHz to 30 MHz bandwidth is enabled on the digital input path
+            /// A low pass filter of 10 MHz to 30 MHz bandwidth is enabled on the digital input path
             Enabled = 1
 
         ],
         // 3: reserved, read only, always value 0
-        // This bit is read only for pins that do not support a configurable slew rate.
-        // Slew rate configuration is valid in all digital pin muxing modes.
-        // digital pins only
+        /// Set Slew Rate
+        ///
+        /// This bit is read only for pins that do not support a configurable slew rate.
+        /// Slew rate configuration is valid in all digital pin muxing modes.
+        /// digital pins only
         SlewRateEnable 2 [
             Fast = 0,
             Slow = 1
         ],
-        // This bit is read only for pins that do not support a configurable pull resistor.
-        // Pull configuration is valid in all digital pin muxing modes.
-        // `Enabled` only has effect on digital pins
+        /// Toggle Pull
+        /// This bit is read only for pins that do not support a configurable pull resistor.
+        /// Pull configuration is valid in all digital pin muxing modes.
+        /// `Enabled` only has effect on digital pins
         PullEnable 1 [
             Disabled = 0,
             Enabled = 1
         ],
-        // This bit is read only for pins that do not support a configurable pull resistor direction.
-        // Pull configuration is valid in all digital pin muxing modes.
-        // `PullEnable` needs to be enabled to take effect
-        // digital pins only
+        /// Set Push/Pull direction
+        ///
+        /// This bit is read only for pins that do not support a configurable pull resistor direction.
+        /// Pull configuration is valid in all digital pin muxing modes.
+        /// `PullEnable` needs to be enabled to take effect
+        /// digital pins only
         PullSelect 0 [
             PullDown = 0,
             PullUp = 1
@@ -141,8 +159,8 @@ bitfields! [ u32,
 ];
 trace_macros!(false);
 
-// Register map for a single GPIO port--aliased to bitband region
-// [^1]: Section 63.3.1
+/// Register map for a single GPIO port--aliased to bitband region
+/// [^1]: Section 63.3.1
 #[repr(C, packed)]
 pub struct GpioBitbandRegisters {
     output: [ReadWrite<u32>; 32],

--- a/chips/mk20/src/gpio.rs
+++ b/chips/mk20/src/gpio.rs
@@ -1,0 +1,583 @@
+//! Implementation of the GPIO Controller
+//! Resources:
+//!     [1] Kinetis K66 Sub-Family Reference Manual
+//!
+
+use core::cell::Cell;
+use core::sync::atomic::Ordering;
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT};
+use common::regs::{ReadWrite, WriteOnly, ReadOnly};
+use core::mem;
+use kernel::hil;
+use nvic::{self, NvicIdx};
+
+// Register map for a single Port Control and Interrupt module
+// [^1]: Section 12.5
+#[repr(C, packed)]
+pub struct PortRegisters {
+    pcr: [ReadWrite<u32, PinControl>; 32],
+    gpclr: WriteOnly<u32>,
+    gpchr: WriteOnly<u32>,
+    _reserved0: [ReadOnly<u32>; 6],
+    isfr: ReadWrite<u32>,
+    _reserved1: [ReadOnly<u32>; 7],
+    dfer: ReadWrite<u32>,
+    dfcr: ReadWrite<u32>,
+    dfwr: ReadWrite<u32>,
+}
+
+trace_macros!(true);
+/// Look at the source for more documentation
+/// would not compile with internal doc comments
+bitfields! [ u32,
+    /// this is pincontol
+    PCR PinControl [
+
+        // 31-25: reserved, read only, always value 0
+        // Interrupt Status Flag
+        // The pin interrupt configuration is valid in all digital pin muxing modes.
+        //
+        // When it in enabled:
+        //     If the pin is configured to generate a DMA request, then the
+        //	    corresponding flag will be cleared automatically at the completion of the requested DMA transfer.
+        //     Otherwise, the flag remains set until a logic one is written to the flag. If the pin is configured for a level
+        //     sensitive interrupt and the pin remains asserted, then the flag is set again immediately after it is cleared.
+        InterruptStatusFlag 24 [
+            // Configured interrupt is not detected.
+            Unactive = 0,
+            Active = 1
+        ]
+        ,
+        // 23-20: reserved, read only, always value 0
+        // Interrupt Configuration
+        // The pin interrupt configuration is valid in all digital pin muxing modes. The corresponding pin is configured
+        // to generate interrupt/DMA request as follows:
+        IRQConfiguration (16, Mask(0b1111)) [
+            InterruptDisabled = 0,
+            DmaRisingEdge = 1,
+            DmaFallingEdge = 2,
+            DmaEitherEdge = 3,
+            InterruptLogicLow = 8,
+            InterruptRisingEdge = 9,
+            InterruptFallingEdge = 10,
+            InterruptEitherEdge = 11,
+            InterruptLogicHigh = 12
+            // other values are reserved
+        ],
+        // Lock the Pin Control Register fields ([15:0]) until next system reset
+        LockRegister 15 [
+            Unlocked = 0,
+            Locked = 1
+        ],
+        // 14-11: reserved, read only, always value 0
+        // Not all pins support all pin muxing slots. Unimplemented pin muxing slots are reserved
+        // and may result in configuring the pin for a different pin muxing slot.
+        PinMuxControl (8, Mask(0b111)) [
+            // pin disabled / analog
+            PinDisabled = 0,
+            // GPIO
+            Alternative1 = 1,
+            // chip specific
+            Alternative2 = 2,
+            // chip specific
+            Alternative3 = 3,
+            // chip specific
+            Alternative4 = 4,
+            // chip specific
+            Alternative5 = 5,
+            // chip specific
+            Alternative6 = 6,
+            // chip specific
+            Alternative7 = 7
+        ],
+        // 7: reserved, read only, always value 0
+        // This bit is read only for pins that do not support a configurable drive strength.
+        // Drive strength configuration is valid in all digital pin muxing modes.
+        // digital pins only
+        DriveStrengthEnable 6 [
+            Low = 0,
+            High = 1
+        ],
+        // This bit is read only for pins that do not support a configurable open drain output.
+        // Open drain configuration is valid in all digital pin muxing modes.
+        // digital pins only
+        OpenDrainEnable 5 [
+            Disabled = 0,
+            Enabled = 1
+        ],
+        // Disable the passive input filter when high speed interfaces of more than 2 MHz are supported on the pin.
+        // digital pins only
+        PassiveFilterEnable 4 [
+            Disabled = 0,
+            // A low pass filter of 10 MHz to 30 MHz bandwidth is enabled on the digital input path
+            Enabled = 1
+
+        ],
+        // 3: reserved, read only, always value 0
+        // This bit is read only for pins that do not support a configurable slew rate.
+        // Slew rate configuration is valid in all digital pin muxing modes.
+        // digital pins only
+        SlewRateEnable 2 [
+            Fast = 0,
+            Slow = 1
+        ],
+        // This bit is read only for pins that do not support a configurable pull resistor.
+        // Pull configuration is valid in all digital pin muxing modes.
+        // `Enabled` only has effect on digital pins
+        PullEnable 1 [
+            Disabled = 0,
+            Enabled = 1
+        ],
+        // This bit is read only for pins that do not support a configurable pull resistor direction.
+        // Pull configuration is valid in all digital pin muxing modes.
+        // `PullEnable` needs to be enabled to take effect
+        // digital pins only
+        PullSelect 0 [
+            PullDown = 0,
+            PullUp = 1
+        ]
+    ]
+];
+trace_macros!(false);
+
+// Register map for a single GPIO port--aliased to bitband region
+// [^1]: Section 63.3.1
+#[repr(C, packed)]
+pub struct GpioBitbandRegisters {
+    output: [ReadWrite<u32>; 32],
+    set: [ReadWrite<u32>; 32],
+    clear: [ReadWrite<u32>; 32],
+    toggle: [ReadWrite<u32>; 32],
+    input: [ReadWrite<u32>; 32],
+    direction: [ReadWrite<u32>; 32],
+}
+
+pub trait PinNum {
+    const PIN: usize;
+}
+
+pub enum PeripheralFunction {
+    Alt0,
+    Alt1,
+    Alt2,
+    Alt3,
+    Alt4,
+    Alt5,
+    Alt6,
+    Alt7
+}
+
+pub struct Port<'a> {
+    regs: *mut PortRegisters,
+    bitband: *mut GpioBitbandRegisters,
+    clients: [Cell<Option<&'a hil::gpio::Client>>; 32],
+    client_data: [Cell<usize>; 32]
+}
+
+pub struct Pin<'a, P: PinNum> {
+    gpio: Gpio<'a>,
+    _pin: PhantomData<P>
+}
+
+pub struct Gpio<'a> {
+    pin: usize,
+    port: &'a Port<'a>,
+    valid: AtomicBool
+}
+
+impl<'a> Port<'a> {
+    const fn new(port: usize) -> Port<'a> {
+        Port {
+            regs: (PORT_BASE_ADDRESS + port*PORT_SIZE) as *mut PortRegisters,
+            bitband: (GPIO_BASE_ADDRESS + port*GPIO_SIZE) as *mut GpioBitbandRegisters,
+            clients: [Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None),
+                      Cell::new(None), Cell::new(None)
+                ],
+            client_data: [Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0),
+                          Cell::new(0), Cell::new(0)
+                ]
+        }
+    }
+
+    pub fn regs(&self) -> &mut PortRegisters {
+        unsafe { mem::transmute(self.regs) }
+    }
+
+    pub fn handle_interrupt(&self) {
+        let regs = self.regs();
+        let mut fired = regs.isfr.get();
+
+        // Writing a logic 1 to the interrupt status flag register clears the interrupt
+        regs.isfr.set(!0);
+
+        loop {
+            let pin = fired.trailing_zeros() as usize;
+            if pin < self.clients.len() {
+                fired &= !(1 << pin);
+                self.clients[pin].get().map(|client| {
+                    client.fired(self.client_data[pin].get());
+                });
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+const PORT_BASE_ADDRESS: usize = 0x4004_9000;
+const PORT_SIZE: usize = 0x1000;
+
+const GPIO_BASE_ADDRESS: usize = 0x43FE_0000;
+const GPIO_SIZE: usize = 0x800;
+
+impl<'a, P: PinNum> Pin<'a, P> {
+    const fn new(port: &'a Port<'a>) -> Pin<'a, P> {
+        Pin {
+            gpio: Gpio {
+                pin: P::PIN,
+                port: port,
+                valid: ATOMIC_BOOL_INIT
+            },
+            _pin: PhantomData,
+        }
+    }
+
+    pub fn claim_as_gpio(&self) -> &Gpio<'a> {
+        let already_allocated = self.gpio.valid.swap(true, Ordering::Relaxed);
+        if already_allocated {
+            let port_name = match self.gpio.pin {
+                0...31 => "A",
+                32...63 => "B",
+                64...95 => "C",
+                96...127 => "D",
+                _ => "E"
+            };
+            panic!("Requested GPIO pin P{}{} is already allocated.", port_name, self.gpio.index());
+        }
+
+        self.set_peripheral_function(PeripheralFunction::Alt1);
+
+        &self.gpio
+    }
+
+    pub fn claim_as(&self, function: functions::Function<P>) {
+        let already_allocated = self.gpio.valid.swap(true, Ordering::Relaxed);
+        if already_allocated {
+            return;
+        }
+
+        self.set_peripheral_function(function.val);
+    }
+
+    fn set_peripheral_function(&self, function: PeripheralFunction) {
+        let port = self.gpio.port.regs();
+
+        port.pcr[self.gpio.index()].modify(PCR::PinMuxControl.val(function as u32));
+    }
+
+    pub fn release_claim(&self) {
+        self.gpio.clear_client();
+        self.gpio.set_client_data(0);
+        self.set_peripheral_function(PeripheralFunction::Alt0);
+        self.gpio.valid.swap(false, Ordering::Relaxed);
+    }
+}
+
+impl<'a> Gpio<'a> {
+    pub fn regs(&self) -> &mut GpioBitbandRegisters {
+        unsafe { mem::transmute(self.port.bitband) }
+    }
+
+    fn index(&self) -> usize {
+        (self.pin % 32) as usize
+    }
+
+    pub fn disable_output(&self) {
+        self.regs().direction[self.index()].set(0);
+    }
+
+    pub fn enable_output(&self) {
+        self.regs().direction[self.index()].set(1);
+    }
+
+    pub fn read(&self) -> bool {
+        self.regs().input[self.index()].get() > 0
+    }
+
+    pub fn toggle(&self) {
+        self.regs().toggle[self.index()].set(1);
+    }
+
+    pub fn set(&self) {
+        self.regs().set[self.index()].set(1);
+    }
+
+    pub fn clear(&self) {
+        self.regs().clear[self.index()].set(1);
+    }
+
+    pub fn set_input_mode(&self, mode: hil::gpio::InputMode) {
+        let config = match mode {
+            hil::gpio::InputMode::PullUp => PCR::PullEnable::SET + PCR::PullSelect::PullUp,
+            hil::gpio::InputMode::PullDown => PCR::PullEnable::SET + PCR::PullSelect::PullDown,
+            hil::gpio::InputMode::PullNone => PCR::PullEnable::CLEAR,
+        };
+
+        self.port.regs().pcr[self.index()].modify(config);
+    }
+
+    pub fn set_interrupt_mode(&self, mode: hil::gpio::InterruptMode) {
+        let config = match mode {
+            hil::gpio::InterruptMode::RisingEdge => PCR::IRQConfiguration::InterruptRisingEdge,
+            hil::gpio::InterruptMode::FallingEdge => PCR::IRQConfiguration::InterruptFallingEdge,
+            hil::gpio::InterruptMode::EitherEdge => PCR::IRQConfiguration::InterruptEitherEdge
+        };
+
+        self.port.regs().pcr[self.index()].modify(config);
+    }
+
+    fn clear_interrupt_status_flag(&self) {
+        self.port.regs().pcr[self.index()].modify(PCR::InterruptStatusFlag::SET);
+    }
+
+    fn enable_interrupt(&self) {
+        unsafe {
+            match self.pin {
+                0...31 => nvic::enable(NvicIdx::PCMA),
+                32...63 => nvic::enable(NvicIdx::PCMB),
+                64...95 => nvic::enable(NvicIdx::PCMC),
+                96...127 => nvic::enable(NvicIdx::PCMD),
+                _ => nvic::enable(NvicIdx::PCME)
+            };
+        }
+    }
+
+    fn disable_interrupt(&self) {
+        self.clear_interrupt_status_flag();
+        self.port.regs().pcr[self.index()].modify(PCR::IRQConfiguration::InterruptDisabled);
+    }
+
+    pub fn clear_client(&self) {
+        if !self.valid.load(Ordering::Relaxed) {
+            return;
+        }
+
+        self.port.clients[self.index()].set(None);
+    }
+
+    pub fn set_client<C: hil::gpio::Client>(&self, client: &'static C) {
+        if !self.valid.load(Ordering::Relaxed) {
+            return;
+        }
+
+        self.port.clients[self.index()].set(Some(client));
+    }
+
+    pub fn set_client_data(&self, data: usize) {
+        if !self.valid.load(Ordering::Relaxed) {
+            return;
+        }
+
+        self.port.client_data[self.index()].set(data);
+    }
+}
+
+impl<'a, P: PinNum> hil::Controller for Pin<'a, P> {
+    type Config = functions::Function<P>;
+
+    fn configure(&self, config: Self::Config) {
+        self.claim_as(config);
+    }
+}
+
+impl<'a> hil::Controller for Gpio<'a> {
+    type Config = (hil::gpio::InputMode, hil::gpio::InterruptMode);
+
+    fn configure(&self, config: Self::Config) {
+        self.set_input_mode(config.0);
+        self.set_interrupt_mode(config.1);
+    }
+}
+
+impl<'a> hil::gpio::PinCtl for Gpio<'a> {
+    fn set_input_mode(&self, mode: hil::gpio::InputMode) {
+        Gpio::set_input_mode(self, mode);
+    }
+}
+
+impl<'a> hil::gpio::Pin for Gpio<'a> {
+    fn disable(&self) {
+        unimplemented!();
+    }
+
+    fn make_output(&self) {
+        self.enable_output();
+    }
+
+    fn make_input(&self) {
+        self.disable_output();
+    }
+
+    fn read(&self) -> bool {
+        self.read()
+    }
+
+    fn toggle(&self) {
+        self.toggle();
+    }
+
+    fn set(&self) {
+        self.set();
+    }
+
+    fn clear(&self) {
+        self.clear();
+    }
+
+    fn enable_interrupt(&self, client_data: usize, mode: hil::gpio::InterruptMode) {
+        Gpio::enable_interrupt(self);
+        self.set_interrupt_mode(mode);
+        self.set_client_data(client_data);
+    }
+
+    fn disable_interrupt(&self) {
+        Gpio::disable_interrupt(self);
+    }
+}
+
+macro_rules! pins {
+    {$($port:ident [$($pintype:ident $pinname:ident $pinnum:expr),*]),*} => {
+        $(
+            $(
+                pub struct $pintype;
+                impl PinNum for $pintype {
+                    const PIN: usize =  $pinnum;
+                }
+                pub static mut $pinname: Pin<$pintype> = Pin::new(unsafe { &$port });
+            )*
+        )*
+    }
+}
+
+pub static mut PA: Port = Port::new(0);
+pub static mut PB: Port = Port::new(1);
+pub static mut PC: Port = Port::new(2);
+pub static mut PD: Port = Port::new(3);
+pub static mut PE: Port = Port::new(4);
+
+pins! {
+    PA [PinA00 PA00 0, PinA01 PA01 1, PinA02 PA02 2, PinA03 PA03 3,
+        PinA04 PA04 4, PinA05 PA05 5, PinA06 PA06 6, PinA07 PA07 7,
+        PinA08 PA08 8, PinA09 PA09 9, PinA10 PA10 10, PinA11 PA11 11,
+        PinA12 PA12 12, PinA13 PA13 13, PinA14 PA14 14, PinA15 PA15 15,
+        PinA16 PA16 16, PinA17 PA17 17, PinA18 PA18 18, PinA19 PA19 19,
+        PinA20 PA20 20, PinA21 PA21 21, PinA22 PA22 22, PinA23 PA23 23,
+        PinA24 PA24 24, PinA25 PA25 25, PinA26 PA26 26, PinA27 PA27 27,
+        PinA28 PA28 28, PinA29 PA29 29, PinA30 PA30 30, PinA31 PA31 31],
+
+    PB [PinB00 PB00 32, PinB01 PB01 33, PinB02 PB02 34, PinB03 PB03 35,
+        PinB04 PB04 36, PinB05 PB05 37, PinB06 PB06 38, PinB07 PB07 39,
+        PinB08 PB08 40, PinB09 PB09 41, PinB10 PB10 42, PinB11 PB11 43,
+        PinB12 PB12 44, PinB13 PB13 45, PinB14 PB14 46, PinB15 PB15 47,
+        PinB16 PB16 48, PinB17 PB17 49, PinB18 PB18 50, PinB19 PB19 51,
+        PinB20 PB20 52, PinB21 PB21 53, PinB22 PB22 54, PinB23 PB23 55,
+        PinB24 PB24 56, PinB25 PB25 57, PinB26 PB26 58, PinB27 PB27 59,
+        PinB28 PB28 60, PinB29 PB29 61, PinB30 PB30 62, PinB31 PB31 63],
+
+    PC [PinC00 PC00 64, PinC01 PC01 65, PinC02 PC02 66, PinC03 PC03 67,
+        PinC04 PC04 68, PinC05 PC05 69, PinC06 PC06 70, PinC07 PC07 71,
+        PinC08 PC08 72, PinC09 PC09 73, PinC10 PC10 74, PinC11 PC11 75,
+        PinC12 PC12 76, PinC13 PC13 77, PinC14 PC14 78, PinC15 PC15 79,
+        PinC16 PC16 80, PinC17 PC17 81, PinC18 PC18 82, PinC19 PC19 83,
+        PinC20 PC20 84, PinC21 PC21 85, PinC22 PC22 86, PinC23 PC23 87,
+        PinC24 PC24 88, PinC25 PC25 89, PinC26 PC26 90, PinC27 PC27 91,
+        PinC28 PC28 92, PinC29 PC29 93, PinC30 PC30 94, PinC31 PC31 95],
+
+    PD [PinD00 PD00 96, PinD01 PD01 97, PinD02 PD02 98, PinD03 PD03 99,
+        PinD04 PD04 100, PinD05 PD05 101, PinD06 PD06 102, PinD07 PD07 103,
+        PinD08 PD08 104, PinD09 PD09 105, PinD10 PD10 106, PinD11 PD11 107,
+        PinD12 PD12 108, PinD13 PD13 109, PinD14 PD14 110, PinD15 PD15 111,
+        PinD16 PD16 112, PinD17 PD17 113, PinD18 PD18 114, PinD19 PD19 115,
+        PinD20 PD20 116, PinD21 PD21 117, PinD22 PD22 118, PinD23 PD23 119,
+        PinD24 PD24 120, PinD25 PD25 121, PinD26 PD26 122, PinD27 PD27 123,
+        PinD28 PD28 124, PinD29 PD29 125, PinD30 PD30 126, PinD31 PD31 127],
+
+    PE [PinE00 PE00 128, PinE01 PE01 129, PinE02 PE02 130, PinE03 PE03 131,
+        PinE04 PE04 132, PinE05 PE05 133, PinE06 PE06 134, PinE07 PE07 135,
+        PinE08 PE08 136, PinE09 PE09 137, PinE10 PE10 138, PinE11 PE11 139,
+        PinE12 PE12 140, PinE13 PE13 141, PinE14 PE14 142, PinE15 PE15 143,
+        PinE16 PE16 144, PinE17 PE17 145, PinE18 PE18 146, PinE19 PE19 147,
+        PinE20 PE20 148, PinE21 PE21 149, PinE22 PE22 150, PinE23 PE23 151,
+        PinE24 PE24 152, PinE25 PE25 153, PinE26 PE26 154, PinE27 PE27 155,
+        PinE28 PE28 156, PinE29 PE29 157, PinE30 PE30 158, PinE31 PE31 159]
+}
+
+pub mod functions {
+    use gpio::*;
+    use core::marker::PhantomData;
+    use gpio::PeripheralFunction::*;
+
+    pub struct Function<P: PinNum> {
+        _pin: PhantomData<P>,
+        pub val: PeripheralFunction,
+    }
+
+    impl<P: PinNum> Function<P> {
+        const fn new(val: PeripheralFunction) -> Function<P> {
+            Function {
+                _pin: PhantomData,
+                val: val
+            }
+        }
+    }
+
+    // Peripheral assignments
+    // UART0: PB16, PB17
+    pub const UART0_RX: Function<PinB16> = Function::new(Alt3);
+    pub const UART0_TX: Function<PinB17> = Function::new(Alt3);
+
+    // SPI0
+    pub const SPI0_MOSI: Function<PinC06> = Function::new(Alt2);
+    pub const SPI0_MISO: Function<PinC07> = Function::new(Alt2);
+    pub const SPI0_SCK: Function<PinA15> = Function::new(Alt2);
+    pub const SPI0_CS0: Function<PinC04> = Function::new(Alt2);
+
+    // SPI1
+    pub const SPI1_MOSI: Function<PinD06> = Function::new(Alt7);
+    pub const SPI1_SCK: Function<PinD05> = Function::new(Alt7);
+}
+
+interrupt_handler!(porta_interrupt, PCMA);
+interrupt_handler!(portb_interrupt, PCMB);
+interrupt_handler!(portc_interrupt, PCMC);
+interrupt_handler!(portd_interrupt, PCMD);
+interrupt_handler!(porte_interrupt, PCME);

--- a/chips/mk20/src/helpers.rs
+++ b/chips/mk20/src/helpers.rs
@@ -1,0 +1,24 @@
+
+/// Define a function for an interrupt and enqueue the interrupt on the global
+/// queue.
+//  TODO: Common functionality. Maybe a better place for this?
+#[macro_export]
+macro_rules! interrupt_handler {
+    ($name: ident, $nvic: ident $(, $body: expr)*) => {
+        #[no_mangle]
+        #[allow(non_snake_case)]
+        #[allow(unused_imports)]
+        pub unsafe extern fn $name() {
+            use kernel::common::Queue;
+            use chip;
+
+            $({
+                $body
+            })*
+
+            let nvic = nvic::NvicIdx::$nvic;
+            nvic::disable(nvic);
+            chip::INTERRUPT_QUEUE.as_mut().unwrap().enqueue(nvic);
+        }
+    }
+}

--- a/chips/mk20/src/lib.rs
+++ b/chips/mk20/src/lib.rs
@@ -1,0 +1,422 @@
+#![crate_name = "mk20"]
+#![crate_type = "rlib"]
+#![feature(asm,core_intrinsics,concat_idents,const_fn,const_cell_new)]
+#![feature(trace_macros)]
+#![no_std]
+
+#[allow(unused_extern_crates)]
+extern crate cortexm4;
+
+#[allow(unused_imports)]
+#[macro_use(debug)]
+extern crate kernel;
+
+#[macro_use]
+mod helpers;
+
+#[allow(dead_code)]
+mod regs;
+
+#[macro_use]
+extern crate common;
+
+pub mod chip;
+pub mod nvic;
+pub mod wdog;
+pub mod gpio;
+pub mod sim;
+pub mod mcg;
+pub mod osc;
+pub mod uart;
+pub mod clock;
+pub mod pit;
+pub mod spi;
+
+// TODO: Should this be moved to the cortexm crate?
+unsafe extern "C" fn unhandled_interrupt() {
+    let mut interrupt_number: u32;
+
+    // IPSR[8:0] holds the currently active interrupt
+    asm!(
+        "mrs    r0, ipsr                    "
+        : "={r0}"(interrupt_number)
+        :
+        : "r0"
+        :
+        );
+
+    interrupt_number = interrupt_number & 0x1ff;
+
+    panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
+}
+
+extern "C" {
+    // _estack is not really a function, but it makes the types work.
+    // You should never actually invoke it!!
+    fn _estack();
+
+    // Defined by platform
+    fn reset_handler();
+
+    // Defined in src/arch/cortex-m4/ctx_switch.S
+    fn SVC_Handler();
+    fn systick_handler();
+
+    fn generic_isr();
+
+    static mut _szero: u32;
+    static mut _ezero: u32;
+    static mut _etext: u32;
+    static mut _srelocate: u32;
+    static mut _erelocate: u32;
+}
+
+// Cortex-M core interrupt vectors
+#[link_section=".vectors"]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+// no_mangle ensures that the symbol is kept until the final binary
+#[no_mangle]
+pub static BASE_VECTORS: [unsafe extern fn(); 16] = [
+    _estack, reset_handler,
+    /* NMI */        unhandled_interrupt,
+    /* Hard Fault */ hard_fault_handler,
+    /* MemManage */  unhandled_interrupt,
+    /* BusFault */   unhandled_interrupt,
+    /* UsageFault */ unhandled_interrupt,
+    unhandled_interrupt, unhandled_interrupt, unhandled_interrupt,
+    unhandled_interrupt,
+    /* SVC */        SVC_Handler,
+    /* DebugMon */   unhandled_interrupt,
+    unhandled_interrupt,
+    /* PendSV */     unhandled_interrupt,
+    /* SysTick */    systick_handler
+];
+
+#[link_section=".vectors"]
+// no_mangle ensures that the symbol is kept until the final binary
+#[no_mangle]
+pub static IRQS: [unsafe extern "C" fn(); 100] = [generic_isr; 100];
+
+#[no_mangle]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+pub static INTERRUPT_TABLE: [Option<unsafe extern fn()>; 100] = [
+    /* DMA0 */          Option::Some(unhandled_interrupt),
+    /* DMA1 */          Option::Some(unhandled_interrupt),
+    /* DMA2 */          Option::Some(unhandled_interrupt),
+    /* DMA3 */          Option::Some(unhandled_interrupt),
+    /* DMA4 */          Option::Some(unhandled_interrupt),
+    /* DMA5 */          Option::Some(unhandled_interrupt),
+    /* DMA6 */          Option::Some(unhandled_interrupt),
+    /* DMA7 */          Option::Some(unhandled_interrupt),
+    /* DMA8 */          Option::Some(unhandled_interrupt),
+    /* DMA9 */          Option::Some(unhandled_interrupt),
+    /* DMA10 */         Option::Some(unhandled_interrupt),
+    /* DMA11 */         Option::Some(unhandled_interrupt),
+    /* DMA12 */         Option::Some(unhandled_interrupt),
+    /* DMA13 */         Option::Some(unhandled_interrupt),
+    /* DMA14 */         Option::Some(unhandled_interrupt),
+    /* DMA15 */         Option::Some(unhandled_interrupt),
+    /* DMAERR */        Option::Some(unhandled_interrupt),
+    /* MCM */           Option::Some(unhandled_interrupt),
+    /* FLASHCC */       Option::Some(unhandled_interrupt),
+    /* FLASHRC */       Option::Some(unhandled_interrupt),
+    /* MODECTRL */      Option::Some(unhandled_interrupt),
+    /* LLWU */          Option::Some(unhandled_interrupt),
+    /* WDOG */          Option::Some(unhandled_interrupt),
+    /* RNG */           Option::Some(unhandled_interrupt),
+    /* I2C0 */          Option::Some(unhandled_interrupt),
+    /* I2C1 */          Option::Some(unhandled_interrupt),
+    /* SPI0 */          Option::Some(spi::spi0_interrupt_handler),
+    /* SPI1 */          Option::Some(spi::spi1_interrupt_handler),
+    /* I2S0_TX */       Option::Some(unhandled_interrupt),
+    /* I2S0_RX */       Option::Some(unhandled_interrupt),
+    /* _RESERVED0 */    Option::Some(unhandled_interrupt),
+    /* UART0 */         Option::Some(uart::uart0_handler),
+    /* UART0_ERR */     Option::Some(unhandled_interrupt),
+    /* UART1 */         Option::Some(uart::uart1_handler),
+    /* UART1_ERR */     Option::Some(unhandled_interrupt),
+    /* UART2 */         Option::Some(unhandled_interrupt),
+    /* UART2_ERR */     Option::Some(unhandled_interrupt),
+    /* UART3 */         Option::Some(unhandled_interrupt),
+    /* UART3_ERR */     Option::Some(unhandled_interrupt),
+    /* ADC0 */          Option::Some(unhandled_interrupt),
+    /* CMP0 */          Option::Some(unhandled_interrupt),
+    /* CMP1 */          Option::Some(unhandled_interrupt),
+    /* FTM0 */          Option::Some(unhandled_interrupt),
+    /* FTM1 */          Option::Some(unhandled_interrupt),
+    /* FTM2 */          Option::Some(unhandled_interrupt),
+    /* CMT */           Option::Some(unhandled_interrupt),
+    /* RTC_ALARM */     Option::Some(unhandled_interrupt),
+    /* RTC_SECONDS */   Option::Some(unhandled_interrupt),
+    /* PIT0 */          Option::Some(unhandled_interrupt),
+    /* PIT1 */          Option::Some(unhandled_interrupt),
+    /* PIT2 */          Option::Some(pit::pit2_handler),
+    /* PIT3 */          Option::Some(unhandled_interrupt),
+    /* PDB */           Option::Some(unhandled_interrupt),
+    /* USBFS_OTG */     Option::Some(unhandled_interrupt),
+    /* USBFS_CHARGE */  Option::Some(unhandled_interrupt),
+    /* _RESERVED1 */    Option::Some(unhandled_interrupt),
+    /* DAC0 */          Option::Some(unhandled_interrupt),
+    /* MCG */           Option::Some(unhandled_interrupt),
+    /* LOWPOWERTIMER */ Option::Some(unhandled_interrupt),
+    /* PCMA */          Option::Some(gpio::porta_interrupt),
+    /* PCMB */          Option::Some(gpio::portb_interrupt),
+    /* PCMC */          Option::Some(gpio::portc_interrupt),
+    /* PCMD */          Option::Some(gpio::portd_interrupt),
+    /* PCME */          Option::Some(gpio::porte_interrupt),
+    /* SOFTWARE */      Option::Some(unhandled_interrupt),
+    /* SPI2 */          Option::Some(spi::spi2_interrupt_handler),
+    /* UART4 */         Option::Some(unhandled_interrupt),
+    /* UART4_ERR */     Option::Some(unhandled_interrupt),
+    /* _RESERVED2 */    Option::Some(unhandled_interrupt),
+    /* _RESERVED3 */    Option::Some(unhandled_interrupt),
+    /* CMP2 */          Option::Some(unhandled_interrupt),
+    /* FTM3 */          Option::Some(unhandled_interrupt),
+    /* DAC1 */          Option::Some(unhandled_interrupt),
+    /* ADC1 */          Option::Some(unhandled_interrupt),
+    /* I2C2 */          Option::Some(unhandled_interrupt),
+    /* CAN0_MSGBUF */   Option::Some(unhandled_interrupt),
+    /* CAN0_BUSOFF */   Option::Some(unhandled_interrupt),
+    /* CAN0_ERR */      Option::Some(unhandled_interrupt),
+    /* CAN0_TX */       Option::Some(unhandled_interrupt),
+    /* CAN0_RX */       Option::Some(unhandled_interrupt),
+    /* CAN0_WKUP */     Option::Some(unhandled_interrupt),
+    /* SDHC */          Option::Some(unhandled_interrupt),
+    /* EMAC_TIMER */    Option::Some(unhandled_interrupt),
+    /* EMAC_TX */       Option::Some(unhandled_interrupt),
+    /* EMAC_RX */       Option::Some(unhandled_interrupt),
+    /* EMAC_ERR */      Option::Some(unhandled_interrupt),
+    /* LPUART0 */       Option::Some(unhandled_interrupt),
+    /* TSI0 */          Option::Some(unhandled_interrupt),
+    /* TPM1 */          Option::Some(unhandled_interrupt),
+    /* TPM2 */          Option::Some(unhandled_interrupt),
+    /* USBHS */         Option::Some(unhandled_interrupt),
+    /* I2C3 */          Option::Some(unhandled_interrupt),
+    /* CMP3 */          Option::Some(unhandled_interrupt),
+    /* USBHS_OTG */     Option::Some(unhandled_interrupt),
+    /* CAN1_MSBBUF */   Option::Some(unhandled_interrupt),
+    /* CAN1_BUSOFF */   Option::Some(unhandled_interrupt),
+    /* CAN1_ERR */      Option::Some(unhandled_interrupt),
+    /* CAN1_TX */       Option::Some(unhandled_interrupt),
+    /* CAN1_RX */       Option::Some(unhandled_interrupt),
+    /* CAN1_WKUP */     Option::Some(unhandled_interrupt),
+];
+
+pub unsafe fn init() {
+    // TODO: Enable the FPU (SCB_CPACR) and LMEM_PCCCR.
+
+    // Relocate data segment.
+    // Assumes data starts right after text segment as specified by the linker
+    // file.
+    let mut pdest = &mut _srelocate as *mut u32;
+    let pend = &mut _erelocate as *mut u32;
+    let mut psrc = &_etext as *const u32;
+
+    if psrc != pdest {
+        while (pdest as *const u32) < pend {
+            *pdest = *psrc;
+            pdest = pdest.offset(1);
+            psrc = psrc.offset(1);
+        }
+    }
+
+    // Clear the zero segment (BSS)
+    let pzero = &_ezero as *const u32;
+    pdest = &mut _szero as *mut u32;
+
+    while (pdest as *const u32) < pzero {
+        *pdest = 0;
+        pdest = pdest.offset(1);
+    }
+}
+
+// TODO: This should be common to all ARM Cortex-M implementations, so I think it should be moved
+// to the cortexm crate.
+unsafe extern "C" fn hard_fault_handler() {
+    use core::intrinsics::offset;
+
+    let faulting_stack: *mut u32;
+    let kernel_stack: bool;
+
+    asm!(
+        "mov    r1, 0                       \n\
+         tst    lr, #4                      \n\
+         itte   eq                          \n\
+         mrseq  r0, msp                     \n\
+         addeq  r1, 1                       \n\
+         mrsne  r0, psp                     "
+        : "={r0}"(faulting_stack), "={r1}"(kernel_stack)
+        :
+        : "r0", "r1"
+        :
+        );
+
+    if kernel_stack {
+        let stacked_r0: u32 = *offset(faulting_stack, 0);
+        let stacked_r1: u32 = *offset(faulting_stack, 1);
+        let stacked_r2: u32 = *offset(faulting_stack, 2);
+        let stacked_r3: u32 = *offset(faulting_stack, 3);
+        let stacked_r12: u32 = *offset(faulting_stack, 4);
+        let stacked_lr: u32 = *offset(faulting_stack, 5);
+        let stacked_pc: u32 = *offset(faulting_stack, 6);
+        let stacked_xpsr: u32 = *offset(faulting_stack, 7);
+
+        let mode_str = "Kernel";
+
+        let shcsr: u32 = core::ptr::read_volatile(0xE000ED24 as *const u32);
+        let cfsr: u32 = core::ptr::read_volatile(0xE000ED28 as *const u32);
+        let hfsr: u32 = core::ptr::read_volatile(0xE000ED2C as *const u32);
+        let mmfar: u32 = core::ptr::read_volatile(0xE000ED34 as *const u32);
+        let bfar: u32 = core::ptr::read_volatile(0xE000ED38 as *const u32);
+
+        let iaccviol = (cfsr & 0x01) == 0x01;
+        let daccviol = (cfsr & 0x02) == 0x02;
+        let munstkerr = (cfsr & 0x08) == 0x08;
+        let mstkerr = (cfsr & 0x10) == 0x10;
+        let mlsperr = (cfsr & 0x20) == 0x20;
+        let mmfarvalid = (cfsr & 0x80) == 0x80;
+
+        let ibuserr = ((cfsr >> 8) & 0x01) == 0x01;
+        let preciserr = ((cfsr >> 8) & 0x02) == 0x02;
+        let impreciserr = ((cfsr >> 8) & 0x04) == 0x04;
+        let unstkerr = ((cfsr >> 8) & 0x08) == 0x08;
+        let stkerr = ((cfsr >> 8) & 0x10) == 0x10;
+        let lsperr = ((cfsr >> 8) & 0x20) == 0x20;
+        let bfarvalid = ((cfsr >> 8) & 0x80) == 0x80;
+
+        let undefinstr = ((cfsr >> 16) & 0x01) == 0x01;
+        let invstate = ((cfsr >> 16) & 0x02) == 0x02;
+        let invpc = ((cfsr >> 16) & 0x04) == 0x04;
+        let nocp = ((cfsr >> 16) & 0x08) == 0x08;
+        let unaligned = ((cfsr >> 16) & 0x100) == 0x100;
+        let divbysero = ((cfsr >> 16) & 0x200) == 0x200;
+
+        let vecttbl = (hfsr & 0x02) == 0x02;
+        let forced = (hfsr & 0x40000000) == 0x40000000;
+
+        let ici_it = (((stacked_xpsr >> 25) & 0x3) << 6) | ((stacked_xpsr >> 10) & 0x3f);
+        let thumb_bit = ((stacked_xpsr >> 24) & 0x1) == 1;
+        let exception_number = (stacked_xpsr & 0x1ff) as usize;
+
+        panic!("{} HardFault.\n\
+               \tKernel version {}\n\
+               \tr0  0x{:x}\n\
+               \tr1  0x{:x}\n\
+               \tr2  0x{:x}\n\
+               \tr3  0x{:x}\n\
+               \tr12 0x{:x}\n\
+               \tlr  0x{:x}\n\
+               \tpc  0x{:x}\n\
+               \tprs 0x{:x} [ N {} Z {} C {} V {} Q {} GE {}{}{}{} ; ICI.IT {} T {} ; Exc {}-{} ]\n\
+               \tsp  0x{:x}\n\
+               \ttop of stack     0x{:x}\n\
+               \tbottom of stack  0x{:x}\n\
+               \tSHCSR 0x{:x}\n\
+               \tCFSR  0x{:x}\n\
+               \tHSFR  0x{:x}\n\
+               \tInstruction Access Violation:       {}\n\
+               \tData Access Violation:              {}\n\
+               \tMemory Management Unstacking Fault: {}\n\
+               \tMemory Management Stacking Fault:   {}\n\
+               \tMemory Management Lazy FP Fault:    {}\n\
+               \tInstruction Bus Error:              {}\n\
+               \tPrecise Data Bus Error:             {}\n\
+               \tImprecise Data Bus Error:           {}\n\
+               \tBus Unstacking Fault:               {}\n\
+               \tBus Stacking Fault:                 {}\n\
+               \tBus Lazy FP Fault:                  {}\n\
+               \tUndefined Instruction Usage Fault:  {}\n\
+               \tInvalid State Usage Fault:          {}\n\
+               \tInvalid PC Load Usage Fault:        {}\n\
+               \tNo Coprocessor Usage Fault:         {}\n\
+               \tUnaligned Access Usage Fault:       {}\n\
+               \tDivide By Zero:                     {}\n\
+               \tBus Fault on Vector Table Read:     {}\n\
+               \tForced Hard Fault:                  {}\n\
+               \tFaulting Memory Address: (valid: {}) {:#010X}\n\
+               \tBus Fault Address:       (valid: {}) {:#010X}\n\
+               ",
+               mode_str,
+               env!("TOCK_KERNEL_VERSION"),
+               stacked_r0,
+               stacked_r1,
+               stacked_r2,
+               stacked_r3,
+               stacked_r12,
+               stacked_lr,
+               stacked_pc,
+               stacked_xpsr,
+               (stacked_xpsr >> 31) & 0x1,
+               (stacked_xpsr >> 30) & 0x1,
+               (stacked_xpsr >> 29) & 0x1,
+               (stacked_xpsr >> 28) & 0x1,
+               (stacked_xpsr >> 27) & 0x1,
+               (stacked_xpsr >> 19) & 0x1,
+               (stacked_xpsr >> 18) & 0x1,
+               (stacked_xpsr >> 17) & 0x1,
+               (stacked_xpsr >> 16) & 0x1,
+               ici_it,
+               thumb_bit,
+               exception_number,
+               kernel::process::ipsr_isr_number_to_str(exception_number),
+               faulting_stack as u32,
+               (_estack as *const ()) as u32,
+               (&_ezero as *const u32) as u32,
+               shcsr,
+               cfsr,
+               hfsr,
+               iaccviol,
+               daccviol,
+               munstkerr,
+               mstkerr,
+               mlsperr,
+               ibuserr,
+               preciserr,
+               impreciserr,
+               unstkerr,
+               stkerr,
+               lsperr,
+               undefinstr,
+               invstate,
+               invpc,
+               nocp,
+               unaligned,
+               divbysero,
+               vecttbl,
+               forced,
+               mmfarvalid,
+               mmfar,
+               bfarvalid,
+               bfar);
+    } else {
+        // hard fault occurred in an app, not the kernel. The app should be
+        //  marked as in an error state and handled by the kernel
+        asm!("ldr r0, =SYSCALL_FIRED
+              mov r1, #1
+              str r1, [r0, #0]
+
+              ldr r0, =APP_FAULT
+              str r1, [r0, #0]
+
+              /* Read the SCB registers. */
+              ldr r0, =SCB_REGISTERS
+              ldr r1, =0xE000ED14
+              ldr r2, [r1, #0] /* CCR */
+              str r2, [r0, #0]
+              ldr r2, [r1, #20] /* CFSR */
+              str r2, [r0, #4]
+              ldr r2, [r1, #24] /* HFSR */
+              str r2, [r0, #8]
+              ldr r2, [r1, #32] /* MMFAR */
+              str r2, [r0, #12]
+              ldr r2, [r1, #36] /* BFAR */
+              str r2, [r0, #16]
+
+              /* Set thread mode to privileged */
+              mov r0, #0
+              msr CONTROL, r0
+
+              movw LR, #0xFFF9
+              movt LR, #0xFFFF");
+    }
+}

--- a/chips/mk20/src/mcg.rs
+++ b/chips/mk20/src/mcg.rs
@@ -1,0 +1,128 @@
+//! Implementation of the Multipurpose Clock Generator
+//!
+
+use ::core::mem;
+
+use regs::mcg::*;
+
+pub use self::C1::CLKS::Value as OscSource;
+pub use self::C1::FRDIV::Value as Frdiv;
+pub use self::C2::RANGE::Value as OscRange;
+
+pub enum State {
+    Fei(Fei),
+    Fee,
+    Fbi,
+    Fbe(Fbe),
+    Pbe(Pbe),
+    Pee,
+    Blpi,
+    Blpe,
+    Stop,
+}
+
+#[derive(Copy,Clone)]
+pub struct Fei;
+
+#[derive(Copy,Clone)]
+pub struct Fbe;
+
+#[derive(Copy,Clone)]
+pub struct Pbe;
+
+pub fn state() -> State {
+    let mcg: &mut Registers = unsafe { mem::transmute(MCG) };
+
+    let clks: OscSource = match mcg.c1.read(C1::CLKS) {
+        1 => OscSource::Internal,
+        2 => OscSource::External,
+        _ => OscSource::LockedLoop
+    };
+
+    let irefs = mcg.c1.is_set(C1::IREFS);
+    let plls = mcg.c6.is_set(C6::PLLS);
+    let lp = mcg.c2.is_set(C2::LP);
+
+    match (clks, irefs, plls, lp) {
+        (OscSource::LockedLoop, true, false, _) => State::Fei(Fei),
+        (OscSource::LockedLoop, false, false, _) => State::Fee,
+        (OscSource::Internal, true, false, false) => State::Fbi,
+        (OscSource::External, false, false, false) => State::Fbe(Fbe),
+        (OscSource::LockedLoop, false, true, _) => State::Pee,
+        (OscSource::External, false, true, false) => State::Pbe(Pbe),
+        (OscSource::Internal, true, false, true) => State::Blpi,
+        (OscSource::External, false, _, true) => State::Blpe,
+        _ => panic!("Not in a recognized power mode!")
+    }
+}
+
+pub struct Xtal {
+    pub range: OscRange, 
+    pub frdiv: Frdiv,
+    pub load: ::osc::OscCapacitance
+}
+
+pub mod xtals {
+    use mcg::{Xtal, OscRange, Frdiv};
+    use osc::OscCapacitance;
+
+    #[allow(non_upper_case_globals)]
+    pub const Teensy16MHz: Xtal = Xtal { 
+        range: OscRange::VeryHigh, 
+        frdiv: Frdiv::Low16_High512,
+        load: OscCapacitance::Load_10pF
+    };
+}
+
+// Source: https://branan.github.io/teensy/2017/01/28/uart.html
+impl Fei {
+    pub fn use_xtal(self, xtal: Xtal) -> Fbe {
+        let mcg: &mut Registers = unsafe { mem::transmute(MCG) };
+
+        mcg.c2.modify(C2::RANGE.val(xtal.range as u8) +
+                      C2::EREFS::SET);
+
+        mcg.c1.write(C1::CLKS::External +
+                     C1::FRDIV.val(xtal.frdiv as u8) +
+                     C1::IREFS::CLEAR);
+
+        while !mcg.s.matches(S::OSCINIT0::SET + 
+                             S::IREFST::CLEAR + 
+                             S::CLKST::External) {}
+
+        Fbe { }
+    }
+}
+
+impl Fbe {
+    pub fn enable_pll(self, multiplier: u8, divider: u8) -> Pbe {
+        let mcg: &mut Registers = unsafe { mem::transmute(MCG) };
+
+        if multiplier < 16 || multiplier > 47 {
+            panic!("Invalid PLL VCO divide factor: {}", multiplier);
+        }
+        if divider < 1 || divider > 8 {
+            panic!("Invalid PLL reference divide factor: {}", divider);
+        }
+
+        mcg.c5.modify(C5::PRDIV.val(divider - 1));
+
+        mcg.c6.modify(C6::VDIV.val(multiplier - 16) +
+                      C6::PLLS::SET);
+
+        // Wait for PLL to be selected and stable PLL lock
+        while !mcg.s.matches(S::PLLST::SET + S::LOCK0::SET) {}
+
+        Pbe { }
+    }
+}
+
+impl Pbe {
+    pub fn use_pll(self) {
+        let mcg: &mut Registers = unsafe { mem::transmute(MCG) };
+
+        mcg.c1.modify(C1::CLKS::LockedLoop);
+
+        while !mcg.s.matches(S::CLKST::Pll) {}
+    }
+}

--- a/chips/mk20/src/nvic.rs
+++ b/chips/mk20/src/nvic.rs
@@ -1,0 +1,155 @@
+//! Implementation of the Freescale MK20 interrupt controller
+
+use core::intrinsics;
+use kernel::common::VolatileCell;
+
+// TODO: This register format is common to all Cortex-M cores, so I think it
+// should be moved to the cortexm crate
+#[repr(C, packed)]
+struct Nvic {
+    iser: [VolatileCell<u32>; 7],
+    _reserved0: [u32; 25],
+    icer: [VolatileCell<u32>; 7],
+    _reserved1: [u32; 25],
+    ispr: [VolatileCell<u32>; 7],
+    _reserved2: [u32; 25],
+    icpr: [VolatileCell<u32>; 7],
+}
+
+#[repr(C)]
+#[derive(Copy,Clone)]
+#[allow(non_camel_case_types)]
+pub enum NvicIdx {
+    DMA0,
+    DMA1,
+    DMA2,
+    DMA3,
+    DMA4,
+    DMA5,
+    DMA6,
+    DMA7,
+    DMA8,
+    DMA9,
+    DMA10,
+    DMA11,
+    DMA12,
+    DMA13,
+    DMA14,
+    DMA15,
+    DMAERR,
+    MCM,
+    FLASHCC,
+    FLASHRC,
+    MODECTRL,
+    LLWU,
+    WDOG,
+    RNG,
+    I2C0,
+    I2C1,
+    SPI0,
+    SPI1,
+    I2S0_TX,
+    I2S0_RX,
+    _RESERVED0,
+    UART0,
+    UART0_ERR,
+    UART1,
+    UART1_ERR,
+    UART2,
+    UART2_ERR,
+    UART3,
+    UART3_ERR,
+    ADC0,
+    CMP0,
+    CMP1,
+    FTM0,
+    FTM1,
+    FTM2,
+    CMT,
+    RTC_ALARM,
+    RTC_SECONDS,
+    PIT0,
+    PIT1,
+    PIT2,
+    PIT3,
+    PDB,
+    USBFS_OTG,
+    USBFS_CHARGE,
+    _RESERVED1,
+    DAC0,
+    MCG,
+    LOWPOWERTIMER,
+    PCMA,
+    PCMB,
+    PCMC,
+    PCMD,
+    PCME,
+    SOFTWARE,
+    SPI2,
+    UART4,
+    UART4_ERR,
+    _RESERVED2,
+    _RESERVED3,
+    CMP2,
+    FTM3,
+    DAC1,
+    ADC1,
+    I2C2,
+    CAN0_MSGBUF,
+    CAN0_BUSOFF,
+    CAN0_ERR,
+    CAN0_TX,
+    CAN0_RX,
+    CAN0_WKUP,
+    SDHC,
+    EMAC_TIMER,
+    EMAC_TX,
+    EMAC_RX,
+    EMAC_ERR,
+    LPUART0,
+    TSI0,
+    TPM1,
+    TPM2,
+    USBHS,
+    I2C3,
+    CMP3,
+    USBHS_OTG,
+    CAN1_MSBBUF,
+    CAN1_BUSOFF,
+    CAN1_ERR,
+    CAN1_TX,
+    CAN1_RX,
+    CAN1_WKUP,
+}
+
+impl ::core::default::Default for NvicIdx {
+    fn default() -> NvicIdx {
+        NvicIdx::DMA0
+    }
+}
+
+// Defined by ARM Cortex-M bus architecture
+// TODO: since these functions/constants are common to all ARM Cortex-M cores, I
+// think they should be moved to the cortexm crate.
+const BASE_ADDRESS: usize = 0xe000e100;
+
+pub unsafe fn enable(signal: NvicIdx) {
+    let nvic: &mut Nvic = intrinsics::transmute(BASE_ADDRESS);
+    let interrupt = signal as usize;
+
+    nvic.iser[interrupt / 32].set(1 << (interrupt & 31));
+}
+
+pub unsafe fn disable(signal: NvicIdx) {
+    let nvic: &mut Nvic = intrinsics::transmute(BASE_ADDRESS);
+    let interrupt = signal as usize;
+
+    nvic.icer[interrupt / 32].set(1 << (interrupt & 31));
+}
+
+pub unsafe fn clear_pending(signal: NvicIdx) {
+    let nvic: &mut Nvic = intrinsics::transmute(BASE_ADDRESS);
+    let interrupt = signal as usize;
+
+    nvic.icpr[interrupt / 32].set(1 << (interrupt & 31));
+}

--- a/chips/mk20/src/osc.rs
+++ b/chips/mk20/src/osc.rs
@@ -1,0 +1,14 @@
+use core::mem;
+use regs::osc::*;
+
+pub use self::CR::CAP::Value as OscCapacitance;
+
+pub fn enable(osc: ::mcg::Xtal) {
+    let regs: &mut Registers = unsafe { mem::transmute(OSC) };
+
+    // Set the capacitance.
+    regs.cr.modify(CR::CAP.val(osc.load as u8));
+
+    // Enable the oscillator.
+    regs.cr.modify(CR::EREFSTEN::SET);
+}

--- a/chips/mk20/src/pit.rs
+++ b/chips/mk20/src/pit.rs
@@ -1,0 +1,133 @@
+use regs::pit::*;
+use core::mem;
+use core::cell::Cell;
+use kernel::hil::time::{Client, Time, Alarm, Frequency};
+use nvic;
+use clock::peripheral_clock_hz;
+
+pub static mut PIT: Pit<'static> = Pit::new();
+
+pub struct Pit<'a> {
+    pub client: Cell<Option<&'a Client>>,
+    alarm: Cell<u32>
+}
+
+impl<'a> Pit<'a> {
+    pub const fn new() -> Self {
+        Pit {
+            client: Cell::new(None),
+            alarm: Cell::new(0)
+        }
+    }
+
+    pub fn init(&self) {
+        use sim::{clocks, Clock};
+
+        clocks::PIT.enable();
+        self.regs().mcr.write(MCR::MDIS::CLEAR +
+                              MCR::FRZ::SET);
+
+        // Configure the lifetime timer.
+        self.pit(0).ldval.set(0xFFFF_FFFF);
+        self.pit(1).ldval.set(0xFFFF_FFFF);
+        self.pit(1).tctrl.modify(TCTRL::CHN::SET);
+
+        // Enable the lifetime timer.
+        self.pit(1).tctrl.modify(TCTRL::TEN::SET);
+        self.pit(0).tctrl.modify(TCTRL::TEN::SET);
+    }
+
+    fn regs(&self) -> &mut Registers {
+        unsafe { mem::transmute(PIT_BASE) }
+    }
+
+    fn pit(&self, index: usize) -> &mut PitRegisters {
+        unsafe { mem::transmute(PIT_ADDRS[index])}
+    }
+
+    pub fn enable(&self) {
+        self.pit(2).tctrl.modify(TCTRL::TEN::SET);
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.pit(2).tctrl.is_set(TCTRL::TEN)
+    }
+
+    pub fn enable_interrupt(&self) {
+        unsafe { nvic::enable(nvic::NvicIdx::PIT2); }
+        self.pit(2).tctrl.modify(TCTRL::TIE::SET);
+    }
+
+    pub fn set_counter(&self, value: u32) {
+        self.pit(2).ldval.set(value);
+    }
+
+    pub fn get_counter(&self)  -> u32 {
+        self.pit(2).ldval.get()
+    }
+
+    pub fn clear_pending(&self) {
+        self.pit(2).tflg.modify(TFLG::TIF::SET);
+        unsafe { nvic::clear_pending(nvic::NvicIdx::PIT2); }
+    }
+
+    pub fn disable(&self) {
+        self.pit(2).tctrl.modify(TCTRL::TEN::CLEAR);
+    }
+
+    pub fn disable_interrupt(&self) {
+        self.pit(2).tctrl.modify(TCTRL::TIE::CLEAR);
+    }
+
+    pub fn set_client(&self, client: &'a Client) {
+        self.client.set(Some(client));
+    }
+
+    pub fn handle_interrupt(&self) {
+        self.disable();
+        self.disable_interrupt();
+        self.clear_pending();
+        self.client.get().map(|client| { client.fired(); });
+    }
+}
+
+pub struct PitFrequency;
+impl Frequency for PitFrequency {
+    fn frequency() -> u32 {
+        peripheral_clock_hz()
+    }
+}
+
+impl<'a> Time for Pit<'a> {
+    type Frequency = PitFrequency;
+    fn disable(&self) {
+        Pit::disable(self);
+        self.disable_interrupt();
+        self.clear_pending();
+    }
+
+    fn is_armed(&self) -> bool {
+        self.is_enabled()
+    }
+}
+
+impl<'a> Alarm for Pit<'a> {
+    fn now(&self) -> u32 {
+        self.regs().ltmr64h.get();
+        ::core::u32::MAX - self.regs().ltmr64l.get()
+    }
+
+    fn set_alarm(&self, ticks: u32) {
+        Time::disable(self);
+        self.alarm.set(ticks.wrapping_sub(self.now()));
+        self.set_counter(self.alarm.get());
+        self.enable_interrupt();
+        self.enable();
+    }
+
+    fn get_alarm(&self) -> u32 {
+        self.alarm.get()
+    }
+}
+
+interrupt_handler!(pit2_handler, PIT2);

--- a/chips/mk20/src/regs/mcg.rs
+++ b/chips/mk20/src/regs/mcg.rs
@@ -1,0 +1,134 @@
+use common::regs::{ReadWrite, ReadOnly};
+
+pub const MCG: *mut Registers = 0x4006_4000 as *mut Registers;
+
+#[repr(C, packed)]
+pub struct Registers {
+    pub c1: ReadWrite<u8, Control1>,
+    pub c2: ReadWrite<u8, Control2>,
+    pub c3: ReadWrite<u8>,
+    pub c4: ReadWrite<u8>,
+    pub c5: ReadWrite<u8, Control5>,
+    pub c6: ReadWrite<u8, Control6>,
+    pub s: ReadOnly<u8, Status>,
+    _reserved0: ReadOnly<u8>,
+    pub sc: ReadWrite<u8>,
+    _reserved1: ReadOnly<u8>,
+    pub atcvh: ReadWrite<u8>,
+    pub atcvl: ReadWrite<u8>,
+    pub c7: ReadWrite<u8>,
+    pub c8: ReadWrite<u8>,
+    pub c9: ReadWrite<u8>,
+    _reserved2: ReadOnly<u8>,
+    pub c11: ReadWrite<u8>,
+    pub c12: ReadWrite<u8>,
+    pub s2: ReadOnly<u8>,
+    pub t3: ReadWrite<u8>
+}
+
+bitfields![u8,
+    C1 Control1 [
+        CLKS (6, Mask(0b11)) [
+            LockedLoop = 0,
+            Internal = 1,
+            External = 2
+        ],
+        FRDIV (4, Mask(0b11)) [
+            Low1_High32 = 0,
+            Low2_High64 = 1,
+            Low4_High128 = 2,
+            Low8_High256 = 3,
+            Low16_High512 = 4,
+            Low32_High1024 = 5,
+            Low64_High1280 = 6,
+            Low128_High1536 = 7
+        ],
+        IREFS 2 [
+            External = 0,
+            SlowInternal = 1
+        ],
+        IRCLKEN 1 [
+            Inactive = 0,
+            Active = 1
+        ],
+        IREFSTEN 0 [
+            IrefDisabledInStop = 0,
+            IrefEnabledInStop = 1
+        ]
+    ],
+
+    C2 Control2 [
+        LOCKRE0 7 [],
+        FCFTRIM 6 [],
+        RANGE (4, Mask(0b11)) [
+            Low = 0,
+            High = 1,
+            VeryHigh = 2
+        ],
+        HGO 3 [
+            LowPower = 0,
+            HighGain = 1
+        ],
+        EREFS 2 [
+            External = 0,
+            Oscillator = 1
+        ],
+        LP 1 [],
+        IRCS 0 [
+            SlowInternal = 0,
+            FastInternal = 1
+        ]
+    ],
+
+    C5 Control5 [
+        PLLCLKEN 6 [],
+        PLLSTEN 5 [],
+        PRDIV (0, Mask(0b111)) [
+            Div1 = 0, Div2 = 1, Div3 = 2, Div4 = 3,
+            Div5 = 4, Div6 = 5, Div7 = 6, Div8 = 7
+        ]
+    ],
+
+    C6 Control6 [
+        LOLIE0 7 [],
+        PLLS 6 [
+            Fll = 0,
+            PllcsOutput = 1
+        ],
+        CME0 5 [],
+        VDIV (0, Mask(0b11111)) [
+            Mul16 = 0, Mul17 = 1, Mul18 = 2, Mul19 = 3,
+            Mul20 = 4, Mul21 = 5, Mul22 = 6, Mul23 = 7,
+            Mul24 = 8, Mul25 = 9, Mul26 = 10, Mul27 = 11,
+            Mul28 = 12, Mul29 = 13, Mul30 = 14, Mul31 = 15,
+            Mul32 = 16, Mul33 = 17, Mul34 = 18, Mul35 = 19,
+            Mul36 = 20, Mul37 = 21, Mul38 = 22, Mul39 = 23,
+            Mul40 = 24, Mul41 = 25, Mul42 = 26, Mul43 = 27,
+            Mul44 = 28, Mul45 = 29, Mul46 = 30, Mul47 = 31
+        ]
+    ],
+
+    S Status [
+        LOLS0 7 [],
+        LOCK0 6 [],
+        PLLST 5 [
+            Fll = 0,
+            PllcsOutput = 1
+        ],
+        IREFST 4 [
+            External = 0,
+            Internal = 1
+        ],
+        CLKST (2, Mask(0b11)) [
+            Fll = 0,
+            Internal = 1,
+            External = 2,
+            Pll = 3
+        ],
+        OSCINIT0 1 [],
+        IRCST 0 [
+            Slow = 0,
+            Fast = 1
+        ]
+    ]
+];

--- a/chips/mk20/src/regs/mod.rs
+++ b/chips/mk20/src/regs/mod.rs
@@ -1,0 +1,7 @@
+pub mod mcg;
+pub mod osc;
+pub mod sim;
+pub mod uart;
+pub mod wdog;
+pub mod pit;
+pub mod spi;

--- a/chips/mk20/src/regs/osc.rs
+++ b/chips/mk20/src/regs/osc.rs
@@ -1,0 +1,42 @@
+use common::regs::ReadWrite;
+
+pub const OSC: *mut Registers = 0x4006_5000 as *mut Registers;
+
+#[repr(C, packed)]
+pub struct Registers {
+    pub cr: ReadWrite<u8, Control>,
+    pub div: ReadWrite<u8, Divider>
+}
+
+bitfields![u8,
+    CR Control [
+        ERCLKEN 7 [],
+        EREFSTEN 5 [],
+        CAP (0, Mask(0b1111)) [
+            Load_0pF = 0b0000,
+            Load_2pF = 0b1000,
+            Load_4pF = 0b0100,
+            Load_6pF = 0b1100,
+            Load_8pF = 0b0010,
+            Load_10pF = 0b1010,
+            Load_12pF = 0b0110,
+            Load_14pF = 0b1110,
+            Load_16pF = 0b0001,
+            Load_18pF = 0b1001,
+            Load_20pF = 0b0101,
+            Load_22pF = 0b1101,
+            Load_24pF = 0b0011,
+            Load_26pF = 0b1011,
+            Load_28pF = 0b0111,
+            Load_30pF = 0b1111
+        ]
+    ],
+    DIV Divider [
+        ERPS (6, Mask(0b11)) [
+            Div1 = 0,
+            Div2 = 1,
+            Div4 = 2,
+            Div8 = 3
+        ]
+    ]
+];

--- a/chips/mk20/src/regs/pit.rs
+++ b/chips/mk20/src/regs/pit.rs
@@ -1,0 +1,40 @@
+use common::regs::{ReadWrite, ReadOnly};
+
+#[repr(C, packed)]
+pub struct Registers {
+    pub mcr: ReadWrite<u32, ModuleControl>,
+    _reserved0: [ReadOnly<u32>; 55],
+    pub ltmr64h: ReadOnly<u32>,
+    pub ltmr64l: ReadOnly<u32>,
+    _reserved1: [ReadOnly<u32>; 2],
+    pub timers: [PitRegisters; 4]
+}
+
+#[repr(C, packed)]
+pub struct PitRegisters {
+    pub ldval: ReadWrite<u32>, 
+    pub cval: ReadOnly<u32>,
+    pub tctrl: ReadWrite<u32, TimerControl>,
+    pub tflg: ReadWrite<u32, TimerFlag>
+}
+
+bitfields! [u32,
+    MCR ModuleControl [
+        MDIS 1,
+        FRZ 0
+    ],
+    TCTRL TimerControl [
+        CHN 2,
+        TIE 1,
+        TEN 0
+    ],
+    TFLG TimerFlag [
+        TIF 0
+    ]
+];
+
+pub const PIT_BASE: *mut Registers = 0x4003_7000 as *mut Registers;
+pub const PIT_ADDRS: [*mut PitRegisters; 4] = [0x4003_7100 as *mut PitRegisters,
+                                               0x4003_7110 as *mut PitRegisters,
+                                               0x4003_7120 as *mut PitRegisters,
+                                               0x4003_7130 as *mut PitRegisters];

--- a/chips/mk20/src/regs/sim.rs
+++ b/chips/mk20/src/regs/sim.rs
@@ -1,0 +1,117 @@
+use common::regs::{ReadWrite, ReadOnly};
+
+#[repr(C, packed)]
+pub struct Registers {
+    pub sopt2: ReadWrite<u32>,
+    _reserved0: ReadWrite<u32>,
+    pub sopt4: ReadWrite<u32>,
+    pub sopt5: ReadWrite<u32>,
+    _reserved1: ReadWrite<u32>,
+    pub sopt7: ReadWrite<u32>,
+    pub sopt8: ReadWrite<u32>,
+    pub sopt9: ReadWrite<u32>,
+    pub sdid: ReadOnly<u32>,
+    pub scgc1: ReadWrite<u32, SystemClockGatingControl1>,
+    pub scgc2: ReadWrite<u32, SystemClockGatingControl2>,
+    pub scgc3: ReadWrite<u32, SystemClockGatingControl3>,
+    pub scgc4: ReadWrite<u32, SystemClockGatingControl4>,
+    pub scgc5: ReadWrite<u32, SystemClockGatingControl5>,
+    pub scgc6: ReadWrite<u32, SystemClockGatingControl6>,
+    pub scgc7: ReadWrite<u32, SystemClockGatingControl7>,
+    pub clkdiv1: ReadWrite<u32, ClockDivider1>,
+    pub clkdiv2: ReadWrite<u32>,
+    pub fcfg1: ReadOnly<u32>,
+    pub fcfg2: ReadOnly<u32>,
+    pub uidh: ReadOnly<u32>,
+    pub uidmh: ReadOnly<u32>,
+    pub uidml: ReadOnly<u32>,
+    pub uidl: ReadOnly<u32>,
+    pub clkdiv3: ReadWrite<u32>,
+    pub clkdiv4: ReadWrite<u32>,
+}
+
+pub const SIM: *mut Registers = 0x40048004 as *mut Registers;
+
+bitfields![u32,
+    SCGC1 SystemClockGatingControl1 [
+        UART4 10,
+        I2C3 7,
+        I2C2 6
+    ],
+    SCGC2 SystemClockGatingControl2 [
+        DAC1 13,
+        DAC0 12,
+        TPM2 10,
+        TPM1 9,
+        LPUART0 4,
+        ENET 0
+    ],
+    SCGC3 SystemClockGatingControl3 [
+        ADC1 27,
+        FTM3 25,
+        FTM2 24,
+        SDHC 17,
+        SPI2 12,
+        FLEXCAN1 4,
+        USBHSDCD 3,
+        USBHSPHY 2,
+        USBHS 1,
+        RNGA 0
+    ],
+    SCGC4 SystemClockGatingControl4 [
+        VREF 20,
+        CMP 19,
+        USBOTG 18,
+        UART3 13,
+        UART2 12,
+        UART1 11,
+        UART0 10,
+        I2C1 7,
+        I2C0 6,
+        CMT 2,
+        EWM 1
+    ],
+    SCGC5 SystemClockGatingControl5 [
+        PORT (9, Mask(0b11111)) [
+            All = 0b11111,
+            A = 0b1,
+            B = 0b10,
+            C = 0b100,
+            D = 0b1000,
+            E = 0b10000
+        ],
+        TSI 5 [],
+        LPTMR 0 []
+    ],
+    SCGC6 SystemClockGatingControl6 [
+        DAC0 0,
+        RTC 29,
+        ADC0 27,
+        FTM2 26,
+        FTM1 25,
+        FTM0 24,
+        PIT 23,
+        PDB 22,
+        USBDCD 21,
+        CRC 18,
+        I2S 15,
+        SPI1 13,
+        SPI0 12,
+        RNGA 9,
+        FLEXCAN0 4,
+        DMAMUX 1,
+        FTF 0
+    ],
+    SCGC7 SystemClockGatingControl7 [
+        SDRAMC 3,
+        MPU 2,
+        DMA 1,
+        FLEXBUS 0
+    ],
+    CLKDIV1 ClockDivider1 [
+        Core (28, Mask(0b1111)) [],
+        Bus (24, Mask(0b1111)) [],
+        FlexBus (20, Mask(0b1111)) [],
+        Flash (16, Mask(0b1111)) []
+    ]
+];

--- a/chips/mk20/src/regs/smc.rs
+++ b/chips/mk20/src/regs/smc.rs
@@ -1,0 +1,67 @@
+use common::regs::{ReadWrite, ReadOnly};
+
+#[repr(C, packed)]
+pub struct Registers {
+    pub pmprot: ReadWrite<u8, PowerModeProtection>,
+    pub pmctrl: ReadWrite<u8, PowerModeControl>,
+    pub stopctrl: ReadWrite<u8, StopControl>,
+    pub pmstat: ReadOnly<u8, PowerModeStatus>
+}
+
+bitfields! [u8,
+    PMPROT PowerModeProtection [
+        AHSRUN 7 [],
+        AVLP 5 [],
+        ALLS 3 [],
+        AVLLS 1 []
+    ],
+    PMCTRL PowerModeControl [
+        RUNM (5, Mask(0b11)) [
+            NormalRun = 0,
+            VeryLowPowerRun = 2,
+            HighSpeedRun = 3
+        ],
+        STOPA 3 [],
+        STOPM (0, Mask(0b111)) [
+            NormalStop = 0,
+            VeryLowPowerStop = 2,
+            LowLeakageStop = 3,
+            VeryLowLeakageStop = 4
+        ]
+    ],
+    STOPCTRL StopControl [
+        PSTOPO (6, Mask(0b11)) [
+            NormalStopMode = 0,
+            PartialStop1 = 1,
+            PartialStop2 = 2
+        ],
+        PORPO 5 [
+            PORDetectEnabledInVLLS0 = 0,
+            PORDetectDisabledInVLLS0 = 1
+        ],
+        RAM2PO 4 [
+            RAM2NotPoweredInLLS2OrVLLS2 = 0,
+            RAM2PoweredInLLS2AndVLLS2 = 1
+        ],
+        LLSM (0, Mask(0b111)) [
+            EnterVLLS0 = 0,
+            EnterVLLS1 = 1,
+            EnterVLLS2OrLLS2 = 2,
+            EnterVLLS3OrLLS3 = 3
+        ]
+    ],
+    PMSTAT PowerModeStatus [
+        PMSTAT (0, Mask(0xFF)) [
+            Run = 1,
+            Stop = 1<<1,
+            VLPR = 1<<2,
+            VLPW = 1<<3,
+            VLPS = 1<<4,
+            LLS = 1<<5,
+            VLLS = 1<<6,
+            HSRUN = 1<<7
+        ]
+    ]
+];
+
+pub const SMC_BASE: *mut Registers = 0x4007_E000 as *mut Registers;

--- a/chips/mk20/src/regs/spi.rs
+++ b/chips/mk20/src/regs/spi.rs
@@ -1,0 +1,202 @@
+use common::regs::{ReadWrite, ReadOnly};
+
+#[repr(C, packed)]
+pub struct Registers {
+    pub mcr: ReadWrite<u32, ModuleConfiguration>,
+    _reserved0: ReadOnly<u32>,
+    pub tcr: ReadWrite<u32, TransferCount>,
+    pub ctar0: ReadWrite<u32, ClockAndTransferAttributes>,
+    pub ctar1: ReadWrite<u32, ClockAndTransferAttributes>,
+    _reserved1: [ReadOnly<u32>; 6],
+    pub sr: ReadWrite<u32, Status>,
+    pub rser: ReadWrite<u32, RequestSelectAndEnable>,
+    pub pushr_data: ReadWrite<u8>,
+    _reserved2: ReadWrite<u8>,
+    pub pushr_cmd: ReadWrite<u16, TxFifoPushCommand>,
+    pub popr: ReadOnly<u32>,
+    pub txfifo: [ReadOnly<u32>; 4],
+    _reserved3: [ReadOnly<u32>; 12],
+    pub rxfifo: [ReadOnly<u32>; 4]
+}
+
+pub const SPI_ADDRS: [*mut Registers; 3] = [0x4002_C000 as *mut Registers,
+                                            0x4002_D000 as *mut Registers,
+                                            0x400A_C000 as *mut Registers];
+
+bitfields![ u32,
+    MCR ModuleConfiguration [
+        MSTR 31 [
+            Master = 1,
+            Slave = 0
+        ],
+        CONT_SCKE 30 [],
+        FRZ 27 [],
+        MTFE 26 [],
+        PCSSE 25 [
+            PeripheralChipSelect = 0,
+            ActiveLowStrobe = 1
+        ],
+        ROOE 24 [
+            IgnoreOverflow = 0,
+            ShiftOverflow = 1
+        ],
+        PCSIS (16, Mask(0b11_1111)) [
+            AllInactiveHigh = 0x3F,
+            AllInactiveLow = 0x0
+        ],
+        DOZE 15 [],
+        MDIS 14 [],
+        DIS_TXF 13 [],
+        DIS_RXF 12 [],
+        CLR_TXF 11 [],
+        CLR_RXF 10 [],
+        SMPL_PT (8, Mask(0b11)) [
+            ZeroCycles = 0,
+            OneCycle = 1,
+            TwoCycles = 2
+        ],
+        HALT 0 []
+    ],
+
+    TCR TransferCount [
+        SPI_TCNT (16, Mask(0xFFFF)) []
+    ],
+
+    CTAR ClockAndTransferAttributes [
+        DBR 31 [],
+        FMSZ (27, Mask(0xF)) [],
+        CPOL 26 [
+            IdleLow = 0,
+            IdleHigh = 1
+        ],
+        CPHA 25 [
+            SampleLeading = 0,
+            SampleTrailing = 1
+        ],
+        LSBFE 24 [
+            MsbFirst = 0,
+            LsbFirst = 1
+        ],
+        PCSSCK (22, Mask(0b11)) [
+            Prescaler1 = 0,
+            Prescaler3 = 1,
+            Prescaler5 = 2,
+            Prescaler7 = 3
+        ],
+        PASC (20, Mask(0b11)) [
+            Delay1 = 0,
+            Delay3 = 1,
+            Delay5 = 2,
+            Delay7 = 3
+        ],
+        PDT (18, Mask(0b11)) [
+            Delay1 = 0,
+            Delay3 = 1,
+            Delay5 = 2,
+            Delay7 = 3
+        ],
+        PBR (16, Mask(0b11)) [
+            BaudRatePrescaler2 = 0,
+            BaudRatePrescaler3 = 1,
+            BaudRatePrescaler5 = 2,
+            BaudRatePrescaler7 = 3
+        ],
+        CSSCK (12, Mask(0b1111)) [
+            DelayScaler2 = 0x0,
+            DelayScaler4 = 0x1,
+            DelayScaler8 = 0x2,
+            DelayScaler16 = 0x3,
+            DelayScaler32 = 0x4,
+            DelayScaler64 = 0x5,
+            DelayScaler128 = 0x6,
+            DelayScaler256 = 0x7,
+            DelayScaler512 = 0x8,
+            DelayScaler1024 = 0x9,
+            DelayScaler2048 = 0xA,
+            DelayScaler4096 = 0xB,
+            DelayScaler8192 = 0xC,
+            DelayScaler16384 = 0xD,
+            DelayScaler32768 = 0xE,
+            DelayScaler65536 = 0xF
+        ],
+        ASC (8, Mask(0b1111)) [],
+        DT (4, Mask(0b1111)) [],
+        BR (0, Mask(0b1111)) [
+            BaudRateScaler2 = 0x0,
+            BaudRateScaler4 = 0x1,
+            BaudRateScaler8 = 0x2,
+            BaudRateScaler16 = 0x3,
+            BaudRateScaler32 = 0x4,
+            BaudRateScaler64 = 0x5,
+            BaudRateScaler128 = 0x6,
+            BaudRateScaler256 = 0x7,
+            BaudRateScaler512 = 0x8,
+            BaudRateScaler1024 = 0x9,
+            BaudRateScaler2048 = 0xA,
+            BaudRateScaler4096 = 0xB,
+            BaudRateScaler8192 = 0xC,
+            BaudRateScaler16384 = 0xD,
+            BaudRateScaler32768 = 0xE,
+            BaudRateScaler65536 = 0xF
+        ]
+    ],
+
+    CTAR_SLAVE ClockAndTransferAttributesSlave [
+        FMSZ (27, Mask(0xF)) [],
+        CPOL 26 [
+            IdleLow = 0,
+            IdleHigh = 1
+        ],
+        CPHA 25 [
+            SampleLeading = 0,
+            SampleTrailing = 1
+        ]
+    ],
+
+    SR Status [
+        TCF 31 [],
+        TXRS 30 [],
+        EOQF 28 [],
+        TFUF 27 [],
+        TFFF 25 [],
+        RFOF 19 [],
+        RFDF 17 [],
+        TXCTR (12, Mask(0xF)) [],
+        TXNXTPTR (8, Mask(0xF)) [],
+        RXCTR (4, Mask(0xF)) [],
+        POPNXTPTR (0, Mask(0xF)) []
+    ],
+
+    RSER RequestSelectAndEnable [
+        TCF_RE 31 [],
+        EOQF_RE 28 [],
+        TFUF_RE 27 [],
+        TFFF_RE 25 [],
+        TFFF_DIRS 24 [
+            Interrupt = 0,
+            Dma = 1
+        ],
+        RFOF_RE 19 [],
+        RFDF_RE 17 [],
+        RFDF_DIRS 16 [
+            Interrupt = 0,
+            Dma = 1
+        ]
+    ]
+];
+
+bitfields![ u16, 
+    PUSHR_CMD TxFifoPushCommand [
+        CONT 15 [
+            ChipSelectInactiveBetweenTxfers = 0,
+            ChipSelectAssertedBetweenTxfers = 1
+        ],
+        CTAS (12, Mask(0b111)) [
+            Ctar0 = 0,
+            Ctar1 = 1
+        ],
+        EOQ 11 [],
+        CTCNT 10 [],
+        PCS (0, Mask(0b111111)) []
+    ]
+];

--- a/chips/mk20/src/regs/uart.rs
+++ b/chips/mk20/src/regs/uart.rs
@@ -1,0 +1,134 @@
+use common::regs::{ReadWrite, ReadOnly};
+
+#[repr(C, packed)]
+pub struct Registers {
+    pub bdh: ReadWrite<u8, BaudRateHigh>,
+    pub bdl: ReadWrite<u8>,
+    pub c1: ReadWrite<u8, Control1>,
+    pub c2: ReadWrite<u8, Control2>,
+    pub s1: ReadOnly<u8, Status1>,
+    pub s2: ReadWrite<u8, Status2>,
+    pub c3: ReadWrite<u8, Control3>,
+    pub d: ReadWrite<u8>,
+    pub ma1: ReadWrite<u8>,
+    pub ma2: ReadWrite<u8>,
+    pub c4: ReadWrite<u8, Control4>,
+    pub c5: ReadWrite<u8, Control5>,
+    pub ed: ReadOnly<u8>,
+    pub modem: ReadWrite<u8>,
+    pub ir: ReadWrite<u8>, // 0x0E
+    _reserved0: ReadWrite<u8>,
+    pub pfifo: ReadWrite<u8>, // 0x10
+    pub cfifo: ReadWrite<u8>,
+    pub sfifo: ReadWrite<u8>,
+    pub twfifo: ReadWrite<u8>,
+    pub tcfifo: ReadOnly<u8>,
+    pub rwfifo: ReadWrite<u8>,
+    pub rcfifo: ReadOnly<u8>, // 0x16
+    _reserved1: ReadWrite<u8>,
+    pub c7816: ReadWrite<u8>, // 0x18
+    pub ie7816: ReadWrite<u8>,
+    pub is7816: ReadWrite<u8>,
+    pub wp7816: ReadWrite<u8>,
+    pub wn7816: ReadWrite<u8>,
+    pub wf7816: ReadWrite<u8>,
+    pub et7816: ReadWrite<u8>,
+    pub tl7816: ReadWrite<u8>, // 0x1F
+    _reserved2: [ReadWrite<u8>; 26],
+    pub ap7816a_t0: ReadWrite<u8>, // 0x3A
+    pub ap7816b_t0: ReadWrite<u8>,
+    pub wp7816a_t0_t1: ReadWrite<u8>,
+    pub wp7816b_t0_t1: ReadWrite<u8>,
+    pub wgp7816_t1: ReadWrite<u8>,
+    pub wp7816c_t1: ReadWrite<u8>,
+}
+
+pub const UART_BASE_ADDRS: [*mut Registers; 5] = [0x4006A000 as *mut Registers,
+                                                  0x4006B000 as *mut Registers,
+                                                  0x4006C000 as *mut Registers,
+                                                  0x4006D000 as *mut Registers,
+                                                  0x400EA000 as *mut Registers];
+
+bitfields! {u8,
+    BDH BaudRateHigh [
+        LBKDIE 7 [],
+        RXEDGIE 6 [],
+        SBNS 5 [
+            One = 0,
+            Two = 1
+        ],
+        SBR (0, Mask(0b11111)) []
+    ],
+    C1 Control1 [
+        LOOPS 7 [],
+        UARTSWAI 6 [],
+        RSRC 5 [],
+        M 4 [
+            EightBit = 0,
+            NineBit = 1
+        ],
+        WAKE 3 [
+            Idle = 0,
+            AddressMark = 1
+        ],
+        ILT 2 [
+            AfterStart = 0,
+            AfterStop = 1
+        ],
+        PE 1 [],
+        PT 0 [
+            Even = 0,
+            Odd = 1
+        ]
+    ],
+    C2 Control2 [
+        TIE 7,
+        TCIE 6,
+        RIE 5,
+        ILIE 4,
+        TE 3,
+        RE 2,
+        RWU 1,
+        SBK 0
+    ],
+    S1 Status1 [
+        TRDE 7,
+        TC 6,
+        RDRF 5,
+        IDLE 4,
+        OR 3,
+        NF 2,
+        FE 1,
+        PF 0
+    ],
+    S2 Status2 [
+        LBKDIF 7,
+        RXEDGIF 6,
+        MSBF 5,
+        RXINV 4,
+        RWUID 3,
+        BRK13 2,
+        LBKDE 1,
+        RAF 0
+    ],
+    C3 Control3 [
+        R8 7,
+        T8 6,
+        TXDIR 5,
+        TXINV 4,
+        ORIE 3,
+        NEIE 2,
+        FEIE 1,
+        PEIE 0
+    ],
+    C4 Control4 [
+        MAEN1 7 [],
+        MAEN2 6 [],
+        M10 5 [],
+        BRFA (0, Mask(0b11111)) []
+    ],
+    C5 Control5 [
+        TDMAS 7,
+        RDMAS 5
+    ]
+}

--- a/chips/mk20/src/regs/wdog.rs
+++ b/chips/mk20/src/regs/wdog.rs
@@ -1,0 +1,44 @@
+use common::regs::ReadWrite;
+
+#[repr(C, packed)]
+pub struct Registers {
+    pub stctrlh: ReadWrite<u16, StatusAndControlHigh>,
+    pub stctrll: ReadWrite<u16>,
+    pub tovalh:  ReadWrite<u16>,
+    pub tovall:  ReadWrite<u16>,
+    pub winh:    ReadWrite<u16>,
+    pub winl:    ReadWrite<u16>,
+    pub refresh: ReadWrite<u16, Refresh>,
+    pub unlock:  ReadWrite<u16, Unlock>,
+    pub tmrouth: ReadWrite<u16>,
+    pub tmroutl: ReadWrite<u16>,
+    pub rstcnt:  ReadWrite<u16>,
+    pub presc:   ReadWrite<u16>,
+}
+
+pub const WDOG: *mut Registers = 0x40052000 as *mut Registers;
+
+bitfields![u16,
+    STCTRLH StatusAndControlHigh [
+        WAITEN 7,
+        STOPEN 6,
+        DBGEN 5,
+        ALLOWUPDATE 4,
+        WINEN 3,
+        IRQSTEN 2,
+        CLKSRC 1,
+        WDOGEN 0
+    ],
+    REFRESH Refresh [
+        KEY (0, Mask(0xFFFF)) [
+            Key1 = 0xA602,
+            Key2 = 0xB480
+        ]
+    ],
+    UNLOCK Unlock [
+        KEY (0, Mask(0xFFFF)) [
+            Key1 = 0xC520,
+            Key2 = 0xD928
+        ]
+    ]
+];

--- a/chips/mk20/src/sim.rs
+++ b/chips/mk20/src/sim.rs
@@ -1,0 +1,147 @@
+//! Implementation of the MK20 System Integration Module
+
+use core::mem;
+use regs::sim::*;
+use common::regs::FieldValue;
+
+pub type Clock1 = FieldValue<u32, SystemClockGatingControl1>;
+pub type Clock2 = FieldValue<u32, SystemClockGatingControl2>;
+pub type Clock3 = FieldValue<u32, SystemClockGatingControl3>;
+pub type Clock4 = FieldValue<u32, SystemClockGatingControl4>;
+pub type Clock5 = FieldValue<u32, SystemClockGatingControl5>;
+pub type Clock6 = FieldValue<u32, SystemClockGatingControl6>;
+pub type Clock7 = FieldValue<u32, SystemClockGatingControl7>;
+
+pub trait Clock {
+    fn enable(self);
+}
+
+impl Clock for Clock1 {
+    fn enable(self) {
+        let regs: &mut Registers = unsafe { mem::transmute(SIM) };
+        regs.scgc1.modify(self);
+    }
+}
+
+impl Clock for Clock2 {
+    fn enable(self) {
+        let regs: &mut Registers = unsafe { mem::transmute(SIM) };
+        regs.scgc2.modify(self);
+    }
+}
+
+impl Clock for Clock3 {
+    fn enable(self) {
+        let regs: &mut Registers = unsafe { mem::transmute(SIM) };
+        regs.scgc3.modify(self);
+    }
+}
+
+impl Clock for Clock4 {
+    fn enable(self) {
+        let regs: &mut Registers = unsafe { mem::transmute(SIM) };
+        regs.scgc4.modify(self);
+    }
+}
+
+impl Clock for Clock5 {
+    fn enable(self) {
+        let regs: &mut Registers = unsafe { mem::transmute(SIM) };
+        regs.scgc5.modify(self);
+    }
+}
+
+impl Clock for Clock6 {
+    fn enable(self) {
+        let regs: &mut Registers = unsafe { mem::transmute(SIM) };
+        regs.scgc6.modify(self);
+    }
+}
+
+impl Clock for Clock7 {
+    fn enable(self) {
+        let regs: &mut Registers = unsafe { mem::transmute(SIM) };
+        regs.scgc7.modify(self);
+    }
+}
+
+pub mod clocks {
+    use sim::{Clock1, Clock2, Clock3, Clock4, Clock5, Clock6, Clock7};
+    use regs::sim::*;
+
+    pub const UART4: Clock1 = SCGC1::UART4::SET;
+    pub const I2C2: Clock1 = SCGC1::I2C2::SET;
+    pub const I2C3: Clock1 = SCGC1::I2C3::SET;
+
+    pub const DAC1: Clock2 = SCGC2::DAC1::SET;
+    pub const DAC0: Clock2 = SCGC2::DAC0::SET;
+    pub const TPM2: Clock2 = SCGC2::TPM2::SET;
+    pub const TPM1: Clock2 = SCGC2::TPM1::SET;
+    pub const LPUART0: Clock2 = SCGC2::LPUART0::SET;
+    pub const ENET: Clock2 = SCGC2::ENET::SET;
+
+    pub const ADC1: Clock3 = SCGC3::ADC1::SET;
+    pub const FTM3: Clock3 = SCGC3::FTM3::SET;
+    pub const FTM2: Clock3 = SCGC3::FTM2::SET;
+    pub const SDHC: Clock3 = SCGC3::SDHC::SET;
+    pub const SPI2: Clock3 = SCGC3::SPI2::SET;
+    pub const FLEXCAN1: Clock3 = SCGC3::FLEXCAN1::SET;
+    pub const USBHSDCD: Clock3 = SCGC3::USBHSDCD::SET;
+    pub const USBHSPHY: Clock3 = SCGC3::USBHSPHY::SET;
+    pub const USBHS: Clock3 = SCGC3::USBHS::SET;
+    pub const RNGA: Clock3 = SCGC3::RNGA::SET;
+
+    pub const VREF: Clock4 = SCGC4::VREF::SET;
+    pub const CMP: Clock4 = SCGC4::CMP::SET;
+    pub const USBOTG: Clock4 = SCGC4::USBOTG::SET;
+    pub const UART3: Clock4 = SCGC4::UART3::SET;
+    pub const UART2: Clock4 = SCGC4::UART2::SET;
+    pub const UART1: Clock4 = SCGC4::UART1::SET;
+    pub const UART0: Clock4 = SCGC4::UART0::SET;
+    pub const I2C1: Clock4 = SCGC4::I2C1::SET;
+    pub const I2C0: Clock4 = SCGC4::I2C0::SET;
+    pub const CMT: Clock4 = SCGC4::CMT::SET;
+    pub const EWM: Clock4 = SCGC4::EWM::SET;
+
+    pub const PORTE: Clock5 = SCGC5::PORT::E;
+    pub const PORTD: Clock5 = SCGC5::PORT::D;
+    pub const PORTC: Clock5 = SCGC5::PORT::C;
+    pub const PORTB: Clock5 = SCGC5::PORT::B;
+    pub const PORTA: Clock5 = SCGC5::PORT::A;
+    pub const PORTABCDE: Clock5 = SCGC5::PORT::All;
+    pub const TSI: Clock5 = SCGC5::TSI::SET;
+    pub const LPTMR: Clock5 = SCGC5::LPTMR::SET;
+
+    // DAC0,
+    pub const RTC: Clock6 = SCGC6::RTC::SET;
+    pub const ADC0: Clock6 = SCGC6::ADC0::SET;
+    // FTM2,
+    pub const FTM1: Clock6 = SCGC6::FTM1::SET;
+    pub const FTM0: Clock6 = SCGC6::FTM0::SET;
+    pub const PIT: Clock6 = SCGC6::PIT::SET;
+    pub const PDB: Clock6 = SCGC6::PDB::SET;
+    pub const USBDCD: Clock6 = SCGC6::USBDCD::SET;
+    pub const CRC: Clock6 = SCGC6::CRC::SET;
+    pub const I2S: Clock6 = SCGC6::I2S::SET;
+    pub const SPI1: Clock6 = SCGC6::SPI1::SET;
+    pub const SPI0: Clock6 = SCGC6::SPI0::SET;
+
+    // RNGA,
+    pub const FLEXCAN0: Clock6 = SCGC6::FLEXCAN0::SET;
+    pub const DMAMUX: Clock6 = SCGC6::DMAMUX::SET;
+    pub const FTF: Clock6 = SCGC6::FTF::SET;
+
+    pub const SDRAMC: Clock7 = SCGC7::SDRAMC::SET;
+    pub const MPU: Clock7 = SCGC7::MPU::SET;
+    pub const DMA: Clock7 = SCGC7::DMA::SET;
+    pub const FLEXBUS: Clock7 = SCGC7::FLEXBUS::SET;
+}
+
+pub fn set_dividers(core: u32, bus: u32, flash: u32) {
+    let regs: &mut Registers = unsafe { mem::transmute(SIM) };
+
+    regs.clkdiv1.modify(CLKDIV1::Core.val(core - 1) + 
+                        CLKDIV1::Bus.val(bus - 1) + 
+                        CLKDIV1::FlexBus.val(bus - 1) +
+                        CLKDIV1::Flash.val(flash - 1));
+}

--- a/chips/mk20/src/spi.rs
+++ b/chips/mk20/src/spi.rs
@@ -1,0 +1,487 @@
+use regs::spi::*;
+use kernel::hil::spi::*;
+use kernel::ReturnCode;
+use kernel::common::take_cell::TakeCell;
+use core::cell::Cell;
+use core::mem;
+use clock;
+use nvic::{self, NvicIdx};
+
+pub enum SpiRole {
+    Master,
+    Slave
+}
+
+pub struct Spi<'a> {
+    regs: *mut Registers,
+    client: Cell<Option<&'a SpiMasterClient>>,
+    index: usize,
+    chip_select_settings: [Cell<u32>; 6],
+    write: TakeCell<'static, [u8]>,
+    read: TakeCell<'static, [u8]>,
+    transfer_len: Cell<usize>,
+}
+
+pub static mut SPI0: Spi<'static> = Spi::new(0);
+pub static mut SPI1: Spi<'static> = Spi::new(1);
+pub static mut SPI2: Spi<'static> = Spi::new(2);
+
+impl<'a> Spi<'a> {
+    pub const fn new(index: usize) -> Spi<'a> {
+        Spi {
+            regs: SPI_ADDRS[index],
+            client: Cell::new(None),
+            index: index,
+            chip_select_settings: [Cell::new(0),
+                                   Cell::new(0),
+                                   Cell::new(0),
+                                   Cell::new(0),
+                                   Cell::new(0),
+                                   Cell::new(0)],
+            write: TakeCell::empty(),
+            read: TakeCell::empty(),
+            transfer_len: Cell::new(0),
+        }
+    }
+
+    fn regs(&self) -> &mut Registers {
+        unsafe { mem::transmute(self.regs) }
+    }
+
+    pub fn enable(&self) {
+        self.regs().mcr.modify(MCR::MDIS::CLEAR);
+    }
+
+    pub fn disable(&self) {
+        self.regs().mcr.modify(MCR::MDIS::SET);
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.regs().sr.is_set(SR::TXRS)
+    }
+
+    pub fn halt(&self) {
+        self.regs().mcr.modify(MCR::HALT::SET);
+        while self.is_running() {}
+    }
+
+    pub fn resume(&self) {
+        self.regs().mcr.modify(MCR::HALT::CLEAR);
+    }
+
+    fn enable_clock(&self) {
+        use sim::{clocks, Clock};
+        match self.index {
+            0 => clocks::SPI0.enable(),
+            1 => clocks::SPI1.enable(),
+            2 => clocks::SPI2.enable(),
+            _ => unreachable!()
+        };
+    }
+
+    fn set_client(&self, client: &'a SpiMasterClient) {
+        self.client.set(Some(client));
+    }
+
+    fn set_role(&self, role: SpiRole) {
+        self.halt();
+        match role {
+            SpiRole::Master => {
+                self.regs().mcr.modify(MCR::MSTR::Master);
+            },
+            SpiRole::Slave => {
+                self.regs().mcr.modify(MCR::MSTR::Slave);
+            }
+        }
+        self.resume();
+    }
+
+    fn set_polarity(&self, polarity: ClockPolarity) {
+        let cpol = match polarity {
+            ClockPolarity::IdleHigh => CTAR::CPOL::IdleHigh,
+            ClockPolarity::IdleLow => CTAR::CPOL::IdleLow
+        };
+        self.halt();
+        self.regs().ctar0.modify(cpol);
+        self.resume();
+    }
+
+    fn get_polarity(&self) -> ClockPolarity {
+        if self.regs().ctar0.matches(CTAR::CPOL::IdleHigh) {
+            ClockPolarity::IdleHigh
+        } else {
+            ClockPolarity::IdleLow
+        }
+    }
+
+    fn set_phase(&self, phase: ClockPhase) {
+        let cpha = match phase {
+            ClockPhase::SampleLeading => CTAR::CPHA::SampleLeading,
+            ClockPhase::SampleTrailing => CTAR::CPHA::SampleTrailing
+        };
+        self.halt();
+        self.regs().ctar0.modify(cpha);
+        self.resume();
+    }
+
+    fn get_phase(&self) -> ClockPhase {
+        if self.regs().ctar0.matches(CTAR::CPHA::SampleLeading) {
+            ClockPhase::SampleLeading
+        } else {
+            ClockPhase::SampleTrailing
+        }
+    }
+
+    pub fn set_data_order(&self, order: DataOrder) {
+        let order = match order {
+            DataOrder::LSBFirst => CTAR::LSBFE::LsbFirst,
+            DataOrder::MSBFirst => CTAR::LSBFE::MsbFirst
+        };
+        self.halt();
+        self.regs().ctar0.modify(order);
+        self.resume();
+    }
+
+    pub fn get_data_order(&self) -> DataOrder {
+        if self.regs().ctar0.matches(CTAR::LSBFE::LsbFirst) {
+            DataOrder::LSBFirst
+        } else {
+            DataOrder::MSBFirst
+        }
+    }
+
+    fn fifo_depth(&self) -> u32 {
+        // SPI0 has a FIFO with 4 entries, all others have a 1 entry "FIFO".
+        match self.index {
+            0 => 4,
+            1 | 2 => 1,
+            _ => unreachable!()
+        }
+    }
+
+    fn num_chip_selects(&self) -> u32 {
+        match self.index {
+            0 => 6,
+            1 => 4,
+            2 => 2,
+            _ => unreachable!()
+        }
+    }
+
+    fn flush_tx_fifo(&self) {
+        self.halt();
+        self.regs().mcr.modify(MCR::CLR_TXF::SET);
+        self.resume();
+    }
+
+    fn flush_rx_fifo(&self) {
+        self.halt();
+        self.regs().mcr.modify(MCR::CLR_RXF::SET);
+        self.resume();
+    }
+
+    fn tx_fifo_ready(&self) -> bool {
+        !(self.regs().sr.read(SR::TXCTR) >= self.fifo_depth())
+    }
+
+    fn rx_fifo_ready(&self) -> bool {
+        self.regs().sr.read(SR::RXCTR) > 0
+    }
+
+    fn baud_rate(dbl: u32, prescaler: u32, scaler: u32) -> u32 {
+        (clock::bus_clock_hz() * (1 + dbl)) / (prescaler * scaler)
+    }
+
+    fn set_baud_rate(&self, rate: u32) -> u32 {
+        let prescalers: [u32; 4] = [ 2, 3, 5, 7 ];
+        let scalers: [u32; 16] = [2, 4, 6, 8,
+                                  1<<4, 1<<5, 1<<6, 1<<7,
+                                  1<<8, 1<<9, 1<<10, 1<<11,
+                                  1<<12, 1<<13, 1<<14, 1<<15];
+        let dbls: [u32; 2] = [0, 1];
+
+        let mut rate_diff = rate;
+        let mut prescaler = 0;
+        let mut scaler = 0;
+        let mut dbl = 0;
+
+        // Since there are only 128 unique settings, just iterate over possible
+        // configurations until we find the best match. If baud rate can be
+        // matched exactly, this loop will terminate early.
+        for d in 0..dbls.len() { // 0 is preferred for DBL, as it affects duty cycle
+            for p in 0..prescalers.len() {
+                for s in 0..scalers.len() {
+                    let curr_rate = Spi::baud_rate(dbls[d],
+                                                   prescalers[p],
+                                                   scalers[s]);
+
+                    // Determine the distance from the target baud rate.
+                    let curr_diff = if curr_rate > rate { curr_rate - rate }
+                                    else { rate - curr_rate };
+
+                    // If we've improved the best configuration, use it.
+                    if curr_diff < rate_diff {
+                        rate_diff = curr_diff;
+                        scaler = s;
+                        prescaler = p;
+                        dbl = d;
+                    }
+
+                    // Terminate if we've found an exact match.
+                    if rate_diff == 0 { break }
+                }
+            }
+        }
+
+        self.halt();
+        self.regs().ctar0.modify(CTAR::DBR.val(dbl as u32) +
+                                 CTAR::PBR.val(prescaler as u32) +
+                                 CTAR::BR.val(scaler as u32));
+        self.resume();
+
+        Spi::baud_rate(dbls[dbl], prescalers[prescaler], scalers[scaler])
+    }
+
+    fn get_baud_rate(&self) -> u32 {
+        let prescaler = match self.regs().ctar0.read(CTAR::PBR) {
+            0 => 2,
+            1 => 3,
+            2 => 5,
+            3 => 7,
+            _ => panic!("Impossible value for baud rate field!")
+        };
+
+        let scaler = match self.regs().ctar0.read(CTAR::BR) {
+            0 => 2,
+            1 => 4,
+            2 => 6,
+            s @ _ => 1 << s
+        };
+
+        let dbl = self.regs().ctar0.read(CTAR::DBR);
+
+        Spi::baud_rate(dbl, prescaler, scaler)
+    }
+
+    pub fn transfer_count(&self) -> u32 {
+        self.regs().sr.read(SR::TXCTR)
+    }
+
+    pub fn start_of_queue(&self) {
+        self.regs().pushr_cmd.modify(PUSHR_CMD::EOQ::CLEAR);
+    }
+
+    fn end_of_queue(&self) {
+        self.regs().pushr_cmd.modify(PUSHR_CMD::EOQ::SET);
+    }
+
+    fn configure_timing(&self) {
+        self.halt();
+        // Set maximum delay after transfer.
+        self.regs().ctar0.modify(CTAR::DT.val(0x0) + CTAR::PDT::Delay7);
+        self.resume();
+    }
+
+    fn set_frame_size(&self, size: u32) {
+        if size > 16 || size < 4 { return }
+
+        self.halt();
+        self.regs().ctar0.modify(CTAR::FMSZ.val(size - 1));
+        self.resume();
+    }
+
+    fn enable_interrupt(&self) {
+        let idx = match self.index {
+            0 => NvicIdx::SPI0,
+            1 => NvicIdx::SPI1,
+            2 => NvicIdx::SPI2,
+            _ => unreachable!()
+        };
+
+        self.halt();
+        unsafe {
+            nvic::enable(idx);
+        }
+        self.regs().rser.modify(RSER::EOQF_RE::SET);
+        self.resume();
+    }
+
+    pub fn handle_interrupt(&self) {
+        // TODO: Determine why the extra interrupt is called
+
+        // End of transfer
+        if self.regs().sr.is_set(SR::EOQF) {
+            self.regs().sr.modify(SR::EOQF::SET);
+
+            self.client.get().map(|client| {
+                match self.write.take() {
+                    Some(wbuf) => client.read_write_done(wbuf, self.read.take(), self.transfer_len.get()),
+                    None => ()
+                };
+            });
+        }
+    }
+}
+
+impl<'a> SpiMaster for Spi<'a> {
+    type ChipSelect = u32;
+
+    fn set_client(&self, client: &'static SpiMasterClient) {
+        Spi::set_client(self, client);
+    }
+
+    fn init(&self) {
+        // Section 57.6.2
+        self.enable_clock();
+        self.flush_rx_fifo();
+        self.flush_tx_fifo();
+        self.set_role(SpiRole::Master);
+        self.enable_interrupt();
+        self.enable();
+
+        self.set_frame_size(8);
+        self.configure_timing();
+        self.regs().mcr.modify(MCR::PCSIS::AllInactiveHigh);
+        self.regs().pushr_cmd.modify(PUSHR_CMD::PCS.val(0));
+    }
+
+    fn is_busy(&self) -> bool {
+        self.is_running()
+    }
+
+    /// Perform an asynchronous read/write operation, whose
+    /// completion is signaled by invoking SpiMasterClient on
+    /// the initialized client. write_buffer must be Some,
+    /// read_buffer may be None. If read_buffer is Some, the
+    /// length of the operation is the minimum of the size of
+    /// the two buffers.
+    fn read_write_bytes(&self,
+                        write_buffer: &'static mut [u8],
+                        read_buffer: Option<&'static mut [u8]>,
+                        len: usize)
+                        -> ReturnCode {
+
+        self.start_of_queue();
+        if let Some(rbuf) = read_buffer {
+            for i in 0..len {
+                while !self.tx_fifo_ready() {}
+
+                if i == len - 1 {
+                    self.end_of_queue();
+                }
+
+                self.regs().pushr_data.set(write_buffer[i]);
+
+                // TODO: this is pretty hacky
+                while !self.rx_fifo_ready() {}
+                rbuf[i] = self.regs().popr.get() as u8;
+            }
+
+            self.read.put(Some(rbuf));
+        } else {
+            for i in 0..len {
+                while !self.tx_fifo_ready() {}
+
+                if i == len - 1 {
+                    self.end_of_queue();
+                }
+
+                self.regs().pushr_data.set(write_buffer[i]);
+            }
+            self.read.put(None);
+        }
+
+        self.write.put(Some(write_buffer));
+        self.transfer_len.set(len);
+
+        ReturnCode::SUCCESS
+    }
+
+    fn write_byte(&self, _val: u8) {
+        unimplemented!();
+    }
+
+    fn read_byte(&self) -> u8 {
+        unimplemented!();
+    }
+
+    fn read_write_byte(&self, _val: u8) -> u8 {
+        unimplemented!();
+    }
+
+    /// Tell the SPI peripheral what to use as a chip select pin.
+    /// The type of the argument is based on what makes sense for the
+    /// peripheral when this trait is implemented.
+    fn specify_chip_select(&self, cs: Self::ChipSelect) {
+        if cs >= self.num_chip_selects() {
+            return;
+        }
+
+        // The PCS field is one-hot (the way this interface uses it).
+        let pcs = self.regs().pushr_cmd.read(PUSHR_CMD::PCS);
+        let old_cs = match pcs {
+            0 | 0b000001 => 0,
+            0b000010 => 1,
+            0b000100 => 2,
+            0b001000 => 3,
+            0b010000 => 4,
+            0b100000 => 5,
+            _ => panic!("Unexpected PCS: {:?}", pcs),
+        };
+
+        let new_cs = cs as usize;
+
+        // Swap in the new configuration.
+        self.halt();
+        self.chip_select_settings[old_cs].set(self.regs().ctar0.get());
+        self.regs().ctar0.set(self.chip_select_settings[new_cs].get());
+        self.resume();
+        self.regs().pushr_cmd.modify(PUSHR_CMD::PCS.val(1 << new_cs));
+    }
+
+    /// Returns the actual rate set
+    fn set_rate(&self, rate: u32) -> u32 {
+        self.set_baud_rate(rate)
+    }
+
+    fn get_rate(&self) -> u32 {
+        self.get_baud_rate()
+    }
+
+    fn set_clock(&self, polarity: ClockPolarity) {
+        self.set_polarity(polarity);
+    }
+
+    fn get_clock(&self) -> ClockPolarity {
+        self.get_polarity()
+    }
+
+    fn set_phase(&self, phase: ClockPhase) {
+        Spi::set_phase(self, phase);
+    }
+
+    fn get_phase(&self) -> ClockPhase {
+        Spi::get_phase(self)
+    }
+
+    // These two functions determine what happens to the chip
+    // select line between transfers. If hold_low() is called,
+    // then the chip select line is held low after transfers
+    // complete. If release_low() is called, then the chip select
+    // line is brought high after a transfer completes. A "transfer"
+    // is any of the read/read_write calls. These functions
+    // allow an application to manually control when the
+    // CS line is high or low, such that it can issue multi-byte
+    // requests with single byte operations.
+    fn hold_low(&self) {
+        self.regs().pushr_cmd.modify(PUSHR_CMD::CONT::ChipSelectInactiveBetweenTxfers);
+    }
+
+    fn release_low(&self) {
+        self.regs().pushr_cmd.modify(PUSHR_CMD::CONT::ChipSelectAssertedBetweenTxfers);
+    }
+}
+
+interrupt_handler!(spi0_interrupt_handler, SPI0);
+interrupt_handler!(spi1_interrupt_handler, SPI1);
+interrupt_handler!(spi2_interrupt_handler, SPI2);

--- a/chips/mk20/src/uart.rs
+++ b/chips/mk20/src/uart.rs
@@ -1,0 +1,226 @@
+//! Implementation of the MK20 UART Peripheral
+
+use core::cell::Cell;
+use kernel::common::take_cell::TakeCell;
+use kernel::hil;
+use kernel::hil::uart;
+use core::mem;
+use nvic;
+use regs::uart::*;
+use clock;
+
+pub struct Uart {
+    index: usize,
+    registers: *mut Registers,
+    client: Cell<Option<&'static uart::Client>>,
+    buffer: TakeCell<'static, [u8]>,
+    rx_len: Cell<usize>,
+    rx_index: Cell<usize>
+}
+
+pub static mut UART0: Uart = Uart::new(0);
+pub static mut UART1: Uart = Uart::new(1);
+pub static mut UART2: Uart = Uart::new(2);
+pub static mut UART3: Uart = Uart::new(3);
+pub static mut UART4: Uart = Uart::new(4);
+
+impl Uart {
+    pub const fn new(index: usize) -> Uart {
+        Uart {
+            index: index,
+            registers: UART_BASE_ADDRS[index],
+            client: Cell::new(None),
+            buffer: TakeCell::empty(),
+            rx_len: Cell::new(0),
+            rx_index: Cell::new(0),
+        }
+    }
+
+    pub fn handle_interrupt(&self) {
+        let regs: &mut Registers = unsafe { mem::transmute(self.registers) };
+        // Read byte from data register; reading S1 and D clears interrupt
+        if regs.s1.is_set(S1::RDRF) {
+            let datum: u8 = regs.d.get();
+
+            // Put byte into buffer, trigger callback if buffer full
+            let mut done = false;
+            let mut index = self.rx_index.get();
+            self.buffer.map( |buf| {
+                buf[index] = datum;
+                index = index + 1;
+                if index >= self.rx_len.get() {
+                    done = true;
+                }
+                self.rx_index.set(index);
+            });
+            if done {
+                self.client.get().map(|client| {
+                    match self.buffer.take() {
+                        Some(buf) => client.receive_complete(buf, index, uart::Error::CommandComplete),
+                        None => ()
+                    }
+                });
+            }
+        }
+    }
+
+    pub fn handle_error(&self) {
+        // TODO: implement
+    }
+
+    fn set_parity(&self, parity: hil::uart::Parity) {
+        let regs: &mut Registers = unsafe { mem::transmute(self.registers) };
+
+        let (pe, pt) = match parity {
+            hil::uart::Parity::None => (C1::PE::CLEAR, C1::PT::Even),
+            hil::uart::Parity::Even => (C1::PE::SET, C1::PT::Even),
+            hil::uart::Parity::Odd => (C1::PE::SET, C1::PT::Odd)
+        };
+
+        // This basic procedure outlined in section 59.9.3.
+        // Set control register 1, which configures the parity.
+        regs.c1.write(pe + pt +
+                      C1::LOOPS::CLEAR +
+                      C1::UARTSWAI::CLEAR +
+                      C1::RSRC::CLEAR +
+                      C1::M::EightBit +
+                      C1::WAKE::Idle +
+                      C1::ILT::AfterStop);
+    }
+
+    fn set_stop_bits(&self, stop_bits: hil::uart::StopBits) {
+        let regs: &mut Registers = unsafe { mem::transmute(self.registers) };
+
+        let stop_bits = match stop_bits {
+            hil::uart::StopBits::One => BDH::SBNS::One,
+            hil::uart::StopBits::Two => BDH::SBNS::Two
+        };
+
+        regs.bdh.modify(stop_bits);
+    }
+
+    fn set_baud_rate(&self, baud_rate: u32) {
+        let regs: &mut Registers = unsafe { mem::transmute(self.registers) };
+
+        // Baud rate generation. Note that UART0 and UART1 are sourced from the core clock, not the
+        // bus clock.
+        let uart_clock = match self.index {
+            0 | 1 => clock::core_clock_hz(),
+            _ => clock::peripheral_clock_hz()
+        };
+
+        let baud_counter: u32 = (uart_clock >> 4) / baud_rate;
+
+        // Set the baud rate.
+        regs.c4.modify(C4::BRFA.val(0));
+        regs.bdh.modify(BDH::SBR.val((baud_counter >> 8) as u8));
+        regs.bdl.set(baud_counter as u8);
+    }
+
+    pub fn enable_rx(&self) {
+        let regs: &mut Registers = unsafe { mem::transmute(self.registers) };
+        regs.c1.modify(C1::ILT::SET); // Idle after stop bit
+        regs.c2.modify(C2::RE::SET);  // Enable UART reception
+    }
+
+    pub fn enable_rx_interrupts(&self) {
+        let regs: &mut Registers = unsafe { mem::transmute(self.registers) };
+        regs.rwfifo.set(1);               // Issue interrupt on each byte
+        regs.c5.modify(C5::RDMAS::CLEAR); // Issue interrupt on RX data
+
+        match self.index {
+            0 => unsafe {nvic::enable(nvic::NvicIdx::UART0)},
+            1 => unsafe {nvic::enable(nvic::NvicIdx::UART1)},
+            2 => unsafe {nvic::enable(nvic::NvicIdx::UART2)},
+            3 => unsafe {nvic::enable(nvic::NvicIdx::UART3)},
+            4 => unsafe {nvic::enable(nvic::NvicIdx::UART4)},
+            _ => unreachable!()
+        };
+        regs.c2.modify(C2::RIE::SET);     // Enable interrupts
+    }
+
+    pub fn enable_tx(&self) {
+        let regs: &mut Registers = unsafe { mem::transmute(self.registers) };
+        regs.c2.modify(C2::TE::SET);
+    }
+
+    fn enable_clock(&self) {
+        use sim::{clocks, Clock};
+        match self.index {
+            0 => clocks::UART0.enable(),
+            1 => clocks::UART1.enable(),
+            2 => clocks::UART2.enable(),
+            3 => clocks::UART3.enable(),
+            4 => clocks::UART4.enable(),
+            _ => unreachable!()
+        };
+    }
+
+    pub fn send_byte(&self, byte: u8) {
+        let regs: &mut Registers = unsafe { mem::transmute(self.registers) };
+
+        while !regs.s1.is_set(S1::TRDE) {}
+        regs.d.set(byte);
+    }
+
+    pub fn tx_ready(&self) -> bool {
+        let regs: &mut Registers = unsafe { mem::transmute(self.registers) };
+        regs.s1.is_set(S1::TC)
+    }
+}
+
+
+/// Implementation of kernel::hil::UART
+impl hil::uart::UART for Uart {
+    fn set_client(&self, client: &'static hil::uart::Client) {
+        self.client.set(Some(client));
+    }
+
+    fn init(&self, params: uart::UARTParams) {
+        self.enable_clock();
+
+        self.set_parity(params.parity);
+        self.set_stop_bits(params.stop_bits);
+        self.set_baud_rate(params.baud_rate);
+
+        self.enable_rx();
+        self.enable_rx_interrupts();
+        self.enable_tx();
+    }
+
+    fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {
+        // This basic procedure outlined in section 59.9.3.
+        for i in 0..tx_len {
+            self.send_byte(tx_data[i]);
+        }
+
+        while !self.tx_ready() {}
+
+        self.client.get().map(move |client|
+            client.transmit_complete(tx_data, uart::Error::CommandComplete)
+        );
+    }
+
+    #[allow(unused_variables)]
+    fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize) {
+        let mut length = rx_len;
+        if rx_len > rx_buffer.len() {
+            length = rx_buffer.len();
+        }
+
+        self.buffer.put(Some(rx_buffer));
+        self.rx_len.set(length);
+        self.rx_index.set(0);
+    }
+}
+
+interrupt_handler!(uart0_handler, UART0);
+interrupt_handler!(uart1_handler, UART1);
+interrupt_handler!(uart2_handler, UART2);
+interrupt_handler!(uart3_handler, UART3);
+interrupt_handler!(uart4_handler, UART4);
+interrupt_handler!(uart0_err_handler, UART0);
+interrupt_handler!(uart1_err_handler, UART1);
+interrupt_handler!(uart2_err_handler, UART2);
+interrupt_handler!(uart3_err_handler, UART3);
+interrupt_handler!(uart4_err_handler, UART4);

--- a/chips/mk20/src/wdog.rs
+++ b/chips/mk20/src/wdog.rs
@@ -1,0 +1,59 @@
+//! Implementation of the MK20 hardware watchdog timer
+
+use core::mem;
+use kernel::hil;
+use regs::wdog::*;
+
+#[inline]
+fn unlock() {
+    let regs: &mut Registers = unsafe { mem::transmute(WDOG) };
+
+    regs.unlock.write(UNLOCK::KEY::Key1);
+    regs.unlock.write(UNLOCK::KEY::Key2);
+    unsafe {
+        asm!("nop" :::: "volatile");
+        asm!("nop" :::: "volatile");
+    }
+}
+
+#[allow(unused_variables)]
+pub fn start(period: usize) {
+    unimplemented!();
+}
+
+pub fn stop() {
+    let regs: &mut Registers = unsafe { mem::transmute(WDOG) };
+
+    // Must write the correct unlock sequence to the WDOG unlock register before reconfiguring
+    // the module.
+    unlock();
+
+    // WDOG disabled in all power modes.
+    // Allow future updates to the watchdog configuration.
+    regs.stctrlh.modify(STCTRLH::ALLOWUPDATE::SET + 
+                        STCTRLH::WAITEN::CLEAR +
+                        STCTRLH::STOPEN::CLEAR +
+                        STCTRLH::DBGEN::CLEAR +
+                        STCTRLH::WDOGEN::CLEAR);
+}
+
+pub fn tickle() {
+    let regs: &mut Registers = unsafe { mem::transmute(WDOG) };
+    regs.refresh.write(REFRESH::KEY::Key1);
+    regs.refresh.write(REFRESH::KEY::Key2);
+}
+
+pub struct Wdog;
+impl hil::watchdog::Watchdog for Wdog {
+    fn start(&self, period: usize) {
+        start(period);
+    }
+
+    fn stop(&self) {
+        stop();
+    }
+
+    fn tickle(&self) {
+        tickle();
+    }
+}

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "common"
+version = "0.1.0"
+

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "common"
+version = "0.1.0"
+authors = ["Shane Leonard <shanel@stanford.edu>"]
+
+[profile.dev]
+panic = "abort"
+lto = true
+opt-level = 0
+debug = true
+
+[profile.release]
+panic = "abort"
+lto = true

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,0 +1,6 @@
+#![no_std]
+
+#![feature(const_fn)]
+
+#[macro_use]
+pub mod regs;

--- a/common/src/regs/README.md
+++ b/common/src/regs/README.md
@@ -1,0 +1,213 @@
+# Register/Bitfield Interface for Tock Teensy Port
+
+This module provides an interface for defining and manipulating memory mapped 
+registers and bitfields. 
+
+## Defining registers
+
+The module provides three types for working with memory mapped registers: `RW`,
+`RO`, and `WO`, providing read-write, read-only, and write-only functionality,
+respectively.
+
+Defining the registers is similar to the C-style approach, where each register
+is a field in a packed struct:
+
+```rust
+use common::regs::{RO, RW, WO};
+
+
+#[repr(C, packed)]
+struct Registers {
+    // Control register: read-write
+    // The 'Control' parameter constrains this register to only use fields from
+    // a certain group (defined below in the bitfields section).
+    cr: RW<u8, Control>,
+
+    // Status register: read-only
+    s: RO<u8, Status>
+
+    // Registers can be bytes, halfwords, or words:
+    // Note that the second type parameter can be omitted, meaning that there
+    // are no bitfields defined for these registers.
+    byte0: RW<u8>,
+    byte1: RW<u8>,
+    short: RW<u16>,
+    word: RW<u32>
+
+    // Etc.
+}
+```
+
+## Defining bitfields
+
+Bitfields are defined through the `bitfields!` macro:
+
+```rust
+bitfields! [ 
+    // First parameter is the register width for the bitfields. Can be u8, u16,
+    // or u32.
+    u8,
+
+    // Each subsequent parameter is a register abbreviation, its descriptive
+    // name, and its associated bitfields.
+    // The descriptive name defines this 'group' of bitfields. Only registers
+    // defined as RW<_, Control> can use these bitfields.
+    CR Control [
+        // Bitfields are defined as:
+        // name (Mask(mask), shift) [ /* optional named values */ ]
+
+        // This is a two-bit field which includes bits 4 and 5
+        RANGE (Mask(0b11), 4) [
+            // Each of these defines a name for a value that the bitfield can be 
+            // written with or matched against. Note that this set is not exclusive--
+            // the field can still be written with arbitrary constants.
+            VeryHigh = 0,
+            High = 1,
+            Low = 2
+        ],
+
+        // A common case is single-bit bitfields, which usually just mean
+        // 'enable' or 'disable' something. This syntax is a shorthand, defining
+        // EN as a field over bit 3, and INT as a field over bit 2.
+        EN 3 [],
+        INT 2 []
+    ],
+
+    // Without the explanatory comments like above, bitfield definition is quite compact:
+    // Status register
+    S Status [
+        TXCOMPLETE 0 [],
+        TXINTERRUPT 1 [],
+        RXCOMPLETE 2 [],
+        RXINTERRUPT 3 [],
+        MODE (Mask(0b11), 4) [
+            FullDuplex = 0,
+            HalfDuplex = 1,
+            Loopback = 2,
+            Disabled = 3
+        ],
+        ERRORCOUNT (Mask(0b11), 6) []
+    ]
+]
+```
+
+
+## Example: Using registers and bitfields
+
+Assuming we have defined a `Registers` struct and the corresponding bitfields as
+in the previous two sections. We also have an immutable reference to the 
+`Registers` struct, named `regs`.
+
+```rust
+// -----------------------------------------------------------------------------
+// RAW ACCESS
+// -----------------------------------------------------------------------------
+
+// Get or set the raw value of the register directly. Nothing fancy:
+regs.cr.set(regs.cr.get() + 1);
+
+
+// -----------------------------------------------------------------------------
+// READ
+// -----------------------------------------------------------------------------
+
+// `range` will contain the unshifted value of the RANGE field, e.g. 0, 1, 2, or 3.
+// The type annotation is not necessary, but provided for clarity here.
+let range: u8 = regs.cr.read(CR::RANGE);
+
+// `en` will be 0 or 1
+let en: u8 = regs.cr.read(CR::EN);
+
+
+// -----------------------------------------------------------------------------
+// MODIFY
+// -----------------------------------------------------------------------------
+
+// Write a value to a bitfield without altering the values in other fields:
+regs.cr.modify(CR::RANGE.val(2)); // Leaves EN, INT unchanged
+
+// Named constants can be used instead of the raw values:
+regs.cr.modify(CR::RANGE::VeryHigh);
+
+// Another example of writing a field with a raw value:
+regs.cr.modify(CR::EN.val(0)); // Leaves RANGE, INT unchanged
+
+// For one-bit fields, the named values SET and CLEAR are automatically
+// defined:
+regs.cr.modify(CR::EN::SET);
+
+// Write multiple values at once, without altering other fields:
+regs.cr.modify(CR::EN::CLEAR + CR::RANGE::Low); // INT unchanged
+
+// Any number of non-overlapping fields can be combined:
+regs.cr.modify(CR::EN::CLEAR + CR::RANGE::High + CR::INT::SET);
+
+
+// -----------------------------------------------------------------------------
+// WRITE
+// -----------------------------------------------------------------------------
+
+// Same interface as modify, except that all unspecified fields are overwritten to zero.
+regs.cr.write(CR::RANGE.val(1)); // implictly sets all other bits to zero
+
+// -----------------------------------------------------------------------------
+// BITFLAGS
+// -----------------------------------------------------------------------------
+
+// For one-bit fields, easily check if they are set or clear:
+let txcomplete: bool = regs.s.is_set(S::TXCOMPLETE);
+
+// -----------------------------------------------------------------------------
+// MATCHING
+// -----------------------------------------------------------------------------
+
+// You can also query a specific register state easily with `matches`:
+
+// Doesn't care about the state of any field except TXCOMPLETE and MODE:
+let ready: bool = regs.s.matches(S::TXCOMPLETE:SET + 
+                                 S::MODE::FullDuplex);
+
+// This is very useful for awaiting for a specific condition:
+while !regs.s.matches(S::TXCOMPLETE::SET + 
+                      S::RXCOMPLETE::SET +
+                      S::TXINTERRUPT::CLEAR) {}
+```
+
+Note that `modify` performs exactly one volatile load and one volatile store,
+`write` performs exactly one volatile store, and `read` performs exactly one
+volatile load. Thus, you are ensured that a single call will set or query all
+fields simultaneously.
+
+## Performance
+
+TODO: specific study
+
+Examining the binaries while testing this interface, everything compiles
+down to the optimal inlined bit twiddling instructions--in other words, there is
+zero runtime cost, as far as my informal preliminary study has found. I will
+eventually be writing a more rigorous test to confirm this.
+
+## Nice type checking
+
+This interface helps the compiler catch some common types of bugs via type checking.
+
+If you define the bitfields for eg a control register, you can give them a
+descriptive group name like `Control`. This group of bitfields will only work with a 
+register of the type `RW<_, Control>` (or `RO/WO`, etc). For instance, if we have 
+the bitfields and registers as defined above,
+
+```rust
+// This line compiles, because CR and regs.cr are both associated with the
+// Control group of bitfields.
+regs.cr.modify(CR::RANGE.val(1));
+
+// This line will not compile, because CR is associated with the Control group,
+// while regs.s is associated with the Status group.
+regs.s.modify(CR::RANGE.val(1));
+
+```
+
+## Usage in Tock Teensy port
+
+All of the Teensy registers are defined in `boards/teensy/src/regs`. The
+registers are used in almost every module in `boards/teensy/src/`

--- a/common/src/regs/macros.rs
+++ b/common/src/regs/macros.rs
@@ -24,8 +24,8 @@ macro_rules! bitmasks {
 
 
     {
-        $(#[$outer:meta])*
-        $valtype:ty, $reg_desc:ident, $field:ident,
+
+        $valtype:ty, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
                     ($shift:expr, Mask($mask:expr)),
                     [$( $(#[$inner:meta])* $valname:ident = $value:expr ),*]
     } => {
@@ -35,6 +35,7 @@ macro_rules! bitmasks {
 
         #[allow(non_snake_case)]
         #[allow(unused)]
+        $(#[$outer])*
         pub mod $field {
             #[allow(unused_imports)]
             use $crate::regs::FieldValue;
@@ -49,6 +50,7 @@ macro_rules! bitmasks {
 
             #[allow(dead_code)]
             #[allow(non_camel_case_types)]
+            $(#[$outer])*
             pub enum Value {
                 $(
                     $(#[$inner])*
@@ -59,16 +61,17 @@ macro_rules! bitmasks {
     };
 
     {
-        $(#[$outer:meta])* $valtype:ty, $reg_desc:ident, $field:ident, $bit:expr,
+         $valtype:ty, $reg_desc:ident, $(#[$outer:meta])* $field:ident, $bit:expr,
         [$( $(#[$inner:meta])* $valname:ident = $value:expr),* ]
     } => {
         #[allow(non_upper_case_globals)]
         #[allow(unused)]
-        $(#[$outer:meta])*
+        $(#[$outer])*
         pub const $field: Field<$valtype, $reg_desc> = Field::<$valtype, $reg_desc>::new(1, $bit);
 
         #[allow(non_snake_case)]
         #[allow(unused)]
+        $(#[$outer])*
         pub mod $field {
             #[allow(unused_imports)]
             use $crate::regs::FieldValue;
@@ -91,6 +94,7 @@ macro_rules! bitmasks {
 
             #[allow(dead_code)]
             #[allow(non_camel_case_types)]
+            $(#[$outer])*
             pub enum Value {
                 $(
                     $(#[$inner])*

--- a/common/src/regs/macros.rs
+++ b/common/src/regs/macros.rs
@@ -1,0 +1,124 @@
+#[macro_export]
+macro_rules! bitmasks {
+    {
+        $(#[$outer:meta])*
+        $valtype:ty, $reg_desc:ident, [
+            $( $(#[$inner:meta])* $field:ident $a:tt ),+
+        ]
+    } => {
+        $(#[$outer])*
+        $( bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $a, []); )*
+    };
+
+
+    {
+        $(#[$outer:meta])*
+        $valtype:ty, $reg_desc:ident, [
+            $( $(#[$inner:meta])* $field:ident $a:tt $b:tt ),+
+        ]
+    } => {
+        $(#[$outer])*
+        $( bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $a, $b); )*
+    };
+
+
+
+    {
+        $(#[$outer:meta])*
+        $valtype:ty, $reg_desc:ident, $field:ident,
+                    ($shift:expr, Mask($mask:expr)),
+                    [$( $(#[$inner:meta])* $valname:ident = $value:expr ),*]
+    } => {
+        #[allow(non_upper_case_globals)]
+        #[allow(unused)]
+        pub const $field: Field<$valtype, $reg_desc> = Field::<$valtype, $reg_desc>::new($mask, $shift);
+
+        #[allow(non_snake_case)]
+        #[allow(unused)]
+        pub mod $field {
+            #[allow(unused_imports)]
+            use $crate::regs::FieldValue;
+            use super::super::$reg_desc;
+
+            $(
+            #[allow(non_upper_case_globals)]
+            #[allow(unused)]
+            $(#[$inner])*
+            pub const $valname: FieldValue<$valtype, $reg_desc> = FieldValue::<$valtype, $reg_desc>::new($mask, $shift, $value);
+            )*
+
+            #[allow(dead_code)]
+            #[allow(non_camel_case_types)]
+            pub enum Value {
+                $(
+                    $(#[$inner])*
+                    $valname = $value,
+                )*
+            }
+        }
+    };
+
+    {
+        $(#[$outer:meta])* $valtype:ty, $reg_desc:ident, $field:ident, $bit:expr,
+        [$( $(#[$inner:meta])* $valname:ident = $value:expr),* ]
+    } => {
+        #[allow(non_upper_case_globals)]
+        #[allow(unused)]
+        $(#[$outer:meta])*
+        pub const $field: Field<$valtype, $reg_desc> = Field::<$valtype, $reg_desc>::new(1, $bit);
+
+        #[allow(non_snake_case)]
+        #[allow(unused)]
+        pub mod $field {
+            #[allow(unused_imports)]
+            use $crate::regs::FieldValue;
+            use super::super::$reg_desc;
+
+            $(
+            #[allow(non_upper_case_globals)]
+            #[allow(unused)]
+            $(#[$inner])*
+            pub const $valname: FieldValue<$valtype, $reg_desc> = FieldValue::<$valtype, $reg_desc>::new(1, $bit, $value);
+            )*
+
+            #[allow(non_upper_case_globals)]
+            #[allow(unused)]
+            pub const SET: FieldValue<$valtype, $reg_desc> = FieldValue::<$valtype, $reg_desc>::new(1, $bit, 1);
+
+            #[allow(non_upper_case_globals)]
+            #[allow(unused)]
+            pub const CLEAR: FieldValue<$valtype, $reg_desc> = FieldValue::<$valtype, $reg_desc>::new(1, $bit, 0);
+
+            #[allow(dead_code)]
+            #[allow(non_camel_case_types)]
+            pub enum Value {
+                $(
+                    $(#[$inner])*
+                    $valname = $value,
+                )*
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! bitfields {
+    {
+        $valtype:ty, $( $(#[$inner:meta])* $reg:ident $reg_desc:ident $fields:tt ),*
+    } => {
+        $(
+            $(#[$inner])*
+            pub struct $reg_desc;
+            impl $crate::regs::RegisterLongName for $reg_desc {}
+
+            #[allow(non_snake_case)]
+            pub mod $reg {
+                use $crate::regs::Field;
+                use super::$reg_desc;
+
+
+                bitmasks!( $valtype, $reg_desc, $fields );
+            }
+        )*
+    }
+}

--- a/common/src/regs/mod.rs
+++ b/common/src/regs/mod.rs
@@ -1,0 +1,252 @@
+//! Implementation of registers and bitfields
+
+#[macro_use]
+pub mod macros;
+
+use core::ops::{BitAnd, BitOr, Not, Shr, Shl, Add};
+use core::marker::PhantomData;
+
+pub trait IntLike: BitAnd<Output=Self> +
+                   BitOr<Output=Self> +
+                   Not<Output=Self> +
+                   Eq +
+                   Shr<u32, Output=Self> +
+                   Shl<u32, Output=Self> + Copy + Clone {
+    fn zero() -> Self;
+}
+
+impl IntLike for u8 {
+    fn zero() -> Self {
+        0
+    }
+}
+impl IntLike for u16 {
+    fn zero() -> Self {
+        0
+    }
+}
+impl IntLike for u32 {
+    fn zero() -> Self {
+        0
+    }
+}
+
+pub trait RegisterLongName {}
+
+impl RegisterLongName for () {}
+
+pub struct ReadWrite<T: IntLike, R: RegisterLongName=()> {
+    value: T,
+    associated_register: PhantomData<R>
+}
+
+pub struct ReadOnly<T: IntLike, R: RegisterLongName=()> {
+    value: T,
+    associated_register: PhantomData<R>
+}
+
+pub struct WriteOnly<T: IntLike, R: RegisterLongName=()> {
+    value: T,
+    associated_register: PhantomData<R>
+}
+
+#[allow(dead_code)]
+impl<T: IntLike, R: RegisterLongName> ReadWrite<T, R> {
+    pub const fn new(value: T) -> Self {
+        ReadWrite {
+            value: value,
+            associated_register: PhantomData
+        }
+    }
+
+    #[inline]
+    pub fn get(&self) -> T {
+        unsafe { ::core::ptr::read_volatile(&self.value) }
+    }
+
+    #[inline]
+    pub fn set(&self, value: T) {
+        unsafe { ::core::ptr::write_volatile(&self.value as *const T as *mut T, value) }
+    }
+
+    #[inline]
+    pub fn read(&self, field: Field<T, R>) -> T
+    {
+        (self.get() & (field.mask << field.shift)) >> field.shift
+    }
+
+    #[inline]
+    pub fn write(&self, field: FieldValue<T, R>) {
+        self.set(field.value);
+    }
+
+    #[inline]
+    pub fn modify(&self, field: FieldValue<T, R>) {
+        let reg: T = self.get();
+        self.set((reg & !field.mask) | field.value);
+    }
+
+    #[inline]
+    pub fn is_set(&self, field: Field<T, R>) -> bool {
+        self.read(field) != T::zero()
+    }
+
+    #[inline]
+    pub fn matches(&self, field: FieldValue<T, R>) -> bool {
+        self.get() & field.mask == field.value
+    }
+}
+
+#[allow(dead_code)]
+impl<T: IntLike, R: RegisterLongName> ReadOnly<T, R> {
+    pub const fn new(value: T) -> Self {
+        ReadOnly {
+            value: value,
+            associated_register: PhantomData
+        }
+    }
+
+    #[inline]
+    pub fn get(&self) -> T {
+        unsafe { ::core::ptr::read_volatile(&self.value) }
+    }
+
+    #[inline]
+    pub fn read(&self, field: Field<T, R>) -> T
+    {
+        (self.get() & (field.mask << field.shift)) >> field.shift
+    }
+
+    #[inline]
+    pub fn is_set(&self, field: Field<T, R>) -> bool {
+        self.read(field) != T::zero()
+    }
+
+    #[inline]
+    pub fn matches(&self, field: FieldValue<T, R>) -> bool {
+        self.get() & field.mask == field.value
+    }
+}
+
+#[allow(dead_code)]
+impl<T: IntLike, R: RegisterLongName> WriteOnly<T, R> {
+    pub const fn new(value: T) -> Self {
+        WriteOnly {
+            value: value,
+            associated_register: PhantomData
+        }
+    }
+
+    #[inline]
+    pub fn set(&self, value: T) {
+        unsafe { ::core::ptr::write_volatile(&self.value as *const T as *mut T, value) }
+    }
+
+    #[inline]
+    pub fn write(&self, field: FieldValue<T, R>) {
+        self.set(field.value);
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct Field<T: IntLike, R: RegisterLongName> {
+    mask: T,
+    shift: u32,
+    associated_register: PhantomData<R>
+}
+
+// For the Field, the mask is unshifted, ie. the LSB should always be set
+impl<R: RegisterLongName> Field<u8, R> {
+    pub const fn new(mask: u8, shift: u32) -> Field<u8, R> {
+        Field {
+            mask: mask,
+            shift: shift,
+            associated_register: PhantomData
+        }
+    }
+
+    pub fn val(&self, value: u8) -> FieldValue<u8, R> {
+        FieldValue::<u8, R>::new(self.mask, self.shift, value)
+    }
+}
+
+impl<R: RegisterLongName> Field<u16, R> {
+    pub const fn new(mask: u16, shift: u32) -> Field<u16, R> {
+        Field {
+            mask: mask,
+            shift: shift,
+            associated_register: PhantomData
+        }
+    }
+
+    pub fn val(&self, value: u16) -> FieldValue<u16, R> {
+        FieldValue::<u16, R>::new(self.mask, self.shift, value)
+    }
+}
+
+impl<R: RegisterLongName> Field<u32, R> {
+    pub const fn new(mask: u32, shift: u32) -> Field<u32, R> {
+        Field {
+            mask: mask,
+            shift: shift,
+            associated_register: PhantomData
+        }
+    }
+
+    pub fn val(&self, value: u32) -> FieldValue<u32, R> {
+        FieldValue::<u32, R>::new(self.mask, self.shift, value)
+    }
+}
+
+
+// For the FieldValue, the masks and values are shifted into their actual location in the register
+#[derive(Copy, Clone)]
+pub struct FieldValue<T: IntLike, R: RegisterLongName> {
+    mask: T,
+    value: T,
+    associated_register: PhantomData<R>
+}
+
+// Necessary to split the implementation of u8 and u32 out because the bitwise math isn't treated
+// as const when the type is generic
+impl<R: RegisterLongName> FieldValue<u8, R> {
+    pub const fn new(mask: u8, shift: u32, value: u8) -> Self {
+        FieldValue {
+            mask: mask << shift,
+            value: (value << shift) & (mask << shift),
+            associated_register: PhantomData
+        }
+    }
+}
+
+impl<R: RegisterLongName> FieldValue<u16, R> {
+    pub const fn new(mask: u16, shift: u32, value: u16) -> Self {
+        FieldValue {
+            mask: mask << shift,
+            value: (value << shift) & (mask << shift),
+            associated_register: PhantomData
+        }
+    }
+}
+
+impl<R: RegisterLongName> FieldValue<u32, R> {
+    pub const fn new(mask: u32, shift: u32, value: u32) -> Self {
+        FieldValue {
+            mask: mask << shift,
+            value: (value << shift) & (mask << shift),
+            associated_register: PhantomData
+        }
+    }
+}
+
+// Combine two fields with the addition operator
+impl<T: IntLike, R: RegisterLongName> Add for FieldValue<T, R> {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        FieldValue {
+            mask: self.mask | rhs.mask,
+            value: self.value | rhs.value,
+            associated_register: PhantomData
+        }
+    }
+}

--- a/libteensy/Makefile
+++ b/libteensy/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all
+all:
+
+
+TOCK_USERLAND_BASE_DIR ?= ../tock/userland
+
+LIBNAME=libteensy
+$(LIBNAME)_DIR=.
+$(LIBNAME)_SRCS=$(wildcard $($(LIBNAME)_DIR)/*.c)
+
+override CPPFLAGS += -I$(TOCK_USERLAND_BASE_DIR)/libtock
+
+include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk

--- a/libteensy/multispi.c
+++ b/libteensy/multispi.c
@@ -1,0 +1,7 @@
+#include "tock.h"
+#include "spi.h"
+#include "multispi.h"
+
+int select_spi_bus(int spi_num) {
+    return command(DRIVER_NUM_SPI, 11, spi_num, 0);
+}

--- a/libteensy/multispi.h
+++ b/libteensy/multispi.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Use the given SPI module.
+ */
+int select_spi_bus(int spi_num);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
### Pull Request Overview
This (still WIP) pull request adds support for the [teensy 3.2](https://www.pjrc.com/teensy/techspecs.html) development board.

I started with forking [@shaneleonard's version of tock](shaneleonard/tock-teensy) (where support for the teensy 3.6 was started) and started modifying it to support the teensy 3.2.
My motivation to port to the teensy 3.2 is that I want to use it to [build keyboard firmware](techhazard/dactyl-build).

I didn't like the layout of including tock itself as a submodule, so I forked the [original project](helena-project/tock) and added my version for the teensy 3.2 in the same way as the already supported boards.

I would very much like to thank both @shaneleonard and the people
behind the tock project for their work upon which I will build.

N.B.: This version is not yet correct at all! Almost all of the values are currently from the 3.6 version

### Testing Strategy
T.B.D.


### TODO or Help Wanted
This pull request still needs to:

- [ ] check the entire teensy codebase (`boards/teensy3.2` and `chips/mk20`) and cross-reference [the mk20 reference manual](https://www.pjrc.com/teensy/K20P64M72SF1RM.pdf) with [the mk66 one](https://www.pjrc.com/teensy/K66P144M180SF5RMV2.pdf) to see where the two chipsets differ.
- [ ] find a good place for the macros in `common/`, perhaps in `chips/mk20` since it's only used there.
- [ ] check if `libteensy` is necessary for anything besides `apps` and find a proper place for it.
- [ ] compare original `Makefile`s and @shaneleonard's, to make it compile again (currently linking with `arm-none-eabi-gcc` fails: `ld returned 1 exit status`
- [ ] verify chip layout (`boards/teensy3.2/chip_layout.ld`).

Help wanted with:
- all of the above :-)
- checking if I'm on the right track
- giving me some pointers about which parts to pay attention to.

### Formatting

- [ ] `make formatall` has been run.

### Merging
I recommend doing a squash merge when this is finished.