### PR TITLE
cc26xx: fix sw_reset check in trng

### DIFF
--- a/chips/cc26xx/src/trng.rs
+++ b/chips/cc26xx/src/trng.rs
@@ -97,7 +97,7 @@ impl Trng {
 
         // Issue a SW reset
         regs.sw_reset.write(SoftwareReset::RESET::SET);
-        while !regs.sw_reset.is_set(SoftwareReset::RESET) {}
+        while regs.sw_reset.is_set(SoftwareReset::RESET) {}
 
         // Set the startup samples
         regs.ctl.modify(Control::STARTUP_CYCLES.val(1));


### PR DESCRIPTION
### Pull Request Overview

Blunder during conversion to the new regs interface, wasn't
caught until tested on cc2650 - worked fine with CC2652 (probably
due to a different clock speed).

The reset is not completed until sw_reset is zeroed, and if it is fast enough it'll reach zero before the while loop.

### Testing Strategy

Tested on both LaunchXL CC265XR1 and SensorTag CC2650STK, flash any app and see if it gets stuck in the reset_handler or not.

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [x] Ran `make formatall`.