### PR TITLE
cc26xx: return expected value for get_alarm in rtc

### DIFF
--- a/chips/cc26xx/src/rtc.rs
+++ b/chips/cc26xx/src/rtc.rs
@@ -162,6 +162,7 @@ impl Alarm for Rtc {
     }
 
     fn get_alarm(&self) -> u32 {
-        self.read_counter()
+        let regs: &RtcRegisters = unsafe { &*self.regs };
+        regs.channel1_cmp.get()
     }
 }


### PR DESCRIPTION
### Pull Request Overview

Discovered that the implementation of `get_alarm` did not return the expected value when working on the radio driver. One-liner which fixes it :)

### Testing Strategy

Tested with the BLE advertising driver, which uses the RTC to periodically send advertisements.

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [x] Ran `make formatall`.
