### PR TITLE
doc: clarify that main's return value may change

### DIFF
--- a/doc/Userland.md
+++ b/doc/Userland.md
@@ -250,8 +250,9 @@ method with the following signature:
 int main(void);
 ```
 
-Applications **should** return 0 from `main`, but `main` is called from `_start`
-and includes an implicit `while()` loop:
+Applications **should** return 0 from `main`. Returning non-zero is undefined and the
+behavior may change in future versions of `libtock`.
+Today, `main` is called from `_start` and includes an implicit `while()` loop:
 
 ```c
 void _start(void* text_start, void* mem_start, void* memory_len, void* app_heap_break) {


### PR DESCRIPTION
# Proposed changes:

[Doc-only]

In reviewing #714, I got to thinking about process behavior, in particular `main`'s return code. Perhaps we should attribute it some significance (e.g. kill processes where `main` failed somehow, maybe respawn if error > 0, kill < 0). Not necessarily a debate to have today, just a thought to let rattle around. In the meantime, be explicit that main should return 0 for forward compatibility.
