### PR TITLE
sam4l: update to cargo.lock

### DIFF
--- a/chips/sam4l/Cargo.lock
+++ b/chips/sam4l/Cargo.lock
@@ -4,7 +4,6 @@ version = "0.1.0"
 dependencies = [
  "cortexm4 0.1.0",
  "kernel 0.1.0",
- "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12,20 +11,9 @@ name = "cortexm4"
 version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
- "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kernel"
 version = "0.1.0"
-dependencies = [
- "rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
-[[package]]
-name = "rust-libcore"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum rust-libcore 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ae7a33830cc02d03ae1e50057d0e4e4b1a84be09bfb158bf95e9c3f3373aa453"


### PR DESCRIPTION
### Pull Request Overview

This pull request would remove a changed file that I have constantly lingering. I'm not sure why cargo.lock for the sam4l crate changed for me, and if anyone else is seeing this change. I do know that I have a troubled history with *.lock files, and if it shouldn't be changing, then I would like to know what I am doing differently on my mac.

