### PR TITLE
update to rustc nightly 2018-03-07

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: rust
 
 env:
-  - RUSTUP_TOOLCHAIN=nightly-2018-01-05
+  - RUSTUP_TOOLCHAIN=nightly-2018-03-07
 
 cache:
   cargo: true
@@ -17,7 +17,7 @@ os:
 # If you change this, you must also change Getting_Started.md, Makefile.common,
 # and Vagrantfile.
 rust:
-  - nightly-2018-01-05
+  - nightly-2018-03-07
 
 before_install:
   - ./.travis-install-gcc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "editor.formatOnSave": true,
-    "rust-client.channel": "nightly-2018-01-05",
+    "rust-client.channel": "nightly-2018-03-07",
 }

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -5,7 +5,7 @@ MAKEFLAGS += -R
 
 MAKEFILE_COMMON_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-export RUSTUP_TOOLCHAIN ?= nightly-2018-01-05
+export RUSTUP_TOOLCHAIN ?= nightly-2018-03-07
 
 TOOLCHAIN ?= arm-none-eabi
 
@@ -69,7 +69,7 @@ endif
 
 
 # Check that rustc is the right nightly - warn not error if wrong, sometimes useful to test others
-RUSTC_VERSION_STRING := rustc 1.24.0-nightly (8e7a609e6 2018-01-04)
+RUSTC_VERSION_STRING := rustc 1.26.0-nightly (2789b067d 2018-03-06)
 ifneq ($(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VERSION_STRING))
   DUMMY := $(shell rustup install $(RUSTUP_TOOLCHAIN))
   ifneq ($(shell RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) rustc --version), $(RUSTC_VERSION_STRING))

--- a/capsules/src/aes_ccm.rs
+++ b/capsules/src/aes_ccm.rs
@@ -399,7 +399,8 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + 'a> AES128CCM<'a, A> {
 }
 
 impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + 'a> symmetric_encryption::AES128CCM<'a>
-    for AES128CCM<'a, A> {
+    for AES128CCM<'a, A>
+{
     fn set_client(&self, client: &'a symmetric_encryption::CCMClient) {
         self.crypt_client.set(Some(client));
     }
@@ -476,7 +477,8 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + 'a> symmetric_encryption::AES12
 }
 
 impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::Client<'a>
-    for AES128CCM<'a, A> {
+    for AES128CCM<'a, A>
+{
     fn crypt_done(&self, _: Option<&'a mut [u8]>, crypt_buf: &'a mut [u8]) {
         self.crypt_buf.replace(crypt_buf);
         match self.state.get() {

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -292,7 +292,8 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CLCustom for FM25CL<'a, S> {
 /// Implement the generic `NonvolatileStorage` interface common to chips that
 /// provide nonvolatile memory.
 impl<'a, S: hil::spi::SpiMasterDevice + 'a> hil::nonvolatile_storage::NonvolatileStorage
-    for FM25CL<'a, S> {
+    for FM25CL<'a, S>
+{
     fn set_client(&self, client: &'static hil::nonvolatile_storage::NonvolatileStorageClient) {
         self.client.set(Some(client));
     }

--- a/capsules/src/nonvolatile_to_pages.rs
+++ b/capsules/src/nonvolatile_to_pages.rs
@@ -84,7 +84,8 @@ impl<'a, F: hil::flash::Flash + 'a> NonvolatileToPages<'a, F> {
 }
 
 impl<'a, F: hil::flash::Flash + 'a> hil::nonvolatile_storage::NonvolatileStorage
-    for NonvolatileToPages<'a, F> {
+    for NonvolatileToPages<'a, F>
+{
     fn set_client(&self, client: &'static hil::nonvolatile_storage::NonvolatileStorageClient) {
         self.client.set(Some(client));
     }

--- a/capsules/src/virtual_flash.rs
+++ b/capsules/src/virtual_flash.rs
@@ -147,7 +147,8 @@ impl<'a, F: hil::flash::Flash + 'a> FlashUser<'a, F> {
 }
 
 impl<'a, F: hil::flash::Flash + 'a, C: hil::flash::Client<Self>> hil::flash::HasClient<'a, C>
-    for FlashUser<'a, F> {
+    for FlashUser<'a, F>
+{
     fn set_client(&'a self, client: &'a C) {
         self.mux.users.push_head(self);
         self.client.set(Some(client));

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -137,7 +137,8 @@ impl<'a, Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for VirtualSpiMaste
 }
 
 impl<'a, Spi: hil::spi::SpiMaster> ListNode<'a, VirtualSpiMasterDevice<'a, Spi>>
-    for VirtualSpiMasterDevice<'a, Spi> {
+    for VirtualSpiMasterDevice<'a, Spi>
+{
     fn next(&'a self) -> &'a ListLink<'a, VirtualSpiMasterDevice<'a, Spi>> {
         &self.next
     }

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![crate_name = "sam4l"]
 #![crate_type = "rlib"]
-#![feature(repr_align, attr_literals, const_cell_new)]
+#![feature(attr_literals, const_cell_new)]
 #![feature(const_atomic_usize_new, const_ptr_null_mut, integer_atomics, try_from)]
 #![feature(asm, core_intrinsics, concat_idents, const_fn)]
 #![no_std]

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -52,7 +52,7 @@ to your `$PATH`.
 Then install the correct nightly version of Rust:
 
 ```bash
-$ rustup install nightly-2018-01-05
+$ rustup install nightly-2018-03-07
 ```
 
 #### Xargo

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! Most `unsafe` code is in this kernel crate.
 
-#![feature(asm, core_intrinsics, unique, nonzero)]
+#![feature(asm, core_intrinsics, unique, nonzero, ptr_internals)]
 #![feature(const_fn, const_cell_new, const_unsafe_cell_new, lang_items)]
 #![no_std]
 

--- a/tools/install_cargo_fmt.sh
+++ b/tools/install_cargo_fmt.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export RUSTUP_TOOLCHAIN=nightly-2018-01-05
+export RUSTUP_TOOLCHAIN=nightly-2018-03-07
 
 # Verify that we're running in the base directory
 if [ ! -x tools/run_cargo_fmt.sh ]; then

--- a/tools/install_cargo_fmt.sh
+++ b/tools/install_cargo_fmt.sh
@@ -15,7 +15,7 @@ fi
 #
 # Note: We install a local copy of rustfmt so as not to interfere with any
 # other use of rustfmt on the machine
-RUSTFMT_VERSION=0.3.4
+RUSTFMT_VERSION=0.3.5
 
 if [[ $(rustc --version) != "rustc 1.24.0-nightly (8e7a609e6 2018-01-04)" ]]; then
 	rustup install $RUSTUP_TOOLCHAIN || (echo "Failed to install rustc. Please read doc/Getting_Started.md"; exit 1)

--- a/tools/netlify-build.sh
+++ b/tools/netlify-build.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -x
 
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-01-05
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-03-07
 
 export PATH="$PATH:$HOME/.cargo/bin"
 

--- a/tools/run_cargo_fmt.sh
+++ b/tools/run_cargo_fmt.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export RUSTUP_TOOLCHAIN=nightly-2018-01-05
+export RUSTUP_TOOLCHAIN=nightly-2018-03-07
 
 # Verify that we're running in the base directory
 if [ ! -x tools/run_cargo_fmt.sh ]; then

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -63,7 +63,7 @@ Vagrant.configure("2") do |config|
   # Set up rust development environment
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     wget https://sh.rustup.rs -O rustup.sh && sh rustup.sh -y
-    source ~/.profile && rustup install nightly-2018-01-05
+    source ~/.profile && rustup install nightly-2018-03-07
   SHELL
 
   # Copy git configuration


### PR DESCRIPTION
### Pull Request Overview

This pull request does the every-two-month update to rustc. Not too much exciting, but did have to add a new feature declaration.

I did want to include some errors that adding `#![feature(ptr_internals)]` avoided in case the suggestions are actually worth us looking into:

```
error[E0658]: use of unstable library feature 'ptr_internals': use NonNull instead and consider PhantomData<T> (if you also use #[may_dangle]), Send, and/or Sync (see issue #0)
 --> /Users/bradjc/git/tock/kernel/src/grant.rs:7:48
  |
7 | use core::ptr::{read_volatile, write_volatile, Unique};
  |                                                ^^^^^^
  |
  = help: add #![feature(ptr_internals)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'ptr_internals': use NonNull instead and consider PhantomData<T> (if you also use #[may_dangle]), Send, and/or Sync (see issue #0)
  --> /Users/bradjc/git/tock/kernel/src/grant.rs:52:11
   |
52 |     data: Unique<T>,
   |           ^^^^^^^^^
   |
   = help: add #![feature(ptr_internals)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'ptr_internals': use NonNull instead and consider PhantomData<T> (if you also use #[may_dangle]), Send, and/or Sync (see issue #0)
 --> /Users/bradjc/git/tock/kernel/src/mem.rs:6:5
  |
6 | use core::ptr::Unique;
  |     ^^^^^^^^^^^^^^^^^
  |
  = help: add #![feature(ptr_internals)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'ptr_internals': use NonNull instead and consider PhantomData<T> (if you also use #[may_dangle]), Send, and/or Sync (see issue #0)
  --> /Users/bradjc/git/tock/kernel/src/mem.rs:16:10
   |
16 |     ptr: Unique<T>,
   |          ^^^^^^^^^
   |
   = help: add #![feature(ptr_internals)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'ptr_internals': use NonNull instead and consider PhantomData<T> (if you also use #[may_dangle]), Send, and/or Sync (see issue #0)
  --> /Users/bradjc/git/tock/kernel/src/grant.rs:59:19
   |
59 |             data: Unique::new_unchecked(data),
   |                   ^^^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(ptr_internals)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'ptr_internals': use NonNull instead and consider PhantomData<T> (if you also use #[may_dangle]), Send, and/or Sync (see issue #0)
  --> /Users/bradjc/git/tock/kernel/src/mem.rs:24:18
   |
24 |             ptr: Unique::new_unchecked(ptr),
   |                  ^^^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(ptr_internals)] to the crate attributes to enable
```

There are also a couple warnings that will go away when the sam4l usart to new regs is merged.


### Testing Strategy

This pull request was tested by running some apps on hail.


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.


### Formatting

- [x] Ran `make formatall`.
