### PR TITLE
Do not ignore errors setting GAP data anymore.

### DIFF
--- a/chips/nrf5x/src/ble_advertising_driver.rs
+++ b/chips/nrf5x/src/ble_advertising_driver.rs
@@ -971,8 +971,7 @@ where
                 .enter(appid, |app, _| {
                     if app.process_status != Some(BLEState::NotInitialized) {
                         app.app_write = Some(slice);
-                        app.set_gap_data(gap_type);
-                        ReturnCode::SUCCESS
+                        app.set_gap_data(gap_type)
                     } else {
                         ReturnCode::EINVAL
                     }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the fact that errors setting gap-data in the ble-advertising driver have been ignored previously.
The main use-case is as follows: The advertising data is limited to 32 bytes. However, it is split up into different types of advertising data. When the system call "allow" is called with the corresponding gap-header type, for every GAP-header type, e.g. uuid or service data, the data is written into the part of the buffer reserved for the gap header. The driver can only know at runtime whether the size of the buffer - and thus the maximal size for a packet - is exceeded. This error has previously been ignored.

### Testing Strategy
I tested my fix as follows: 
 - Adv-Packet with 32 bytes of GAP-data (including size and type bytes) => SUCCESS
 - Adv-Packet with 33 bytes of GAP-data => ESIZE


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] Userland: The application README has been added, updated, or no updates are required.

### Formatting

- [x] `make formatall` has been run.
