### PR TITLE
kernel: regs: handle case when field is 32 bits

### DIFF
--- a/kernel/src/common/regs/macros.rs
+++ b/kernel/src/common/regs/macros.rs
@@ -53,7 +53,7 @@ macro_rules! register_bitmasks {
         #[allow(non_upper_case_globals)]
         #[allow(unused)]
         pub const $field: Field<$valtype, $reg_desc> =
-            Field::<$valtype, $reg_desc>::new((1<<$numbits)-1, $offset);
+            Field::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1), $offset);
 
         #[allow(non_snake_case)]
         #[allow(unused)]
@@ -68,18 +68,21 @@ macro_rules! register_bitmasks {
             #[allow(unused)]
             $(#[$inner])*
             pub const $valname: FieldValue<$valtype, $reg_desc> =
-                FieldValue::<$valtype, $reg_desc>::new((1<<$numbits)-1, $offset, $value);
+                FieldValue::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1),
+                    $offset, $value);
             )*
 
             #[allow(non_upper_case_globals)]
             #[allow(unused)]
             pub const SET: FieldValue<$valtype, $reg_desc> =
-                FieldValue::<$valtype, $reg_desc>::new((1<<$numbits)-1, $offset, (1<<$numbits)-1);
+                FieldValue::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1),
+                    $offset, (1<<($numbits-1))+((1<<($numbits-1))-1));
 
             #[allow(non_upper_case_globals)]
             #[allow(unused)]
             pub const CLEAR: FieldValue<$valtype, $reg_desc> =
-                FieldValue::<$valtype, $reg_desc>::new((1<<$numbits)-1, $offset, 0);
+                FieldValue::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1),
+                    $offset, 0);
 
             #[allow(dead_code)]
             #[allow(non_camel_case_types)]


### PR DESCRIPTION
### Pull Request Overview

Because you can't shift past the size of the underlying type in rust, we
could not create the mask for a register field that is 32 bits using the
equation `(1<<numbits)-1`. This changes that calculation to be two
steps, which avoids the problem. It does however mean it won't work for
0, but we can't have a 0 bit register field.

New version:

```
(1<<($numbits-1))+((1<<($numbits-1))-1)
```


### Testing Strategy

This pull request was tested by playing around on rust playground.


### TODO or Help Wanted

If someone has a nicer way to do this, great.


### Documentation Updated

Just a bug fix.

### Formatting

- [x] `make formatall` has been run.
