### PR TITLE
Fixing broken links in capsule documentation

### DIFF
--- a/capsules/README.md
+++ b/capsules/README.md
@@ -74,7 +74,7 @@ These capsules provide a `Driver` interface for common MCU peripherals.
 - **[I2C](src/i2c_master_slave_driver.rs)**: I2C master and slave access.
 - **[RNG](src/rng.rs)**: Random number generation.
 - **[SPI](src/spi.rs)**: SPI master and slave.
-- **[Symmetric Encryption](src/symmetric_encryption.rs)**: AES encryption.
+- **[Symmetric Encryption](src/aes_ccm.rs)**: AES encryption.
 
 
 ### Helpful Userspace Capsules
@@ -99,7 +99,7 @@ simultaneously) support for generic sensor interfaces.
 - **[Asynchronous GPIO](src/gpio_async.rs)**: GPIO pins accessed by split-phase
   calls.
 - **[9DOF](src/ninedof.rs)**: 9DOF sensors (acceleration, magnetometer, gyroscope).
-- **[Nonvolatile Storage](src/nonvolatile_storage.rs)**: Persistent storage for
+- **[Nonvolatile Storage](src/nonvolatile_storage_driver.rs)**: Persistent storage for
   userspace.
 
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes two broken links in the capsules documentation. I happened to run into them while going over them and they were quick enough to fix!


### Testing Strategy

Checked out the links in the GitHub renderer and they now link to the correct files.


### TODO or Help Wanted

This is my first pull request to Tock so let me know if I need to change anything to fit into your maintenance process!
