### PR TITLE
Allow direct use of FieldValue mask

### DIFF
--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -763,10 +763,9 @@ pub fn deep_sleep_ready() -> bool {
         /* added by us */ ClockMaskPbb::HRAMC1::SET +
         /* added by us */ ClockMaskPbb::PDCA::SET;
 
-    // FIXME: This match is wrong
-    let hsb = PM_REGS.hsbmask.matches_all(deep_sleep_hsbmask);
-    let pba = PM_REGS.pbamask.matches_all(deep_sleep_pbamask);
-    let pbb = PM_REGS.pbbmask.matches_all(deep_sleep_pbbmask);
+    let hsb = PM_REGS.hsbmask.get() & !deep_sleep_hsbmask.mask() == 0;
+    let pba = PM_REGS.pbamask.get() & !deep_sleep_pbamask.mask() == 0;
+    let pbb = PM_REGS.pbbmask.get() & !deep_sleep_pbbmask.mask() == 0;
     let gpio = gpio::INTERRUPT_COUNT.load(Ordering::Relaxed) == 0;
     hsb && pba && pbb && gpio
 }

--- a/kernel/src/common/regs/mod.rs
+++ b/kernel/src/common/regs/mod.rs
@@ -268,6 +268,11 @@ impl<R: RegisterLongName> FieldValue<u8, R> {
             associated_register: PhantomData,
         }
     }
+
+    /// Get the raw bitmask represented by this FieldValue.
+    pub fn mask(self) -> u8 {
+        self.mask as u8
+    }
 }
 
 impl<R: RegisterLongName> From<FieldValue<u8, R>> for u8 {
@@ -299,6 +304,11 @@ impl<R: RegisterLongName> FieldValue<u32, R> {
             value: (value << shift) & (mask << shift),
             associated_register: PhantomData,
         }
+    }
+
+    /// Get the raw bitmask represented by this FieldValue.
+    pub fn mask(self) -> u32 {
+        self.mask as u32
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

I'm not sure if this is the right way to go or not. One approach would
be to keep adding more comparison methods to the registers object, in
this case something like `any_other_bits_set`, but I think that this is
a less common check.

I'm getting the value I want out of the registers system in the creation
of the mask. It's a semantically tricky thing to then "invert" the mask,
asking for all other fields that I didn't explicitly name already. At a
certain point, doing the bit manipulation direclty is clearer, and I
think this is that point.

### Testing Strategy

WIP: app still runs just fine, next up is validating that it's actually low power. Setting up that test as we speak, but wanted to see if people had objections to making `mask` public?


### TODO or Help Wanted

Are we okay with this approach?


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
