### PR TITLE
Revert "sam4l: update usart to use RegManager"

### DIFF
--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -14,7 +14,6 @@ static mut WRITER: Writer = Writer { initialized: false };
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
         let uart = unsafe { &mut sam4l::usart::USART0 };
-        let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
             uart.init(uart::UARTParams {
@@ -23,12 +22,12 @@ impl Write for Writer {
                 parity: uart::Parity::None,
                 hw_flow_control: false,
             });
-            uart.enable_tx(regs_manager);
+            uart.enable_tx();
         }
         // XXX: I'd like to get this working the "right" way, but I'm not sure how
         for c in s.bytes() {
-            uart.send_byte(regs_manager, c);
-            while !uart.tx_ready(regs_manager) {}
+            uart.send_byte(c);
+            while !uart.tx_ready() {}
         }
         Ok(())
     }

--- a/boards/imix/src/i2c_dummy.rs
+++ b/boards/imix/src/i2c_dummy.rs
@@ -86,7 +86,7 @@ impl hil::i2c::I2CHwMasterClient for AccelClient {
                 debug!("Activating Sensor...");
                 buffer[0] = 0x2A as u8; // CTRL_REG1
                 buffer[1] = 1; // Bit 1 sets `active`
-                dev.write(0x1e, i2c::START | i2c::STOP, buffer, 2);
+                dev.write(0x1e, buffer, 2);
                 self.state.set(Activating);
             }
             Activating => {
@@ -210,6 +210,6 @@ pub fn i2c_li_test() {
     buf[0] = 0;
     buf[1] = 0b10100000;
     buf[2] = 0b00000000;
-    dev.write(0x44, i2c::START | i2c::STOP, buf, 3);
+    dev.write(0x44, buf, 3);
     i2c_client.state.set(LiClientState::Enabling);
 }

--- a/boards/imix/src/i2c_dummy.rs
+++ b/boards/imix/src/i2c_dummy.rs
@@ -86,7 +86,7 @@ impl hil::i2c::I2CHwMasterClient for AccelClient {
                 debug!("Activating Sensor...");
                 buffer[0] = 0x2A as u8; // CTRL_REG1
                 buffer[1] = 1; // Bit 1 sets `active`
-                dev.write(0x1e, buffer, 2);
+                dev.write(0x1e, i2c::START | i2c::STOP, buffer, 2);
                 self.state.set(Activating);
             }
             Activating => {
@@ -210,6 +210,6 @@ pub fn i2c_li_test() {
     buf[0] = 0;
     buf[1] = 0b10100000;
     buf[2] = 0b00000000;
-    dev.write(0x44, buf, 3);
+    dev.write(0x44, i2c::START | i2c::STOP, buf, 3);
     i2c_client.state.set(LiClientState::Enabling);
 }

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -13,7 +13,6 @@ static mut WRITER: Writer = Writer { initialized: false };
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
         let uart = unsafe { &mut sam4l::usart::USART3 };
-        let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
             uart.init(uart::UARTParams {
@@ -22,12 +21,12 @@ impl Write for Writer {
                 parity: uart::Parity::None,
                 hw_flow_control: false,
             });
-            uart.enable_tx(regs_manager);
+            uart.enable_tx();
         }
         // XXX: I'd like to get this working the "right" way, but I'm not sure how
         for c in s.bytes() {
-            uart.send_byte(regs_manager, c);
-            while !uart.tx_ready(regs_manager) {}
+            uart.send_byte(c);
+            while !uart.tx_ready() {}
         }
         Ok(())
     }

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -257,10 +257,6 @@ impl DMAChannel {
         }
     }
 
-    pub fn is_enabled(&self) -> bool {
-        self.enabled.get()
-    }
-
     pub fn handle_interrupt(&mut self) {
         let registers: &DMARegisters = unsafe { &*self.registers };
         registers


### PR DESCRIPTION
This reverts commit ee68206bc6889f651964a4bd2d7479f4eb441cf0.

Uart console doesn't work with this commit.




### Testing Strategy

This pull request was tested by:

- Using crash_dummy, pressing the button, nothing prints.
- Running hail. Output looks like:

    ```
    0x20008600[Hail] Transmits name over BLE.

    ␀�+RXZ�WH�]��on controls LED.
    [Hail Sensor Reading]
      Temperature:  3060 1/100 degrees C
      Humidity:     2165 0.01%
      Light:        15
      Acceleration: 974
      A0:           2182 mV
      A1:           2651 mV
      A2:           2669 mV
      A3:           2577 mV
      A4:           2624 mV
      A5:           2600 mV
      D0:           0
      D1:           0
      D6:           0
      D7:           0
    ␂␀h�*+�␋�U�k�Ɂ�������u�
      Temperature:  3059 1/100 degrees C
      Humidity:     2164 0.01%
      Light:        15
      Acceleratio
    ```


### TODO or Help Wanted

Ideally we would fix the issue with ee68206bc6889f651964a4bd2d7479f4eb441cf0.

