### PR TITLE
chips/cc26xx: Use new regs interface

### DIFF
--- a/chips/cc26xx/src/gpio.rs
+++ b/chips/cc26xx/src/gpio.rs
@@ -7,7 +7,7 @@
 use core::cell::Cell;
 use core::ops::{Index, IndexMut};
 use ioc;
-use kernel::common::VolatileCell;
+use kernel::common::regs::{ReadWrite, WriteOnly};
 use kernel::hil;
 
 const NUM_PINS: usize = 32;
@@ -16,17 +16,17 @@ const GPIO_BASE: *const GpioRegisters = 0x4002_2000 as *const GpioRegisters;
 #[repr(C)]
 pub struct GpioRegisters {
     _reserved0: [u8; 0x90],
-    pub dout_set: VolatileCell<u32>,
+    pub dout_set: WriteOnly<u32>,
     _reserved1: [u8; 0xC],
-    pub dout_clr: VolatileCell<u32>,
+    pub dout_clr: WriteOnly<u32>,
     _reserved2: [u8; 0xC],
-    pub dout_tgl: VolatileCell<u32>,
+    pub dout_tgl: WriteOnly<u32>,
     _reserved3: [u8; 0xC],
-    pub din: VolatileCell<u32>,
+    pub din: ReadWrite<u32>,
     _reserved4: [u8; 0xC],
-    pub doe: VolatileCell<u32>,
+    pub doe: ReadWrite<u32>,
     _reserved5: [u8; 0xC],
-    pub evflags: VolatileCell<u32>,
+    pub evflags: ReadWrite<u32>,
 }
 
 pub struct GPIOPin {

--- a/chips/cc26xx/src/prcm.rs
+++ b/chips/cc26xx/src/prcm.rs
@@ -11,7 +11,7 @@
 //! It also manages the clocks attached to almost every peripheral, which needs to
 //! be enabled before usage.
 
-use kernel::common::regs::{ReadOnly, WriteOnly, ReadWrite};
+use kernel::common::regs::{ReadOnly, ReadWrite, WriteOnly};
 
 #[repr(C)]
 struct PrcmRegisters {

--- a/chips/cc26xx/src/prcm.rs
+++ b/chips/cc26xx/src/prcm.rs
@@ -11,48 +11,77 @@
 //! It also manages the clocks attached to almost every peripheral, which needs to
 //! be enabled before usage.
 
-use kernel::common::VolatileCell;
+use kernel::common::regs::{ReadOnly, WriteOnly, ReadWrite};
 
 #[repr(C)]
 struct PrcmRegisters {
-    _reserved0: [VolatileCell<u8>; 0x28],
+    _reserved0: [ReadOnly<u8>; 0x28],
 
     // Write 1 in order to load settings
-    pub clk_load_ctl: VolatileCell<u32>,
+    pub clk_load_ctl: ReadWrite<u32, ClockLoad::Register>,
 
-    _reserved1: [VolatileCell<u8>; 0x10],
+    _reserved1: [ReadOnly<u8>; 0x10],
 
     // TRNG, Crypto, and UDMA
-    pub sec_dma_clk_run: VolatileCell<u32>,
-    pub sec_dma_clk_sleep: VolatileCell<u32>,
-    pub sec_dma_clk_deep_sleep: VolatileCell<u32>,
+    pub sec_dma_clk_run: ReadWrite<u32, SECDMAClockGate::Register>,
+    pub sec_dma_clk_sleep: ReadWrite<u32, SECDMAClockGate::Register>,
+    pub sec_dma_clk_deep_sleep: ReadWrite<u32, SECDMAClockGate::Register>,
 
-    pub gpio_clk_gate_run: VolatileCell<u32>,
-    pub gpio_clk_gate_sleep: VolatileCell<u32>,
-    pub gpio_clk_gate_deep_sleep: VolatileCell<u32>,
+    pub gpio_clk_gate_run: ReadWrite<u32, ClockGate::Register>,
+    pub gpio_clk_gate_sleep: ReadWrite<u32, ClockGate::Register>,
+    pub gpio_clk_gate_deep_sleep: ReadWrite<u32, ClockGate::Register>,
 
-    _reserved3: [VolatileCell<u8>; 0x18],
+    _reserved3: [ReadOnly<u8>; 0x18],
 
-    pub uart_clk_gate_run: VolatileCell<u32>,
-    pub uart_clk_gate_sleep: VolatileCell<u32>,
-    pub uart_clk_gate_deep_sleep: VolatileCell<u32>,
+    pub uart_clk_gate_run: ReadWrite<u32, ClockGate::Register>,
+    pub uart_clk_gate_sleep: ReadWrite<u32, ClockGate::Register>,
+    pub uart_clk_gate_deep_sleep: ReadWrite<u32, ClockGate::Register>,
 
-    _reserved4: [VolatileCell<u8>; 0xB4],
+    _reserved4: [ReadOnly<u8>; 0xB4],
 
     // Power domain control 0
-    pub pd_ctl0: VolatileCell<u32>,
-    pub pd_ctl0_rfc: VolatileCell<u32>,
-    pub pd_ctl0_serial: VolatileCell<u32>,
-    pub pd_ctl0_peripheral: VolatileCell<u32>,
+    pub pd_ctl0: ReadWrite<u32, PowerDomain0::Register>,
+    pub pd_ctl0_rfc: WriteOnly<u32, PowerDomainSingle::Register>,
+    pub pd_ctl0_serial: WriteOnly<u32, PowerDomainSingle::Register>,
+    pub pd_ctl0_peripheral: WriteOnly<u32, PowerDomainSingle::Register>,
 
-    _reserved5: [VolatileCell<u8>; 0x04],
+    _reserved5: [ReadOnly<u8>; 0x04],
 
     // Power domain status 0
-    pub pd_stat0: VolatileCell<u32>,
-    pub pd_stat0_rfc: VolatileCell<u32>,
-    pub pd_stat0_serial: VolatileCell<u32>,
-    pub pd_stat0_periph: VolatileCell<u32>,
+    pub pd_stat0: ReadOnly<u32, PowerDomainStatus0::Register>,
+    pub pd_stat0_rfc: ReadOnly<u32, PowerDomainSingle::Register>,
+    pub pd_stat0_serial: ReadOnly<u32, PowerDomainSingle::Register>,
+    pub pd_stat0_periph: ReadOnly<u32, PowerDomainSingle::Register>,
 }
+
+register_bitfields![
+    u32,
+    ClockLoad [
+        LOAD_DONE   OFFSET(1) NUMBITS(1) [],
+        LOAD        OFFSET(0) NUMBITS(1) []
+    ],
+    SECDMAClockGate [
+        DMA_CLK_EN      OFFSET(8) NUMBITS(1) [],
+        TRNG_CLK_EN     OFFSET(1) NUMBITS(1) [],
+        CRYPTO_CLK_EN   OFFSET(0) NUMBITS(1) []
+    ],
+    ClockGate [
+        CLK_EN  OFFSET(0) NUMBITS(1) []
+    ],
+    PowerDomain0 [
+        PERIPH_ON   OFFSET(2) NUMBITS(1) [],
+        SERIAL_ON   OFFSET(1) NUMBITS(1) [],
+        RFC_ON      OFFSET(0) NUMBITS(1) []
+    ],
+    PowerDomainSingle [
+        ON  OFFSET(0) NUMBITS(1) []
+    ],
+    PowerDomainStatus0 [
+        PERIPH_ON   OFFSET(2) NUMBITS(1) [],
+        SERIAL_ON   OFFSET(1) NUMBITS(1) [],
+        RFC_ON      OFFSET(0) NUMBITS(1) []
+    ]
+];
 
 const PRCM_BASE: *mut PrcmRegisters = 0x4008_2000 as *mut PrcmRegisters;
 
@@ -62,9 +91,9 @@ const PRCM_BASE: *mut PrcmRegisters = 0x4008_2000 as *mut PrcmRegisters;
 */
 fn prcm_commit() {
     let regs: &PrcmRegisters = unsafe { &*PRCM_BASE };
-    regs.clk_load_ctl.set(1);
+    regs.clk_load_ctl.write(ClockLoad::LOAD::SET);
     // Wait for the settings to take effect
-    while (regs.clk_load_ctl.get() & 0b10) == 0 {}
+    while !regs.clk_load_ctl.is_set(ClockLoad::LOAD_DONE) {}
 }
 
 pub enum PowerDomain {
@@ -84,10 +113,10 @@ impl Power {
 
         match domain {
             PowerDomain::Peripherals => {
-                regs.pd_ctl0.set(regs.pd_ctl0.get() | 0x4);
+                regs.pd_ctl0.modify(PowerDomain0::PERIPH_ON::SET);
             }
             PowerDomain::Serial => {
-                regs.pd_ctl0.set(regs.pd_ctl0.get() | 0x2);
+                regs.pd_ctl0.modify(PowerDomain0::SERIAL_ON::SET);
             }
             _ => {
                 panic!("Tried to turn on a power domain not yet specified!");
@@ -98,8 +127,8 @@ impl Power {
     pub fn is_enabled(domain: PowerDomain) -> bool {
         let regs: &PrcmRegisters = unsafe { &*PRCM_BASE };
         match domain {
-            PowerDomain::Peripherals => (regs.pd_stat0_periph.get() & 1) >= 1,
-            PowerDomain::Serial => (regs.pd_stat0_serial.get() & 1) >= 1,
+            PowerDomain::Peripherals => regs.pd_stat0_periph.is_set(PowerDomainSingle::ON),
+            PowerDomain::Serial => regs.pd_stat0_serial.is_set(PowerDomainSingle::ON),
             _ => false,
         }
     }
@@ -110,9 +139,9 @@ pub struct Clock(());
 impl Clock {
     pub fn enable_gpio() {
         let regs: &PrcmRegisters = unsafe { &*PRCM_BASE };
-        regs.gpio_clk_gate_run.set(1);
-        regs.gpio_clk_gate_sleep.set(1);
-        regs.gpio_clk_gate_deep_sleep.set(1);
+        regs.gpio_clk_gate_run.write(ClockGate::CLK_EN::SET);
+        regs.gpio_clk_gate_sleep.write(ClockGate::CLK_EN::SET);
+        regs.gpio_clk_gate_deep_sleep.write(ClockGate::CLK_EN::SET);
 
         prcm_commit();
     }


### PR DESCRIPTION
### Pull Request Overview
This is a rewrite to use the new regs interface in cc26xx.

### Files updated ###

- [x] ioc.rs
- [x] prcm.rs
- [x] gpio.rs

Did not update AON implementation due to that it will be updated in the future and rewritten.

### Formatting

- [x] Ran `make formatall`.