### PR TITLE
tools: semantic instead of lexical version compare

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -3,6 +3,8 @@
 MAKEFLAGS += -r
 MAKEFLAGS += -R
 
+MAKEFILE_COMMON_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 export RUSTUP_TOOLCHAIN ?= nightly-2018-01-05
 
 TOOLCHAIN ?= arm-none-eabi
@@ -79,7 +81,7 @@ ifneq ($(XARGO_NAME), xargo)
   $(shell sleep 3s)
   $(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) cargo install xargo)
   XARGO_VERSION := $(strip $(word 2, $(XARGO_CALL)))
-else ifeq ($(shell expr $(XARGO_VERSION) \< $(MINIMUM_XARGO_VERSION)), 1)
+else ifeq ($(shell $(MAKEFILE_COMMON_PATH)../tools/semver.sh $(XARGO_VERSION) \< $(MINIMUM_XARGO_VERSION)), true)
   $(warning Required tool `xargo` is out-of-date.)
   $(warning Running `cargo install cargo-update` and `cargo install-update xargo` in 3 seconds (ctrl-c to cancel))
   $(shell sleep 3s)

--- a/tools/semver.sh
+++ b/tools/semver.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Adapted from
+# https://stackoverflow.com/questions/4023830/
+
+vercomp () {
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    # fill empty fields in ver1 with zeros
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            # fill empty fields in ver2 with zeros
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 2
+        fi
+    done
+    return 0
+}
+
+testvercomp () {
+    vercomp $1 $2
+    case $? in
+        0) op='=';;
+        1) op='>';;
+        2) op='<';;
+    esac
+    if [[ $op != $3 ]]
+    then
+        #echo "FAIL: Expected '$3', Actual '$op', Arg1 '$1', Arg2 '$2'"
+        echo false
+    else
+        echo true
+    fi
+}
+
+testvercomp $1 $3 $2


### PR DESCRIPTION
### Pull Request Overview

Addresses the problem raised in #717.

This is a bit obnoxious to do in a cross-platform way, but this pure-bash
solution should work according to the wonderful wonderful Internet.

### Testing Strategy

Running the script with faked versions to make sure it did the right thing.


### TODO or Help Wanted

### Documentation Updated

- [X] ~~Kernel: The relevant files in `/docs` have been updated or no updates are required.~~
- [X] ~~Userland: The application README has been added, updated, or no updates are required.~~

### Formatting

- [X] ~~`make formatall` has been run.~~
