### PR TITLE
debug: flush the buffer if needed before panic'ing

### DIFF
--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -1,6 +1,7 @@
 use core::fmt::*;
+use core::str;
+use kernel::{debug, process};
 use kernel::hil::uart::{self, UART};
-use kernel::process;
 use sam4l;
 
 pub struct Writer {
@@ -60,6 +61,9 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
         "\tKernel version {}\r\n",
         env!("TOCK_KERNEL_VERSION")
     ));
+
+    // Flush debug buffer if needed
+    debug::flush(writer);
 
     // Print fault status once
     let procs = &mut process::PROCS;

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -1,6 +1,6 @@
 use core::fmt::*;
+use kernel::{debug, process};
 use kernel::hil::uart::{self, UART};
-use kernel::process;
 use sam4l;
 
 pub struct Writer {
@@ -60,6 +60,9 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
         "\tKernel version {}\r\n",
         env!("TOCK_KERNEL_VERSION")
     ));
+
+    // Flush debug buffer if needed
+    debug::flush(writer);
 
     // Print fault status once
     let procs = &mut process::PROCS;

--- a/boards/nrf51dk/src/io.rs
+++ b/boards/nrf51dk/src/io.rs
@@ -1,4 +1,5 @@
 use core::fmt::{write, Arguments, Write};
+use kernel::debug;
 use kernel::hil::uart::{self, UART};
 use nrf51;
 use nrf5x;
@@ -75,6 +76,9 @@ pub unsafe extern "C" fn rust_begin_unwind(
         "\tKernel version {}\r\n",
         env!("TOCK_KERNEL_VERSION")
     ));
+
+    // Flush debug buffer if needed
+    debug::flush(writer);
 
     // Print fault status once
     let procs = &mut process::PROCS;

--- a/boards/nrf52dk/src/io.rs
+++ b/boards/nrf52dk/src/io.rs
@@ -1,4 +1,5 @@
 use core::fmt::{write, Arguments, Write};
+use kernel::debug;
 use kernel::hil::uart::{self, UART};
 use nrf52;
 use nrf5x;
@@ -72,6 +73,9 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
         "\tKernel version {}\r\n",
         env!("TOCK_KERNEL_VERSION")
     ));
+
+    // Flush debug buffer if needed
+    debug::flush(writer);
 
     // Print fault status once
     let procs = &mut process::PROCS;


### PR DESCRIPTION
### Pull Request Overview

If there are entries in the debug buffer that haven't started printing
when a panic occurs, they'll be dropped. This remedies that.

In the short term, just implemented for hail. With a forthcoming panic
consolidation, it'll propagate to all boards.

### Formatting

- [x] `make formatall` has been run.
