### PR TITLE
[nrf5x lint] Enable rust lint for docs

### DIFF
--- a/boards/nrf51dk/src/io.rs
+++ b/boards/nrf51dk/src/io.rs
@@ -33,6 +33,7 @@ impl Write for Writer {
     }
 }
 
+/// Panic handler
 #[cfg(not(test))]
 #[no_mangle]
 #[lang = "panic_fmt"]

--- a/boards/nrf51dk/src/io.rs
+++ b/boards/nrf51dk/src/io.rs
@@ -5,11 +5,11 @@ use kernel::hil::uart::{self, UART};
 use nrf51;
 use nrf5x;
 
-pub struct Writer {
+struct Writer {
     initialized: bool,
 }
 
-pub static mut WRITER: Writer = Writer { initialized: false };
+static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -122,10 +122,10 @@ impl kernel::Platform for Platform {
     }
 }
 
-/// Entry point after processor have been initialized
-/// that include copy Flash to RAM and zero out the BSS section
+/// Entry point in the vector table called on hard reset.
 #[no_mangle]
 pub unsafe fn reset_handler() {
+    // Loads relocations and clears BSS
     nrf51::init();
 
     // LEDs

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -38,6 +38,8 @@
 #![no_std]
 #![no_main]
 #![feature(lang_items, compiler_builtins_lib)]
+#![deny(missing_docs)]
+#![deny(warnings)]
 
 extern crate capsules;
 extern crate compiler_builtins;
@@ -54,6 +56,7 @@ use kernel::hil::uart::UART;
 use nrf5x::pinmux::Pinmux;
 use nrf5x::rtc::{Rtc, RTC};
 
+/// UART Writer
 #[macro_use]
 pub mod io;
 #[allow(dead_code)]
@@ -84,6 +87,7 @@ static mut APP_MEMORY: [u8; 8192] = [0; 8192];
 
 static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None];
 
+/// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static nrf5x::ble_advertising_driver::BLE<
         'static,
@@ -118,6 +122,8 @@ impl kernel::Platform for Platform {
     }
 }
 
+/// Entry point after processor have been initialized
+/// that include copy Flash to RAM and zero out the BSS section
 #[no_mangle]
 pub unsafe fn reset_handler() {
     nrf51::init();

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -39,7 +39,6 @@
 #![no_main]
 #![feature(lang_items, compiler_builtins_lib)]
 #![deny(missing_docs)]
-#![deny(warnings)]
 
 extern crate capsules;
 extern crate compiler_builtins;

--- a/boards/nrf52dk/src/io.rs
+++ b/boards/nrf52dk/src/io.rs
@@ -5,15 +5,14 @@ use kernel::hil::uart::{self, UART};
 use nrf52;
 use nrf5x;
 
-pub struct Writer {
+struct Writer {
     initialized: bool,
 }
 
-pub static mut WRITER: Writer = Writer { initialized: false };
+static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        // The UART is not enabled yet
         let uart = unsafe { &mut nrf52::uart::UART0 };
         if !self.initialized {
             self.initialized = true;
@@ -37,6 +36,7 @@ impl Write for Writer {
 #[cfg(not(test))]
 #[no_mangle]
 #[lang = "panic_fmt"]
+/// Panic handler
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
     // The nRF52 DK LEDs (see back of board)
     const LED1_PIN: usize = 17;

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -63,6 +63,8 @@
 #![no_std]
 #![no_main]
 #![feature(lang_items, compiler_builtins_lib)]
+#![deny(missing_docs)]
+#![deny(warnings)]
 
 extern crate capsules;
 extern crate compiler_builtins;
@@ -88,6 +90,7 @@ const BUTTON3_PIN: usize = 15;
 const BUTTON4_PIN: usize = 16;
 const BUTTON_RST_PIN: usize = 21;
 
+/// UART Writer
 #[macro_use]
 pub mod io;
 
@@ -106,6 +109,7 @@ static mut APP_MEMORY: [u8; 32768] = [0; 32768];
 
 static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None, None, None];
 
+/// Supported drivers by the platform
 pub struct Platform {
     ble_radio: &'static nrf5x::ble_advertising_driver::BLE<
         'static,
@@ -145,7 +149,8 @@ impl kernel::Platform for Platform {
     }
 }
 
-// this is called once crt0.s is loaded
+/// Entry point after processor have been initialized
+/// that include copy Flash to RAM and zero out the BSS section
 #[no_mangle]
 pub unsafe fn reset_handler() {
     nrf52::init();

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -149,10 +149,10 @@ impl kernel::Platform for Platform {
     }
 }
 
-/// Entry point after processor have been initialized
-/// that include copy Flash to RAM and zero out the BSS section
+/// Entry point in the vector table called on hard reset.
 #[no_mangle]
 pub unsafe fn reset_handler() {
+    // Loads relocations and clears BSS
     nrf52::init();
 
     // make non-volatile memory writable and activate the reset button (pin 21)

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -64,7 +64,6 @@
 #![no_main]
 #![feature(lang_items, compiler_builtins_lib)]
 #![deny(missing_docs)]
-#![deny(warnings)]
 
 extern crate capsules;
 extern crate compiler_builtins;


### PR DESCRIPTION
### Pull Request Overview

Enables Rust lint in the board crates that denies missing docs

### Testing Strategy

This pull request was tested by building it for nrf5x-dk

### TODO or Help Wanted


### Documentation Updated

~- [ ] Kernel: The relevant files in `/docs` have been updated or no updates are required.~
~- [ ] Userland: The application README has been added, updated, or no updates are required.~

### Formatting

- [x] `make formatall` has been run.