### PR TITLE
Remove extraneous AES test

### DIFF
--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -56,6 +56,7 @@ use nrf5x::rtc::{Rtc, RTC};
 
 #[macro_use]
 pub mod io;
+#[allow(dead_code)]
 mod aes_test;
 
 // The nRF51 DK LEDs (see back of board)
@@ -341,9 +342,6 @@ pub unsafe fn reset_handler() {
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
-
-    // aes128-ctr test remove later
-    aes_test::run();
 
     kernel::main(
         &platform,

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -91,6 +91,7 @@ const BUTTON_RST_PIN: usize = 21;
 #[macro_use]
 pub mod io;
 
+#[allow(dead_code)]
 mod aes_test;
 
 // State for loading and holding applications.
@@ -366,8 +367,6 @@ pub unsafe fn reset_handler() {
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
-
-    aes_test::run();
 
     kernel::main(
         &platform,


### PR DESCRIPTION
### Pull Request Overview

This pull request removes some extraneous tests left over from #684. 

### Formatting

- [X] `make formatall` has been run.
