### PR TITLE
netlify: less verbose wget

### DIFF
--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -10,7 +10,7 @@ export PATH="$PATH:$HOME/.cargo/bin"
 
 cargo install xargo
 
-wget 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2?revision=375265d4-e9b5-41c8-bf23-56cbe927e156?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2017-q4-major' -O arm.tgz
+wget -nv 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2?revision=375265d4-e9b5-41c8-bf23-56cbe927e156?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2017-q4-major' -O arm.tgz
 
 tar -xf arm.tgz
 export PATH="$PATH:$(pwd)/gcc-arm-none-eabi-7-2017-q4-major/bin"


### PR DESCRIPTION
### Pull Request Overview

This removes the progress output for wget on netlify builds, which makes the deploy logs much more readable.