### PR TITLE
debug: move panic logic into kernel

### DIFF
--- a/boards/nrf51dk/src/io.rs
+++ b/boards/nrf51dk/src/io.rs
@@ -1,5 +1,6 @@
-use core::fmt::{write, Arguments, Write};
+use core::fmt::{Arguments, Write};
 use kernel::debug;
+use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 use nrf51;
 use nrf5x;
@@ -32,91 +33,13 @@ impl Write for Writer {
     }
 }
 
-#[macro_export]
-macro_rules! print {
-        ($($arg:tt)*) => (
-            {
-                use core::fmt::write;
-                let writer = &mut $crate::io::WRITER;
-                let _ = write(writer, format_args!($($arg)*));
-            }
-        );
-}
-
-#[macro_export]
-macro_rules! println {
-        ($fmt:expr) => (print!(concat!($fmt, "\n")));
-            ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
-}
-
 #[cfg(not(test))]
-#[lang = "panic_fmt"]
 #[no_mangle]
-pub unsafe extern "C" fn rust_begin_unwind(
-    _args: Arguments,
-    _file: &'static str,
-    _line: usize,
-) -> ! {
-    use kernel::hil::gpio::Pin;
-    use kernel::process;
+#[lang = "panic_fmt"]
+pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
     // The nRF51 DK LEDs (see back of board)
     const LED1_PIN: usize = 21;
-    const LED2_PIN: usize = 22;
-
+    let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    let _ = writer.write_fmt(format_args!(
-        "\r\nKernel panic at {}:{}:\r\n\t\"",
-        _file, _line
-    ));
-    let _ = write(writer, _args);
-    let _ = writer.write_str("\"\r\n");
-
-    // Print version of the kernel
-    let _ = writer.write_fmt(format_args!(
-        "\tKernel version {}\r\n",
-        env!("TOCK_KERNEL_VERSION")
-    ));
-
-    // Flush debug buffer if needed
-    debug::flush(writer);
-
-    // Print fault status once
-    let procs = &mut process::PROCS;
-    if procs.len() > 0 {
-        procs[0].as_mut().map(|process| {
-            process.fault_str(writer);
-        });
-    }
-
-    // print data about each process
-    let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
-    let procs = &mut process::PROCS;
-    for idx in 0..procs.len() {
-        procs[idx].as_mut().map(|process| {
-            process.statistics_str(writer);
-        });
-    }
-    let led0 = &nrf5x::gpio::PORT[LED1_PIN];
-    let led1 = &nrf5x::gpio::PORT[LED2_PIN];
-
-    led0.make_output();
-    led1.make_output();
-    loop {
-        for _ in 0..1000000 {
-            led0.clear();
-            led1.clear();
-        }
-        for _ in 0..100000 {
-            led0.set();
-            led1.set();
-        }
-        for _ in 0..1000000 {
-            led0.clear();
-            led1.clear();
-        }
-        for _ in 0..500000 {
-            led0.set();
-            led1.set();
-        }
-    }
+    debug::panic(led, writer, args, file, line)
 }

--- a/boards/nrf52dk/src/io.rs
+++ b/boards/nrf52dk/src/io.rs
@@ -1,5 +1,6 @@
-use core::fmt::{write, Arguments, Write};
+use core::fmt::{Arguments, Write};
 use kernel::debug;
+use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 use nrf52;
 use nrf5x;
@@ -33,87 +34,13 @@ impl Write for Writer {
     }
 }
 
-#[macro_export]
-macro_rules! print {
-        ($($arg:tt)*) => (
-            {
-                use core::fmt::write;
-                let writer = &mut $crate::io::WRITER;
-                let _ = write(writer, format_args!($($arg)*));
-            }
-        );
-}
-
-#[macro_export]
-macro_rules! println {
-        ($fmt:expr) => (print!(concat!($fmt, "\n")));
-            ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
-}
-
 #[cfg(not(test))]
 #[no_mangle]
 #[lang = "panic_fmt"]
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
-    use kernel::hil::gpio::Pin;
-    use kernel::process;
     // The nRF52 DK LEDs (see back of board)
     const LED1_PIN: usize = 17;
-    const LED2_PIN: usize = 18;
-
+    let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    let _ = writer.write_fmt(format_args!(
-        "\r\nKernel panic at {}:{}:\r\n\t\"",
-        file, line
-    ));
-    let _ = write(writer, args);
-    let _ = writer.write_str("\"\r\n");
-
-    // Print version of the kernel
-    let _ = writer.write_fmt(format_args!(
-        "\tKernel version {}\r\n",
-        env!("TOCK_KERNEL_VERSION")
-    ));
-
-    // Flush debug buffer if needed
-    debug::flush(writer);
-
-    // Print fault status once
-    let procs = &mut process::PROCS;
-    if procs.len() > 0 {
-        procs[0].as_mut().map(|process| {
-            process.fault_str(writer);
-        });
-    }
-
-    // print data about each process
-    let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
-    let procs = &mut process::PROCS;
-    for idx in 0..procs.len() {
-        procs[idx].as_mut().map(|process| {
-            process.statistics_str(writer);
-        });
-    }
-    let led0 = &nrf5x::gpio::PORT[LED1_PIN];
-    let led1 = &nrf5x::gpio::PORT[LED2_PIN];
-
-    led0.make_output();
-    led1.make_output();
-    loop {
-        for _ in 0..1000000 {
-            led0.clear();
-            led1.clear();
-        }
-        for _ in 0..100000 {
-            led0.set();
-            led1.set();
-        }
-        for _ in 0..1000000 {
-            led0.clear();
-            led1.clear();
-        }
-        for _ in 0..500000 {
-            led0.set();
-            led1.set();
-        }
-    }
+    debug::panic(led, writer, args, file, line)
 }

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -41,7 +41,115 @@ use core::ptr::{read_volatile, write_volatile};
 use driver::Driver;
 use hil;
 use mem::AppSlice;
+use process;
 use returncode::ReturnCode;
+
+///////////////////////////////////////////////////////////////////
+// panic! support routines
+
+/// Tock default panic routine.
+///
+/// **NOTE:** The supplied `writer` must be synchronous.
+pub unsafe fn panic<L: hil::led::Led, W: Write>(
+    led: &mut L,
+    writer: &mut W,
+    args: Arguments,
+    file: &'static str,
+    line: u32,
+) -> ! {
+    panic_begin();
+    panic_banner(writer, args, file, line);
+    // Flush debug buffer if needed
+    flush(writer);
+    panic_process_info(writer);
+    panic_blink_forever(led)
+}
+
+/// Generic panic entry.
+///
+/// This opaque method should always be called at the beginning of a board's
+/// panic method to allow hooks for any core kernel cleanups that may be
+/// appropriate.
+pub unsafe fn panic_begin() {
+    // Let any outstanding uart DMA's finish
+    asm!("nop");
+    asm!("nop");
+    for _ in 0..200000 {
+        asm!("nop");
+    }
+    asm!("nop");
+    asm!("nop");
+}
+
+/// Lightweight prints about the current panic and kernel version.
+///
+/// **NOTE:** The supplied `writer` must be synchronous.
+pub unsafe fn panic_banner<W: Write>(
+    writer: &mut W,
+    args: Arguments,
+    file: &'static str,
+    line: u32,
+) {
+    let _ = writer.write_fmt(format_args!(
+        "\r\n\nKernel panic at {}:{}:\r\n\t\"",
+        file, line
+    ));
+    let _ = write(writer, args);
+    let _ = writer.write_str("\"\r\n");
+
+    // Print version of the kernel
+    let _ = writer.write_fmt(format_args!(
+        "\tKernel version {}\r\n",
+        env!("TOCK_KERNEL_VERSION")
+    ));
+}
+
+/// More detailed prints about all processes.
+///
+/// **NOTE:** The supplied `writer` must be synchronous.
+pub unsafe fn panic_process_info<W: Write>(writer: &mut W) {
+    // Print fault status once
+    let procs = &mut process::PROCS;
+    if procs.len() > 0 {
+        procs[0].as_mut().map(|process| {
+            process.fault_str(writer);
+        });
+    }
+
+    // print data about each process
+    let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
+    let procs = &mut process::PROCS;
+    for idx in 0..procs.len() {
+        procs[idx].as_mut().map(|process| {
+            process.statistics_str(writer);
+        });
+    }
+}
+
+/// Blinks a recognizable pattern forever.
+///
+/// If a multi-color LED is used for the panic pattern, it is
+/// advised to turn off other LEDs before calling this method.
+pub fn panic_blink_forever<L: hil::led::Led>(led: &mut L) -> ! {
+    led.init();
+    loop {
+        for _ in 0..1000000 {
+            led.on();
+        }
+        for _ in 0..100000 {
+            led.off();
+        }
+        for _ in 0..1000000 {
+            led.on();
+        }
+        for _ in 0..500000 {
+            led.off();
+        }
+    }
+}
+
+// panic! support routines
+///////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////
 // debug_gpio! support


### PR DESCRIPTION
### Pull Request Overview

This pull request refactors panic logic to the kernel crate instead of copying to every board.

### Testing Strategy

Compile-tested only at the moment.

### TODO or Help Wanted

Make sure this doesn't break boards if you have a moment, otherwise I'll do it soon-ish when I have hardware on hand again.

### Documentation Updated

- [X] Relevant comments have been included.

### Formatting

- [X] `make formatall` has been run.
