### PR TITLE
kernel: split register matches to any and all

### DIFF
--- a/chips/nrf52/src/clock.rs
+++ b/chips/nrf52/src/clock.rs
@@ -206,7 +206,7 @@ impl Clock {
     /// Check if the high frequency clock has started
     pub fn high_started(&self) -> bool {
         let regs = unsafe { &*self.registers };
-        regs.events_hfclkstarted.matches(Status::READY.val(1))
+        regs.events_hfclkstarted.matches_all(Status::READY.val(1))
     }
 
     /// Read clock source from the high frequency clock
@@ -221,7 +221,7 @@ impl Clock {
     /// Check if the high frequency clock is running
     pub fn high_running(&self) -> bool {
         let regs = unsafe { &*self.registers };
-        regs.hfclkstat.matches(HfClkStat::STATE::RUNNING)
+        regs.hfclkstat.matches_all(HfClkStat::STATE::RUNNING)
     }
 
     /// Start the low frequency clock
@@ -239,7 +239,7 @@ impl Clock {
     /// Check if the low frequency clock has started
     pub fn low_started(&self) -> bool {
         let regs = unsafe { &*self.registers };
-        regs.events_lfclkstarted.matches(Status::READY::SET)
+        regs.events_lfclkstarted.matches_all(Status::READY::SET)
     }
 
     /// Read clock source from the low frequency clock
@@ -255,7 +255,7 @@ impl Clock {
     /// Check if the low frequency clock is running
     pub fn low_running(&self) -> bool {
         let regs = unsafe { &*self.registers };
-        regs.lfclkstat.matches(LfClkStat::STATE::RUNNING)
+        regs.lfclkstat.matches_all(LfClkStat::STATE::RUNNING)
     }
 
     /// Set low frequency clock source

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -577,7 +577,7 @@ impl Adc {
             // wait until buffers are enabled
             timeout = 100000;
             while !regs.sr
-                .matches(Status::BGREQ::SET + Status::REFBUF::SET + Status::EN::SET)
+                .matches_all(Status::BGREQ::SET + Status::REFBUF::SET + Status::EN::SET)
             {
                 timeout -= 1;
                 if timeout == 0 {

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -765,9 +765,10 @@ pub fn deep_sleep_ready() -> bool {
         /* added by us */ ClockMaskPbb::PDCA::SET;
 
     unsafe {
-        let hsb = (*PM_REGS).hsbmask.matches(deep_sleep_hsbmask);
-        let pba = (*PM_REGS).pbamask.matches(deep_sleep_pbamask);
-        let pbb = (*PM_REGS).pbbmask.matches(deep_sleep_pbbmask);
+        // FIXME: This match is wrong
+        let hsb = (*PM_REGS).hsbmask.matches_all(deep_sleep_hsbmask);
+        let pba = (*PM_REGS).pbamask.matches_all(deep_sleep_pbamask);
+        let pbb = (*PM_REGS).pbbmask.matches_all(deep_sleep_pbbmask);
         let gpio = gpio::INTERRUPT_COUNT.load(Ordering::Relaxed) == 0;
         hsb && pba && pbb && gpio
     }

--- a/chips/sam4l/src/scif.rs
+++ b/chips/sam4l/src/scif.rs
@@ -228,14 +228,14 @@ pub fn oscillator_disable() {
 
 pub unsafe fn setup_dfll_rc32k_48mhz() {
     unsafe fn wait_dfll0_ready() {
-        while (*SCIF).pclksr.matches(Interrupt::DFLL0RDY::CLEAR) {}
+        while (*SCIF).pclksr.matches_all(Interrupt::DFLL0RDY::CLEAR) {}
     }
 
     // Check to see if the DFLL is already setup or is not locked
     if (*SCIF)
         .dfll0conf
-        .matches(Dfll::MODE::OpenLoop + Dfll::EN::CLEAR)
-        || (*SCIF).pclksr.matches(Interrupt::DFLL0LOCKF::CLEAR)
+        .matches_all(Dfll::MODE::OpenLoop + Dfll::EN::CLEAR)
+        || (*SCIF).pclksr.matches_all(Interrupt::DFLL0LOCKF::CLEAR)
     {
         // Enable the GENCLK_SRC_RC32K
         bscif::enable_rc32k();
@@ -296,7 +296,7 @@ pub unsafe fn setup_dfll_rc32k_48mhz() {
         (*SCIF).dfll0conf.set(scif_dfll0conf_new);
 
         // Now wait for the DFLL to become locked
-        while (*SCIF).pclksr.matches(Interrupt::DFLL0LOCKF::CLEAR) {}
+        while (*SCIF).pclksr.matches_all(Interrupt::DFLL0LOCKF::CLEAR) {}
     }
 }
 
@@ -309,7 +309,7 @@ pub unsafe fn setup_osc_16mhz_fast_startup() {
     );
 
     // Wait for oscillator to be ready
-    while (*SCIF).pclksr.matches(Interrupt::OSC0RDY::CLEAR) {}
+    while (*SCIF).pclksr.matches_all(Interrupt::OSC0RDY::CLEAR) {}
 }
 
 pub unsafe fn setup_osc_16mhz_slow_startup() {
@@ -321,7 +321,7 @@ pub unsafe fn setup_osc_16mhz_slow_startup() {
     );
 
     // Wait for oscillator to be ready
-    while (*SCIF).pclksr.matches(Interrupt::OSC0RDY::CLEAR) {}
+    while (*SCIF).pclksr.matches_all(Interrupt::OSC0RDY::CLEAR) {}
 }
 
 pub unsafe fn setup_pll_osc_48mhz() {
@@ -333,7 +333,7 @@ pub unsafe fn setup_pll_osc_48mhz() {
     );
 
     // Wait for the PLL to become locked
-    while (*SCIF).pclksr.matches(Interrupt::PLL0LOCK::CLEAR) {}
+    while (*SCIF).pclksr.matches_all(Interrupt::PLL0LOCK::CLEAR) {}
 }
 
 pub fn generic_clock_disable(clock: GenericClock) {

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -333,7 +333,7 @@ impl SpiHw {
 
     fn get_clock(&self) -> ClockPolarity {
         let csr = self.get_active_csr();
-        if csr.matches(ChipSelectParams::CPOL::InactiveLow) {
+        if csr.matches_all(ChipSelectParams::CPOL::InactiveLow) {
             ClockPolarity::IdleLow
         } else {
             ClockPolarity::IdleHigh
@@ -350,7 +350,7 @@ impl SpiHw {
 
     fn get_phase(&self) -> ClockPhase {
         let csr = self.get_active_csr();
-        if csr.matches(ChipSelectParams::NCPHA::CaptureTrailing) {
+        if csr.matches_all(ChipSelectParams::NCPHA::CaptureTrailing) {
             ClockPhase::SampleTrailing
         } else {
             ClockPhase::SampleLeading
@@ -376,11 +376,11 @@ impl SpiHw {
         if self.role.get() == SpiRole::SpiMaster {
             let spi = &SpiRegisterManager::new(&self);
 
-            if spi.registers.mr.matches(Mode::PCS::PCS3) {
+            if spi.registers.mr.matches_all(Mode::PCS::PCS3) {
                 Peripheral::Peripheral3
-            } else if spi.registers.mr.matches(Mode::PCS::PCS2) {
+            } else if spi.registers.mr.matches_all(Mode::PCS::PCS2) {
                 Peripheral::Peripheral2
-            } else if spi.registers.mr.matches(Mode::PCS::PCS1) {
+            } else if spi.registers.mr.matches_all(Mode::PCS::PCS1) {
                 Peripheral::Peripheral1
             } else {
                 // default

--- a/kernel/src/common/regs/mod.rs
+++ b/kernel/src/common/regs/mod.rs
@@ -133,7 +133,12 @@ impl<T: IntLike, R: RegisterLongName> ReadWrite<T, R> {
     }
 
     #[inline]
-    pub fn matches(&self, field: FieldValue<T, R>) -> bool {
+    pub fn matches_any(&self, field: FieldValue<T, R>) -> bool {
+        self.get() & field.mask != T::zero()
+    }
+
+    #[inline]
+    pub fn matches_all(&self, field: FieldValue<T, R>) -> bool {
         self.get() & field.mask == field.value
     }
 }
@@ -163,7 +168,12 @@ impl<T: IntLike, R: RegisterLongName> ReadOnly<T, R> {
     }
 
     #[inline]
-    pub fn matches(&self, field: FieldValue<T, R>) -> bool {
+    pub fn matches_any(&self, field: FieldValue<T, R>) -> bool {
+        self.get() & field.mask != T::zero()
+    }
+
+    #[inline]
+    pub fn matches_all(&self, field: FieldValue<T, R>) -> bool {
         self.get() & field.mask == field.value
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request clarifies the semantics of the `matches` method by renaming it to `matches_all`, as it requires all of the fields to be as specified. It also then adds a `matches_any` method, which gives a mechanism for checking if any of certain fields are set.


### Testing Strategy

Hail still hails.

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [X] Ran `make formatall`.
