### PR TITLE
SAM4L: update flash peripheral to new register interface

### DIFF
--- a/chips/sam4l/src/flashcalw.rs
+++ b/chips/sam4l/src/flashcalw.rs
@@ -25,7 +25,7 @@ use core::cell::Cell;
 use core::ops::{Index, IndexMut};
 use helpers::{DeferredCall, Task};
 use kernel::ReturnCode;
-use kernel::common::VolatileCell;
+use kernel::common::regs::{ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil;
 use pm;
@@ -33,26 +33,275 @@ use pm;
 /// Struct of the FLASHCALW registers. Section 14.10 of the datasheet.
 #[repr(C)]
 struct FlashcalwRegisters {
-    fcr: VolatileCell<u32>,
-    fcmd: VolatileCell<u32>,
-    fsr: VolatileCell<u32>,
-    fpr: VolatileCell<u32>,
-    fvr: VolatileCell<u32>,
-    fgpfrhi: VolatileCell<u32>,
-    fgpfrlo: VolatileCell<u32>,
-    _reserved1: [VolatileCell<u32>; 251],
-    ctrl: VolatileCell<u32>,
-    sr: VolatileCell<u32>,
-    _reserved2: [VolatileCell<u32>; 4],
-    maint0: VolatileCell<u32>,
-    maint1: VolatileCell<u32>,
-    mcfg: VolatileCell<u32>,
-    men: VolatileCell<u32>,
-    mctrl: VolatileCell<u32>,
-    msr: VolatileCell<u32>,
-    _reserved3: [VolatileCell<u32>; 49],
-    pvr: VolatileCell<u32>,
+    fcr: ReadWrite<u32, FlashControl::Register>,
+    fcmd: ReadWrite<u32, FlashCommand::Register>,
+    fsr: ReadOnly<u32, FlashStatus::Register>,
+    fpr: ReadOnly<u32, FlashParameter::Register>,
+    fvr: ReadOnly<u32, FlashVersion::Register>,
+    fgpfrhi: ReadOnly<u32, FlashGeneralPurposeFuseHigh::Register>,
+    fgpfrlo: ReadOnly<u32, FlashGeneralPurposeFuseLow::Register>,
+    _reserved1: [u32; 251],
+    ctrl: WriteOnly<u32, PicoCacheControl::Register>,
+    sr: ReadWrite<u32, PicoCacheStatus::Register>,
+    _reserved2: [u32; 4],
+    maint0: WriteOnly<u32, PicoCacheMaintenance0::Register>,
+    maint1: WriteOnly<u32, PicoCacheMaintenance1::Register>,
+    mcfg: ReadWrite<u32, PicoCacheMonitorConfiguration::Register>,
+    men: ReadWrite<u32, PicoCacheMonitorEnable::Register>,
+    mctrl: WriteOnly<u32, PicoCacheMonitorStatus::Register>,
+    msr: ReadOnly<u32, PicoCacheMonitorStatus::Register>,
 }
+
+register_bitfields![u32,
+    FlashControl [
+        /// Wait State 1 Optimization
+        WS1OPT OFFSET(7) NUMBITS(1) [
+            NoOptimize = 0,
+            Optimize = 1
+        ],
+        /// Flash Wait State
+        FWS OFFSET(6) NUMBITS(1) [
+            ZeroWaitStates = 0,
+            OneWaitState = 1
+        ],
+        /// ECC Error Interrupt Enable
+        ECCE OFFSET(4) NUMBITS(1) [],
+        /// Programming Error Interrupt Enable
+        PROGE OFFSET(3) NUMBITS(1) [],
+        /// Lock Error Interrupt Enable
+        LOCKE OFFSET(2) NUMBITS(1) [],
+        /// Flash Ready Interrupt Enable
+        FRDY OFFSET(0) NUMBITS(1) []
+    ],
+
+    FlashCommand [
+        /// Write protection key
+        KEY OFFSET(24) NUMBITS(8) [],
+        /// Page number
+        PAGEN OFFSET(8) NUMBITS(16) [],
+        /// Command
+        CMD OFFSET(0) NUMBITS(6) [
+            NOP = 0,
+            WP = 1,
+            EP = 2,
+            CPB = 3,
+            LP = 4,
+            UP = 5,
+            EA = 6,
+            WGPB = 7,
+            EGPB = 8,
+            SSB = 9,
+            PGPFB = 10,
+            EAGPF = 11,
+            QPR = 12,
+            WUP = 13,
+            EUP = 14,
+            QPRUP = 15,
+            HSEN = 16,
+            HSDIS = 17
+        ]
+    ],
+
+    FlashStatus [
+        /// Lock region x Lock Status
+        LOCK15 31,
+        LOCK14 30,
+        LOCK13 29,
+        LOCK12 28,
+        LOCK11 27,
+        LOCK10 26,
+        LOCK9 25,
+        LOCK8 24,
+        LOCK7 23,
+        LOCK6 22,
+        LOCK5 21,
+        LOCK4 20,
+        LOCK3 19,
+        LOCK2 18,
+        LOCK1 17,
+        LOCK0 16,
+        ///ECC Error Status
+        ///
+        /// WARNING! Datasheet has this bit listed in two places...
+        ECCERR 9,
+        /// High Speed Mode
+        HSMODE 6,
+        /// Quick Page Read Result
+        QPRR 5,
+        /// Security Fuses Status
+        SECURITY 4,
+        /// Programming Error Status
+        PROGE 3,
+        /// Lock Error Status
+        LOCKE 2,
+        /// Flash Ready Status
+        FRDY 0
+    ],
+
+    FlashParameter [
+        /// Page Size
+        PSZ OFFSET(8) NUMBITS(3) [
+            Bytes32 = 0,
+            Bytes64 = 1,
+            Bytes128 = 2,
+            Bytes256 = 3,
+            Bytes512 = 4,
+            Bytes1024 = 5,
+            Bytes2048 = 6,
+            Bytes4096 = 7
+        ],
+        /// Flash Size
+        FSZ OFFSET(0) NUMBITS(4) [
+            KBytes4 = 0,
+            KBytes8 = 1,
+            KBytes16 = 2,
+            KBytes32 = 3,
+            KBytes48 = 4,
+            KBytes64 = 5,
+            KBytes96 = 6,
+            KBytes128 = 7,
+            KBytes192 = 8,
+            KBytes256 = 9,
+            KBytes384 = 10,
+            KBytes512 = 11,
+            KBytes768 = 12,
+            KBytes1024 = 13,
+            KBytes2048 = 14
+        ]
+    ],
+
+    FlashVersion [
+        /// Variant Number
+        VARIANT OFFSET(16) NUMBITS(4) [],
+        /// Version Number
+        VERSION OFFSET(0) NUMBITS(12) []
+    ],
+
+    FlashGeneralPurposeFuseHigh [
+        /// General Purpose Fuse
+        GPF63 31,
+        GPF62 30,
+        GPF61 29,
+        GPF60 28,
+        GPF59 27,
+        GPF58 26,
+        GPF57 25,
+        GPF56 24,
+        GPF55 23,
+        GPF54 22,
+        GPF53 21,
+        GPF52 20,
+        GPF51 19,
+        GPF50 18,
+        GPF49 17,
+        GPF48 16,
+        GPF47 15,
+        GPF46 14,
+        GPF45 13,
+        GPF44 12,
+        GPF43 11,
+        GPF42 10,
+        GPF41 9,
+        GPF40 8,
+        GPF39 7,
+        GPF38 6,
+        GPF37 5,
+        GPF36 4,
+        GPF35 3,
+        GPF34 2,
+        GPF33 1,
+        GPF32 0
+    ],
+
+    FlashGeneralPurposeFuseLow [
+        GPF31 31,
+        GPF30 30,
+        GPF29 29,
+        GPF28 28,
+        GPF27 27,
+        GPF26 26,
+        GPF25 25,
+        GPF24 24,
+        GPF23 23,
+        GPF22 22,
+        GPF21 21,
+        GPF20 20,
+        GPF19 19,
+        GPF18 18,
+        GPF17 17,
+        GPF16 16,
+        GPF15 15,
+        GPF14 14,
+        GPF13 13,
+        GPF12 12,
+        GPF11 11,
+        GPF10 10,
+        GPF9 9,
+        GPF8 8,
+        GPF7 7,
+        GPF6 6,
+        GPF5 5,
+        GPF4 4,
+        GPF3 3,
+        GPF2 2,
+        GPF1 1,
+        GPF0 0
+    ],
+
+    PicoCacheControl [
+        /// Cache Enable
+        CEN OFFSET(0) NUMBITS(1) [
+            Disable = 0,
+            Enable = 1
+        ]
+    ],
+
+    PicoCacheStatus [
+        /// Cache Controller Status
+        CSTS OFFSET(0) NUMBITS(1) [
+            Disabled = 0,
+            Enabled = 1
+        ]
+    ],
+
+    PicoCacheMaintenance0 [
+        /// Cache Controller Invalidate All
+        INVALL 0
+    ],
+
+    PicoCacheMaintenance1 [
+        /// Invalidate Index
+        INDEX OFFSET(4) NUMBITS(4) []
+    ],
+
+    PicoCacheMonitorConfiguration [
+        /// Cache Controller Monitor Counter Mode
+        MODE OFFSET(0) NUMBITS(1) [
+            CycleCount = 0,
+            IhitCount = 1,
+            DhitCount = 2
+        ]
+    ],
+
+    PicoCacheMonitorEnable [
+        /// Monitor Enable
+        MENABLE OFFSET(0) NUMBITS(1) [
+            Disable = 0,
+            Enable = 1
+        ]
+    ],
+
+    PicoCacheMonitorControl [
+        /// Monitor Software Reset
+        SWRST 0
+    ],
+
+    PicoCacheMonitorStatus [
+        /// Monitor Event Counter
+        EVENTCNT OFFSET(0) NUMBITS(32) []
+    ]
+];
+
 const FLASHCALW_BASE_ADDRS: usize = 0x400A0000;
 
 #[allow(dead_code)]
@@ -176,7 +425,6 @@ pub static mut FLASH_CONTROLLER: FLASHCALW = FLASHCALW::new(
 // Few constants relating to module configuration.
 const PAGE_SIZE: u32 = 512;
 const NB_OF_REGIONS: u32 = 16;
-const FLASHCALW_CMD_KEY: u32 = 0xA5 << 24;
 
 #[cfg(CONFIG_FLASH_READ_MODE_HIGH_SPEED_DISABLE)]
 const FREQ_PS1_FWS_1_FWU_MAX_FREQ: u32 = 12000000;
@@ -217,16 +465,16 @@ impl FLASHCALW {
 
     //  Flush the cache. Should be called after every write!
     fn invalidate_cache(&self) {
-        let registers: &FlashcalwRegisters = unsafe { &*self.registers };
-        registers.maint0.set(0x1);
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
+        regs.maint0.write(PicoCacheMaintenance0::INVALL::SET);
     }
 
     pub fn enable_picocache(&self, enable: bool) {
-        let registers: &FlashcalwRegisters = unsafe { &*self.registers };
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         if enable {
-            registers.ctrl.set(0x1);
+            regs.ctrl.write(PicoCacheControl::CEN::Enable);
         } else {
-            registers.ctrl.set(0x0);
+            regs.ctrl.write(PicoCacheControl::CEN::Disable);
         }
     }
 
@@ -244,36 +492,21 @@ impl FLASHCALW {
     }
 
     pub fn pico_enabled(&self) -> bool {
-        let registers: &FlashcalwRegisters = unsafe { &*self.registers };
-        registers.sr.get() & 0x1 != 0
-    }
-
-    // Helper to read a flashcalw register (espically if your function is doing so once)
-    fn read_register(&self, key: RegKey) -> u32 {
-        let registers: &FlashcalwRegisters = unsafe { &*self.registers };
-
-        match key {
-            RegKey::CONTROL => registers.fcr.get(),
-            RegKey::COMMAND => registers.fcmd.get(),
-            RegKey::STATUS => registers.fsr.get(),
-            RegKey::PARAMETER => registers.fpr.get(),
-            RegKey::VERSION => registers.fvr.get(),
-            RegKey::GPFRHI => registers.fgpfrhi.get(),
-            RegKey::GPFRLO => registers.fgpfrlo.get(),
-        }
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
+        regs.sr.is_set(PicoCacheStatus::CSTS)
     }
 
     pub fn handle_interrupt(&self) {
-        //  disable the interrupt line for flash
-        self.enable_ready_int(false);
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
 
-        let error_status = self.get_error_status();
+        // Disable the interrupt line for flash
+        regs.fcr.modify(FlashControl::FRDY::CLEAR);
 
         // Since the only interrupt on is FRDY, a command should have
         // either completed or failed at this point.
 
         // Check for errors and report to Client if there are any
-        if error_status != 0 {
+        if self.is_error() {
             let attempted_operation = self.current_state.get();
 
             // Reset state now that we are ready to do a new operation.
@@ -357,11 +590,12 @@ impl FLASHCALW {
 
     /// FLASH properties.
     pub fn get_flash_size(&self) -> u32 {
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         let flash_sizes = [
             4, 8, 16, 32, 48, 64, 96, 128, 192, 256, 384, 512, 768, 1024, 2048
         ];
         // get the FSZ number and lookup in the table for the size.
-        flash_sizes[self.read_register(RegKey::PARAMETER) as usize & 0xf] << 10
+        flash_sizes[regs.fpr.read(FlashParameter::FSZ) as usize] << 10
     }
 
     pub fn get_page_count(&self) -> u32 {
@@ -385,30 +619,17 @@ impl FLASHCALW {
     }
 
     /// FLASHC Control
-    #[allow(dead_code)]
-    fn get_wait_state(&self) -> u32 {
-        if self.read_register(RegKey::CONTROL) & bit!(6) == 0 {
-            0
-        } else {
-            1
-        }
-    }
-
     fn set_wait_state(&self, wait_state: u32) {
         let regs: &FlashcalwRegisters = unsafe { &*self.registers };
-        if wait_state == 1 {
-            regs.fcr.set(regs.fcr.get() | bit!(6));
-        } else {
-            regs.fcr.set(regs.fcr.get() & !bit!(6));
-        }
+        regs.fcr.modify(FlashControl::FWS.val(wait_state));
     }
 
     fn enable_ws1_read_opt(&mut self, enable: bool) {
         let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         if enable {
-            regs.fcr.set(regs.fcr.get() | bit!(7));
+            regs.fcr.modify(FlashControl::WS1OPT::Optimize);
         } else {
-            regs.fcr.set(regs.fcr.get() | !bit!(7));
+            regs.fcr.modify(FlashControl::WS1OPT::NoOptimize);
         }
     }
 
@@ -472,142 +693,66 @@ impl FLASHCALW {
 
         // Since we are running at a fast speed we have to set a clock delay
         // for flash, as well as enable fast flash mode.
-        let flashcalw_fcr = regs.fcr.get();
-        regs.fcr.set(flashcalw_fcr | (1 << 6));
+        regs.fcr.modify(FlashControl::FWS::OneWaitState);
 
         // Enable high speed mode for flash
-        let flashcalw_fcmd = regs.fcmd.get();
-        let flashcalw_fcmd_new1 = flashcalw_fcmd & (!(0x3F << 0));
-        let flashcalw_fcmd_new2 = flashcalw_fcmd_new1 | (0xA5 << 24) | (0x10 << 0);
-        regs.fcmd.set(flashcalw_fcmd_new2);
+        regs.fcmd
+            .modify(FlashCommand::KEY.val(0xA5) + FlashCommand::CMD::HSEN);
 
         // And wait for the flash to be ready
-        while regs.fsr.get() & (1 << 0) == 0 {}
-    }
-
-    #[allow(dead_code)]
-    fn is_ready_int_enabled(&self) -> bool {
-        (self.read_register(RegKey::CONTROL) & bit!(0)) != 0
-    }
-
-    fn enable_ready_int(&self, enable: bool) {
-        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
-        if enable {
-            regs.fcr.set(regs.fcr.get() | bit!(0));
-        } else {
-            regs.fcr.set(regs.fcr.get() & !bit!(0));
-        }
-    }
-
-    #[allow(dead_code)]
-    fn is_lock_error_int_enabled(&self) -> bool {
-        (self.read_register(RegKey::CONTROL) & bit!(2)) != 0
-    }
-
-    fn enable_lock_error_int(&self, enable: bool) {
-        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
-        if enable {
-            regs.fcr.set(regs.fcr.get() | bit!(2));
-        } else {
-            regs.fcr.set(regs.fcr.get() & !bit!(2));
-        }
-    }
-
-    #[allow(dead_code)]
-    fn is_prog_error_int_enabled(&self) -> bool {
-        (self.read_register(RegKey::CONTROL) & bit!(3)) != 0
-    }
-
-    fn enable_prog_error_int(&self, enable: bool) {
-        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
-        if enable {
-            regs.fcr.set(regs.fcr.get() | bit!(3));
-        } else {
-            regs.fcr.set(regs.fcr.get() & !bit!(3));
-        }
-    }
-
-    #[allow(dead_code)]
-    fn is_ecc_int_enabled(&self) -> bool {
-        (self.read_register(RegKey::CONTROL) & bit!(4)) != 0
-    }
-
-    fn enable_ecc_int(&self, enable: bool) {
-        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
-        if enable {
-            regs.fcr.set(regs.fcr.get() | bit!(4));
-        } else {
-            regs.fcr.set(regs.fcr.get() & !bit!(4));
-        }
+        while !regs.fsr.is_set(FlashStatus::FRDY) {}
     }
 
     /// Flashcalw status
 
     pub fn is_ready(&self) -> bool {
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         unsafe {
             pm::enable_clock(self.pb_clock);
         }
-        self.read_register(RegKey::STATUS) & bit!(0) != 0
+        regs.fsr.is_set(FlashStatus::FRDY)
     }
 
-    fn get_error_status(&self) -> u32 {
+    fn is_error(&self) -> bool {
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         unsafe {
             pm::enable_clock(self.pb_clock);
         }
-        self.read_register(RegKey::STATUS) & (bit!(3) | bit!(2))
-    }
-
-    #[allow(dead_code)]
-    fn is_lock_error(&self) -> bool {
-        unsafe {
-            pm::enable_clock(self.pb_clock);
-        }
-        self.read_register(RegKey::STATUS) & bit!(2) != 0
-    }
-
-    #[allow(dead_code)]
-    fn is_programming_error(&self) -> bool {
-        unsafe {
-            pm::enable_clock(self.pb_clock);
-        }
-        self.read_register(RegKey::STATUS) & bit!(3) != 0
+        regs.fsr.is_set(FlashStatus::LOCKE) | regs.fsr.is_set(FlashStatus::PROGE)
     }
 
     /// Flashcalw command control
     fn get_page_number(&self) -> u32 {
-        // create a mask for the page number field
-        let mut page_mask: u32 = bit!(8) - 1;
-        page_mask |= page_mask << 24;
-        page_mask = !page_mask;
-
-        (self.read_register(RegKey::COMMAND) & page_mask) >> 8
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
+        regs.fcmd.read(FlashCommand::PAGEN)
     }
 
     pub fn issue_command(&self, command: FlashCMD, page_number: i32) {
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
         unsafe {
             pm::enable_clock(self.pb_clock);
         }
+        // For most commands we wait for the interrupt, for some certain
+        // fast/rarely used commands or commands that don't generate interrupts
+        // it is better to wait (or at least that is how this driver was
+        // originally implemented).
         if command != FlashCMD::QPRUP && command != FlashCMD::QPR && command != FlashCMD::CPB
             && command != FlashCMD::HSEN
         {
             // Enable ready interrupt.
-            self.enable_ready_int(true);
+            regs.fcr.modify(FlashControl::FRDY::SET);
         }
 
-        let cmd_regs: &FlashcalwRegisters = unsafe { &*self.registers };
-        let mut reg_val: u32 = cmd_regs.fcmd.get();
+        // Setup the command register to run this command.
+        let mut cmd = FlashCommand::KEY.val(0xA5) + FlashCommand::CMD.val(command as u32);
 
-        let clear_cmd_mask: u32 = !(bit!(6) - 1);
-        reg_val &= clear_cmd_mask;
-
-        // craft the command
+        // If this command relies on using a certain page, we need to add that
+        // in as well.
         if page_number >= 0 {
-            reg_val = FLASHCALW_CMD_KEY | (page_number as u32) << 8 | command as u32;
-        } else {
-            reg_val |= FLASHCALW_CMD_KEY | command as u32;
+            cmd += FlashCommand::PAGEN.val(page_number as u32);
         }
 
-        cmd_regs.fcmd.set(reg_val); // write the cmd
+        regs.fcmd.write(cmd);
 
         // Since we don't enable interrupts for these commands, spin wait
         // until they are finished. In particular, QPR and QPRUP will not issue
@@ -615,7 +760,7 @@ impl FLASHCALW {
         if command == FlashCMD::QPRUP || command == FlashCMD::QPR || command == FlashCMD::CPB
             || command == FlashCMD::HSEN
         {
-            while (cmd_regs.fsr.get() & 0x01) != 0x01 {}
+            while !regs.fsr.is_set(FlashStatus::FRDY) {}
         }
     }
 
@@ -629,22 +774,13 @@ impl FLASHCALW {
     }
 
     /// FLASHCALW Protection Mechanisms
-    #[allow(dead_code)]
-    fn is_security_bit_active(&self) -> bool {
-        (self.read_register(RegKey::STATUS) & bit!(4)) != 0
-    }
-
-    #[allow(dead_code)]
-    fn set_security_bit(&self) {
-        self.issue_command(FlashCMD::SSB, -1);
-    }
-
     pub fn is_page_region_locked(&self, page_number: u32) -> bool {
         self.is_region_locked(self.get_page_region(page_number as i32))
     }
 
     pub fn is_region_locked(&self, region: u32) -> bool {
-        (self.read_register(RegKey::STATUS) & bit!(region + 16)) != 0
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
+        (regs.fsr.get() & bit!(region + 16)) != 0
     }
 
     pub fn lock_page_region(&self, page_number: i32, lock: bool) {
@@ -655,28 +791,14 @@ impl FLASHCALW {
         }
     }
 
-    #[allow(dead_code)]
-    fn lock_region(&self, region: u32, lock: bool) {
-        let first_page: i32 = self.get_region_first_page_number(region) as i32;
-        self.lock_page_region(first_page, lock);
-    }
-
     /// Flashcalw Access to Flash Pages
     fn clear_page_buffer(&self) {
         self.issue_command(FlashCMD::CPB, -1);
     }
 
     fn is_page_erased(&self) -> bool {
-        let registers: &FlashcalwRegisters = unsafe { &*self.registers };
-        let status = registers.fsr.get();
-
-        (status & bit!(5)) != 0
-    }
-
-    #[allow(dead_code)]
-    fn quick_page_read(&self, page_number: i32) -> bool {
-        self.issue_command(FlashCMD::QPR, page_number);
-        self.is_page_erased()
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
+        regs.fsr.is_set(FlashStatus::QPRR)
     }
 
     fn flashcalw_erase_page(&self, page_number: i32) {
@@ -744,6 +866,8 @@ impl FLASHCALW {
 // Implementation of high level calls using the low-lv functions.
 impl FLASHCALW {
     pub fn configure(&mut self) {
+        let regs: &FlashcalwRegisters = unsafe { &*self.registers };
+
         // Enable all clocks (if they aren't on already...).
         unsafe {
             pm::enable_clock(self.ahb_clock);
@@ -753,10 +877,10 @@ impl FLASHCALW {
 
         // Configure all other interrupts explicitly. Note the issue_command
         // function turns this on when need be.
-        self.enable_ready_int(false);
-        self.enable_lock_error_int(false);
-        self.enable_prog_error_int(false);
-        self.enable_ecc_int(false);
+        regs.fcr.modify(
+            FlashControl::FRDY::CLEAR + FlashControl::LOCKE::CLEAR + FlashControl::PROGE::CLEAR
+                + FlashControl::ECCE::CLEAR,
+        );
 
         // Enable wait state 1 optimization.
         self.enable_ws1_read_opt(true);

--- a/kernel/src/common/regs/mod.rs
+++ b/kernel/src/common/regs/mod.rs
@@ -4,7 +4,7 @@
 pub mod macros;
 
 use core::marker::PhantomData;
-use core::ops::{Add, BitAnd, BitOr, Not, Shl, Shr};
+use core::ops::{Add, AddAssign, BitAnd, BitOr, Not, Shl, Shr};
 
 pub trait IntLike
     : BitAnd<Output = Self>
@@ -248,5 +248,16 @@ impl<T: IntLike, R: RegisterLongName> Add for FieldValue<T, R> {
             value: self.value | rhs.value,
             associated_register: PhantomData,
         }
+    }
+}
+
+// Combine two fields with the += operator
+impl<T: IntLike, R: RegisterLongName> AddAssign for FieldValue<T, R> {
+    fn add_assign(&mut self, rhs: FieldValue<T, R>) {
+        *self = FieldValue {
+            mask: self.mask | rhs.mask,
+            value: self.value | rhs.value,
+            associated_register: PhantomData,
+        };
     }
 }

--- a/userland/examples/tests/nonvolatile_storage/README.md
+++ b/userland/examples/tests/nonvolatile_storage/README.md
@@ -1,0 +1,83 @@
+Nonvolatile Storage Test App
+============================
+
+This app writes to flash storage and reads it back to test that flash storage
+is working. It requires that a
+`capsules::nonvolatile_storage_driver::NonvolatileStorage` interface be provided
+to userland.
+
+
+
+Example Hail Setup
+------------------
+
+One way to provide the Driver interface with Hail looks like:
+
+```diff
+--- a/boards/hail/src/main.rs
++++ b/boards/hail/src/main.rs
+@@ -74,6 +74,7 @@ struct Hail {
+     ipc: kernel::ipc::IPC,
+     crc: &'static capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
+     dac: &'static capsules::dac::Dac<'static>,
++    nv: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
+ }
+
+ /// Mapping of integer syscalls to objects that implement syscalls.
+@@ -104,6 +105,8 @@ impl Platform for Hail {
+             capsules::dac::DRIVER_NUM => f(Some(self.dac)),
+
+             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
++
++            27 => f(Some(self.nv)),
+             _ => f(None),
+         }
+     }
+@@ -443,6 +446,38 @@ pub unsafe fn reset_handler() {
+         capsules::dac::Dac::new(&mut sam4l::dac::DAC)
+     );
+
++    // Flash
++    let mux_flash = static_init!(
++        capsules::virtual_flash::MuxFlash<'static, sam4l::flashcalw::FLASHCALW>,
++        capsules::virtual_flash::MuxFlash::new(&sam4l::flashcalw::FLASH_CONTROLLER));
++    hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, mux_flash);
++
++    // Nonvolatile Storage
++    let virtual_flash_nv = static_init!(
++        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
++        capsules::virtual_flash::FlashUser::new(mux_flash));
++    pub static mut NV_PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
++
++    let nv_nv_to_page = static_init!(
++        capsules::nonvolatile_to_pages::NonvolatileToPages<'static,
++            capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
++        capsules::nonvolatile_to_pages::NonvolatileToPages::new(
++            virtual_flash_nv,
++            &mut NV_PAGEBUFFER));
++    hil::flash::HasClient::set_client(virtual_flash_nv, nv_nv_to_page);
++
++    pub static mut NV_BUFFER: [u8; 512] = [0; 512];
++    let nv = static_init!(
++        capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
++        capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
++            nv_nv_to_page, kernel::Grant::create(),
++            0x60000, // Start address for userspace accessible region
++            0x20000, // Length of userspace accessible region
++            0,       // Start address of kernel accessible region
++            0,       // Length of kernel accessible region
++            &mut NV_BUFFER));
++    hil::nonvolatile_storage::NonvolatileStorage::set_client(nv_nv_to_page, nv);
++
+     let hail = Hail {
+         console: console,
+         gpio: gpio,
+@@ -460,6 +495,7 @@ pub unsafe fn reset_handler() {
+         ipc: kernel::ipc::IPC::new(),
+         crc: crc,
+         dac: dac,
++        nv: nv,
+     };
+
+     // Need to reset the nRF on boot
+```


### PR DESCRIPTION
### Pull Request Overview

This pull request:

1. Updates the flash driver to the new register interface.
2. Removes many getters and setters in the flash driver. These effectively wrapped reading and writing register bits, but were never actually used, and now that the register interface makes these easy and expressive there is little use in having all of the dead code around.
2. Implements `+=` for register fields in the new register interface setup.
3. Adds some documentation to the nonvolatile storage test app.


### Testing Strategy

This pull request was tested by running the nonvolatile storage test app.





### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
