### PR TITLE
tools: build docs on netlify rather than travis

### DIFF
--- a/.travis-deploy-netlify
+++ b/.travis-deploy-netlify
@@ -4,13 +4,14 @@
 # https://therocketeers.github.io/blog/using-travis-ci-to-deploy-jekyll-on-netlify/
 
 set -e
+set -u
 set -x
 
 ./tools/build-all-docs.sh
 
 pushd doc
 
-zip -r website.zip rustdoc/
+zip -q -r website.zip rustdoc/
 
 # NETLIFYKEY is secret. Set in travis web config.
 NETLIFY_SITE_NAME=docs-tockosorg.netlify.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,3 @@ script:
   - pushd userland/examples; ./format_all.sh || exit; popd
   - tools/toc.sh
 
-after_success:
-  - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && ./.travis-deploy-netlify

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,3 @@
+rustdoc/
+
+website.zip

--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -x
+
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-01-05
+
+export PATH="$PATH:$HOME/.cargo/bin"
+
+cargo install xargo
+
+wget 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2?revision=375265d4-e9b5-41c8-bf23-56cbe927e156?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2017-q4-major' -O arm.tgz
+
+tar -xf arm.tgz
+export PATH="$PATH:$(pwd)/gcc-arm-none-eabi-7-2017-q4-major/bin"
+
+tools/build-all-docs.sh


### PR DESCRIPTION
### Pull Request Overview

Building as an after-success hook on travis hid failures. Building on netlify
directly will let the docs be a parallel effort and should catch failures at
PR time correctly.

This is a squash of a few things:

  - travis: don't spew zip info
  - netlify: try building docs on there instead of travis
  - tools: can't use sudo on netlify
  - tools: ignore built doc artifacts
  - travis: remove netlify from travis