### PR TITLE
Update MAC layer to default to IEEE 802.15.4-2006 instead of IEEE 802.15.4-2015

### DIFF
--- a/capsules/src/ieee802154/framer.rs
+++ b/capsules/src/ieee802154/framer.rs
@@ -733,7 +733,7 @@ impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> MacDevice<'a> for Framer<'a, M, A> 
             frame_pending: false,
             // Unicast data frames request acknowledgement
             ack_requested: true,
-            version: FrameVersion::V2015,
+            version: FrameVersion::V2006,
             seq: Some(self.data_sequence.get()),
             dst_pan: Some(dst_pan),
             dst_addr: Some(dst_addr),

--- a/capsules/src/ieee802154/xmac.rs
+++ b/capsules/src/ieee802154/xmac.rs
@@ -238,7 +238,7 @@ impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> XMac<'a, R, A> {
                 frame_type: FrameType::Multipurpose,
                 frame_pending: false,
                 ack_requested: true,
-                version: FrameVersion::V2015,
+                version: FrameVersion::V2006,
                 seq: Some(self.tx_preamble_seq_num.get()),
                 dst_pan: tx_header.dst_pan,
                 dst_addr: tx_header.dst_addr,


### PR DESCRIPTION
This change is desirable because wireshark will only parse 6LoWPAN packets if they are transmitted over
IEEE 802.15.4-2006, and because the Thread specification requires IEEE 802.15.4-2006. If anyone has any reasons they think the default should be left as 2015, speak up.

### Pull Request Overview

This pull request updates the MAC layer to default to IEEE 802.15.4-2006 instead of IEEE 802.15.4-2015