### PR TITLE
Automatic peripheral clock management

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -62,7 +62,7 @@ struct Hail {
     temp: &'static capsules::temperature::TemperatureSensor<'static>,
     ninedof: &'static capsules::ninedof::NineDof<'static>,
     humidity: &'static capsules::humidity::HumiditySensor<'static>,
-    spi: &'static capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
+    spi: &'static capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>,
     nrf51822: &'static capsules::nrf51822_serialization::Nrf51822Serialization<
         'static,
         sam4l::usart::USART,
@@ -316,7 +316,7 @@ pub unsafe fn reset_handler() {
     // Initialize and enable SPI HAL
     // Set up an SPI MUX, so there can be multiple clients
     let mux_spi = static_init!(
-        MuxSpiMaster<'static, sam4l::spi::Spi>,
+        MuxSpiMaster<'static, sam4l::spi::SpiHw>,
         MuxSpiMaster::new(&sam4l::spi::SPI)
     );
 
@@ -327,13 +327,13 @@ pub unsafe fn reset_handler() {
     // Create a virtualized client for SPI system call interface
     // CS line is CS0
     let syscall_spi_device = static_init!(
-        VirtualSpiMasterDevice<'static, sam4l::spi::Spi>,
+        VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>,
         VirtualSpiMasterDevice::new(mux_spi, 0)
     );
 
     // Create the SPI system call capsule, passing the client
     let spi_syscalls = static_init!(
-        capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
+        capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>,
         capsules::spi::Spi::new(syscall_spi_device)
     );
 

--- a/boards/imix/src/i2c_dummy.rs
+++ b/boards/imix/src/i2c_dummy.rs
@@ -86,7 +86,7 @@ impl hil::i2c::I2CHwMasterClient for AccelClient {
                 debug!("Activating Sensor...");
                 buffer[0] = 0x2A as u8; // CTRL_REG1
                 buffer[1] = 1; // Bit 1 sets `active`
-                dev.write(0x1e, i2c::START | i2c::STOP, buffer, 2);
+                dev.write(0x1e, buffer, 2);
                 self.state.set(Activating);
             }
             Activating => {
@@ -210,6 +210,6 @@ pub fn i2c_li_test() {
     buf[0] = 0;
     buf[1] = 0b10100000;
     buf[2] = 0b00000000;
-    dev.write(0x44, i2c::START | i2c::STOP, buf, 3);
+    dev.write(0x44, buf, 3);
     i2c_client.state.set(LiClientState::Enabling);
 }

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -13,6 +13,7 @@ static mut WRITER: Writer = Writer { initialized: false };
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
         let uart = unsafe { &mut sam4l::usart::USART3 };
+        let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
             uart.init(uart::UARTParams {
@@ -21,12 +22,12 @@ impl Write for Writer {
                 parity: uart::Parity::None,
                 hw_flow_control: false,
             });
-            uart.enable_tx();
+            uart.enable_tx(regs_manager);
         }
         // XXX: I'd like to get this working the "right" way, but I'm not sure how
         for c in s.bytes() {
-            uart.send_byte(c);
-            while !uart.tx_ready() {}
+            uart.send_byte(regs_manager, c);
+            while !uart.tx_ready(regs_manager) {}
         }
         Ok(())
     }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -67,7 +67,7 @@ static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, Non
 
 // Save some deep nesting
 type RF233Device =
-    capsules::rf233::RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>;
+    capsules::rf233::RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>;
 
 struct Imix {
     console: &'static capsules::console::Console<'static, sam4l::usart::USART>,
@@ -79,7 +79,7 @@ struct Imix {
     adc: &'static capsules::adc::Adc<'static, sam4l::adc::Adc>,
     led: &'static capsules::led::LED<'static, sam4l::gpio::GPIOPin>,
     button: &'static capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
-    spi: &'static capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
+    spi: &'static capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>,
     ipc: kernel::ipc::IPC,
     ninedof: &'static capsules::ninedof::NineDof<'static>,
     radio_driver: &'static capsules::ieee802154::RadioDriver<'static>,
@@ -319,7 +319,7 @@ pub unsafe fn reset_handler() {
 
     // Set up an SPI MUX, so there can be multiple clients
     let mux_spi = static_init!(
-        MuxSpiMaster<'static, sam4l::spi::Spi>,
+        MuxSpiMaster<'static, sam4l::spi::SpiHw>,
         MuxSpiMaster::new(&sam4l::spi::SPI)
     );
     sam4l::spi::SPI.set_client(mux_spi);
@@ -329,13 +329,13 @@ pub unsafe fn reset_handler() {
     // Create a virtualized client for SPI system call interface,
     // then the system call capsule
     let syscall_spi_device = static_init!(
-        VirtualSpiMasterDevice<'static, sam4l::spi::Spi>,
+        VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>,
         VirtualSpiMasterDevice::new(mux_spi, 3)
     );
 
     // Create the SPI systemc call capsule, passing the client
     let spi_syscalls = static_init!(
-        capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
+        capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>,
         capsules::spi::Spi::new(syscall_spi_device)
     );
 
@@ -373,12 +373,12 @@ pub unsafe fn reset_handler() {
 
     // Create a second virtualized SPI client, for the RF233
     let rf233_spi = static_init!(
-        VirtualSpiMasterDevice<'static, sam4l::spi::Spi>,
+        VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>,
         VirtualSpiMasterDevice::new(mux_spi, 3)
     );
     // Create the RF233 driver, passing its pins and SPI client
-    let rf233: &RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>> = static_init!(
-        RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::Spi>>,
+    let rf233: &RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>> = static_init!(
+        RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>,
         RF233::new(
             rf233_spi,
             &sam4l::gpio::PA[09], // reset

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -257,6 +257,10 @@ impl DMAChannel {
         }
     }
 
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.get()
+    }
+
     pub fn handle_interrupt(&mut self) {
         let registers: &DMARegisters = unsafe { &*self.registers };
         registers

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -13,7 +13,7 @@ use core::cell::Cell;
 use dma::{DMAChannel, DMAClient, DMAPeripheral};
 use kernel::{ClockInterface, StaticRef};
 use kernel::common::VolatileCell;
-use kernel::common::peripherals::{AutomaticPeripheralManagement, PeripheralManager};
+use kernel::common::peripherals::{PeripheralManagement, PeripheralManager};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
 use pm;
@@ -177,7 +177,7 @@ pub struct I2CHw {
     slave_write_buffer_index: Cell<u8>,
 }
 
-impl AutomaticPeripheralManagement<TWIMClock> for I2CHw {
+impl PeripheralManagement<TWIMClock> for I2CHw {
     type RegisterType = TWIMRegisters;
 
     fn get_registers(&self) -> &TWIMRegisters {
@@ -203,7 +203,7 @@ impl AutomaticPeripheralManagement<TWIMClock> for I2CHw {
 }
 type TWIMRegisterManager<'a> = PeripheralManager<'a, I2CHw, TWIMClock>;
 
-impl AutomaticPeripheralManagement<TWISClock> for I2CHw {
+impl PeripheralManagement<TWISClock> for I2CHw {
     type RegisterType = TWISRegisters;
 
     fn get_registers<'a>(&'a self) -> &'a TWISRegisters {

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -11,6 +11,7 @@
 
 use core::cell::Cell;
 use dma::{DMAChannel, DMAClient, DMAPeripheral};
+use kernel::{ClockInterface, MMIOClockGuard, MMIOClockInterface, MMIOInterface, MMIOManager};
 use kernel::common::VolatileCell;
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
@@ -96,12 +97,65 @@ pub enum Speed {
     FastPlus1M,
 }
 
-// This represents an abstraction of the peripheral hardware.
+/// Wrapper for TWIM clock that ensures TWIS clock is off
+struct TWIMClock {
+    master: pm::Clock,
+    slave: Option<pm::Clock>,
+}
+impl ClockInterface for TWIMClock {
+    type PlatformClockType = pm::Clock;
+
+    fn is_enabled(&self) -> bool {
+        self.master.is_enabled()
+    }
+
+    fn enable(&self) {
+        self.slave.map(|slave_clock| {
+            if slave_clock.is_enabled() {
+                panic!("I2C: Request for master clock, but slave active");
+            }
+        });
+        self.master.enable();
+    }
+
+    fn disable(&self) {
+        self.master.disable();
+    }
+}
+
+/// Wrapper for TWIS clock that ensures TWIM clock is off
+struct TWISClock {
+    master: pm::Clock,
+    slave: Option<pm::Clock>,
+}
+impl ClockInterface for TWISClock {
+    type PlatformClockType = pm::Clock;
+
+    fn is_enabled(&self) -> bool {
+        let slave_clock = self.slave.expect("I2C: Use of slave with no clock");
+        slave_clock.is_enabled()
+    }
+
+    fn enable(&self) {
+        let slave_clock = self.slave.expect("I2C: Use of slave with no clock");
+        if self.master.is_enabled() {
+            panic!("I2C: Request for slave clock, but master active");
+        }
+        slave_clock.enable();
+    }
+
+    fn disable(&self) {
+        let slave_clock = self.slave.expect("I2C: Use of slave with no clock");
+        slave_clock.disable();
+    }
+}
+
+/// Abstraction of the I2C hardware
 pub struct I2CHw {
-    registers: *mut TWIMRegisters, // Pointer to the I2C registers in memory
-    slave_registers: Option<*mut TWISRegisters>, // Pointer to the I2C TWIS registers in memory
-    master_clock: pm::Clock,
-    slave_clock: Option<pm::Clock>,
+    master_mmio_address: *mut TWIMRegisters,
+    slave_mmio_address: Option<*mut TWISRegisters>,
+    master_clock: TWIMClock,
+    slave_clock: TWISClock,
     dma: Cell<Option<&'static DMAChannel>>,
     dma_pids: (DMAPeripheral, DMAPeripheral),
     master_client: Cell<Option<&'static hil::i2c::I2CHwMasterClient>>,
@@ -118,35 +172,109 @@ pub struct I2CHw {
     slave_write_buffer_index: Cell<u8>,
 }
 
+/// Manage clocks for TWIM (I2C Master)
+///
+/// The TWIMClock guards conflicts with TWIS clock.
+impl MMIOClockGuard<I2CHw, TWIMClock> for I2CHw {
+    fn before_mmio_access(&self, clock: &TWIMClock, _: &TWIMRegisters) {
+        if clock.is_enabled() == false {
+            clock.enable();
+        }
+    }
+
+    fn after_mmio_access(&self, clock: &TWIMClock, registers: &TWIMRegisters) {
+        let mask = registers.interrupt_mask.get();
+        if mask == 0 {
+            clock.disable();
+        }
+    }
+}
+
+/// Manage clocks for TWIS (I2C Slave)
+///
+/// The TWISClock guards conflicts with TWIM clock.
+impl MMIOClockGuard<I2CHw, TWISClock> for I2CHw {
+    fn before_mmio_access(&self, clock: &TWISClock, _: &TWISRegisters) {
+        if clock.is_enabled() == false {
+            clock.enable();
+        }
+    }
+
+    fn after_mmio_access(&self, clock: &TWISClock, registers: &TWISRegisters) {
+        let mask = registers.interrupt_mask.get();
+        if mask == 0 {
+            clock.disable();
+        }
+    }
+}
+
+impl MMIOInterface<TWIMClock> for I2CHw {
+    type MMIORegisterType = TWIMRegisters;
+
+    fn get_hardware_address(&self) -> *mut TWIMRegisters {
+        self.master_mmio_address
+    }
+}
+impl MMIOClockInterface<TWIMClock> for I2CHw {
+    fn get_clock(&self) -> &TWIMClock {
+        &self.master_clock
+    }
+}
+type TWIMRegisterManager<'a> = MMIOManager<'a, I2CHw, TWIMClock>;
+
+impl MMIOInterface<TWISClock> for I2CHw {
+    type MMIORegisterType = TWISRegisters;
+
+    fn get_hardware_address(&self) -> *mut TWISRegisters {
+        self.slave_mmio_address
+            .expect("Access of non-existant slave")
+    }
+}
+impl MMIOClockInterface<TWISClock> for I2CHw {
+    fn get_clock(&self) -> &TWISClock {
+        &self.slave_clock
+    }
+}
+
+type TWISRegisterManager<'a> = MMIOManager<'a, I2CHw, TWISClock>;
+
+const fn create_twims_clocks(
+    master: pm::Clock,
+    slave: Option<pm::Clock>,
+) -> (TWIMClock, TWISClock) {
+    (TWIMClock { master, slave }, TWISClock { master, slave })
+}
 pub static mut I2C0: I2CHw = I2CHw::new(
     I2C_BASE_ADDRS[0],
     Some(I2C_SLAVE_BASE_ADDRS[0]),
-    pm::Clock::PBA(pm::PBAClock::TWIM0),
-    Some(pm::Clock::PBA(pm::PBAClock::TWIS0)),
+    create_twims_clocks(
+        pm::Clock::PBA(pm::PBAClock::TWIM0),
+        Some(pm::Clock::PBA(pm::PBAClock::TWIS0)),
+    ),
     DMAPeripheral::TWIM0_RX,
     DMAPeripheral::TWIM0_TX,
 );
 pub static mut I2C1: I2CHw = I2CHw::new(
     I2C_BASE_ADDRS[1],
     Some(I2C_SLAVE_BASE_ADDRS[1]),
-    pm::Clock::PBA(pm::PBAClock::TWIM1),
-    Some(pm::Clock::PBA(pm::PBAClock::TWIS1)),
+    create_twims_clocks(
+        pm::Clock::PBA(pm::PBAClock::TWIM1),
+        Some(pm::Clock::PBA(pm::PBAClock::TWIS1)),
+    ),
     DMAPeripheral::TWIM1_RX,
     DMAPeripheral::TWIM1_TX,
 );
 pub static mut I2C2: I2CHw = I2CHw::new(
     I2C_BASE_ADDRS[2],
     None,
-    pm::Clock::PBA(pm::PBAClock::TWIM2),
-    None,
+    create_twims_clocks(pm::Clock::PBA(pm::PBAClock::TWIM2), None),
     DMAPeripheral::TWIM2_RX,
     DMAPeripheral::TWIM2_TX,
 );
 pub static mut I2C3: I2CHw = I2CHw::new(
     I2C_BASE_ADDRS[3],
     None,
-    pm::Clock::PBA(pm::PBAClock::TWIM3),
-    None,
+    create_twims_clocks(pm::Clock::PBA(pm::PBAClock::TWIM3), None),
     DMAPeripheral::TWIM3_RX,
     DMAPeripheral::TWIM3_TX,
 );
@@ -161,16 +289,15 @@ impl I2CHw {
     const fn new(
         base_addr: *mut TWIMRegisters,
         slave_base_addr: Option<*mut TWISRegisters>,
-        master_clock: pm::Clock,
-        slave_clock: Option<pm::Clock>,
+        clocks: (TWIMClock, TWISClock),
         dma_rx: DMAPeripheral,
         dma_tx: DMAPeripheral,
     ) -> I2CHw {
         I2CHw {
-            registers: base_addr as *mut TWIMRegisters,
-            slave_registers: slave_base_addr,
-            master_clock: master_clock,
-            slave_clock: slave_clock,
+            master_mmio_address: base_addr as *mut TWIMRegisters,
+            slave_mmio_address: slave_base_addr,
+            master_clock: clocks.0,
+            slave_clock: clocks.1,
             dma: Cell::new(None),
             dma_pids: (dma_rx, dma_tx),
             master_client: Cell::new(None),
@@ -190,7 +317,7 @@ impl I2CHw {
 
     /// Set the clock prescaler and the time widths of the I2C signals
     /// in the CWGR register to make the bus run at a particular I2C speed.
-    fn set_bus_speed(&self) {
+    fn set_bus_speed(&self, regs_manager: &TWIMRegisterManager) {
         // Set I2C waveform timing parameters based on ASF code
         let system_frequency = pm::get_system_frequency();
         let mut exp = 0;
@@ -213,8 +340,7 @@ impl I2CHw {
 
         let cwgr = ((exp & 0x7) << 28) | ((data & 0xF) << 24) | ((stasto & 0xFF) << 16)
             | ((high & 0xFF) << 8) | ((low & 0xFF) << 0);
-        let regs: &TWIMRegisters = unsafe { &*self.registers };
-        regs.clock_waveform_generator.set(cwgr);
+        regs_manager.registers.clock_waveform_generator.set(cwgr);
     }
 
     pub fn set_dma(&self, dma: &'static DMAChannel) {
@@ -231,11 +357,16 @@ impl I2CHw {
 
     pub fn handle_interrupt(&self) {
         use kernel::hil::i2c::Error;
-        let regs: &TWIMRegisters = unsafe { &*self.registers };
 
-        let old_status = regs.status.get();
+        let old_status = {
+            let regs_manager = &TWIMRegisterManager::new(&self);
 
-        regs.status_clear.set(!0);
+            let old_status = regs_manager.registers.status.get();
+
+            regs_manager.registers.status_clear.set(!0);
+
+            old_status
+        };
 
         let err = match old_status {
             x if x & (1 <<  8) != 0 /*ANACK*/  => Some(Error::AddressNak),
@@ -249,15 +380,22 @@ impl I2CHw {
         self.on_deck.set(None);
         match on_deck {
             None => {
-                regs.command.set(0);
-                regs.next_command.set(0);
+                {
+                    let regs_manager = &TWIMRegisterManager::new(&self);
+
+                    regs_manager.registers.command.set(0);
+                    regs_manager.registers.next_command.set(0);
+                    self.disable_interrupts(regs_manager);
+
+                    if err.is_some() {
+                        // enable, reset, disable
+                        regs_manager.registers.control.set(0x1 << 0);
+                        regs_manager.registers.control.set(0x1 << 7);
+                        regs_manager.registers.control.set(0x1 << 1);
+                    }
+                }
 
                 err.map(|err| {
-                    // enable, reset, disable
-                    regs.control.set(0x1 << 0);
-                    regs.control.set(0x1 << 7);
-                    regs.control.set(0x1 << 1);
-
                     self.master_client.get().map(|client| {
                         let buf = match self.dma.get() {
                             Some(dma) => {
@@ -282,15 +420,24 @@ impl I2CHw {
                 // no more interrupts. So, we just read the byte we have
                 // and call this I2C command complete.
                 if (len == 1) && (old_status & 0x01 != 0) {
-                    regs.command.set(0);
-                    regs.next_command.set(0);
+                    let the_byte = {
+                        let regs_manager = &TWIMRegisterManager::new(&self);
+
+                        regs_manager.registers.command.set(0);
+                        regs_manager.registers.next_command.set(0);
+                        self.disable_interrupts(regs_manager);
+
+                        if err.is_some() {
+                            // enable, reset, disable
+                            regs_manager.registers.control.set(0x1 << 0);
+                            regs_manager.registers.control.set(0x1 << 7);
+                            regs_manager.registers.control.set(0x1 << 1);
+                        }
+
+                        regs_manager.registers.receive_holding.get() as u8
+                    };
 
                     err.map(|err| {
-                        // enable, reset, disable
-                        regs.control.set(0x1 << 0);
-                        regs.control.set(0x1 << 7);
-                        regs.control.set(0x1 << 1);
-
                         self.master_client.get().map(|client| {
                             let buf = match self.dma.get() {
                                 Some(dma) => {
@@ -302,19 +449,22 @@ impl I2CHw {
                             };
                             buf.map(|buf| {
                                 // Save the already read byte.
-                                buf[0] = regs.receive_holding.get() as u8;
+                                buf[0] = the_byte;
                                 client.command_complete(buf, err);
                             });
                         });
                     });
                 } else {
-                    // Enable transaction error interrupts
-                    regs.interrupt_enable.set(
-                        (1 << 3)    // CCOMP   - Command completed
+                    {
+                        let regs_manager = &TWIMRegisterManager::new(&self);
+                        // Enable transaction error interrupts
+                        regs_manager.registers.interrupt_enable.set(
+                            (1 << 3)    // CCOMP   - Command completed
                                    | (1 << 8)    // ANAK   - Address not ACKd
                                    | (1 << 9)    // DNAK   - Data not ACKd
                                    | (1 << 10),
-                    ); // ARBLST - Arbitration lost
+                        ); // ARBLST - Arbitration lost
+                    }
                     self.dma.get().map(|dma| {
                         let buf = dma.abort_xfer().unwrap();
                         dma.prepare_xfer(dma_periph, buf, len);
@@ -325,11 +475,16 @@ impl I2CHw {
         }
     }
 
-    fn setup_xfer(&self, chip: u8, flags: usize, read: bool, len: u8) {
-        let regs: &TWIMRegisters = unsafe { &*self.registers };
-
+    fn setup_xfer(
+        &self,
+        regs_manager: &TWIMRegisterManager,
+        chip: u8,
+        flags: usize,
+        read: bool,
+        len: u8,
+    ) {
         // disable before configuring
-        regs.control.set(0x1 << 1);
+        regs_manager.registers.control.set(0x1 << 1);
 
         let read = if read { 1 } else { 0 };
         let command = ((chip as usize) << 1) // 7 bit address at offset 1 (8th
@@ -338,23 +493,28 @@ impl I2CHw {
                     | (1 << 15) // VALID
                     | (len as usize) << 16 // NBYTES (at most 255)
                     | read;
-        regs.command.set(command as u32);
-        regs.next_command.set(0);
+        regs_manager.registers.command.set(command as u32);
+        regs_manager.registers.next_command.set(0);
 
         // Enable transaction error interrupts
-        regs.interrupt_enable.set(
-            (1 << 3)    // CCOMP   - Command completed
-                       | (1 << 8)    // ANAK   - Address not ACKd
-                       | (1 << 9)    // DNAK   - Data not ACKd
-                       | (1 << 10),
-        ); // ARBLST - Abitration lost
+        regs_manager.registers.interrupt_enable.set(
+            (1 << 3)     // CCOMP   - Command completed
+                                                    | (1 << 8)   // ANAK   - Address not ACKd
+                                                    | (1 << 9)   // DNAK   - Data not ACKd
+                                                    | (1 << 10), // ARBLST - Abitration lost
+        );
     }
 
-    fn setup_nextfer(&self, chip: u8, flags: usize, read: bool, len: u8) {
-        let regs: &TWIMRegisters = unsafe { &*self.registers };
-
+    fn setup_nextfer(
+        &self,
+        regs_manager: &TWIMRegisterManager,
+        chip: u8,
+        flags: usize,
+        read: bool,
+        len: u8,
+    ) {
         // disable before configuring
-        regs.control.set(0x1 << 1);
+        regs_manager.registers.control.set(0x1 << 1);
 
         let read = if read { 1 } else { 0 };
         let command = ((chip as usize) << 1) // 7 bit address at offset 1 (8th
@@ -363,63 +523,63 @@ impl I2CHw {
                     | (1 << 15) // VALID
                     | (len as usize) << 16 // NBYTES (at most 255)
                     | read;
-        regs.next_command.set(command as u32);
+        regs_manager.registers.next_command.set(command as u32);
 
         // Enable
-        regs.control.set(0x1 << 0);
+        regs_manager.registers.control.set(0x1 << 0);
     }
 
-    fn master_enable(&self) {
-        let regs: &TWIMRegisters = unsafe { &*self.registers };
-
+    fn master_enable(&self, regs_manager: &TWIMRegisterManager) {
         // Enable to begin transfer
-        regs.control.set(0x1 << 0);
+        regs_manager.registers.control.set(0x1 << 0);
     }
 
-    pub fn write(&self, chip: u8, flags: usize, data: &'static mut [u8], len: u8) {
+    fn write(&self, chip: u8, flags: usize, data: &'static mut [u8], len: u8) {
+        let regs_manager = &TWIMRegisterManager::new(&self);
         self.dma.get().map(move |dma| {
             dma.enable();
             dma.prepare_xfer(self.dma_pids.1, data, len as usize);
-            self.setup_xfer(chip, flags, false, len);
-            self.master_enable();
+            self.setup_xfer(regs_manager, chip, flags, false, len);
+            self.master_enable(regs_manager);
             dma.start_xfer();
         });
     }
 
-    pub fn read(&self, chip: u8, flags: usize, data: &'static mut [u8], len: u8) {
+    fn read(&self, chip: u8, flags: usize, data: &'static mut [u8], len: u8) {
+        let regs_manager = &TWIMRegisterManager::new(&self);
         self.dma.get().map(move |dma| {
             dma.enable();
             dma.prepare_xfer(self.dma_pids.0, data, len as usize);
-            self.setup_xfer(chip, flags, true, len);
-            self.master_enable();
+            self.setup_xfer(regs_manager, chip, flags, true, len);
+            self.master_enable(regs_manager);
             dma.start_xfer();
         });
     }
 
-    pub fn write_read(&self, chip: u8, data: &'static mut [u8], split: u8, read_len: u8) {
+    fn write_read(&self, chip: u8, data: &'static mut [u8], split: u8, read_len: u8) {
+        let regs_manager = &TWIMRegisterManager::new(&self);
         self.dma.get().map(move |dma| {
             dma.enable();
             dma.prepare_xfer(self.dma_pids.1, data, split as usize);
-            self.setup_xfer(chip, START, false, split);
-            self.setup_nextfer(chip, START | STOP, true, read_len);
+            self.setup_xfer(regs_manager, chip, START, false, split);
+            self.setup_nextfer(regs_manager, chip, START | STOP, true, read_len);
             self.on_deck.set(Some((self.dma_pids.0, read_len as usize)));
             dma.start_xfer();
         });
     }
 
-    fn disable_interrupts(&self) {
-        let regs: &TWIMRegisters = unsafe { &*self.registers };
-        regs.interrupt_disable.set(!0);
+    fn disable_interrupts(&self, regs_manager: &TWIMRegisterManager) {
+        regs_manager.registers.interrupt_disable.set(!0);
     }
 
     /// Handle possible interrupt for TWIS module.
     pub fn handle_slave_interrupt(&self) {
-        self.slave_registers.map(|slave_registers| {
-            let regs: &TWISRegisters = unsafe { &*slave_registers };
+        if self.slave_mmio_address.is_some() {
+            let regs_manager = &TWISRegisterManager::new(&self);
 
             // Get current status from the hardware.
-            let status = regs.status.get();
-            let imr = regs.interrupt_mask.get();
+            let status = regs_manager.registers.status.get();
+            let imr = regs_manager.registers.interrupt_mask.get();
             let interrupts = status & imr;
 
             // Check for errors.
@@ -429,7 +589,7 @@ impl I2CHw {
                 // waits for a new START condition.
                 if interrupts & (1 << 14) > 0 {
                     // Restart and wait for the next start byte
-                    regs.status_clear.set(status);
+                    regs_manager.registers.status_clear.set(status);
                     return;
                 }
 
@@ -438,7 +598,7 @@ impl I2CHw {
 
             // Check if we got the address match interrupt
             if interrupts & (1 << 16) > 0 {
-                regs.nbytes.set(0);
+                regs_manager.registers.nbytes.set(0);
 
                 // Did we get a read or a write?
                 if status & (1 << 5) > 0 {
@@ -446,11 +606,16 @@ impl I2CHw {
                     // read.
 
                     // Clear the byte transfer done if set (copied from ASF)
-                    regs.status_clear.set(1 << 23);
+                    regs_manager.registers.status_clear.set(1 << 23);
 
                     // Setup interrupts that we now care about
-                    regs.interrupt_enable.set((1 << 3) | (1 << 23));
-                    regs.interrupt_enable
+                    regs_manager
+                        .registers
+                        .interrupt_enable
+                        .set((1 << 3) | (1 << 23));
+                    regs_manager
+                        .registers
+                        .interrupt_enable
                         .set((1 << 14) | (1 << 13) | (1 << 12) | (1 << 7) | (1 << 6));
 
                     if self.slave_read_buffer.is_some() {
@@ -460,16 +625,19 @@ impl I2CHw {
 
                         if len >= 1 {
                             self.slave_read_buffer.map(|buffer| {
-                                regs.transmit_holding.set(buffer[0] as u32);
+                                regs_manager
+                                    .registers
+                                    .transmit_holding
+                                    .set(buffer[0] as u32);
                             });
                             self.slave_read_buffer_index.set(1);
                         } else {
                             // Send dummy byte
-                            regs.transmit_holding.set(0x2e);
+                            regs_manager.registers.transmit_holding.set(0x2e);
                         }
 
                         // Make it happen by clearing status.
-                        regs.status_clear.set(status);
+                        regs_manager.registers.status_clear.set(status);
                     } else {
                         // Call to upper layers asking for a buffer to send
                         self.slave_client.get().map(|client| {
@@ -480,14 +648,17 @@ impl I2CHw {
                     // Slave is in receive mode, AKA we got a write.
 
                     // Get transmission complete and rxready interrupts.
-                    regs.interrupt_enable.set((1 << 3) | (1 << 0));
+                    regs_manager
+                        .registers
+                        .interrupt_enable
+                        .set((1 << 3) | (1 << 0));
 
                     // Set index to 0
                     self.slave_write_buffer_index.set(0);
 
                     if self.slave_write_buffer.is_some() {
                         // Clear to continue with existing buffer.
-                        regs.status_clear.set(status);
+                        regs_manager.registers.status_clear.set(status);
                     } else {
                         // Call to upper layers asking for a buffer to
                         // read into.
@@ -502,11 +673,11 @@ impl I2CHw {
                 if interrupts & (1 << 3) > 0 {
                     // Transmission complete
 
-                    let nbytes = regs.nbytes.get();
+                    let nbytes = regs_manager.registers.nbytes.get();
 
-                    regs.interrupt_disable.set(0xFFFFFFFF);
-                    regs.interrupt_enable.set(1 << 16);
-                    regs.status_clear.set(status);
+                    regs_manager.registers.interrupt_disable.set(0xFFFFFFFF);
+                    regs_manager.registers.interrupt_enable.set(1 << 16);
+                    regs_manager.registers.status_clear.set(status);
 
                     if status & (1 << 5) > 0 {
                         // read
@@ -527,12 +698,13 @@ impl I2CHw {
 
                         if len > idx {
                             self.slave_write_buffer.map(|buffer| {
-                                buffer[idx as usize] = regs.receive_holding.get() as u8;
+                                buffer[idx as usize] =
+                                    regs_manager.registers.receive_holding.get() as u8;
                             });
                             self.slave_write_buffer_index.set(idx + 1);
                         } else {
                             // Just drop on floor
-                            regs.receive_holding.get();
+                            regs_manager.registers.receive_holding.get();
                         }
 
                         self.slave_client.get().map(|client| {
@@ -556,20 +728,23 @@ impl I2CHw {
 
                         if len > idx {
                             self.slave_read_buffer.map(|buffer| {
-                                regs.transmit_holding.set(buffer[idx as usize] as u32);
+                                regs_manager
+                                    .registers
+                                    .transmit_holding
+                                    .set(buffer[idx as usize] as u32);
                             });
                             self.slave_read_buffer_index.set(idx + 1);
                         } else {
                             // Send dummy byte
-                            regs.transmit_holding.set(0xdf);
+                            regs_manager.registers.transmit_holding.set(0xdf);
                         }
                     } else {
                         // Send a default byte
-                        regs.transmit_holding.set(0xdc);
+                        regs_manager.registers.transmit_holding.set(0xdc);
                     }
 
                     // Make it happen by clearing status.
-                    regs.status_clear.set(status);
+                    regs_manager.registers.status_clear.set(status);
                 } else if interrupts & (1 << 0) > 0 {
                     // Receive byte ready.
 
@@ -588,26 +763,27 @@ impl I2CHw {
 
                             if len > idx {
                                 self.slave_write_buffer.map(|buffer| {
-                                    buffer[idx as usize] = regs.receive_holding.get() as u8;
+                                    buffer[idx as usize] =
+                                        regs_manager.registers.receive_holding.get() as u8;
                                 });
                                 self.slave_write_buffer_index.set(idx + 1);
                             } else {
                                 // Just drop on floor
-                                regs.receive_holding.get();
+                                regs_manager.registers.receive_holding.get();
                             }
                         } else {
                             // Just drop on floor
-                            regs.receive_holding.get();
+                            regs_manager.registers.receive_holding.get();
                         }
                     } else {
                         // Just drop on floor
-                        regs.receive_holding.get();
+                        regs_manager.registers.receive_holding.get();
                     }
 
-                    regs.status_clear.set(status);
+                    regs_manager.registers.status_clear.set(status);
                 }
             }
-        });
+        }
     }
 
     /// Receive the bytes the I2C master is writing to us.
@@ -616,19 +792,19 @@ impl I2CHw {
         self.slave_write_buffer_len.set(len);
 
         if self.slave_enabled.get() {
-            self.slave_registers.map(|slave_registers| {
-                let regs: &TWISRegisters = unsafe { &*slave_registers };
+            if self.slave_mmio_address.is_some() {
+                let regs_manager = &TWISRegisterManager::new(&self);
 
-                let status = regs.status.get();
-                let imr = regs.interrupt_mask.get();
+                let status = regs_manager.registers.status.get();
+                let imr = regs_manager.registers.interrupt_mask.get();
                 let interrupts = status & imr;
 
                 // Address match status bit still set, so we need to tell the TWIS
                 // to continue.
                 if (interrupts & (1 << 16) > 0) && (status & (1 << 5) == 0) {
-                    regs.status_clear.set(status);
+                    regs_manager.registers.status_clear.set(status);
                 }
-            });
+            }
         }
     }
 
@@ -639,44 +815,44 @@ impl I2CHw {
         self.slave_read_buffer_index.set(0);
 
         if self.slave_enabled.get() {
-            // Check to see if we should send the first byte.
-            self.slave_registers.map(|slave_registers| {
-                let regs: &TWISRegisters = unsafe { &*slave_registers };
+            if self.slave_mmio_address.is_some() {
+                let regs_manager = &TWISRegisterManager::new(&self);
 
-                let status = regs.status.get();
-                let imr = regs.interrupt_mask.get();
+                // Check to see if we should send the first byte.
+                let status = regs_manager.registers.status.get();
+                let imr = regs_manager.registers.interrupt_mask.get();
                 let interrupts = status & imr;
 
                 // Address match status bit still set. We got this function
                 // call in response to an incoming read. Send the first
                 // byte.
                 if (interrupts & (1 << 16) > 0) && (status & (1 << 5) > 0) {
-                    regs.status_clear.set(1 << 23);
+                    regs_manager.registers.status_clear.set(1 << 23);
 
                     let len = self.slave_read_buffer_len.get();
 
                     if len >= 1 {
                         self.slave_read_buffer.map(|buffer| {
-                            regs.transmit_holding.set(buffer[0] as u32);
+                            regs_manager
+                                .registers
+                                .transmit_holding
+                                .set(buffer[0] as u32);
                         });
                         self.slave_read_buffer_index.set(1);
                     } else {
                         // Send dummy byte
-                        regs.transmit_holding.set(0x75);
+                        regs_manager.registers.transmit_holding.set(0x75);
                     }
 
                     // Make it happen by clearing status.
-                    regs.status_clear.set(status);
+                    regs_manager.registers.status_clear.set(status);
                 }
-            });
+            }
         }
     }
 
-    fn slave_disable_interrupts(&self) {
-        self.slave_registers.map(|slave_registers| {
-            let regs: &TWISRegisters = unsafe { &*slave_registers };
-            regs.interrupt_disable.set(!0);
-        });
+    fn slave_disable_interrupts(&self, regs_manager: &TWISRegisterManager) {
+        regs_manager.registers.interrupt_disable.set(!0);
     }
 
     pub fn slave_set_address(&self, address: u8) {
@@ -684,8 +860,8 @@ impl I2CHw {
     }
 
     pub fn slave_listen(&self) {
-        self.slave_registers.map(|slave_registers| {
-            let regs: &TWISRegisters = unsafe { &*slave_registers };
+        if self.slave_mmio_address.is_some() {
+            let regs_manager = &TWISRegisterManager::new(&self);
 
             // Enable and configure
             let control = (((self.my_slave_address.get() as usize) & 0x7F) << 16) |
@@ -693,11 +869,11 @@ impl I2CHw {
                            (1 << 13) | // CUP - count nbytes up
                            (1 << 4)  | // STREN - stretch clock enable
                            (1 << 2); //.. SMATCH - ack on slave address
-            regs.control.set(control as u32);
+            regs_manager.registers.control.set(control as u32);
 
             // Set this separately because that makes the HW happy.
-            regs.control.set((control as u32) | 0x1);
-        });
+            regs_manager.registers.control.set((control as u32) | 0x1);
+        }
     }
 }
 
@@ -708,39 +884,34 @@ impl DMAClient for I2CHw {
 impl hil::i2c::I2CMaster for I2CHw {
     /// This enables the entire I2C peripheral
     fn enable(&self) {
-        // Enable the clock for the TWIM module
-        unsafe {
-            pm::enable_clock(self.master_clock);
-        }
-
         //disable the i2c slave peripheral
         hil::i2c::I2CSlave::disable(self);
 
-        let regs: &TWIMRegisters = unsafe { &*self.registers };
+        let regs_manager = &TWIMRegisterManager::new(&self);
 
         // enable, reset, disable
-        regs.control.set(0x1 << 0);
-        regs.control.set(0x1 << 7);
-        regs.control.set(0x1 << 1);
+        regs_manager.registers.control.set(0x1 << 0);
+        regs_manager.registers.control.set(0x1 << 7);
+        regs_manager.registers.control.set(0x1 << 1);
 
         // Init the bus speed
-        self.set_bus_speed();
+        self.set_bus_speed(regs_manager);
 
         // slew
-        regs.slew_rate.set((0x2 << 28) | (7 << 16) | (7 << 0));
+        regs_manager
+            .registers
+            .slew_rate
+            .set((0x2 << 28) | (7 << 16) | (7 << 0));
 
         // clear interrupts
-        regs.status_clear.set(!0);
+        regs_manager.registers.status_clear.set(!0);
     }
 
     /// This disables the entire I2C peripheral
     fn disable(&self) {
-        let regs: &TWIMRegisters = unsafe { &*self.registers };
-        regs.control.set(0x1 << 1);
-        unsafe {
-            pm::disable_clock(self.master_clock);
-        }
-        self.disable_interrupts();
+        let regs_manager = &TWIMRegisterManager::new(&self);
+        regs_manager.registers.control.set(0x1 << 1);
+        self.disable_interrupts(regs_manager);
     }
 
     fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
@@ -758,34 +929,31 @@ impl hil::i2c::I2CMaster for I2CHw {
 
 impl hil::i2c::I2CSlave for I2CHw {
     fn enable(&self) {
-        self.slave_clock.map(|slave_clock| unsafe {
-            pm::disable_clock(self.master_clock);
-            pm::enable_clock(slave_clock);
-        });
-
-        self.slave_registers.map(|slave_registers| {
-            let regs: &TWISRegisters = unsafe { &*slave_registers };
+        if self.slave_mmio_address.is_some() {
+            let regs_manager = &TWISRegisterManager::new(&self);
 
             // enable, reset, disable
-            regs.control.set(0x1 << 0);
-            regs.control.set(0x1 << 7);
-            regs.control.set(0);
+            regs_manager.registers.control.set(0x1 << 0);
+            regs_manager.registers.control.set(0x1 << 7);
+            regs_manager.registers.control.set(0);
 
             // slew
-            regs.slew_rate.set((0x2 << 28) | (7 << 0));
+            regs_manager.registers.slew_rate.set((0x2 << 28) | (7 << 0));
 
             // clear interrupts
-            regs.status_clear.set(!0);
+            regs_manager.registers.status_clear.set(!0);
 
             // We want to interrupt only on slave address match so we can
             // wait for a message from a master and then decide what to do
             // based on read/write.
-            regs.interrupt_enable.set((1 << 16));
+            regs_manager.registers.interrupt_enable.set((1 << 16));
 
             // Also setup all of the error interrupts.
-            regs.interrupt_enable
+            regs_manager
+                .registers
+                .interrupt_enable
                 .set((1 << 14) | (1 << 13) | (1 << 12) | (1 << 7) | (1 << 6));
-        });
+        }
 
         self.slave_enabled.set(true);
     }
@@ -794,15 +962,11 @@ impl hil::i2c::I2CSlave for I2CHw {
     fn disable(&self) {
         self.slave_enabled.set(false);
 
-        self.slave_registers.map(|slave_registers| {
-            let regs: &TWISRegisters = unsafe { &*slave_registers };
-
-            regs.control.set(0);
-            self.slave_clock.map(|slave_clock| unsafe {
-                pm::disable_clock(slave_clock);
-            });
-        });
-        self.slave_disable_interrupts();
+        if self.slave_mmio_address.is_some() {
+            let regs_manager = &TWISRegisterManager::new(&self);
+            regs_manager.registers.control.set(0);
+            self.slave_disable_interrupts(regs_manager);
+        }
     }
 
     fn set_address(&self, addr: u8) {

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -108,8 +108,6 @@ struct TWIMClock {
     slave: Option<pm::Clock>,
 }
 impl ClockInterface for TWIMClock {
-    type PlatformClockType = pm::Clock;
-
     fn is_enabled(&self) -> bool {
         self.master.is_enabled()
     }
@@ -134,8 +132,6 @@ struct TWISClock {
     slave: Option<pm::Clock>,
 }
 impl ClockInterface for TWISClock {
-    type PlatformClockType = pm::Clock;
-
     fn is_enabled(&self) -> bool {
         let slave_clock = self.slave.expect("I2C: Use of slave with no clock");
         slave_clock.is_enabled()

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -6,6 +6,7 @@ use core::cell::Cell;
 use core::sync::atomic::Ordering;
 use flashcalw;
 use gpio;
+use kernel::ClockInterface;
 use kernel::common::VolatileCell;
 use scif;
 
@@ -453,6 +454,46 @@ pub fn deep_sleep_ready() -> bool {
             && (*PM_REGS).pbamask.get() & !(DEEP_SLEEP_PBAMASK) == 0
             && (*PM_REGS).pbbmask.get() & !(DEEP_SLEEP_PBBMASK) == 0
             && gpio::INTERRUPT_COUNT.load(Ordering::Relaxed) == 0
+    }
+}
+
+impl ClockInterface for Clock {
+    type PlatformClockType = Clock;
+
+    fn is_enabled(&self) -> bool {
+        unsafe {
+            match self {
+                &Clock::HSB(v) => get_clock!(HSB: hsbmask & (1 << (v as u32))),
+                &Clock::PBA(v) => get_clock!(PBA: pbamask & (1 << (v as u32))),
+                &Clock::PBB(v) => get_clock!(PBB: pbbmask & (1 << (v as u32))),
+                &Clock::PBC(v) => get_clock!(PBC: pbcmask & (1 << (v as u32))),
+                &Clock::PBD(v) => get_clock!(PBD: pbdmask & (1 << (v as u32))),
+            }
+        }
+    }
+
+    fn enable(&self) {
+        unsafe {
+            match self {
+                &Clock::HSB(v) => mask_clock!(HSB: hsbmask | 1 << (v as u32)),
+                &Clock::PBA(v) => mask_clock!(PBA: pbamask | 1 << (v as u32)),
+                &Clock::PBB(v) => mask_clock!(PBB: pbbmask | 1 << (v as u32)),
+                &Clock::PBC(v) => mask_clock!(PBC: pbcmask | 1 << (v as u32)),
+                &Clock::PBD(v) => mask_clock!(PBD: pbdmask | 1 << (v as u32)),
+            }
+        }
+    }
+
+    fn disable(&self) {
+        unsafe {
+            match self {
+                &Clock::HSB(v) => mask_clock!(HSB: hsbmask & !(1 << (v as u32))),
+                &Clock::PBA(v) => mask_clock!(PBA: pbamask & !(1 << (v as u32))),
+                &Clock::PBB(v) => mask_clock!(PBB: pbbmask & !(1 << (v as u32))),
+                &Clock::PBC(v) => mask_clock!(PBC: pbcmask & !(1 << (v as u32))),
+                &Clock::PBD(v) => mask_clock!(PBD: pbdmask & !(1 << (v as u32))),
+            }
+        }
     }
 }
 

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -458,8 +458,6 @@ pub fn deep_sleep_ready() -> bool {
 }
 
 impl ClockInterface for Clock {
-    type PlatformClockType = Clock;
-
     fn is_enabled(&self) -> bool {
         unsafe {
             match self {

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -12,7 +12,7 @@ use dma::DMAChannel;
 use dma::DMAClient;
 use dma::DMAPeripheral;
 use kernel::{ClockInterface, ReturnCode, StaticRef};
-use kernel::common::peripherals::{AutomaticPeripheralManagement, PeripheralManager};
+use kernel::common::peripherals::{PeripheralManagement, PeripheralManager};
 use kernel::common::regs::{self, ReadOnly, ReadWrite, WriteOnly};
 use kernel::hil::spi;
 use kernel::hil::spi::ClockPhase;
@@ -196,7 +196,7 @@ pub struct SpiHw {
 const SPI_BASE: StaticRef<SpiRegisters> =
     unsafe { StaticRef::new(0x40008000 as *const SpiRegisters) };
 
-impl AutomaticPeripheralManagement<pm::Clock> for SpiHw {
+impl PeripheralManagement<pm::Clock> for SpiHw {
     type RegisterType = SpiRegisters;
 
     fn get_registers(&self) -> &SpiRegisters {

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -163,9 +163,6 @@ mod spi_consts {
     }
 }
 
-const SPI_BASE: StaticRef<SpiRegisters> =
-    unsafe { StaticRef::new(0x40008000 as *const SpiRegisters) };
-
 /// Values for selected peripherals
 #[derive(Copy, Clone)]
 pub enum Peripheral {
@@ -183,7 +180,6 @@ pub enum SpiRole {
 
 /// Abstraction of the SPI Hardware
 pub struct SpiHw {
-    mmio_address: StaticRef<SpiRegisters>,
     client: Cell<Option<&'static SpiMasterClient>>,
     dma_read: Cell<Option<&'static DMAChannel>>,
     dma_write: Cell<Option<&'static DMAChannel>>,
@@ -197,11 +193,14 @@ pub struct SpiHw {
     role: Cell<SpiRole>,
 }
 
+const SPI_BASE: StaticRef<SpiRegisters> =
+    unsafe { StaticRef::new(0x40008000 as *const SpiRegisters) };
+
 impl MMIOInterface<pm::Clock> for SpiHw {
     type MMIORegisterType = SpiRegisters;
 
     fn get_registers(&self) -> &SpiRegisters {
-        &*self.mmio_address
+        &*SPI_BASE
     }
 }
 
@@ -231,7 +230,6 @@ impl SpiHw {
     /// Creates a new SPI object, with peripheral 0 selected
     const fn new() -> SpiHw {
         SpiHw {
-            mmio_address: SPI_BASE,
             client: Cell::new(None),
             dma_read: Cell::new(None),
             dma_write: Cell::new(None),

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -11,33 +11,35 @@ use core::cmp;
 use dma::DMAChannel;
 use dma::DMAClient;
 use dma::DMAPeripheral;
-use kernel::ReturnCode;
+use kernel::{ClockInterface, MMIOClockGuard, MMIOClockInterface, MMIOInterface, MMIOManager,
+             ReturnCode};
 use kernel::common::regs::{self, ReadOnly, ReadWrite, WriteOnly};
 use kernel::hil::spi;
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
+use kernel::hil::spi::SpiMaster;
 use kernel::hil::spi::SpiMasterClient;
 use kernel::hil::spi::SpiSlaveClient;
 use pm;
 
 #[repr(C)]
-pub struct Registers {
-    pub cr: WriteOnly<u32, Control::Register>,
-    pub mr: ReadWrite<u32, Mode::Register>,
-    pub rdr: ReadOnly<u32>,
-    pub tdr: WriteOnly<u32, TransmitData::Register>,
-    pub sr: ReadOnly<u32, Status::Register>,
-    pub ier: WriteOnly<u32, InterruptFlags::Register>,
-    pub idr: WriteOnly<u32, InterruptFlags::Register>,
-    pub imr: ReadOnly<u32, InterruptFlags::Register>,
+pub struct SpiRegisters {
+    cr: WriteOnly<u32, Control::Register>,
+    mr: ReadWrite<u32, Mode::Register>,
+    rdr: ReadOnly<u32>,
+    tdr: WriteOnly<u32, TransmitData::Register>,
+    sr: ReadOnly<u32, Status::Register>,
+    ier: WriteOnly<u32, InterruptFlags::Register>,
+    idr: WriteOnly<u32, InterruptFlags::Register>,
+    imr: ReadOnly<u32, InterruptFlags::Register>,
     _reserved0: [ReadOnly<u32>; 4],
-    pub csr: [ReadWrite<u32, ChipSelectParams::Register>; 4],
+    csr: [ReadWrite<u32, ChipSelectParams::Register>; 4],
     _reserved1: [ReadOnly<u32>; 41],
-    pub wpcr: ReadWrite<u32, WriteProtectionControl::Register>,
-    pub wpsr: ReadOnly<u32>,
+    wpcr: ReadWrite<u32, WriteProtectionControl::Register>,
+    wpsr: ReadOnly<u32>,
     _reserved2: [ReadOnly<u32>; 3],
-    pub features: ReadOnly<u32>,
-    pub version: ReadOnly<u32>,
+    features: ReadOnly<u32>,
+    version: ReadOnly<u32>,
 }
 
 register_bitfields![u32,
@@ -178,9 +180,9 @@ pub enum SpiRole {
     SpiSlave,
 }
 
-/// The SAM4L supports four peripherals.
-pub struct Spi {
-    registers: *mut Registers,
+/// Abstraction of the SPI Hardware
+pub struct SpiHw {
+    mmio_address: *mut SpiRegisters,
     client: Cell<Option<&'static SpiMasterClient>>,
     dma_read: Cell<Option<&'static DMAChannel>>,
     dma_write: Cell<Option<&'static DMAChannel>>,
@@ -194,13 +196,41 @@ pub struct Spi {
     role: Cell<SpiRole>,
 }
 
-pub static mut SPI: Spi = Spi::new();
+impl MMIOInterface<pm::Clock> for SpiHw {
+    type MMIORegisterType = SpiRegisters;
 
-impl Spi {
+    fn get_hardware_address(&self) -> *mut SpiRegisters {
+        self.mmio_address
+    }
+}
+
+impl MMIOClockInterface<pm::Clock> for SpiHw {
+    fn get_clock(&self) -> &pm::Clock {
+        &pm::Clock::PBA(pm::PBAClock::SPI)
+    }
+}
+
+impl MMIOClockGuard<SpiHw, pm::Clock> for SpiHw {
+    fn before_mmio_access(&self, clock: &pm::Clock, _: &SpiRegisters) {
+        clock.enable();
+    }
+
+    fn after_mmio_access(&self, clock: &pm::Clock, _: &SpiRegisters) {
+        if !self.is_busy() {
+            clock.disable();
+        }
+    }
+}
+
+type SpiRegisterManager<'a> = MMIOManager<'a, SpiHw, pm::Clock>;
+
+pub static mut SPI: SpiHw = SpiHw::new();
+
+impl SpiHw {
     /// Creates a new SPI object, with peripheral 0 selected
-    pub const fn new() -> Spi {
-        Spi {
-            registers: SPI_BASE as *mut Registers,
+    const fn new() -> SpiHw {
+        SpiHw {
+            mmio_address: SPI_BASE as *mut SpiRegisters,
             client: Cell::new(None),
             dma_read: Cell::new(None),
             dma_write: Cell::new(None),
@@ -212,15 +242,12 @@ impl Spi {
         }
     }
 
-    fn init_as_role(&self, role: SpiRole) {
-        let regs: &Registers = unsafe { &*self.registers };
-
+    fn init_as_role(&self, regs_manager: &SpiRegisterManager, role: SpiRole) {
         self.role.set(role);
-        self.enable_clock();
 
         if self.role.get() == SpiRole::SpiMaster {
             // Only need to set LASTXFER if we are master
-            regs.cr.write(Control::LASTXFER::SET);
+            regs_manager.registers.cr.write(Control::LASTXFER::SET);
         }
 
         // Sets bits per transfer to 8
@@ -234,29 +261,28 @@ impl Spi {
         };
 
         // Disable mode fault detection (open drain outputs not supported)
-        regs.mr.modify(mode + Mode::MODFDIS::SET);
+        regs_manager.registers.mr.modify(mode + Mode::MODFDIS::SET);
     }
 
     pub fn enable(&self) {
-        let regs: &Registers = unsafe { &*self.registers };
+        let regs_manager = &SpiRegisterManager::new(&self);
 
-        self.enable_clock();
-        regs.cr.write(Control::SPIEN::SET);
+        regs_manager.registers.cr.write(Control::SPIEN::SET);
 
         if self.role.get() == SpiRole::SpiSlave {
-            regs.ier.write(InterruptFlags::NSSR::SET); // Enable NSSR
+            regs_manager.registers.ier.write(InterruptFlags::NSSR::SET); // Enable NSSR
         }
     }
 
     pub fn disable(&self) {
-        let regs: &Registers = unsafe { &*self.registers };
+        let regs_manager = &SpiRegisterManager::new(&self);
 
         self.dma_read.get().map(|read| read.disable());
         self.dma_write.get().map(|write| write.disable());
-        regs.cr.write(Control::SPIDIS::SET);
+        regs_manager.registers.cr.write(Control::SPIDIS::SET);
 
         if self.role.get() == SpiRole::SpiSlave {
-            regs.idr.write(InterruptFlags::NSSR::SET);; // Disable NSSR
+            regs_manager.registers.idr.write(InterruptFlags::NSSR::SET);; // Disable NSSR
         }
     }
 
@@ -296,7 +322,7 @@ impl Spi {
         clock / scbr
     }
 
-    pub fn get_baud_rate(&self) -> u32 {
+    fn get_baud_rate(&self) -> u32 {
         let clock = 48000000;
         let scbr = self.get_active_csr().read(ChipSelectParams::SCBR);
         clock / scbr
@@ -339,27 +365,27 @@ impl Spi {
     pub fn set_active_peripheral(&self, peripheral: Peripheral) {
         // Slave cannot set active peripheral
         if self.role.get() == SpiRole::SpiMaster {
-            let regs: &Registers = unsafe { &*self.registers };
+            let regs_manager = &SpiRegisterManager::new(&self);
             let mr = match peripheral {
                 Peripheral::Peripheral0 => Mode::PCS::PCS0,
                 Peripheral::Peripheral1 => Mode::PCS::PCS1,
                 Peripheral::Peripheral2 => Mode::PCS::PCS2,
                 Peripheral::Peripheral3 => Mode::PCS::PCS3,
             };
-            regs.mr.modify(mr);
+            regs_manager.registers.mr.modify(mr);
         }
     }
 
     /// Returns the currently active peripheral
-    pub fn get_active_peripheral(&self) -> Peripheral {
+    fn get_active_peripheral(&self) -> Peripheral {
         if self.role.get() == SpiRole::SpiMaster {
-            let regs: &Registers = unsafe { &*self.registers };
+            let regs_manager = &SpiRegisterManager::new(&self);
 
-            if regs.mr.matches(Mode::PCS::PCS3) {
+            if regs_manager.registers.mr.matches(Mode::PCS::PCS3) {
                 Peripheral::Peripheral3
-            } else if regs.mr.matches(Mode::PCS::PCS2) {
+            } else if regs_manager.registers.mr.matches(Mode::PCS::PCS2) {
                 Peripheral::Peripheral2
-            } else if regs.mr.matches(Mode::PCS::PCS1) {
+            } else if regs_manager.registers.mr.matches(Mode::PCS::PCS1) {
                 Peripheral::Peripheral1
             } else {
                 // default
@@ -374,13 +400,13 @@ impl Spi {
     /// Returns the value of CSR0, CSR1, CSR2, or CSR3,
     /// whichever corresponds to the active peripheral
     fn get_active_csr(&self) -> &regs::ReadWrite<u32, ChipSelectParams::Register> {
-        let regs: &Registers = unsafe { &*self.registers };
+        let regs_manager = &SpiRegisterManager::new(&self);
 
         match self.get_active_peripheral() {
-            Peripheral::Peripheral0 => &regs.csr[0],
-            Peripheral::Peripheral1 => &regs.csr[1],
-            Peripheral::Peripheral2 => &regs.csr[2],
-            Peripheral::Peripheral3 => &regs.csr[3],
+            Peripheral::Peripheral0 => &regs_manager.registers.csr[0],
+            Peripheral::Peripheral1 => &regs_manager.registers.csr[1],
+            Peripheral::Peripheral2 => &regs_manager.registers.csr[2],
+            Peripheral::Peripheral3 => &regs_manager.registers.csr[3],
         }
     }
 
@@ -390,17 +416,11 @@ impl Spi {
         self.dma_write.set(Some(write));
     }
 
-    fn enable_clock(&self) {
-        unsafe {
-            pm::enable_clock(pm::Clock::PBA(pm::PBAClock::SPI));
-        }
-    }
-
     pub fn handle_interrupt(&self) {
-        let regs: &Registers = unsafe { &*self.registers };
+        let regs_manager = &SpiRegisterManager::new(&self);
 
         self.slave_client.get().map(|client| {
-            if regs.sr.is_set(Status::NSSR) {
+            if regs_manager.registers.sr.is_set(Status::NSSR) {
                 // NSSR
                 client.chip_selected()
             }
@@ -466,7 +486,7 @@ impl Spi {
     }
 }
 
-impl spi::SpiMaster for Spi {
+impl spi::SpiMaster for SpiHw {
     type ChipSelect = u8;
 
     fn set_client(&self, client: &'static SpiMasterClient) {
@@ -476,7 +496,8 @@ impl spi::SpiMaster for Spi {
     /// By default, initialize SPI to operate at 40KHz, clock is
     /// idle on low, and sample on the leading edge.
     fn init(&self) {
-        self.init_as_role(SpiRole::SpiMaster);
+        let regs_manager = &SpiRegisterManager::new(&self);
+        self.init_as_role(regs_manager, SpiRole::SpiMaster);
     }
 
     fn is_busy(&self) -> bool {
@@ -486,13 +507,13 @@ impl spi::SpiMaster for Spi {
     /// Write a byte to the SPI and discard the read; if an
     /// asynchronous operation is outstanding, do nothing.
     fn write_byte(&self, out_byte: u8) {
-        let regs: &Registers = unsafe { &*self.registers };
+        let regs_manager = &SpiRegisterManager::new(&self);
 
         let tdr = (out_byte as u32) & spi_consts::tdr::TD;
         // Wait for data to leave TDR and enter serializer, so TDR is free
         // for this next byte
-        while !regs.sr.is_set(Status::TDRE) {}
-        regs.tdr.set(tdr);
+        while !regs_manager.registers.sr.is_set(Status::TDRE) {}
+        regs_manager.registers.tdr.set(tdr);
     }
 
     /// Write 0 to the SPI and return the read; if an
@@ -504,13 +525,13 @@ impl spi::SpiMaster for Spi {
     /// Write a byte to the SPI and return the read; if an
     /// asynchronous operation is outstanding, do nothing.
     fn read_write_byte(&self, val: u8) -> u8 {
-        let regs: &Registers = unsafe { &*self.registers };
+        let regs_manager = &SpiRegisterManager::new(&self);
 
         self.write_byte(val);
         // Wait for receive data register full
-        while !regs.sr.is_set(Status::RDRF) {}
+        while !regs_manager.registers.sr.is_set(Status::RDRF) {}
         // Return read value
-        regs.rdr.get() as u8
+        regs_manager.registers.rdr.get() as u8
     }
 
     /// Asynchronous buffer read/write of SPI.
@@ -584,7 +605,7 @@ impl spi::SpiMaster for Spi {
     }
 }
 
-impl spi::SpiSlave for Spi {
+impl spi::SpiSlave for SpiHw {
     // Set to None to disable the whole thing
     fn set_client(&self, client: Option<&'static SpiSlaveClient>) {
         self.slave_client.set(client);
@@ -595,14 +616,15 @@ impl spi::SpiSlave for Spi {
     }
 
     fn init(&self) {
-        self.init_as_role(SpiRole::SpiSlave);
+        let regs_manager = &SpiRegisterManager::new(&self);
+        self.init_as_role(regs_manager, SpiRole::SpiSlave);
     }
 
     /// This sets the value in the TDR register, to be sent as soon as the
     /// chip select pin is low.
     fn set_write_byte(&self, write_byte: u8) {
-        let regs: &Registers = unsafe { &*self.registers };
-        regs.tdr.set(write_byte as u32);
+        let regs_manager = &SpiRegisterManager::new(&self);
+        regs_manager.registers.tdr.set(write_byte as u32);
     }
 
     fn read_write_bytes(
@@ -631,7 +653,7 @@ impl spi::SpiSlave for Spi {
     }
 }
 
-impl DMAClient for Spi {
+impl DMAClient for SpiHw {
     fn xfer_done(&self, _pid: DMAPeripheral) {
         // Only callback that the transfer is done if either:
         // 1) The transfer was TX only and TX finished

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -276,6 +276,64 @@ const USART_BASE_ADDRS: [*mut UsartRegisters; 4] = [
     0x40030000 as *mut UsartRegisters,
 ];
 
+pub struct USARTRegManager<'a> {
+    registers: &'a UsartRegisters,
+    clock: pm::Clock,
+    rx_dma: Option<&'static dma::DMAChannel>,
+    tx_dma: Option<&'static dma::DMAChannel>,
+    is_panic: bool,
+}
+
+impl<'a> USARTRegManager<'a> {
+    fn real_new(usart: &USART, is_panic: bool) -> USARTRegManager {
+        unsafe {
+            if pm::is_clock_enabled(usart.clock) == false {
+                pm::enable_clock(usart.clock);
+            }
+        }
+        let regs: &UsartRegisters = unsafe { &*usart.registers };
+        USARTRegManager {
+            registers: regs,
+            clock: usart.clock,
+            rx_dma: usart.rx_dma.get(),
+            tx_dma: usart.tx_dma.get(),
+            is_panic: is_panic,
+        }
+    }
+
+    fn new(usart: &USART) -> USARTRegManager {
+        USARTRegManager::real_new(usart, false)
+    }
+
+    pub fn panic_new(usart: &USART) -> USARTRegManager {
+        USARTRegManager::real_new(usart, true)
+    }
+}
+
+impl<'a> Drop for USARTRegManager<'a> {
+    fn drop(&mut self) {
+        // Anything listening for RX or TX interrupts?
+        let ints_active = self.registers.imr.matches(
+            Interrupt::RXBUFF::SET + Interrupt::TXEMPTY::SET + Interrupt::TIMEOUT::SET
+                + Interrupt::PARE::SET + Interrupt::FRAME::SET + Interrupt::OVRE::SET
+                + Interrupt::TXRDY::SET + Interrupt::RXRDY::SET,
+        );
+
+        let rx_active = self.rx_dma.map_or(false, |rx_dma| rx_dma.is_enabled());
+        let tx_active = self.tx_dma.map_or(false, |tx_dma| tx_dma.is_enabled());
+
+        // Special-case panic here as panic does not actually use the
+        // USART driver code in this file, rather it writes the registers
+        // directly and we can't safely reason about what the custom panic
+        // USART driver is doing / expects.
+        if !(rx_active || tx_active || ints_active || self.is_panic) {
+            unsafe {
+                pm::disable_clock(self.clock);
+            }
+        }
+    }
+}
+
 #[derive(Copy, Clone, PartialEq)]
 #[allow(non_camel_case_types)]
 pub enum USARTStateRX {
@@ -388,44 +446,28 @@ impl USART {
         self.tx_dma.set(Some(tx_dma));
     }
 
-    pub fn enable_rx(&self) {
-        self.enable_clock();
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.cr.write(Control::RXEN::SET);
+    fn enable_rx(&self, usart: &USARTRegManager) {
+        usart.registers.cr.write(Control::RXEN::SET);
     }
 
-    pub fn enable_tx(&self) {
-        self.enable_clock();
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.cr.write(Control::TXEN::SET);
+    pub fn enable_tx(&self, usart: &USARTRegManager) {
+        usart.registers.cr.write(Control::TXEN::SET);
     }
 
-    pub fn disable_rx(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.cr.write(Control::RXDIS::SET);
-
+    fn disable_rx(&self, usart: &USARTRegManager) {
+        usart.registers.cr.write(Control::RXDIS::SET);
         self.usart_rx_state.set(USARTStateRX::Idle);
-        if self.usart_tx_state.get() == USARTStateTX::Idle {
-            // TX disabled too
-            self.disable_clock();
-        }
     }
 
-    pub fn disable_tx(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.cr.write(Control::TXDIS::SET);
-
+    fn disable_tx(&self, usart: &USARTRegManager) {
+        usart.registers.cr.write(Control::TXDIS::SET);
         self.usart_tx_state.set(USARTStateTX::Idle);
-        if self.usart_rx_state.get() == USARTStateRX::Idle {
-            // RX disabled too
-            self.disable_clock();
-        }
     }
 
-    pub fn abort_rx(&self, error: hil::uart::Error) {
+    fn abort_rx(&self, usart: &USARTRegManager, error: hil::uart::Error) {
         if self.usart_rx_state.get() == USARTStateRX::DMA_Receiving {
-            self.disable_rx_interrupts();
-            self.disable_rx();
+            self.disable_rx_interrupts(usart);
+            self.disable_rx(usart);
             self.usart_rx_state.set(USARTStateRX::Idle);
 
             // get buffer
@@ -450,10 +492,10 @@ impl USART {
         }
     }
 
-    pub fn abort_tx(&self, error: hil::uart::Error) {
+    fn abort_tx(&self, usart: &USARTRegManager, error: hil::uart::Error) {
         if self.usart_tx_state.get() == USARTStateTX::DMA_Transmitting {
-            self.disable_tx_interrupts();
-            self.disable_tx();
+            self.disable_tx_interrupts(usart);
+            self.disable_tx(usart);
             self.usart_tx_state.set(USARTStateTX::Idle);
 
             // get buffer
@@ -478,106 +520,86 @@ impl USART {
         }
     }
 
-    pub fn enable_tx_empty_interrupt(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.ier.write(Interrupt::TXEMPTY::SET);
+    fn enable_tx_empty_interrupt(&self, usart: &USARTRegManager) {
+        usart.registers.ier.write(Interrupt::TXEMPTY::SET);
     }
 
-    pub fn disable_tx_empty_interrupt(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.idr.write(Interrupt::TXEMPTY::SET);
+    fn disable_tx_empty_interrupt(&self, usart: &USARTRegManager) {
+        usart.registers.idr.write(Interrupt::TXEMPTY::SET);
     }
 
-    pub fn enable_rx_error_interrupts(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.ier
+    fn enable_rx_error_interrupts(&self, usart: &USARTRegManager) {
+        usart
+            .registers
+            .ier
             .write(Interrupt::PARE::SET + Interrupt::FRAME::SET + Interrupt::OVRE::SET);
     }
 
-    pub fn disable_rx_interrupts(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.idr.write(
+    fn disable_rx_interrupts(&self, usart: &USARTRegManager) {
+        usart.registers.idr.write(
             Interrupt::RXBUFF::SET + Interrupt::TIMEOUT::SET + Interrupt::PARE::SET
                 + Interrupt::FRAME::SET + Interrupt::OVRE::SET + Interrupt::RXRDY::SET,
         );
     }
 
-    pub fn disable_tx_interrupts(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.idr
+    fn disable_tx_interrupts(&self, usart: &USARTRegManager) {
+        usart
+            .registers
+            .idr
             .write(Interrupt::TXEMPTY::SET + Interrupt::TXRDY::SET);
     }
 
-    pub fn disable_interrupts(&self) {
-        self.disable_rx_interrupts();
-        self.disable_tx_interrupts();
+    fn disable_interrupts(&self, usart: &USARTRegManager) {
+        self.disable_rx_interrupts(usart);
+        self.disable_tx_interrupts(usart);
     }
 
-    pub fn reset(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-
-        regs.cr
+    fn reset(&self, usart: &USARTRegManager) {
+        usart
+            .registers
+            .cr
             .write(Control::RSTSTA::SET + Control::RSTTX::SET + Control::RSTRX::SET);
 
-        self.abort_rx(hil::uart::Error::ResetError);
-        self.enable_clock(); // in case abort_rx turned them off
-        self.abort_tx(hil::uart::Error::ResetError);
+        self.abort_rx(usart, hil::uart::Error::ResetError);
+        self.abort_tx(usart, hil::uart::Error::ResetError);
     }
 
     pub fn handle_interrupt(&self) {
-        // only handle interrupts if the clock is enabled for this peripheral.
-        // Now, why are we occasionally getting interrupts with the clock
-        // disabled? That is a good question that I don't have the answer to.
-        // They don't even seem to be causing a problem, but seemed bad, so I
-        // stopped it from occurring just in case it caused issues in the
-        // future.
-        if self.is_clock_enabled() {
-            let regs: &UsartRegisters = unsafe { &*self.registers };
+        let usart = &USARTRegManager::new(&self);
 
-            if regs.csr.is_set(ChannelStatus::TIMEOUT) && regs.imr.is_set(Interrupt::TIMEOUT) {
-                // Reset status registers. We need to do this first because some
-                // interrupts signal us to turn off our clock.
-                regs.cr.write(Control::RSTSTA::SET);
-                self.disable_rx_timeout();
-                self.abort_rx(hil::uart::Error::CommandComplete);
-            } else if regs.csr.is_set(ChannelStatus::TXEMPTY) && regs.imr.is_set(Interrupt::TXEMPTY)
-            {
-                regs.cr.write(Control::RSTSTA::SET);
-                self.disable_tx_empty_interrupt();
-                self.disable_tx();
-                self.usart_tx_state.set(USARTStateTX::Idle);
-            } else if regs.csr.is_set(ChannelStatus::PARE) {
-                regs.cr.write(Control::RSTSTA::SET);
-                self.abort_rx(hil::uart::Error::ParityError);
-            } else if regs.csr.is_set(ChannelStatus::FRAME) {
-                regs.cr.write(Control::RSTSTA::SET);
-                self.abort_rx(hil::uart::Error::FramingError);
-            } else if regs.csr.is_set(ChannelStatus::OVRE) {
-                regs.cr.write(Control::RSTSTA::SET);
-                self.abort_rx(hil::uart::Error::OverrunError);
-            }
+        // TODO: Ideally we would read the actual registers once and let the
+        // compiler sort out a switch tree basd on the if/else chain. The
+        // underlying volatile reads makes this code as-written inefficient.
+        // However, doing so with the current registers interface doesn't
+        // really work.
+        //
+        //let status = usart.registers.csr.get();
+        //let mask = usart.registers.imr.get();
+
+        if usart.registers.csr.is_set(ChannelStatus::TIMEOUT)
+            && usart.registers.imr.is_set(Interrupt::TIMEOUT)
+        {
+            self.disable_rx_timeout(usart);
+            self.abort_rx(usart, hil::uart::Error::CommandComplete);
+        } else if usart.registers.csr.is_set(ChannelStatus::TXEMPTY)
+            && usart.registers.imr.is_set(Interrupt::TXEMPTY)
+        {
+            self.disable_tx_empty_interrupt(usart);
+            self.disable_tx(usart);
+            self.usart_tx_state.set(USARTStateTX::Idle);
+        } else if usart.registers.csr.is_set(ChannelStatus::PARE) {
+            self.abort_rx(usart, hil::uart::Error::ParityError);
+        } else if usart.registers.csr.is_set(ChannelStatus::FRAME) {
+            self.abort_rx(usart, hil::uart::Error::FramingError);
+        } else if usart.registers.csr.is_set(ChannelStatus::OVRE) {
+            self.abort_rx(usart, hil::uart::Error::OverrunError);
         }
+
+        // Reset status registers.
+        usart.registers.cr.write(Control::RSTSTA::SET);
     }
 
-    fn enable_clock(&self) {
-        unsafe {
-            pm::enable_clock(self.clock);
-        }
-    }
-
-    fn disable_clock(&self) {
-        unsafe {
-            pm::disable_clock(self.clock);
-        }
-    }
-
-    fn is_clock_enabled(&self) -> bool {
-        unsafe { pm::is_clock_enabled(self.clock) }
-    }
-
-    fn set_baud_rate(&self, baud_rate: u32) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-
+    fn set_baud_rate(&self, usart: &USARTRegManager, baud_rate: u32) {
         let system_frequency = pm::get_system_frequency();
 
         // The clock divisor is calculated differently in UART and SPI modes.
@@ -587,62 +609,64 @@ impl USART {
             _ => 0,
         };
 
-        regs.brgr.write(BaudRate::CD.val(cd));
+        usart.registers.brgr.write(BaudRate::CD.val(cd));
     }
 
     /// In non-SPI mode, this drives RTS low.
     /// In SPI mode, this asserts (drives low) the chip select line.
-    fn rts_enable_spi_assert_cs(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.cr.write(Control::RTSEN::SET);
+    fn rts_enable_spi_assert_cs(&self, usart: &USARTRegManager) {
+        usart.registers.cr.write(Control::RTSEN::SET);
     }
 
     /// In non-SPI mode, this drives RTS high.
     /// In SPI mode, this de-asserts (drives high) the chip select line.
-    fn rts_disable_spi_deassert_cs(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.cr.write(Control::RTSDIS::SET);
+    fn rts_disable_spi_deassert_cs(&self, usart: &USARTRegManager) {
+        usart.registers.cr.write(Control::RTSDIS::SET);
     }
 
-    fn enable_rx_timeout(&self, timeout: u8) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.rtor.write(RxTimeout::TO.val(timeout as u32));
+    fn enable_rx_timeout(&self, usart: &USARTRegManager, timeout: u8) {
+        usart
+            .registers
+            .rtor
+            .write(RxTimeout::TO.val(timeout as u32));
 
         // enable timeout interrupt
-        regs.ier.write(Interrupt::TIMEOUT::SET);
+        usart.registers.ier.write(Interrupt::TIMEOUT::SET);
 
         // start timeout
-        regs.cr.write(Control::STTTO::SET);
+        usart.registers.cr.write(Control::STTTO::SET);
     }
 
-    fn disable_rx_timeout(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.rtor.write(RxTimeout::TO.val(0));
+    fn disable_rx_timeout(&self, usart: &USARTRegManager) {
+        usart.registers.rtor.write(RxTimeout::TO.val(0));
 
         // enable timeout interrupt
-        regs.idr.write(Interrupt::TIMEOUT::SET);
+        usart.registers.idr.write(Interrupt::TIMEOUT::SET);
     }
 
-    fn enable_rx_terminator(&self, _terminator: u8) {
+    fn enable_rx_terminator(&self, _regs_manage: &USARTRegManager, _terminator: u8) {
         // XXX: implement me
         panic!("didn't write terminator stuff yet");
     }
 
     // for use by panic in io.rs
-    pub fn send_byte(&self, byte: u8) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.thr.write(TransmitHold::TXCHR.val(byte as u32));
+    pub fn send_byte(&self, usart: &USARTRegManager, byte: u8) {
+        usart
+            .registers
+            .thr
+            .write(TransmitHold::TXCHR.val(byte as u32));
     }
 
     // for use by panic in io.rs
-    pub fn tx_ready(&self) -> bool {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.csr.is_set(ChannelStatus::TXRDY)
+    pub fn tx_ready(&self, usart: &USARTRegManager) -> bool {
+        usart.registers.csr.is_set(ChannelStatus::TXRDY)
     }
 }
 
 impl dma::DMAClient for USART {
     fn xfer_done(&self, pid: dma::DMAPeripheral) {
+        let usart = &USARTRegManager::new(&self);
+
         match self.usart_mode.get() {
             UsartMode::Uart => {
                 // determine if it was an RX or TX transfer
@@ -650,8 +674,8 @@ impl dma::DMAClient for USART {
                     // RX transfer was completed
 
                     // disable RX and RX interrupts
-                    self.disable_rx_interrupts();
-                    self.disable_rx();
+                    self.disable_rx_interrupts(usart);
+                    self.disable_rx(usart);
                     self.usart_rx_state.set(USARTStateRX::Idle);
 
                     // get buffer
@@ -684,7 +708,7 @@ impl dma::DMAClient for USART {
                     // note that the DMA has finished but TX cannot yet be disabled yet because
                     // there may still be bytes left in the TX buffer.
                     self.usart_tx_state.set(USARTStateTX::Transfer_Completing);
-                    self.enable_tx_empty_interrupt();
+                    self.enable_tx_empty_interrupt(usart);
 
                     // get buffer
                     let buffer = self.tx_dma.get().map_or(None, |tx_dma| {
@@ -716,7 +740,7 @@ impl dma::DMAClient for USART {
                     self.spi_chip_select.get().map_or_else(
                         || {
                             // Do "else" case first. Thanks, rust.
-                            self.rts_disable_spi_deassert_cs();
+                            self.rts_disable_spi_deassert_cs(usart);
                         },
                         |cs| {
                             cs.set();
@@ -725,10 +749,10 @@ impl dma::DMAClient for USART {
 
                     // note that the DMA has finished but TX cannot be disabled yet
                     self.usart_tx_state.set(USARTStateTX::Transfer_Completing);
-                    self.enable_tx_empty_interrupt();
+                    self.enable_tx_empty_interrupt(usart);
 
                     self.usart_rx_state.set(USARTStateRX::Idle);
-                    self.disable_rx();
+                    self.disable_rx(usart);
 
                     // get buffer
                     let txbuf = self.tx_dma.get().map_or(None, |dma| {
@@ -773,16 +797,13 @@ impl hil::uart::UART for USART {
     fn init(&self, params: hil::uart::UARTParams) {
         self.usart_mode.set(UsartMode::Uart);
 
-        // enable USART clock
-        //  must do this before writing any registers
-        self.enable_clock();
+        let usart = &USARTRegManager::new(&self);
 
         // disable interrupts
-        self.disable_interrupts();
+        self.disable_interrupts(usart);
 
         // stop any TX and RX and clear status
-        self.reset();
-        self.enable_clock();
+        self.reset(usart);
 
         // set USART mode register
         let mut mode = Mode::OVER::SET; // OVER: oversample at 8x
@@ -806,25 +827,20 @@ impl hil::uart::UART for USART {
             false => Mode::MODE::NORMAL,
         };
 
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        regs.mr.write(mode);
+        usart.registers.mr.write(mode);
 
         // Set baud rate
-        self.set_baud_rate(params.baud_rate);
-
-        self.disable_clock();
+        self.set_baud_rate(usart, params.baud_rate);
     }
 
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {
-        // enable USART clock
-        //  must do this before writing any registers
-        self.enable_clock();
+        let usart = &USARTRegManager::new(&self);
 
         // quit current transmission if any
-        self.abort_tx(hil::uart::Error::RepeatCallError);
+        self.abort_tx(usart, hil::uart::Error::RepeatCallError);
 
         // enable TX
-        self.enable_tx();
+        self.enable_tx(usart);
         self.usart_tx_state.set(USARTStateTX::DMA_Transmitting);
 
         // set up dma transfer and start transmission
@@ -836,12 +852,10 @@ impl hil::uart::UART for USART {
     }
 
     fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize) {
-        // enable USART clock
-        //  must do this before writing any registers
-        self.enable_clock();
+        let usart = &USARTRegManager::new(&self);
 
         // quit current reception if any
-        self.abort_rx(hil::uart::Error::RepeatCallError);
+        self.abort_rx(usart, hil::uart::Error::RepeatCallError);
 
         // truncate rx_len if necessary
         let mut length = rx_len;
@@ -850,8 +864,8 @@ impl hil::uart::UART for USART {
         }
 
         // enable RX
-        self.enable_rx();
-        self.enable_rx_error_interrupts();
+        self.enable_rx(usart);
+        self.enable_rx_error_interrupts(usart);
         self.usart_rx_state.set(USARTStateRX::DMA_Receiving);
 
         // set up dma transfer and start reception
@@ -865,20 +879,18 @@ impl hil::uart::UART for USART {
 
 impl hil::uart::UARTAdvanced for USART {
     fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8) {
-        // enable USART clock
-        //  must do this before writing any registers
-        self.enable_clock();
+        let usart = &USARTRegManager::new(&self);
 
         // quit current reception if any
-        self.abort_rx(hil::uart::Error::RepeatCallError);
+        self.abort_rx(usart, hil::uart::Error::RepeatCallError);
 
         // enable RX
-        self.enable_rx();
-        self.enable_rx_error_interrupts();
+        self.enable_rx(usart);
+        self.enable_rx_error_interrupts(usart);
         self.usart_rx_state.set(USARTStateRX::DMA_Receiving);
 
         // enable receive timeout
-        self.enable_rx_timeout(interbyte_timeout);
+        self.enable_rx_timeout(usart, interbyte_timeout);
 
         // set up dma transfer and start reception
         self.rx_dma.get().map(move |dma| {
@@ -890,20 +902,18 @@ impl hil::uart::UARTAdvanced for USART {
     }
 
     fn receive_until_terminator(&self, rx_buffer: &'static mut [u8], terminator: u8) {
-        // enable USART clock
-        //  must do this before writing any registers
-        self.enable_clock();
+        let usart = &USARTRegManager::new(&self);
 
         // quit current reception if any
-        self.abort_rx(hil::uart::Error::RepeatCallError);
+        self.abort_rx(usart, hil::uart::Error::RepeatCallError);
 
         // enable RX
-        self.enable_rx();
-        self.enable_rx_error_interrupts();
+        self.enable_rx(usart);
+        self.enable_rx_error_interrupts(usart);
         self.usart_rx_state.set(USARTStateRX::DMA_Receiving);
 
         // enable receive terminator
-        self.enable_rx_terminator(terminator);
+        self.enable_rx_terminator(usart, terminator);
 
         // set up dma transfer and start reception
         self.rx_dma.get().map(move |dma| {
@@ -920,24 +930,21 @@ impl hil::spi::SpiMaster for USART {
     type ChipSelect = Option<&'static hil::gpio::Pin>;
 
     fn init(&self) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
+        let usart = &USARTRegManager::new(&self);
 
         self.usart_mode.set(UsartMode::Spi);
-        self.enable_clock();
 
         // Set baud rate, default to 2 MHz.
-        self.set_baud_rate(2000000);
+        self.set_baud_rate(usart, 2000000);
 
-        regs.mr.write(
+        usart.registers.mr.write(
             Mode::MODE::SPI_MASTER + Mode::USCLKS::CLK_USART + Mode::CHRL::BITS8 + Mode::PAR::NONE
                 + Mode::CLKO::SET,
         );
 
         // Set four bit periods of guard time before RTS/CTS toggle after a
         // message.
-        regs.ttgr.write(TxTimeGuard::TG.val(4));
-
-        self.disable_clock();
+        usart.registers.ttgr.write(TxTimeGuard::TG.val(4));
     }
 
     fn set_client(&self, client: &'static hil::spi::SpiMasterClient) {
@@ -955,8 +962,10 @@ impl hil::spi::SpiMaster for USART {
         read_buffer: Option<&'static mut [u8]>,
         len: usize,
     ) -> ReturnCode {
-        self.enable_tx();
-        self.enable_rx();
+        let usart = &USARTRegManager::new(&self);
+
+        self.enable_tx(usart);
+        self.enable_rx(usart);
 
         // Calculate the correct length for the transmission
         let buflen = read_buffer.as_ref().map_or(write_buffer.len(), |rbuf| {
@@ -971,7 +980,7 @@ impl hil::spi::SpiMaster for USART {
             || {
                 // Do the "else" case first. If a CS pin was provided as the
                 // CS line, we use the HW RTS pin as the CS line instead.
-                self.rts_enable_spi_assert_cs();
+                self.rts_enable_spi_assert_cs(usart);
             },
             |cs| {
                 cs.clear();
@@ -1014,26 +1023,35 @@ impl hil::spi::SpiMaster for USART {
     }
 
     fn write_byte(&self, val: u8) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        self.enable_clock();
-        regs.cr.write(Control::RXEN::SET + Control::TXEN::SET);
-        regs.thr.write(TransmitHold::TXCHR.val(val as u32));
+        let usart = &USARTRegManager::new(&self);
+        usart
+            .registers
+            .cr
+            .write(Control::RXEN::SET + Control::TXEN::SET);
+        usart
+            .registers
+            .thr
+            .write(TransmitHold::TXCHR.val(val as u32));
     }
 
     fn read_byte(&self) -> u8 {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        self.enable_clock();
-        regs.rhr.read(ReceiverHold::RXCHR) as u8
+        let usart = &USARTRegManager::new(&self);
+        usart.registers.rhr.read(ReceiverHold::RXCHR) as u8
     }
 
     fn read_write_byte(&self, val: u8) -> u8 {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        self.enable_clock();
-        regs.cr.write(Control::RXEN::SET + Control::TXEN::SET);
+        let usart = &USARTRegManager::new(&self);
+        usart
+            .registers
+            .cr
+            .write(Control::RXEN::SET + Control::TXEN::SET);
 
-        regs.thr.write(TransmitHold::TXCHR.val(val as u32));
-        while !regs.csr.is_set(ChannelStatus::RXRDY) {}
-        regs.rhr.read(ReceiverHold::RXCHR) as u8
+        usart
+            .registers
+            .thr
+            .write(TransmitHold::TXCHR.val(val as u32));
+        while !usart.registers.csr.is_set(ChannelStatus::RXRDY) {}
+        usart.registers.rhr.read(ReceiverHold::RXCHR) as u8
     }
 
     /// Pass in a None to use the HW chip select pin on the USART (RTS).
@@ -1043,8 +1061,8 @@ impl hil::spi::SpiMaster for USART {
 
     /// Returns the actual rate set
     fn set_rate(&self, rate: u32) -> u32 {
-        self.enable_clock();
-        self.set_baud_rate(rate);
+        let usart = &USARTRegManager::new(&self);
+        self.set_baud_rate(usart, rate);
 
         // Calculate what rate will actually be
         let system_frequency = pm::get_system_frequency();
@@ -1053,33 +1071,30 @@ impl hil::spi::SpiMaster for USART {
     }
 
     fn get_rate(&self) -> u32 {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        self.enable_clock();
+        let usart = &USARTRegManager::new(&self);
         let system_frequency = pm::get_system_frequency();
-        let cd = regs.brgr.read(BaudRate::CD);
+        let cd = usart.registers.brgr.read(BaudRate::CD);
         system_frequency / cd
     }
 
     fn set_clock(&self, polarity: hil::spi::ClockPolarity) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        self.enable_clock();
+        let usart = &USARTRegManager::new(&self);
         // Note that in SPI mode MSBF bit is clock polarity (CPOL)
         match polarity {
             hil::spi::ClockPolarity::IdleLow => {
-                regs.mr.modify(Mode::MSBF::CLEAR);
+                usart.registers.mr.modify(Mode::MSBF::CLEAR);
             }
             hil::spi::ClockPolarity::IdleHigh => {
-                regs.mr.modify(Mode::MSBF::SET);
+                usart.registers.mr.modify(Mode::MSBF::SET);
             }
         }
     }
 
     fn get_clock(&self) -> hil::spi::ClockPolarity {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        self.enable_clock();
+        let usart = &USARTRegManager::new(&self);
 
         // Note that in SPI mode MSBF bit is clock polarity (CPOL)
-        let idle = regs.mr.read(Mode::MSBF);
+        let idle = usart.registers.mr.read(Mode::MSBF);
         match idle {
             0 => hil::spi::ClockPolarity::IdleLow,
             _ => hil::spi::ClockPolarity::IdleHigh,
@@ -1087,24 +1102,22 @@ impl hil::spi::SpiMaster for USART {
     }
 
     fn set_phase(&self, phase: hil::spi::ClockPhase) {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        self.enable_clock();
+        let usart = &USARTRegManager::new(&self);
 
         // Note that in SPI mode SYNC bit is clock phase
         match phase {
             hil::spi::ClockPhase::SampleLeading => {
-                regs.mr.modify(Mode::SYNC::SET);
+                usart.registers.mr.modify(Mode::SYNC::SET);
             }
             hil::spi::ClockPhase::SampleTrailing => {
-                regs.mr.modify(Mode::SYNC::CLEAR);
+                usart.registers.mr.modify(Mode::SYNC::CLEAR);
             }
         }
     }
 
     fn get_phase(&self) -> hil::spi::ClockPhase {
-        let regs: &UsartRegisters = unsafe { &*self.registers };
-        self.enable_clock();
-        let phase = regs.mr.read(Mode::SYNC);
+        let usart = &USARTRegManager::new(&self);
+        let phase = usart.registers.mr.read(Mode::SYNC);
 
         // Note that in SPI mode SYNC bit is clock phase
         match phase {

--- a/kernel/src/common/mmio.rs
+++ b/kernel/src/common/mmio.rs
@@ -1,0 +1,165 @@
+//! Memory Mapped I/O Interfaces
+//!
+//! Most peripherals are implemented as memory mapped I/O. Intrinsically, this
+//! means that accessing a peripheral requires dereferencing a raw pointer that
+//! points to the peripheral's memory.
+//!
+//! Generally, Tock peripherals are modeled by two structures, such as:
+//!
+//! ```rust
+//! /// The MMIO Structure.
+//! #[repr(C)]
+//! #[allow(dead_code)]
+//! pub struct PeripheralRegisters {
+//!     control: VolatileCell<u32>,
+//!     interrupt_mask: VolatileCell<u32>,
+//! }
+//!
+//! /// The Tock object that holds all information for this peripheral.
+//! pub struct PeripheralHardware {
+//!     mmio_address: *mut PeripheralRegisters,
+//!     clock: &ChipSpecificPeripheralClock,
+//! }
+//! ```
+//!
+//! The first structure mirrors the MMIO specification. The second structure
+//! holds a pointer to the actual address in memory. It also holds other
+//! information for the peripheral. Kernel traits will be implemented for this
+//! peripheral hardware structure. As the peripheral cannot derefence the raw
+//! MMIO pointer safely, Tock provides the MMIOManager interface:
+//!
+//! ```rust
+//! impl hil::uart::UART for PeripheralHardware {
+//!    fn init(&self, params: hil::uart::UARTParams) {
+//!        let regs_manager = &MMIOManager::new(self);
+//!        regs_manager.registers.control.set(0x0);
+//!        //           ^^^^^^^^^-- This is type &PeripheralRegisters
+//! ```
+//!
+//! Each peripheral must tell the kernel where its registers live in memory:
+//!
+//! ```rust
+//! /// Teaching the kernel how to create PeripheralRegisters.
+//! impl MMIOInterface<pm::Clock> for PeripheralHardware {
+//!     type MMIORegisterType = PeripheralRegisters;
+//!
+//!     fn get_hardware_address(&self) -> *mut PeripheralRegisters {
+//!         self.mmio_address
+//!     }
+//! }
+//! ```
+//!
+//! Note, this example kept the `mmio_address` in the `PeripheralHardware`
+//! structure, which is useful when there are multiple copies of the same
+//! peripheral (e.g. multiple UARTs). For single-instance peripherals, it's
+//! fine to simply return the address directly from `get_hardware_address`.
+//!
+//! Peripheral Clocks
+//! -----------------
+//!
+//! To facilitate low-power operation, MMIOManager captures the peripheral's
+//! clock upon instantiation. The intention is to exploit
+//! [Ownership Based Resource Management](https://doc.rust-lang.org/beta/nomicon/obrm.html)
+//! to capture peripheral power state.
+//!
+//! To enable this, peripherals must inform the kernel which clock they use,
+//! and when the clock should be enabled and disabled. Implementations of the
+//! `before/after_mmio_access` methods must take care to not access hardware
+//! without enabling clocks if needed if they use hardware for bookkeeping.
+//!
+//! ```rust
+//! /// Teaching the kernel which clock controls SpiHw.
+//! impl MMIOClockInterface<pm::Clock> for SpiHw {
+//!     fn get_clock(&self) -> &pm::Clock {
+//!         &pm::Clock::PBA(pm::PBAClock::SPI)
+//!     }
+//! }
+//!
+//! /// Logic for when the SpiHw clock should be enabled and disabled.
+//! impl MMIOClockGuard<SpiHw, pm::Clock> for SpiHw {
+//!     fn before_mmio_access(&self, clock: &pm::Clock, _registers: &SpiRegisters) {
+//!         clock.enable();
+//!     }
+//!
+//!     fn after_mmio_access(&self, clock: &pm::Clock, _registers: &SpiRegisters) {
+//!         if !self.is_busy() {
+//!             clock.disable();
+//!         }
+//!     }
+//! }
+//! ```
+
+use ClockInterface;
+
+/// A structure encapsulating a peripheral should implement this trait.
+pub trait MMIOInterface<C>
+where
+    C: ClockInterface,
+{
+    type MMIORegisterType;
+
+    fn get_hardware_address(&self) -> *mut Self::MMIORegisterType;
+}
+
+/// A structure encapsulating a clocked peripheral should implement this trait.
+pub trait MMIOClockInterface<C>
+where
+    C: ClockInterface,
+{
+    fn get_clock(&self) -> &C;
+}
+
+/// Hooks for peripherals to enable and disable clocks as appropriate.
+pub trait MMIOClockGuard<H, C>
+where
+    H: MMIOInterface<C>,
+    C: ClockInterface,
+{
+    fn before_mmio_access(&self, &C, &H::MMIORegisterType);
+    fn after_mmio_access(&self, &C, &H::MMIORegisterType);
+}
+
+/// Structures encapsulating periphal hardware (those implementing the
+/// MMIOInterface trait) should instantiate an instance of this method to
+/// accesss memory mapped registers.
+///
+/// ```rust
+/// let mmio = &MMIOManager::new(self);
+/// mmio.registers.control.set(0x1);
+/// ```
+pub struct MMIOManager<'a, H, C>
+where
+    H: 'a + MMIOInterface<C> + MMIOClockGuard<H, C>,
+    C: 'a + ClockInterface,
+{
+    pub registers: &'a H::MMIORegisterType,
+    peripheral_hardware: &'a H,
+    clock: &'a C,
+}
+
+impl<'a, H, C> MMIOManager<'a, H, C>
+where
+    H: 'a + MMIOInterface<C> + MMIOClockInterface<C> + MMIOClockGuard<H, C>,
+    C: 'a + ClockInterface,
+{
+    pub fn new(peripheral_hardware: &'a H) -> MMIOManager<'a, H, C> {
+        let registers = unsafe { &*peripheral_hardware.get_hardware_address() };
+        let clock = peripheral_hardware.get_clock();
+        peripheral_hardware.before_mmio_access(clock, registers);
+        MMIOManager {
+            registers,
+            peripheral_hardware,
+            clock,
+        }
+    }
+}
+impl<'a, H, C> Drop for MMIOManager<'a, H, C>
+where
+    H: 'a + MMIOInterface<C> + MMIOClockGuard<H, C>,
+    C: 'a + ClockInterface,
+{
+    fn drop(&mut self) {
+        self.peripheral_hardware
+            .after_mmio_access(self.clock, self.registers);
+    }
+}

--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -8,13 +8,12 @@ pub mod volatile_cell;
 pub mod static_ref;
 pub mod list;
 pub mod math;
-pub mod mmio;
+pub mod peripherals;
 
 #[macro_use]
 pub mod regs;
 
 pub use self::list::{List, ListLink, ListNode};
-pub use self::mmio::{MMIOClockGuard, MMIOClockInterface, MMIOInterface, MMIOManager};
 pub use self::queue::Queue;
 pub use self::ring_buffer::RingBuffer;
 pub use self::static_ref::StaticRef;

--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -17,4 +17,5 @@ pub use self::list::{List, ListLink, ListNode};
 pub use self::mmio::{MMIOClockGuard, MMIOClockInterface, MMIOInterface, MMIOManager};
 pub use self::queue::Queue;
 pub use self::ring_buffer::RingBuffer;
+pub use self::static_ref::StaticRef;
 pub use self::volatile_cell::VolatileCell;

--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -8,11 +8,13 @@ pub mod volatile_cell;
 pub mod static_ref;
 pub mod list;
 pub mod math;
+pub mod mmio;
 
 #[macro_use]
 pub mod regs;
 
 pub use self::list::{List, ListLink, ListNode};
+pub use self::mmio::{MMIOClockGuard, MMIOClockInterface, MMIOInterface, MMIOManager};
 pub use self::queue::Queue;
 pub use self::ring_buffer::RingBuffer;
 pub use self::volatile_cell::VolatileCell;

--- a/kernel/src/common/peripherals.rs
+++ b/kernel/src/common/peripherals.rs
@@ -1,4 +1,4 @@
-//! Automatic Peripheral Management
+//! Peripheral Management
 //!
 //! Most peripherals are implemented as memory mapped I/O (MMIO).
 //! Intrinsically, this means that accessing a peripheral requires
@@ -40,7 +40,7 @@
 //!
 //! ```rust
 //! /// Teaching the kernel how to create PeripheralRegisters.
-//! impl AutomaticPeripheralManagement<pm::Clock> for PeripheralHardware {
+//! impl PeripheralManagement<pm::Clock> for PeripheralHardware {
 //!     type RegisterType = PeripheralRegisters;
 //!
 //!     fn get_registers(&self) -> &PeripheralRegisters {
@@ -69,7 +69,7 @@
 //!
 //! ```rust
 //! /// Teaching the kernel which clock controls SpiHw.
-//! impl AutomaticPeripheralManagement<pm::Clock> for SpiHw {
+//! impl PeripheralManagement<pm::Clock> for SpiHw {
 //!     fn get_clock(&self) -> &pm::Clock {
 //!         &pm::Clock::PBA(pm::PBAClock::SPI)
 //!     }
@@ -89,7 +89,7 @@
 use ClockInterface;
 
 /// A structure encapsulating a peripheral should implement this trait.
-pub trait AutomaticPeripheralManagement<C>
+pub trait PeripheralManagement<C>
 where
     C: ClockInterface,
 {
@@ -117,7 +117,7 @@ where
 }
 
 /// Structures encapsulating periphal hardware (those implementing the
-/// AutomaticPeripheralManagement trait) should instantiate an instance of this
+/// PeripheralManagement trait) should instantiate an instance of this
 /// method to accesss memory mapped registers.
 ///
 /// ```rust
@@ -126,7 +126,7 @@ where
 /// ```
 pub struct PeripheralManager<'a, H, C>
 where
-    H: 'a + AutomaticPeripheralManagement<C>,
+    H: 'a + PeripheralManagement<C>,
     C: 'a + ClockInterface,
 {
     pub registers: &'a H::RegisterType,
@@ -136,7 +136,7 @@ where
 
 impl<'a, H, C> PeripheralManager<'a, H, C>
 where
-    H: 'a + AutomaticPeripheralManagement<C>,
+    H: 'a + PeripheralManagement<C>,
     C: 'a + ClockInterface,
 {
     pub fn new(peripheral_hardware: &'a H) -> PeripheralManager<'a, H, C> {
@@ -153,7 +153,7 @@ where
 
 impl<'a, H, C> Drop for PeripheralManager<'a, H, C>
 where
-    H: 'a + AutomaticPeripheralManagement<C>,
+    H: 'a + PeripheralManagement<C>,
     C: 'a + ClockInterface,
 {
     fn drop(&mut self) {

--- a/kernel/src/common/peripherals.rs
+++ b/kernel/src/common/peripherals.rs
@@ -1,8 +1,8 @@
-//! Memory Mapped I/O Interfaces
+//! Automatic Peripheral Management
 //!
-//! Most peripherals are implemented as memory mapped I/O. Intrinsically, this
-//! means that accessing a peripheral requires dereferencing a raw pointer that
-//! points to the peripheral's memory.
+//! Most peripherals are implemented as memory mapped I/O (MMIO).
+//! Intrinsically, this means that accessing a peripheral requires
+//! dereferencing a raw pointer that points to the peripheral's memory.
 //!
 //! Generally, Tock peripherals are modeled by two structures, such as:
 //!
@@ -26,22 +26,22 @@
 //! holds a pointer to the actual address in memory. It also holds other
 //! information for the peripheral. Kernel traits will be implemented for this
 //! peripheral hardware structure. As the peripheral cannot derefence the raw
-//! MMIO pointer safely, Tock provides the MMIOManager interface:
+//! MMIO pointer safely, Tock provides the PeripheralManager interface:
 //!
 //! ```rust
 //! impl hil::uart::UART for PeripheralHardware {
 //!    fn init(&self, params: hil::uart::UARTParams) {
-//!        let regs_manager = &MMIOManager::new(self);
-//!        regs_manager.registers.control.set(0x0);
-//!        //           ^^^^^^^^^-- This is type &PeripheralRegisters
+//!        let peripheral = &PeripheralManager::new(self);
+//!        peripheral.registers.control.set(0x0);
+//!        //         ^^^^^^^^^-- This is type &PeripheralRegisters
 //! ```
 //!
 //! Each peripheral must tell the kernel where its registers live in memory:
 //!
 //! ```rust
 //! /// Teaching the kernel how to create PeripheralRegisters.
-//! impl MMIOInterface<pm::Clock> for PeripheralHardware {
-//!     type MMIORegisterType = PeripheralRegisters;
+//! impl AutomaticPeripheralManagement<pm::Clock> for PeripheralHardware {
+//!     type RegisterType = PeripheralRegisters;
 //!
 //!     fn get_registers(&self) -> &PeripheralRegisters {
 //!         &*self.mmio_address
@@ -57,7 +57,7 @@
 //! Peripheral Clocks
 //! -----------------
 //!
-//! To facilitate low-power operation, MMIOManager captures the peripheral's
+//! To facilitate low-power operation, PeripheralManager captures the peripheral's
 //! clock upon instantiation. The intention is to exploit
 //! [Ownership Based Resource Management](https://doc.rust-lang.org/beta/nomicon/obrm.html)
 //! to capture peripheral power state.
@@ -69,14 +69,11 @@
 //!
 //! ```rust
 //! /// Teaching the kernel which clock controls SpiHw.
-//! impl MMIOClockInterface<pm::Clock> for SpiHw {
+//! impl AutomaticPeripheralManagement<pm::Clock> for SpiHw {
 //!     fn get_clock(&self) -> &pm::Clock {
 //!         &pm::Clock::PBA(pm::PBAClock::SPI)
 //!     }
-//! }
 //!
-//! /// Logic for when the SpiHw clock should be enabled and disabled.
-//! impl MMIOClockGuard<SpiHw, pm::Clock> for SpiHw {
 //!     fn before_mmio_access(&self, clock: &pm::Clock, _registers: &SpiRegisters) {
 //!         clock.enable();
 //!     }
@@ -92,61 +89,61 @@
 use ClockInterface;
 
 /// A structure encapsulating a peripheral should implement this trait.
-pub trait MMIOInterface<C>
+pub trait AutomaticPeripheralManagement<C>
 where
     C: ClockInterface,
 {
-    type MMIORegisterType;
+    type RegisterType;
 
-    fn get_registers(&self) -> &Self::MMIORegisterType;
-}
+    /// How to get a reference to the physical hardware registers (the MMIO struct).
+    fn get_registers(&self) -> &Self::RegisterType;
 
-/// A structure encapsulating a clocked peripheral should implement this trait.
-pub trait MMIOClockInterface<C>
-where
-    C: ClockInterface,
-{
+    /// Which clock feeds this peripheral.
+    ///
+    /// For peripherals with no clock, use `&::kernel::platform::NO_CLOCK_CONTROL`.
     fn get_clock(&self) -> &C;
-}
 
-/// Hooks for peripherals to enable and disable clocks as appropriate.
-pub trait MMIOClockGuard<H, C>
-where
-    H: MMIOInterface<C>,
-    C: ClockInterface,
-{
-    fn before_mmio_access(&self, &C, &H::MMIORegisterType);
-    fn after_mmio_access(&self, &C, &H::MMIORegisterType);
+    /// Called before peripheral access.
+    ///
+    /// Responsible for ensure the periphal can be safely accessed, e.g. that
+    /// its clock is powered on.
+    fn before_peripheral_access(&self, &C, &Self::RegisterType);
+
+    /// Called after periphal access.
+    ///
+    /// Currently used primarily for power management to check whether the
+    /// peripheral can be powered off.
+    fn after_peripheral_access(&self, &C, &Self::RegisterType);
 }
 
 /// Structures encapsulating periphal hardware (those implementing the
-/// MMIOInterface trait) should instantiate an instance of this method to
-/// accesss memory mapped registers.
+/// AutomaticPeripheralManagement trait) should instantiate an instance of this
+/// method to accesss memory mapped registers.
 ///
 /// ```rust
-/// let mmio = &MMIOManager::new(self);
-/// mmio.registers.control.set(0x1);
+/// let peripheral = &PeripheralManager::new(self);
+/// peripheral.registers.control.set(0x1);
 /// ```
-pub struct MMIOManager<'a, H, C>
+pub struct PeripheralManager<'a, H, C>
 where
-    H: 'a + MMIOInterface<C> + MMIOClockGuard<H, C>,
+    H: 'a + AutomaticPeripheralManagement<C>,
     C: 'a + ClockInterface,
 {
-    pub registers: &'a H::MMIORegisterType,
+    pub registers: &'a H::RegisterType,
     peripheral_hardware: &'a H,
     clock: &'a C,
 }
 
-impl<'a, H, C> MMIOManager<'a, H, C>
+impl<'a, H, C> PeripheralManager<'a, H, C>
 where
-    H: 'a + MMIOInterface<C> + MMIOClockInterface<C> + MMIOClockGuard<H, C>,
+    H: 'a + AutomaticPeripheralManagement<C>,
     C: 'a + ClockInterface,
 {
-    pub fn new(peripheral_hardware: &'a H) -> MMIOManager<'a, H, C> {
+    pub fn new(peripheral_hardware: &'a H) -> PeripheralManager<'a, H, C> {
         let registers = peripheral_hardware.get_registers();
         let clock = peripheral_hardware.get_clock();
-        peripheral_hardware.before_mmio_access(clock, registers);
-        MMIOManager {
+        peripheral_hardware.before_peripheral_access(clock, registers);
+        PeripheralManager {
             registers,
             peripheral_hardware,
             clock,
@@ -154,13 +151,13 @@ where
     }
 }
 
-impl<'a, H, C> Drop for MMIOManager<'a, H, C>
+impl<'a, H, C> Drop for PeripheralManager<'a, H, C>
 where
-    H: 'a + MMIOInterface<C> + MMIOClockGuard<H, C>,
+    H: 'a + AutomaticPeripheralManagement<C>,
     C: 'a + ClockInterface,
 {
     fn drop(&mut self) {
         self.peripheral_hardware
-            .after_mmio_access(self.clock, self.registers);
+            .after_peripheral_access(self.clock, self.registers);
     }
 }

--- a/kernel/src/common/static_ref.rs
+++ b/kernel/src/common/static_ref.rs
@@ -8,8 +8,7 @@ use core::ops::Deref;
 /// given a raw address and acts similarly to `extern` definitions, except
 /// `StaticRef` is subject to module and crate bounderies, while `extern`
 /// definitions can be imported anywhere.
-///
-/// TODO(alevy): move into `common` crate or replace with other mechanism.
+#[derive(Debug)]
 pub struct StaticRef<T> {
     ptr: *const T,
 }
@@ -25,6 +24,14 @@ impl<T> StaticRef<T> {
         StaticRef { ptr: ptr }
     }
 }
+
+impl<T> Clone for StaticRef<T> {
+    fn clone(&self) -> Self {
+        StaticRef { ptr: self.ptr }
+    }
+}
+
+impl<T> Copy for StaticRef<T> {}
 
 impl<T> Deref for StaticRef<T> {
     type Target = T;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -38,10 +38,12 @@ mod syscall;
 mod platform;
 
 pub use callback::{AppId, Callback};
+pub use common::{MMIOClockGuard, MMIOClockInterface, MMIOInterface, MMIOManager};
 pub use driver::Driver;
 pub use grant::Grant;
 pub use mem::{AppPtr, AppSlice, Private, Shared};
 pub use platform::{mpu, systick, Chip, Platform};
+pub use platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
 pub use platform::systick::SysTick;
 pub use process::{Process, State};
 pub use returncode::ReturnCode;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -38,7 +38,7 @@ mod syscall;
 mod platform;
 
 pub use callback::{AppId, Callback};
-pub use common::{MMIOClockGuard, MMIOClockInterface, MMIOInterface, MMIOManager, StaticRef};
+pub use common::StaticRef;
 pub use driver::Driver;
 pub use grant::Grant;
 pub use mem::{AppPtr, AppSlice, Private, Shared};

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -38,7 +38,7 @@ mod syscall;
 mod platform;
 
 pub use callback::{AppId, Callback};
-pub use common::{MMIOClockGuard, MMIOClockInterface, MMIOInterface, MMIOManager};
+pub use common::{MMIOClockGuard, MMIOClockInterface, MMIOInterface, MMIOManager, StaticRef};
 pub use driver::Driver;
 pub use grant::Grant;
 pub use mem::{AppPtr, AppSlice, Private, Shared};

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -26,8 +26,6 @@ pub trait Chip {
 
 /// Generic operations that clock-like things are expected to support.
 pub trait ClockInterface {
-    type PlatformClockType;
-
     fn is_enabled(&self) -> bool;
     fn enable(&self);
     fn disable(&self);
@@ -36,7 +34,6 @@ pub trait ClockInterface {
 /// Helper struct for interfaces that expect clocks, but have no clock control
 pub struct NoClockControl {}
 impl ClockInterface for NoClockControl {
-    type PlatformClockType = NoClockControl;
     fn is_enabled(&self) -> bool {
         true
     }

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -23,3 +23,26 @@ pub trait Chip {
     fn systick(&self) -> &Self::SysTick;
     fn prepare_for_sleep(&self) {}
 }
+
+/// Generic operations that clock-like things are expected to support.
+pub trait ClockInterface {
+    type PlatformClockType;
+
+    fn is_enabled(&self) -> bool;
+    fn enable(&self);
+    fn disable(&self);
+}
+
+/// Helper struct for interfaces that expect clocks, but have no clock control
+pub struct NoClockControl {}
+impl ClockInterface for NoClockControl {
+    type PlatformClockType = NoClockControl;
+    fn is_enabled(&self) -> bool {
+        true
+    }
+    fn enable(&self) {}
+    fn disable(&self) {}
+}
+
+/// Instance of NoClockControl for things that need references to `ClockInterface` objects
+pub static mut NO_CLOCK_CONTROL: NoClockControl = NoClockControl {};


### PR DESCRIPTION
### Pull Request Overview

This introduces a new mechanism for handling MMIO.

Nominally, every peripheral has an array of MMIO registers that live at some address in memory. The creation of a Rust object to access these registers is an unsafe operation, as it binds an arbitrary pointer to the a registers structure. Critically, this transformation was the _only_ use of unsafe in the chips crate, so by moving the creation step to the kernel, we should be able to phase out the use of unsafe in all of chips.

The next idea is the `MMIOClockInterface`. The idea here is that most peripherals have a clock that:

  - Must be enabled before accessing the peripheral
  - Must be left enabled while the peripheral is doing something (or waiting for something!)
  - Should be disabled whenever the peripheral is not in use

Since we've encapsulated access to the MMIO registers for the peripheral, we can enforce these by tying the ownership semantics of the MMIO registers to the clocks. Specifically, so long as the kernel knows how to enable and disable clocks (aka the MMIOClockInterface), before handing back a reference to the peripheral, the kernel will ensure the clock is on. Whenever peripheral access is complete, the drop method will then turn the clock off if it can be turned off. Note that the check to possibly disable the clock is unique to each peripheral.

### Testing Strategy

Only tested on hails. Predominantly by testing various USART-only and/or I2C test apps. I've verified with measurements that I2C goes into a low-power state between operations, while ping-ponging between I2C master and slave. (aside: This interface was critical to tracking down bugs to make this work, there was an ugly path in the interrupt handlers that tried to enable both TWIM and TWIS clock that Rust caught at _compile-time_, very cool)

### TODO or Help Wanted

The USART has a custom manager to deal with supporting `panic!`. I have some WIP stuff to clean up panics that should hopefully make this cleaner as well.

There are some other issues that impeded low-power I2C operation that I've pulled out to a separate PR (coming momentarily) as they're really orthogonal.

### Documentation Updated

- [x] Kernel: The relevant files in `/docs` have been updated or no updates are required.
- [x] ~~Userland: The application README has been added, updated, or no updates are required.~~

### Formatting

- [x] `make formatall` has been run.

-----

[Rendered](https://deploy-preview-760--docs-tockosorg.netlify.com/kernel/common/peripherals/index.html)
