### PR TITLE
sam4l: update usart to use RegManager (again)

### DIFF
--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -13,6 +13,7 @@ static mut WRITER: Writer = Writer { initialized: false };
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
         let uart = unsafe { &mut sam4l::usart::USART3 };
+        let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
             uart.init(uart::UARTParams {
@@ -21,12 +22,12 @@ impl Write for Writer {
                 parity: uart::Parity::None,
                 hw_flow_control: false,
             });
-            uart.enable_tx();
+            uart.enable_tx(regs_manager);
         }
         // XXX: I'd like to get this working the "right" way, but I'm not sure how
         for c in s.bytes() {
-            uart.send_byte(c);
-            while !uart.tx_ready() {}
+            uart.send_byte(regs_manager, c);
+            while !uart.tx_ready(regs_manager) {}
         }
         Ok(())
     }

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -257,6 +257,10 @@ impl DMAChannel {
         }
     }
 
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.get()
+    }
+
     pub fn handle_interrupt(&mut self) {
         let registers: &DMARegisters = unsafe { &*self.registers };
         registers


### PR DESCRIPTION
### Pull Request Overview

This undoes #823, with the fix of shifting from `matches` (which was
implicitly `matches_all`) to `matches_any`.

### Testing Strategy

It prints correctly again!

```
[Hail Sensor Reading]
  Temperature:  2743 1/100 degrees C
  Humidity:     2657 0.01%
  Light:        234
  Acceleration: 994
  A0:           1686 mV
  A1:           1848 mV
  A2:           1931 mV
  A3:           1871 mV
  A4:           1938 mV
  A5:           1892 mV
  D0:           0
  D1:           0
  D6:           0
  D7:           0

[Hail Sensor Reading]
  Temperature:  2743 1/100 degrees C
  Humidity:     2658 0.01%
  Light:        234
  Acceleration: 998
  A0:           1801 mV
  A1:           1869 mV
  A2:           1838 mV
  A3:           1860 mV
  A4:           1987 mV
  A5:           1836 mV
  D0:           0
  D1:           0
  D6:           0
  D7:           0
```


### Documentation Updated

- [x] ~~Kernel: Updated the relevant files in `/docs`, or no updates are required.~~
- [x] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [x] Ran `make formatall`.
