### PR TITLE
make: fix bug in xargo 3.11

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -104,6 +104,12 @@ else ifeq ($(shell $(MAKEFILE_COMMON_PATH)../tools/semver.sh $(XARGO_VERSION) \<
   XARGO_VERSION := $(strip $(word 2, $(XARGO_CALL)))
 endif
 
+# Xargo 3.11 is broken an expects a `bin` folder to exist that doesn't. Work around
+# this by creating the bin folder ourselves if it doesn't exist.
+RUST_SYSROOT := $(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --print sysroot)
+RUST_HOST := $(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc -vV | grep host | cut -b 7-)
+$(shell mkdir -p $(RUST_SYSROOT)/lib/rustlib/$(RUST_HOST)/bin)
+
 # Dump configuration for verbose builds
 ifneq ($(V),)
   $(info )


### PR DESCRIPTION
Xargo as of 3.11 expects a bin folder to exist that we don't have. If we just create
it then the tool copy in
https://github.com/japaric/xargo/commit/9787b692be1cb7d3602a4b2d68d4b545af2f5cc2
just works and everything is great.

### TODO or Help Wanted

This pull request might be the wrong way to go, and might not work for everyone. But it's a start.


