### PR TITLE
[Symmetric Encryption HIL] Don't use block_size in the key context

### DIFF
--- a/boards/imix/src/aes_test.rs
+++ b/boards/imix/src/aes_test.rs
@@ -1,6 +1,6 @@
 use capsules::test::aes::TestAes128Cbc;
 use capsules::test::aes::TestAes128Ctr;
-use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE};
+use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
 use sam4l::aes::{Aes, AES};
 
 pub unsafe fn run_aes128_ctr() {
@@ -20,7 +20,7 @@ pub unsafe fn run_aes128_cbc() {
 unsafe fn static_init_test_ctr() -> &'static mut TestAes128Ctr<'static, Aes<'static>> {
     let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
     let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
-    let key = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+    let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
     let iv = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
 
     static_init!(
@@ -32,7 +32,7 @@ unsafe fn static_init_test_ctr() -> &'static mut TestAes128Ctr<'static, Aes<'sta
 unsafe fn static_init_test_cbc() -> &'static mut TestAes128Cbc<'static, Aes<'static>> {
     let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
     let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
-    let key = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+    let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
     let iv = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
 
     static_init!(

--- a/boards/nrf51dk/src/aes_test.rs
+++ b/boards/nrf51dk/src/aes_test.rs
@@ -1,5 +1,5 @@
 use capsules::test::aes::TestAes128Ctr;
-use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE};
+use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
 use nrf5x::aes::{AesECB, AESECB};
 
 pub fn run() {
@@ -16,7 +16,7 @@ fn static_init_test() -> &'static mut TestAes128Ctr<'static, AesECB<'static>> {
     unsafe {
         let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
         let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
-        let key = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+        let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
         let iv = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
 
         static_init!(

--- a/boards/nrf52dk/src/aes_test.rs
+++ b/boards/nrf52dk/src/aes_test.rs
@@ -1,5 +1,5 @@
 use capsules::test::aes::TestAes128Ctr;
-use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE};
+use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
 use nrf5x::aes::{AesECB, AESECB};
 
 pub unsafe fn run() {
@@ -12,7 +12,7 @@ pub unsafe fn run() {
 unsafe fn static_init_test() -> &'static mut TestAes128Ctr<'static, AesECB<'static>> {
     let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
     let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
-    let key = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
+    let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
     let iv = static_init!([u8; AES128_BLOCK_SIZE], [0; AES128_BLOCK_SIZE]);
 
     static_init!(

--- a/capsules/src/aes_ccm.rs
+++ b/capsules/src/aes_ccm.rs
@@ -34,8 +34,8 @@ use core::cell::Cell;
 use kernel::ReturnCode;
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::symmetric_encryption;
-use kernel::hil::symmetric_encryption::{AES128, AES128CBC, AES128Ctr};
-use kernel::hil::symmetric_encryption::{AES128_BLOCK_SIZE, CCM_NONCE_LENGTH};
+use kernel::hil::symmetric_encryption::{AES128, AES128CBC, AES128Ctr, AES128_BLOCK_SIZE,
+                                        AES128_KEY_SIZE, CCM_NONCE_LENGTH};
 use net::stream::{encode_bytes, encode_u16};
 use net::stream::SResult;
 
@@ -59,7 +59,7 @@ pub struct AES128CCM<'a, A: AES128<'a> + AES128Ctr + AES128CBC + 'a> {
 
     buf: TakeCell<'static, [u8]>,
     pos: Cell<(usize, usize, usize, usize)>,
-    key: Cell<[u8; AES128_BLOCK_SIZE]>,
+    key: Cell<[u8; AES128_KEY_SIZE]>,
     nonce: Cell<[u8; CCM_NONCE_LENGTH]>,
     saved_tag: Cell<[u8; AES128_BLOCK_SIZE]>,
 }
@@ -399,10 +399,10 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + 'a> symmetric_encryption::AES12
     }
 
     fn set_key(&self, key: &[u8]) -> ReturnCode {
-        if key.len() < AES128_BLOCK_SIZE {
+        if key.len() < AES128_KEY_SIZE {
             ReturnCode::EINVAL
         } else {
-            let mut new_key = [0u8; AES128_BLOCK_SIZE];
+            let mut new_key = [0u8; AES128_KEY_SIZE];
             new_key.copy_from_slice(key);
             self.key.set(new_key);
             ReturnCode::SUCCESS

--- a/capsules/src/test/aes.rs
+++ b/capsules/src/test/aes.rs
@@ -4,7 +4,8 @@ use core::cell::Cell;
 use kernel::ReturnCode;
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
-use kernel::hil::symmetric_encryption::{AES128, AES128CBC, AES128Ctr, AES128_BLOCK_SIZE};
+use kernel::hil::symmetric_encryption::{AES128, AES128CBC, AES128Ctr, AES128_BLOCK_SIZE,
+                                        AES128_KEY_SIZE};
 
 pub struct TestAes128Ctr<'a, A: 'a> {
     aes: &'a A,
@@ -325,7 +326,7 @@ impl<'a, A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for Te
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-const KEY: [u8; AES128_BLOCK_SIZE] = [
+const KEY: [u8; AES128_KEY_SIZE] = [
     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c
 ];

--- a/capsules/src/test/aes_ccm.rs
+++ b/capsules/src/test/aes_ccm.rs
@@ -3,7 +3,7 @@
 use core::cell::Cell;
 use kernel::ReturnCode;
 use kernel::common::take_cell::TakeCell;
-use kernel::hil::symmetric_encryption::{AES128CCM, AES128_BLOCK_SIZE, CCMClient, CCM_NONCE_LENGTH};
+use kernel::hil::symmetric_encryption::{AES128CCM, AES128_KEY_SIZE, CCMClient, CCM_NONCE_LENGTH};
 
 pub struct Test<'a, A: AES128CCM<'a> + 'a> {
     aes_ccm: &'a A,
@@ -198,7 +198,7 @@ impl<'a, A: AES128CCM<'a> + 'a> CCMClient for Test<'a, A> {
     }
 }
 
-static KEY: [u8; AES128_BLOCK_SIZE] = [
+static KEY: [u8; AES128_KEY_SIZE] = [
     0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF
 ];
 

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -131,7 +131,9 @@ impl<'a> AesECB<'a> {
 
             // get number of bytes to be used in the keystream/block
             let take = match end_idx.checked_sub(current_idx) {
-                Some(v) if v > 16 => 16,
+                Some(v) if v > symmetric_encryption::AES128_BLOCK_SIZE => {
+                    symmetric_encryption::AES128_BLOCK_SIZE
+                }
                 Some(v) => v,
                 None => 0,
             };
@@ -207,7 +209,7 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     }
 
     fn set_key(&self, key: &[u8]) -> ReturnCode {
-        if key.len() != 16 {
+        if key.len() != symmetric_encryption::AES128_KEY_SIZE {
             ReturnCode::EINVAL
         } else {
             for (i, c) in key.iter().enumerate() {
@@ -220,12 +222,12 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     }
 
     fn set_iv(&self, iv: &[u8]) -> ReturnCode {
-        if iv.len() != 16 {
+        if iv.len() != symmetric_encryption::AES128_BLOCK_SIZE {
             ReturnCode::EINVAL
         } else {
             for (i, c) in iv.iter().enumerate() {
                 unsafe {
-                    ECB_DATA[i + 16] = *c;
+                    ECB_DATA[i + PLAINTEXT_START] = *c;
                 }
             }
             ReturnCode::SUCCESS

--- a/chips/sam4l/src/aes.rs
+++ b/chips/sam4l/src/aes.rs
@@ -4,7 +4,7 @@ use core::cell::Cell;
 use kernel::common::VolatileCell;
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
-use kernel::hil::symmetric_encryption::AES128_BLOCK_SIZE;
+use kernel::hil::symmetric_encryption::{AES128_BLOCK_SIZE, AES128_KEY_SIZE};
 use kernel::returncode::ReturnCode;
 use pm;
 use scif;
@@ -342,7 +342,7 @@ impl<'a> hil::symmetric_encryption::AES128<'a> for Aes<'a> {
     }
 
     fn set_key(&self, key: &[u8]) -> ReturnCode {
-        if key.len() != AES128_BLOCK_SIZE {
+        if key.len() != AES128_KEY_SIZE {
             return ReturnCode::EINVAL;
         }
 

--- a/kernel/src/hil/symmetric_encryption.rs
+++ b/kernel/src/hil/symmetric_encryption.rs
@@ -13,6 +13,7 @@ pub trait Client<'a> {
 /// The number of bytes used for AES block operations.  Keys and IVs must have this length,
 /// and encryption/decryption inputs must be have a multiple of this length.
 pub const AES128_BLOCK_SIZE: usize = 16;
+pub const AES128_KEY_SIZE: usize = 16;
 
 pub trait AES128<'a> {
     /// Enable the AES hardware.
@@ -26,7 +27,7 @@ pub trait AES128<'a> {
     fn set_client(&'a self, client: &'a Client<'a>);
 
     /// Set the encryption key.
-    /// Returns `EINVAL` if length is not `AES128_BLOCK_SIZE`
+    /// Returns `EINVAL` if length is not `AES128_KEY_SIZE`
     fn set_key(&self, key: &[u8]) -> ReturnCode;
 
     /// Set the IV (or initial counter).


### PR DESCRIPTION
### Pull Request Overview

Changes usage of constants in the AES128 interface because we assume the block size and key size are the same. Well. yes they are both 16 bytes in AES128 but that is not the case for AES192 and AES256 so I wanted to clarify that!

### Testing Strategy

Run the AES_CTR Tests on nRF52-DK


### TODO or Help Wanted


### Documentation Updated

- ~~[ ] Kernel: The relevant files in `/docs` have been updated or no updates are required.~~
- ~~[ ] Userland: The application README has been added, updated, or no updates are required.~~

### Formatting

- [x] `make formatall` has been run.
