### PR TITLE
doc: add super quick setup steps

### DIFF
--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -11,7 +11,28 @@ developing Tock.
 3. [arm-none-eabi toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) (version >= 5.2)
 4. Command line utilities: wget, sed, make, cmake
 
+### Super Quick Setup
+
+MacOS:
+```
+$ curl https://sh.rustup.rs -sSf | sh
+$ brew tap ARMmbed/homebrew-formulae && brew update && brew install arm-none-eabi-gcc
+$ pip3 install tockloader --user
+```
+
+Ubuntu:
+```
+$ curl https://sh.rustup.rs -sSf | sh
+$ sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa && sudo apt update && sudo apt install gcc-arm-embedded
+$ pip3 install tockloader --user
+```
+
+Then build the kernel by running `make` in the `boards/<platform>` directory.
+
 ### Installing Requirements
+
+These steps go into a little more depth. Note that the build system is capable
+of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -17,7 +17,7 @@ MacOS:
 ```
 $ curl https://sh.rustup.rs -sSf | sh
 $ brew tap ARMmbed/homebrew-formulae && brew update && brew install arm-none-eabi-gcc
-$ pip3 install tockloader --user
+$ pip3 install tockloader
 ```
 
 Ubuntu:

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -25,6 +25,7 @@ Ubuntu:
 $ curl https://sh.rustup.rs -sSf | sh
 $ sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa && sudo apt update && sudo apt install gcc-arm-embedded
 $ pip3 install tockloader --user
+$ grep -q dialout <(groups $(whoami)) || sudo usermod -a -G dialout $(whoami) # Note, will need to reboot if prompted for password
 ```
 
 Then build the kernel by running `make` in the `boards/<platform>` directory.


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the bare minimum steps you have to do to get Tock working on two common platforms. Every time I'm setting up Tock on a new computer/VM I always want these steps, and I think that experienced developers will appreciate the straight to the point directions. Plus, they don't require you to manually install anything that the build scripts are just going to do for you.



### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
