### PR TITLE
Require docs for hail, imix crates

### DIFF
--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -4,11 +4,11 @@ use kernel::{debug, process};
 use kernel::hil::uart::{self, UART};
 use sam4l;
 
-pub struct Writer {
+struct Writer {
     initialized: bool,
 }
 
-pub static mut WRITER: Writer = Writer { initialized: false };
+static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
@@ -32,6 +32,7 @@ impl Write for Writer {
     }
 }
 
+/// Panic handler.
 #[cfg(not(test))]
 #[no_mangle]
 #[lang = "panic_fmt"]
@@ -107,21 +108,4 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
             led.set();
         }
     }
-}
-
-#[macro_export]
-macro_rules! print {
-        ($($arg:tt)*) => (
-            {
-                use core::fmt::write;
-                let writer = unsafe { &mut $crate::io::WRITER };
-                let _ = write(writer, format_args!($($arg)*));
-            }
-        );
-}
-
-#[macro_export]
-macro_rules! println {
-        ($fmt:expr) => (print!(concat!($fmt, "\n")));
-            ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
 }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![no_main]
 #![feature(asm, const_fn, lang_items, compiler_builtins_lib)]
+#![deny(missing_docs)]
 
 extern crate capsules;
 extern crate compiler_builtins;
@@ -22,6 +23,9 @@ use kernel::hil;
 use kernel::hil::Controller;
 use kernel::hil::spi::SpiMaster;
 
+/// Support routines for debugging I/O.
+///
+/// Note: Use of this module will trample any other USART0 configuration.
 #[macro_use]
 pub mod io;
 #[allow(dead_code)]

--- a/boards/hail/src/test_take_map_cell.rs
+++ b/boards/hail/src/test_take_map_cell.rs
@@ -40,5 +40,5 @@ unsafe fn test_map_cell<'a, A>(tc: &MapCell<A>) {
     ::core::ptr::write_volatile(dwt_ctl, ::core::ptr::read_volatile(dwt_ctl) | 1);
     tc.map(|_| ());
     let end = ::core::ptr::read_volatile(dwt_cycles);
-    println!("time: {}, size: {}", end, ::core::mem::size_of_val(tc));
+    debug!("time: {}, size: {}", end, ::core::mem::size_of_val(tc));
 }

--- a/boards/imix/src/i2c_dummy.rs
+++ b/boards/imix/src/i2c_dummy.rs
@@ -22,7 +22,7 @@ impl hil::i2c::I2CHwMasterClient for ScanClient {
         let mut dev_id = self.dev_id.get();
 
         if error == hil::i2c::Error::CommandComplete {
-            println!("{:#x}", dev_id);
+            debug!("{:#x}", dev_id);
         }
 
         let dev: &mut I2CMaster = unsafe { &mut i2c::I2C2 };
@@ -31,7 +31,7 @@ impl hil::i2c::I2CHwMasterClient for ScanClient {
             self.dev_id.set(dev_id);
             dev.write(dev_id, buffer, 2);
         } else {
-            println!(
+            debug!(
                 "Done scanning for I2C devices. Buffer len: {}",
                 buffer.len()
             );
@@ -50,7 +50,7 @@ pub fn i2c_scan_slaves() {
     let dev: &mut I2CMaster = dev;
     dev.enable();
 
-    println!("Scanning for I2C devices...");
+    debug!("Scanning for I2C devices...");
     dev.write(i2c_client.dev_id.get(), unsafe { &mut DATA }, 2);
 }
 
@@ -82,15 +82,15 @@ impl hil::i2c::I2CHwMasterClient for AccelClient {
 
         match self.state.get() {
             ReadingWhoami => {
-                println!("WHOAMI Register 0x{:x} ({})", buffer[0], error);
-                println!("Activating Sensor...");
+                debug!("WHOAMI Register 0x{:x} ({})", buffer[0], error);
+                debug!("Activating Sensor...");
                 buffer[0] = 0x2A as u8; // CTRL_REG1
                 buffer[1] = 1; // Bit 1 sets `active`
                 dev.write(0x1e, i2c::START | i2c::STOP, buffer, 2);
                 self.state.set(Activating);
             }
             Activating => {
-                println!("Sensor Activated ({})", error);
+                debug!("Sensor Activated ({})", error);
                 buffer[0] = 0x01 as u8; // X-MSB register
                                         // Reading 6 bytes will increment the register pointer through
                                         // X-MSB, X-LSB, Y-MSB, Y-LSB, Z-MSB, Z-LSB
@@ -106,7 +106,7 @@ impl hil::i2c::I2CHwMasterClient for AccelClient {
                 let y = ((y >> 2) * 976) / 1000;
                 let z = ((z >> 2) * 976) / 1000;
 
-                println!(
+                debug!(
                     "Accel data ready x: {}, y: {}, z: {} ({})",
                     x >> 2,
                     y >> 2,
@@ -121,8 +121,8 @@ impl hil::i2c::I2CHwMasterClient for AccelClient {
                 self.state.set(ReadingAccelData);
             }
             Deactivating => {
-                println!("Sensor deactivated ({})", error);
-                println!("Reading Accel's WHOAMI...");
+                debug!("Sensor deactivated ({})", error);
+                debug!("Reading Accel's WHOAMI...");
                 buffer[0] = 0x0D as u8; // 0x0D == WHOAMI register
                 dev.write_read(0x1e, buffer, 1, 1);
                 self.state.set(AccelClientState::ReadingWhoami);
@@ -141,7 +141,7 @@ pub fn i2c_accel_test() {
     dev.enable();
 
     let buf = unsafe { &mut DATA };
-    println!("Reading Accel's WHOAMI...");
+    debug!("Reading Accel's WHOAMI...");
     buf[0] = 0x0D as u8; // 0x0D == WHOAMI register
     dev.write_read(0x1e, buf, 1, 1);
     i2c_client.state.set(AccelClientState::ReadingWhoami);
@@ -173,7 +173,7 @@ impl hil::i2c::I2CHwMasterClient for LiClient {
 
         match self.state.get() {
             Enabling => {
-                println!("Reading Lumminance Registers ({})", error);
+                debug!("Reading Lumminance Registers ({})", error);
                 buffer[0] = 0x02 as u8;
                 buffer[0] = 0;
                 dev.write_read(0x44, buffer, 1, 2);
@@ -181,7 +181,7 @@ impl hil::i2c::I2CHwMasterClient for LiClient {
             }
             ReadingLI => {
                 let intensity = ((buffer[1] as usize) << 8) | buffer[0] as usize;
-                println!("Light Intensity: {}% ({})", (intensity * 100) >> 16, error);
+                debug!("Light Intensity: {}% ({})", (intensity * 100) >> 16, error);
                 buffer[0] = 0x02 as u8;
                 dev.write_read(0x44, buffer, 1, 2);
                 self.state.set(ReadingLI);
@@ -206,7 +206,7 @@ pub fn i2c_li_test() {
     dev.enable();
 
     let buf = unsafe { &mut DATA };
-    println!("Enabling LI...");
+    debug!("Enabling LI...");
     buf[0] = 0;
     buf[1] = 0b10100000;
     buf[2] = 0b00000000;

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -3,11 +3,11 @@ use kernel::{debug, process};
 use kernel::hil::uart::{self, UART};
 use sam4l;
 
-pub struct Writer {
+struct Writer {
     initialized: bool,
 }
 
-pub static mut WRITER: Writer = Writer { initialized: false };
+static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
@@ -31,6 +31,7 @@ impl Write for Writer {
     }
 }
 
+/// Panic handler.
 #[cfg(not(test))]
 #[no_mangle]
 #[lang = "panic_fmt"]
@@ -98,21 +99,4 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
             led.set();
         }
     }
-}
-
-#[macro_export]
-macro_rules! print {
-        ($($arg:tt)*) => (
-            {
-                use core::fmt::write;
-                let writer = unsafe { &mut $crate::io::WRITER };
-                let _ = write(writer, format_args!($($arg)*));
-            }
-        );
-}
-
-#[macro_export]
-macro_rules! println {
-        ($fmt:expr) => (print!(concat!($fmt, "\n")));
-            ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
 }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -1,6 +1,12 @@
+//! Board file for Imix development platform.
+//!
+//! - <https://github.com/helena-project/tock/tree/master/boards/imix>
+//! - <https://github.com/helena-project/imix>
+
 #![no_std]
 #![no_main]
 #![feature(asm, const_fn, lang_items, compiler_builtins_lib, const_cell_new)]
+#![deny(missing_docs)]
 
 extern crate capsules;
 extern crate compiler_builtins;
@@ -24,6 +30,9 @@ use kernel::hil::spi::SpiMaster;
 use kernel::hil::symmetric_encryption;
 use kernel::hil::symmetric_encryption::{AES128, AES128CCM};
 
+/// Support routines for debugging I/O.
+///
+/// Note: Use of this module will trample any other USART3 configuration.
 #[macro_use]
 pub mod io;
 
@@ -203,6 +212,12 @@ unsafe fn set_pin_primary_functions() {
     PC[31].configure(None); //... D2          -- GPIO Pin
 }
 
+/// Reset Handler.
+///
+/// This symbol is loaded into vector table by the SAM4L chip crate.
+/// When the chip first powers on or later does a hard reset, after the core
+/// initializes all the hardware, the address of this function is loaded and
+/// execution begins here.
 #[no_mangle]
 pub unsafe fn reset_handler() {
     sam4l::init();


### PR DESCRIPTION
### Pull Request Overview

Enables Rust lint in the board crates that denies missing docs and warnings.

This PR compliments #768 for the other boards.

### Documentation Updated

- ~~[ ] Kernel: The relevant files in `/docs` have been updated or no updates are required.~~
- ~~[ ] Userland: The application README has been added, updated, or no updates are required.~~

### Formatting

- [X] `make formatall` has been run.
