### PR TITLE
[nrf51] regard the UART as fully-debugged now

### DIFF
--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -2,9 +2,16 @@
 //! kit (DK), a.k.a. the PCA10028. </br>
 //! This is an nRF51422 SoC (a Cortex M0 core with a BLE transceiver) with many
 //! exported pins, LEDs, and buttons. </br>
-//! Currently the kernel provides application alarms, and GPIO. </br>
-//! It will provide a console
-//! once the UART is fully implemented and debugged.
+//!
+//! Currently the kernel provides:
+//!
+//! * Timers
+//! * GPIO
+//! * UART
+//! * AES Encryption
+//! * Bluetooth Low Energy Advertisements
+//! * Temperature Sensor
+//! * True Random Number Generator
 //!
 //! ### Pin configuration
 //! * 0 -> LED1 (pin 21)


### PR DESCRIPTION
### Pull Request Overview

Fixes docs which states that UART on nrf51dk is not debugged which may be confusing to people

### Testing Strategy

Built the docs locally

### TODO or Help Wanted



### Documentation Updated

~- [ ] Kernel: The relevant files in `/docs` have been updated or no updates are required.~
~- [ ] Userland: The application README has been added, updated, or no updates are required.~

### Formatting

- [x] `make formatall` has been run.
