### PR TITLE
doc: courses: make boards compile again

### DIFF
--- a/doc/courses/sensys/exercises/board/Cargo.lock
+++ b/doc/courses/sensys/exercises/board/Cargo.lock
@@ -1,14 +1,3 @@
-[root]
-name = "hail-sensys"
-version = "0.1.0"
-dependencies = [
- "capsules 0.1.0",
- "cortexm4 0.1.0",
- "kernel 0.1.0",
- "sam4l 0.1.0",
- "sensys 0.1.0",
-]
-
 [[package]]
 name = "capsules"
 version = "0.1.0"
@@ -21,6 +10,17 @@ name = "cortexm4"
 version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
+]
+
+[[package]]
+name = "hail-sensys"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+ "sam4l 0.1.0",
+ "sensys 0.1.0",
 ]
 
 [[package]]

--- a/doc/courses/sensys/exercises/board/src/main.rs
+++ b/doc/courses/sensys/exercises/board/src/main.rs
@@ -69,7 +69,6 @@ struct Hail {
     ipc: kernel::ipc::IPC,
     crc: &'static capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
     dac: &'static capsules::dac::Dac<'static>,
-    aes: &'static capsules::symmetric_encryption::Crypto<'static, sam4l::aes::Aes>,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -95,7 +94,6 @@ impl Platform for Hail {
             capsules::rng::DRIVER_NUM => f(Some(self.rng)),
 
             capsules::crc::DRIVER_NUM => f(Some(self.crc)),
-            capsules::symmetric_encryption::DRIVER_NUM => f(Some(self.aes)),
 
             capsules::dac::DRIVER_NUM => f(Some(self.dac)),
 
@@ -440,19 +438,6 @@ pub unsafe fn reset_handler() {
         capsules::dac::Dac::new(&mut sam4l::dac::DAC)
     );
 
-    // AES
-    let aes = static_init!(
-        capsules::symmetric_encryption::Crypto<'static, sam4l::aes::Aes>,
-        capsules::symmetric_encryption::Crypto::new(
-            &mut sam4l::aes::AES,
-            kernel::Grant::create(),
-            &mut capsules::symmetric_encryption::KEY,
-            &mut capsules::symmetric_encryption::BUF,
-            &mut capsules::symmetric_encryption::IV
-        )
-    );
-    hil::symmetric_encryption::SymmetricEncryption::set_client(&sam4l::aes::AES, aes);
-
     let hail = Hail {
         console: console,
         sensys: sensys,
@@ -470,7 +455,6 @@ pub unsafe fn reset_handler() {
         ipc: kernel::ipc::IPC::new(),
         crc: crc,
         dac: dac,
-        aes: aes,
     };
 
     // Need to reset the nRF on boot

--- a/doc/courses/sosp/exercises/board/Cargo.lock
+++ b/doc/courses/sosp/exercises/board/Cargo.lock
@@ -1,14 +1,3 @@
-[root]
-name = "hail-sosp"
-version = "0.1.0"
-dependencies = [
- "capsules 0.1.0",
- "cortexm4 0.1.0",
- "kernel 0.1.0",
- "sam4l 0.1.0",
- "sosp 0.1.0",
-]
-
 [[package]]
 name = "capsules"
 version = "0.1.0"
@@ -21,6 +10,17 @@ name = "cortexm4"
 version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
+]
+
+[[package]]
+name = "hail-sosp"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+ "sam4l 0.1.0",
+ "sosp 0.1.0",
 ]
 
 [[package]]

--- a/doc/courses/sosp/exercises/board/src/main.rs
+++ b/doc/courses/sosp/exercises/board/src/main.rs
@@ -69,7 +69,6 @@ struct Hail {
     ipc: kernel::ipc::IPC,
     crc: &'static capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
     dac: &'static capsules::dac::Dac<'static>,
-    aes: &'static capsules::symmetric_encryption::Crypto<'static, sam4l::aes::Aes>,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -95,7 +94,6 @@ impl Platform for Hail {
             capsules::rng::DRIVER_NUM => f(Some(self.rng)),
 
             capsules::crc::DRIVER_NUM => f(Some(self.crc)),
-            capsules::symmetric_encryption::DRIVER_NUM => f(Some(self.aes)),
 
             capsules::dac::DRIVER_NUM => f(Some(self.dac)),
 
@@ -440,19 +438,6 @@ pub unsafe fn reset_handler() {
         capsules::dac::Dac::new(&mut sam4l::dac::DAC)
     );
 
-    // AES
-    let aes = static_init!(
-        capsules::symmetric_encryption::Crypto<'static, sam4l::aes::Aes>,
-        capsules::symmetric_encryption::Crypto::new(
-            &mut sam4l::aes::AES,
-            kernel::Grant::create(),
-            &mut capsules::symmetric_encryption::KEY,
-            &mut capsules::symmetric_encryption::BUF,
-            &mut capsules::symmetric_encryption::IV
-        )
-    );
-    hil::symmetric_encryption::SymmetricEncryption::set_client(&sam4l::aes::AES, aes);
-
     let hail = Hail {
         console: console,
         sosp: sosp,
@@ -470,7 +455,6 @@ pub unsafe fn reset_handler() {
         ipc: kernel::ipc::IPC::new(),
         crc: crc,
         dac: dac,
-        aes: aes,
     };
 
     // Need to reset the nRF on boot


### PR DESCRIPTION
### Pull Request Overview

This pull request removes symmetric encryption from the example board in the sensys/sosp tutorials so they compile again.


### Testing Strategy

This pull request was tested by ensuring the boards compile.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
