### PR TITLE
Cleanup userland_generic.ld

### DIFF
--- a/userland/userland_generic.ld
+++ b/userland/userland_generic.ld
@@ -20,7 +20,7 @@ MEMORY {
 }
 
 SECTIONS {
-/* Text section, Code! */
+    /* Text section, Code! */
     .text :
     {
         _text = .;
@@ -53,7 +53,7 @@ SECTIONS {
         /* Size of data section */
         LONG(SIZEOF(.data));
         /* Offset of BSS section in memory */
-        LONG(_sbss);
+        LONG(_bss);
         /* Size of BSS section */
         LONG(SIZEOF(.bss));
         /* First address offset after program flash, where elf2tbf places
@@ -66,79 +66,59 @@ SECTIONS {
         KEEP (*(.syscalls))
         _etext = .;
         *(.ARM.extab*)
+        . = ALIGN(4); /* Make sure we're word-aligned here */
     } > FLASH =0xFF
 
 
-/* App state section. Used for persistent app data. */
+    /* App state section. Used for persistent app data. */
     .app_state :
     {
         KEEP (*(.app_state))
     } > FLASH =0xFF
 
-/* Beginning of SRAM */
-    _sram_start = .;
-
-/* Global Offset Table */
+    /* Global Offset Table */
     .got :
     {
         _got = .;
         *(.got*)
-        _egot = .;
-        _plt = .;
         *(.got.plt*)
-        _eplt = .;
     } > SRAM AT > FLASH
 
-/* Data section, static initialized variables
- *  Note: This is placed in Flash after the text section, but needs to be
- *  moved to SRAM at runtime
- */
+    /* Data section, static initialized variables
+     *  Note: This is placed in Flash after the text section, but needs to be
+     *  moved to SRAM at runtime
+     */
     .data :
     {
         _data = .;
         KEEP(*(.data*))
-        _edata = .;
     } > SRAM AT > FLASH
 
-/* BSS section, static uninitialized variables */
-    _sbss = .;
+    /* BSS section, static uninitialized variables */
     .bss :
     {
         _bss = .;
         KEEP(*(.bss*))
         *(COMMON)
-        _ebss = .;
     } > SRAM
 
-/*
- * __NOTE__: The following symbols are used only to pass information
- * through the elf -> tbf -> Tock kernel.
- *
- * The kernel will place the stack at the beginning of the SRAM section so
- * that stack overflows run off the end of the memory segment and trigger an
- * MPU violation instead of overwriting data/got/bss information. This means
- * the actual location of symbols in those sections in memory will be offset
- * by STACK_SIZE.
- */
+    /*
+     * __NOTE__: The following symbols are used only to hint to elf2tbf how much
+     * total memory to request from the OS.
+     */
     .stack :
     {
-        _stack = .;
         . += STACK_SIZE;
-        _estack = .;
     } > SRAM
 
     .app_heap :
     {
-        _app_heap = .;
         . += APP_HEAP_SIZE;
-        _eapp_heap = .;
     } > SRAM
 
     .kernel_heap :
     {
-        _kernel_heap = .;
         . += KERNEL_HEAP_SIZE;
-        _ekernel_heap = .;
     } > SRAM
 
     _sram_end = .;
@@ -146,15 +126,19 @@ SECTIONS {
     {
     } > FLASH
 
-/* ARM Exception support
- *
- * This contains compiler-generated support for unwinding the stack,
- * consisting of key-value pairs of function addresses and information on
- * how to unwind stack frames.
- * https://wiki.linaro.org/KenWerner/Sandbox/libunwind?action=AttachFile&do=get&target=libunwind-LDS.pdf
- *
- * .ARM.exidx is sorted, so has to go in its own output section.
- */
+    /* ARM Exception support
+     *
+     * This contains compiler-generated support for unwinding the stack,
+     * consisting of key-value pairs of function addresses and information on
+     * how to unwind stack frames.
+     * https://wiki.linaro.org/KenWerner/Sandbox/libunwind?action=AttachFile&do=get&target=libunwind-LDS.pdf
+     *
+     * .ARM.exidx is sorted, so has to go in its own output section.
+     *
+     * __NOTE__: It's at the end because we currently don't actually serialize
+     * it to the binary in elf2tbf. If it was before the RAM sections, it would
+     * through off our calculations of the header.
+     */
     PROVIDE_HIDDEN (__exidx_start = .);
     .ARM.exidx :
     {


### PR DESCRIPTION
### Pull Request Overview

This pull request cleans up the generic linker script used for userland apps. In particular, it improves a few comments and removes unused symbols

**Importantly** it fixes a bug where the RAM sections could end up in non-word aligned locations in the app binary on flash. This can happen because RODATA may be non-word sized (e.g. if there is an odd-sized string) and there are no actual sections after RODATA to "re-align" it. On some architectures (looking at you Cortex-M0) this causes a fault during loading/relocation because non-word-align memory loads are not permitted. The fix is just to explicitly word-align the end of the text segment.

### Testing Strategy

This pull request was tested by running a bunch of apps, including the original culprite (`ble_advertising`) as well as explicitly inspecting the compiled ELF and TBF to verify the output is as expected.

### Formatting

- [x] `make formatall` has been run.
