### PR TITLE
Add "deactivate callback" command.

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -772,13 +772,18 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Driver for Adc<'a, A> {
     /// _appid - application identifier, unused
     /// allow_num - which allow call this is
     /// slice - representation of application memory to copy data into
-    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        _appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         match allow_num {
             // Pass buffer for samples to go into
             0 => {
                 // set first buffer
                 self.app.map(|state| {
-                    state.app_buf1 = Some(slice);
+                    state.app_buf1 = slice;
                 });
 
                 ReturnCode::SUCCESS
@@ -788,7 +793,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Driver for Adc<'a, A> {
             1 => {
                 // set second buffer
                 self.app.map(|state| {
-                    state.app_buf2 = Some(slice);
+                    state.app_buf2 = slice;
                 });
 
                 ReturnCode::SUCCESS

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -804,12 +804,17 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Driver for Adc<'a, A> {
     /// subscribe_num - which subscribe call this is
     /// callback - callback object which can be scheduled to signal the
     ///            application
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // subscribe to ADC sample done (from all types of sampling)
             0 => {
                 // set callback
-                self.callback.set(Some(callback));
+                self.callback.set(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -74,10 +74,15 @@ impl<'a, A: Alarm> Driver for AlarmDriver<'a, A> {
     /// ### `_subscribe_num`
     ///
     /// - `0`: Subscribe to alarm expiration
-    fn subscribe(&self, _subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        _subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         self.app_alarm
-            .enter(callback.app_id(), |td, _allocator| {
-                td.callback = Some(callback);
+            .enter(app_id, |td, _allocator| {
+                td.callback = callback;
                 ReturnCode::SUCCESS
             })
             .unwrap_or_else(|err| err.into())

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -62,11 +62,16 @@ impl<'a> Driver for AmbientLight<'a> {
     ///
     /// - `0`: Subscribe to light intensity readings. The callback signature is
     /// `fn(lux: usize)`, where `lux` is the light intensity in lux (lx).
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 => self.apps
-                .enter(callback.app_id(), |app, _| {
-                    app.callback = Some(callback);
+                .enter(app_id, |app, _| {
+                    app.callback = callback;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -188,11 +188,16 @@ impl<'a> Driver for AppFlash<'a> {
     /// ### `subscribe_num`
     ///
     /// - `0`: Set a write_done callback.
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 => self.apps
-                .enter(callback.app_id(), |app, _| {
-                    app.callback = Some(callback);
+                .enter(app_id, |app, _| {
+                    app.callback = callback;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -171,11 +171,16 @@ impl<'a> Driver for AppFlash<'a> {
     /// ### `allow_num`
     ///
     /// - `0`: Set write buffer. This entire buffer will be written to flash.
-    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         match allow_num {
             0 => self.apps
                 .enter(appid, |app, _| {
-                    app.buffer = Some(slice);
+                    app.buffer = slice;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -125,11 +125,16 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
     ///   interrupt will be called with two parameters: the index of the button
     ///   that triggered the interrupt and the pressed/not pressed state of the
     ///   button.
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 => self.apps
-                .enter(callback.app_id(), |cntr, _| {
-                    cntr.0 = Some(callback);
+                .enter(app_id, |cntr, _| {
+                    cntr.0 = callback;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -187,11 +187,16 @@ impl<'a, U: UART> Driver for Console<'a, U> {
     /// ### `subscribe_num`
     ///
     /// - `1`: Write buffer completed callback
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             1 /* putstr/write_done */ => {
-                self.apps.enter(callback.app_id(), |app, _| {
-                    app.write_callback = Some(callback);
+                self.apps.enter(app_id, |app, _| {
+                    app.write_callback = callback;
                     ReturnCode::SUCCESS
                 }).unwrap_or_else(|err| {
                     match err {

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -170,11 +170,16 @@ impl<'a, U: UART> Driver for Console<'a, U> {
     /// ### `allow_num`
     ///
     /// - `1`: Writeable buffer for write buffer
-    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         match allow_num {
             1 => self.apps
                 .enter(appid, |app, _| {
-                    app.write_buffer = Some(slice);
+                    app.write_buffer = slice;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -170,12 +170,17 @@ impl<'a, C: hil::crc::CRC> Driver for Crc<'a, C> {
     /// `allow_num` zero, which is used to provide a buffer over which
     /// to compute a CRC computation.
     ///
-    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         match allow_num {
             // Provide user buffer to compute CRC over
             0 => self.apps
                 .enter(appid, |app, _| {
-                    app.buffer = Some(slice);
+                    app.buffer = slice;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -200,12 +200,17 @@ impl<'a, C: hil::crc::CRC> Driver for Crc<'a, C> {
     ///
     ///   * `result` is the result of the CRC computation when `status == EBUSY`.
     ///
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // Set callback for CRC result
             0 => self.apps
-                .enter(callback.app_id(), |app, _| {
-                    app.callback = Some(callback);
+                .enter(app_id, |app, _| {
+                    app.callback = callback;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -129,12 +129,17 @@ impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
     ///
     /// - `0`: Subscribe to interrupts from all pins with interrupts enabled.
     ///        The callback signature is `fn(pin_num: usize, pin_state: bool)`
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // subscribe to all pin interrupts (no affect or reliance on
             // individual pins being configured as interrupts)
             0 => {
-                self.callback.set(Some(callback));
+                self.callback.set(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -93,17 +93,22 @@ impl<'a, Port: hil::gpio_async::Port> Driver for GPIOAsync<'a, Port> {
     /// - `1`: Setup a callback for when a **GPIO interrupt** occurs. This
     ///   callback will be called with two arguments, the first being the port
     ///   number of the interrupting pin, and the second being the pin number.
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // Set callback for `done()` events
             0 => {
-                self.callback.set(Some(callback));
+                self.callback.set(callback);
                 ReturnCode::SUCCESS
             }
 
             // Set callback for pin interrupts
             1 => {
-                self.interrupt_callback.set(Some(callback));
+                self.interrupt_callback.set(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -102,10 +102,10 @@ impl<'a> HumiditySensor<'a> {
         }
     }
 
-    fn configure_callback(&self, callback: Callback) -> ReturnCode {
+    fn configure_callback(&self, callback: Option<Callback>, app_id: AppId) -> ReturnCode {
         self.apps
-            .enter(callback.app_id(), |app, _| {
-                app.callback = Some(callback);
+            .enter(app_id, |app, _| {
+                app.callback = callback;
                 ReturnCode::SUCCESS
             })
             .unwrap_or_else(|err| err.into())
@@ -127,10 +127,15 @@ impl<'a> hil::sensors::HumidityClient for HumiditySensor<'a> {
 }
 
 impl<'a> Driver for HumiditySensor<'a> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // subscribe to temperature reading with callback
-            0 => self.configure_callback(callback),
+            0 => self.configure_callback(callback, app_id),
             _ => ReturnCode::ENOSUPPORT,
         }
     }

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -251,11 +251,16 @@ impl<'a> Driver for I2CMasterSlaveDriver<'a> {
         }
     }
 
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 => {
                 self.app.map(|app| {
-                    app.callback = Some(callback);
+                    app.callback = callback;
                 });
                 ReturnCode::SUCCESS
             }

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -216,34 +216,39 @@ impl<'a> hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'a> {
 }
 
 impl<'a> Driver for I2CMasterSlaveDriver<'a> {
-    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        _appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         match allow_num {
             // Pass in a buffer for transmitting a `write` to another
             // I2C device.
             0 => {
                 self.app.map(|app| {
-                    app.master_tx_buffer = Some(slice);
+                    app.master_tx_buffer = slice;
                 });
                 ReturnCode::SUCCESS
             }
             // Pass in a buffer for doing a read from another I2C device.
             1 => {
                 self.app.map(|app| {
-                    app.master_rx_buffer = Some(slice);
+                    app.master_rx_buffer = slice;
                 });
                 ReturnCode::SUCCESS
             }
             // Pass in a buffer for handling a read issued by another I2C master.
             2 => {
                 self.app.map(|app| {
-                    app.slave_tx_buffer = Some(slice);
+                    app.slave_tx_buffer = slice;
                 });
                 ReturnCode::SUCCESS
             }
             // Pass in a buffer for handling a write issued by another I2C master.
             3 => {
                 self.app.map(|app| {
-                    app.slave_rx_buffer = Some(slice);
+                    app.slave_rx_buffer = slice;
                 });
                 ReturnCode::SUCCESS
             }

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -532,13 +532,18 @@ impl<'a> Driver for RadioDriver<'a> {
     /// - `2`: Config buffer. Used to contain miscellaneous data associated with
     ///        some commands because the system call parameters / return codes are
     ///        not enough to convey the desired information.
-    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         match allow_num {
             0 | 1 | 2 => self.do_with_app(appid, |app| {
                 match allow_num {
-                    0 => app.app_read = Some(slice),
-                    1 => app.app_write = Some(slice),
-                    2 => app.app_cfg = Some(slice),
+                    0 => app.app_read = slice,
+                    1 => app.app_write = slice,
+                    2 => app.app_cfg = slice,
                     _ => {}
                 }
                 ReturnCode::SUCCESS

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -553,14 +553,19 @@ impl<'a> Driver for RadioDriver<'a> {
     ///
     /// - `0`: Setup callback for when frame is received.
     /// - `1`: Setup callback for when frame is transmitted.
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
-            0 => self.do_with_app(callback.app_id(), |app| {
-                app.rx_callback = Some(callback);
+            0 => self.do_with_app(app_id, |app| {
+                app.rx_callback = callback;
                 ReturnCode::SUCCESS
             }),
-            1 => self.do_with_app(callback.app_id(), |app| {
-                app.tx_callback = Some(callback);
+            1 => self.do_with_app(app_id, |app| {
+                app.tx_callback = callback;
                 ReturnCode::SUCCESS
             }),
             _ => ReturnCode::ENOSUPPORT,

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -215,12 +215,17 @@ impl<'a> gpio::Client for LPS25HB<'a> {
 }
 
 impl<'a> Driver for LPS25HB<'a> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // Set a callback
             0 => {
                 // Set callback function
-                self.callback.set(Some(callback));
+                self.callback.set(callback);
                 ReturnCode::SUCCESS
             }
             // default

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -476,10 +476,15 @@ impl<'a> Driver for LTC294XDriver<'a> {
     ///   - `3`: `done()` was called.
     ///   - `4`: Read the voltage.
     ///   - `5`: Read the current.
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 => {
-                self.callback.set(Some(callback));
+                self.callback.set(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -414,10 +414,15 @@ impl<'a> Driver for MAX17205Driver<'a> {
     /// ### `subscribe_num`
     ///
     /// - `0`: Setup a callback for when all events complete or data is ready.
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 => {
-                self.callback.set(Some(callback));
+                self.callback.set(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -142,11 +142,16 @@ impl<'a> hil::sensors::NineDofClient for NineDof<'a> {
 }
 
 impl<'a> Driver for NineDof<'a> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 => self.apps
-                .enter(callback.app_id(), |app, _| {
-                    app.callback = Some(callback);
+                .enter(app_id, |app, _| {
+                    app.callback = callback;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -468,12 +468,17 @@ impl<'a> Driver for NonvolatileStorage<'a> {
     ///
     /// - `0`: Setup a buffer to read from the nonvolatile storage into.
     /// - `1`: Setup a buffer to write bytes to the nonvolatile storage.
-    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         self.apps
             .enter(appid, |app, _| {
                 match allow_num {
-                    0 => app.buffer_read = Some(slice),
-                    1 => app.buffer_write = Some(slice),
+                    0 => app.buffer_read = slice,
+                    1 => app.buffer_write = slice,
                     _ => return ReturnCode::ENOSUPPORT,
                 }
                 ReturnCode::SUCCESS

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -487,12 +487,17 @@ impl<'a> Driver for NonvolatileStorage<'a> {
     ///
     /// - `0`: Setup a read done callback.
     /// - `1`: Setup a write done callback.
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         self.apps
-            .enter(callback.app_id(), |app, _| {
+            .enter(app_id, |app, _| {
                 match subscribe_num {
-                    0 => app.callback_read = Some(callback),
-                    1 => app.callback_write = Some(callback),
+                    0 => app.callback_read = callback,
+                    1 => app.callback_write = callback,
                     _ => return ReturnCode::ENOSUPPORT,
                 }
                 ReturnCode::SUCCESS

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -89,12 +89,17 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
     ///
     /// - `0`: Provide a RX buffer.
     /// - `1`: Provide a TX buffer.
-    fn allow(&self, _appid: AppId, allow_type: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        _appid: AppId,
+        allow_type: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         match allow_type {
             // Provide an RX buffer.
             0 => {
                 self.app.map(|app| {
-                    app.rx_buffer = Some(slice);
+                    app.rx_buffer = slice;
                     app.rx_recv_so_far = 0;
                     app.rx_recv_total = 0;
                 });
@@ -103,7 +108,7 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
 
             // Provide a TX buffer.
             1 => {
-                self.app.map(|app| app.tx_buffer = Some(slice));
+                self.app.map(|app| app.tx_buffer = slice);
                 ReturnCode::SUCCESS
             }
             _ => ReturnCode::ENOSUPPORT,

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -118,11 +118,16 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
     /// ### `subscribe_num`
     ///
     /// - `0`: Set callback.
-    fn subscribe(&self, subscribe_type: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_type: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_type {
             // Add a callback
             0 => {
-                self.app.map(|app| app.callback = Some(callback));
+                self.app.map(|app| app.callback = callback);
 
                 // Start the receive now that we have a callback.
                 self.rx_buffer

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -150,10 +150,15 @@ impl<'a> Driver for PCA9544A<'a> {
     ///
     /// - `0`: Callback is triggered when a channel is finished being selected
     ///   or when the current channel setup is returned.
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 => {
-                self.callback.set(Some(callback));
+                self.callback.set(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -131,12 +131,17 @@ impl<'a, RNG: rng::RNG> rng::Client for SimpleRng<'a, RNG> {
 }
 
 impl<'a, RNG: rng::RNG> Driver for SimpleRng<'a, RNG> {
-    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         // pass buffer in from application
         match allow_num {
             0 => self.apps
                 .enter(appid, |app, _| {
-                    app.buffer = Some(slice);
+                    app.buffer = slice;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -144,11 +144,16 @@ impl<'a, RNG: rng::RNG> Driver for SimpleRng<'a, RNG> {
         }
     }
 
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 => self.apps
-                .enter(callback.app_id(), |app, _| {
-                    app.callback = Some(callback);
+                .enter(app_id, |app, _| {
+                    app.callback = callback;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -1511,11 +1511,16 @@ impl<'a, A: hil::time::Alarm + 'a> Driver for SDCardDriver<'a, A> {
         }
     }
 
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // Set callback
             0 => {
-                self.app.map(|app| app.callback = Some(callback));
+                self.app.map(|app| app.callback = callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -1493,17 +1493,22 @@ impl<'a, A: hil::time::Alarm + 'a> SDCardClient for SDCardDriver<'a, A> {
 
 /// Connections to userspace syscalls
 impl<'a, A: hil::time::Alarm + 'a> Driver for SDCardDriver<'a, A> {
-    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        _appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         match allow_num {
             // Pass read buffer in from application
             0 => {
-                self.app.map(|app| app.read_buffer = Some(slice));
+                self.app.map(|app| app.read_buffer = slice);
                 ReturnCode::SUCCESS
             }
 
             // Pass write buffer in from application
             1 => {
-                self.app.map(|app| app.write_buffer = Some(slice));
+                self.app.map(|app| app.write_buffer = slice);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -127,19 +127,24 @@ impl<'a, S: SpiMasterDevice> Spi<'a, S> {
 }
 
 impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
-    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        _appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         match allow_num {
             // Pass in a read buffer to receive bytes into.
             0 => {
                 self.app.map(|app| {
-                    app.app_read = Some(slice);
+                    app.app_read = slice;
                 });
                 ReturnCode::SUCCESS
             }
             // Pass in a write buffer to transmit bytes from.
             1 => {
                 self.app.map(|app| {
-                    app.app_write = Some(slice);
+                    app.app_write = slice;
                 });
                 ReturnCode::SUCCESS
             }
@@ -354,14 +359,19 @@ impl<'a, S: SpiSlaveDevice> Driver for SpiSlave<'a, S> {
     ///
     /// - allow_num 1: Provides an app_write buffer to send transfers from.
     ///
-    fn allow(&self, _appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        _appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
         match allow_num {
             0 => {
-                self.app.map(|app| app.app_read = Some(slice));
+                self.app.map(|app| app.app_read = slice);
                 ReturnCode::SUCCESS
             }
             1 => {
-                self.app.map(|app| app.app_write = Some(slice));
+                self.app.map(|app| app.app_write = slice);
                 ReturnCode::SUCCESS
             }
             _ => ReturnCode::ENOSUPPORT,

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -147,11 +147,16 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
         }
     }
 
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 /* read_write */ => {
                 self.app.map(|app| {
-                    app.callback = Some(callback);
+                    app.callback = callback;
                 });
                 ReturnCode::SUCCESS
             },
@@ -374,14 +379,19 @@ impl<'a, S: SpiSlaveDevice> Driver for SpiSlave<'a, S> {
     ///                  driven low, meaning that the slave was selected by
     ///                  the Spi master. This occurs immediately before
     ///                  a data transfer.
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             0 /* read_write */ => {
-                self.app.map(|app| app.callback = Some(callback));
+                self.app.map(|app| app.callback = callback);
                 ReturnCode::SUCCESS
             },
             1 /* chip selected */ => {
-                self.app.map(|app| app.selected_callback = Some(callback));
+                self.app.map(|app| app.selected_callback = callback);
                 ReturnCode::SUCCESS
             },
             _ => ReturnCode::ENOSUPPORT

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -92,10 +92,10 @@ impl<'a> TemperatureSensor<'a> {
             .unwrap_or_else(|err| err.into())
     }
 
-    fn configure_callback(&self, callback: Callback) -> ReturnCode {
+    fn configure_callback(&self, callback: Option<Callback>, app_id: AppId) -> ReturnCode {
         self.apps
-            .enter(callback.app_id(), |app, _| {
-                app.callback = Some(callback);
+            .enter(app_id, |app, _| {
+                app.callback = callback;
                 ReturnCode::SUCCESS
             })
             .unwrap_or_else(|err| err.into())
@@ -117,10 +117,15 @@ impl<'a> hil::sensors::TemperatureClient for TemperatureSensor<'a> {
 }
 
 impl<'a> Driver for TemperatureSensor<'a> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // subscribe to temperature reading with callback
-            0 => self.configure_callback(callback),
+            0 => self.configure_callback(callback, app_id),
             _ => ReturnCode::ENOSUPPORT,
         }
     }

--- a/capsules/src/tmp006.rs
+++ b/capsules/src/tmp006.rs
@@ -269,7 +269,12 @@ impl<'a> Client for TMP006<'a> {
 }
 
 impl<'a> Driver for TMP006<'a> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // single temperature reading with callback
             0 => {
@@ -277,7 +282,7 @@ impl<'a> Driver for TMP006<'a> {
                 self.repeated_mode.set(false);
 
                 // set callback function
-                self.callback.set(Some(callback));
+                self.callback.set(callback);
 
                 // enable sensor
                 //  turn up the sampling rate so we get the sample faster
@@ -292,7 +297,7 @@ impl<'a> Driver for TMP006<'a> {
                 self.repeated_mode.set(true);
 
                 // set callback function
-                self.callback.set(Some(callback));
+                self.callback.set(callback);
 
                 // enable temperature sensor
                 self.enable_sensor(self.sampling_period.get());

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -433,12 +433,17 @@ impl<'a> gpio::Client for TSL2561<'a> {
 }
 
 impl<'a> Driver for TSL2561<'a> {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // Set a callback
             0 => {
                 // Set callback function
-                self.callback.set(Some(callback));
+                self.callback.set(callback);
                 ReturnCode::SUCCESS
             }
             // default

--- a/capsules/src/usb_user.rs
+++ b/capsules/src/usb_user.rs
@@ -102,12 +102,17 @@ impl<'a, C> Driver for UsbSyscallDriver<'a, C>
 where
     C: hil::usb::Client,
 {
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // Set callback for result
             0 => self.apps
-                .enter(callback.app_id(), |app, _| {
-                    app.callback = Some(callback);
+                .enter(app_id, |app, _| {
+                    app.callback = callback;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or_else(|err| err.into()),

--- a/chips/nrf5x/src/ble_advertising_driver.rs
+++ b/chips/nrf5x/src/ble_advertising_driver.rs
@@ -964,13 +964,13 @@ where
         &self,
         appid: kernel::AppId,
         allow_num: usize,
-        slice: kernel::AppSlice<kernel::Shared, u8>,
+        slice: Option<kernel::AppSlice<kernel::Shared, u8>>,
     ) -> ReturnCode {
         match AllowType::from_usize(allow_num) {
             Some(AllowType::BLEGap(gap_type)) => self.app
                 .enter(appid, |app, _| {
                     if app.process_status != Some(BLEState::NotInitialized) {
-                        app.app_write = Some(slice);
+                        app.app_write = slice;
                         app.set_gap_data(gap_type)
                     } else {
                         ReturnCode::EINVAL
@@ -981,7 +981,7 @@ where
             Some(AllowType::PassiveScanning) => self.app
                 .enter(appid, |app, _| match app.process_status {
                     Some(BLEState::NotInitialized) | Some(BLEState::Initialized) => {
-                        app.app_read = Some(slice);
+                        app.app_read = slice;
                         app.process_status = Some(BLEState::Initialized);
                         ReturnCode::SUCCESS
                     }
@@ -992,7 +992,7 @@ where
             Some(AllowType::InitAdvertisementBuffer) => self.app
                 .enter(appid, |app, _| {
                     if let Some(BLEState::NotInitialized) = app.process_status {
-                        app.advertisement_buf = Some(slice);
+                        app.advertisement_buf = slice;
                         app.process_status = Some(BLEState::Initialized);
                         app.initialize_advertisement_buffer();
                         ReturnCode::SUCCESS

--- a/chips/nrf5x/src/ble_advertising_driver.rs
+++ b/chips/nrf5x/src/ble_advertising_driver.rs
@@ -1005,13 +1005,18 @@ where
         }
     }
 
-    fn subscribe(&self, subscribe_num: usize, callback: kernel::Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<kernel::Callback>,
+        app_id: kernel::AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // Callback for scanning
             0 => self.app
-                .enter(callback.app_id(), |app, _| match app.process_status {
+                .enter(app_id, |app, _| match app.process_status {
                     Some(BLEState::NotInitialized) | Some(BLEState::Initialized) => {
-                        app.scan_callback = Some(callback);
+                        app.scan_callback = callback;
                         ReturnCode::SUCCESS
                     }
                     _ => ReturnCode::EINVAL,

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -147,7 +147,7 @@ None.
 ### 1: Subscribe
 
 Subscribe assigns callback functions to be executed in response to various
-events.
+events. A null pointer to a callback disables a previously set callback.
 
 ```rust
 subscribe(driver: u32, subscribe_number: u32, callback: u32, userdata: u32) -> ReturnCode as u32
@@ -214,6 +214,7 @@ additional meaning such as the number of devices present, as is the case in the
 ### 3: Allow
 
 Allow marks a region of memory as shared between the kernel and application.
+A null pointer revokes sharing a region.
 
 ```rust
 allow(driver: u32, allow_number: u32, pointer: usize, size: u32) -> ReturnCode as u32

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -103,8 +103,4 @@ impl Callback {
             )
         }
     }
-
-    pub fn app_id(&self) -> AppId {
-        self.app_id
-    }
 }

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -171,7 +171,9 @@ impl DebugWriter {
                         AppId::kernel_new(APPID_IDX),
                     );
                     let slice_len = slice.len();
-                    if driver.allow(AppId::kernel_new(APPID_IDX), 1, slice) != ReturnCode::SUCCESS {
+                    if driver.allow(AppId::kernel_new(APPID_IDX), 1, Some(slice))
+                        != ReturnCode::SUCCESS
+                    {
                         panic!("Debug print allow fail");
                     }
                     write_volatile(&mut DEBUG_WRITER.output_active_len, slice_len);

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -175,7 +175,12 @@ impl DebugWriter {
                         panic!("Debug print allow fail");
                     }
                     write_volatile(&mut DEBUG_WRITER.output_active_len, slice_len);
-                    if driver.subscribe(1, KERNEL_CONSOLE_CALLBACK) != ReturnCode::SUCCESS {
+                    if driver.subscribe(
+                        1,
+                        Some(KERNEL_CONSOLE_CALLBACK),
+                        AppId::kernel_new(APPID_IDX),
+                    ) != ReturnCode::SUCCESS
+                    {
                         panic!("Debug print subscribe fail");
                     }
                     if driver.command(1, slice_len, 0, AppId::kernel_new(APPID_IDX))

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -70,7 +70,12 @@ pub trait Driver {
     /// the magnitude of the return value of can signify extra information such
     /// as error type.
     #[allow(unused_variables)]
-    fn subscribe(&self, minor_num: usize, callback: ::Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        minor_num: usize,
+        callback: Option<::Callback>,
+        app_id: ::AppId,
+    ) -> ReturnCode {
         ReturnCode::ENOSUPPORT
     }
 

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -106,7 +106,12 @@ pub trait Driver {
     /// driver should not rely on the contents of the buffer to remain
     /// unchanged.
     #[allow(unused_variables)]
-    fn allow(&self, app: ::AppId, minor_num: usize, slice: ::AppSlice<::Shared, u8>) -> ReturnCode {
+    fn allow(
+        &self,
+        app: ::AppId,
+        minor_num: usize,
+        slice: Option<::AppSlice<::Shared, u8>>,
+    ) -> ReturnCode {
         ReturnCode::ENOSUPPORT
     }
 }

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -83,7 +83,12 @@ impl IPC {
 impl Driver for IPC {
     /// subscribe enables processes using IPC to register callbacks that fire
     /// when notify() is called.
-    fn subscribe(&self, subscribe_num: usize, callback: Callback) -> ReturnCode {
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
         match subscribe_num {
             // subscribe(0)
             //
@@ -94,8 +99,8 @@ impl Driver for IPC {
             // The callback that is passed to subscribe is called when another
             // process notifies the server process.
             0 => self.data
-                .enter(callback.app_id(), |data, _| {
-                    data.callback = Some(callback);
+                .enter(app_id, |data, _| {
+                    data.callback = callback;
                     ReturnCode::SUCCESS
                 })
                 .unwrap_or(ReturnCode::EBUSY),
@@ -112,8 +117,8 @@ impl Driver for IPC {
                     ReturnCode::EINVAL /* Maximum of 8 IPC's exceeded */
                 } else {
                     self.data
-                        .enter(callback.app_id(), |data, _| {
-                            data.client_callbacks[svc_id - 1] = Some(callback);
+                        .enter(app_id, |data, _| {
+                            data.client_callbacks[svc_id - 1] = callback;
                             ReturnCode::SUCCESS
                         })
                         .unwrap_or(ReturnCode::EBUSY)

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -94,17 +94,13 @@ pub unsafe fn do_process<P: Platform, C: Chip>(
                 let callback_ptr_raw = process.r2() as *mut ();
                 let appdata = process.r3();
 
-                let res = if callback_ptr_raw as usize == 0 {
-                    ReturnCode::EINVAL
-                } else {
-                    let callback_ptr = NonZero::new_unchecked(callback_ptr_raw);
+                let callback_ptr = NonZero::new(callback_ptr_raw);
+                let callback = callback_ptr.map(|ptr| ::Callback::new(appid, appdata, ptr));
 
-                    let callback = ::Callback::new(appid, appdata, callback_ptr);
-                    platform.with_driver(driver_num, |driver| match driver {
-                        Some(d) => d.subscribe(subdriver_num, Some(callback), appid),
-                        None => ReturnCode::ENODEVICE,
-                    })
-                };
+                let res = platform.with_driver(driver_num, |driver| match driver {
+                    Some(d) => d.subscribe(subdriver_num, callback, appid),
+                    None => ReturnCode::ENODEVICE,
+                });
                 process.set_return_code(res);
             }
             Some(Syscall::COMMAND) => {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -101,7 +101,7 @@ pub unsafe fn do_process<P: Platform, C: Chip>(
 
                     let callback = ::Callback::new(appid, appdata, callback_ptr);
                     platform.with_driver(driver_num, |driver| match driver {
-                        Some(d) => d.subscribe(subdriver_num, callback),
+                        Some(d) => d.subscribe(subdriver_num, Some(callback), appid),
                         None => ReturnCode::ENODEVICE,
                     })
                 };

--- a/userland/libtock/tock.h
+++ b/userland/libtock/tock.h
@@ -59,6 +59,12 @@ bool driver_exists(uint32_t driver);
 #define TOCK_EUNINSTALLED -12
 #define TOCK_ENOACK       -13
 
+// Pass this to the subscribe syscall as a function pointer to deactivate the callback.
+#define TOCK_DEACTIVATE_CALLBACK    0
+
+// Pass this to the allow syscall as pointer to revoke the "allow"-syscall.
+#define TOCK_REVOKE_ALLOW           0
+
 const char* tock_strerror(int tock_errno);
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a "drop callback" and "drop allow" functionality in order to be able to deactivate callbacks. Not beeing able to deactivate a callback forces user data pointers passed to the callback to have unlimited lifetime.

Callbacks are dropped by subscribing a callback with a null function pointer. Allows are dropped by allowing a null slice.


### Testing Strategy
Positive cases:
We tested the new function in the temperature driver by setting a callback and deleting it before running "subscribe". The original callback is not triggered anymore.
We tested the new allow by allowing a proper string to the console and then allowing a null pointer. The string is not printed anymore but the driver is still able to print strings.

Regression testing: 
Temperature and console drivers have been tested directly and are working. The rot13 service and client are still working - this is in my opinion the most subtle point.

### TODO or Help Wanted
I'd be happy about a code review as well as more regression testing.

### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [x] `make formatall` has been run.
