### PR TITLE
launchxl: basic uart support

### DIFF
--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -2,15 +2,49 @@ use cc26xx;
 use core::fmt::{Arguments, Write};
 use kernel::debug;
 use kernel::hil::led;
+use kernel::hil::uart::{self, UART};
 
-struct Writer {}
+pub struct Writer {
+    initialized: bool,
+}
 
-static mut WRITER: Writer = Writer {};
+pub static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
-    fn write_str(&mut self, _s: &str) -> ::core::fmt::Result {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        let uart = unsafe { &mut cc26xx::uart::UART0 };
+        if !self.initialized {
+            self.initialized = true;
+            uart.init(uart::UARTParams {
+                baud_rate: 115200,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+            });
+        }
+        for c in s.bytes() {
+            uart.send_byte(c);
+            while !uart.tx_ready() {}
+        }
         Ok(())
     }
+}
+
+#[macro_export]
+macro_rules! print {
+        ($($arg:tt)*) => (
+            {
+                use core::fmt::write;
+                let writer = &mut $crate::io::WRITER;
+                let _ = write(writer, format_args!($($arg)*));
+            }
+        );
+}
+
+#[macro_export]
+macro_rules! println {
+        ($fmt:expr) => (print!(concat!($fmt, "\r\n")));
+            ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\r\n"), $($arg)*));
 }
 
 #[cfg(not(test))]

--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -4,11 +4,11 @@ use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 
-pub struct Writer {
+struct Writer {
     initialized: bool,
 }
 
-pub static mut WRITER: Writer = Writer { initialized: false };
+static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {

--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -3,6 +3,7 @@ use core::fmt::{Arguments, Write};
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
+use UART0;
 
 pub struct Writer {
     initialized: bool,
@@ -12,7 +13,7 @@ pub static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        let uart = unsafe { &mut cc26xx::uart::UART0 };
+        let uart = unsafe { &mut UART0 };
         if !self.initialized {
             self.initialized = true;
             uart.init(uart::UARTParams {

--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -30,23 +30,6 @@ impl Write for Writer {
     }
 }
 
-#[macro_export]
-macro_rules! print {
-        ($($arg:tt)*) => (
-            {
-                use core::fmt::write;
-                let writer = &mut $crate::io::WRITER;
-                let _ = write(writer, format_args!($($arg)*));
-            }
-        );
-}
-
-#[macro_export]
-macro_rules! println {
-        ($fmt:expr) => (print!(concat!($fmt, "\r\n")));
-            ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\r\n"), $($arg)*));
-}
-
 #[cfg(not(test))]
 #[lang = "panic_fmt"]
 #[no_mangle]

--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -3,7 +3,6 @@ use core::fmt::{Arguments, Write};
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
-use UART0;
 
 pub struct Writer {
     initialized: bool,
@@ -13,7 +12,7 @@ pub static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        let uart = unsafe { &mut UART0 };
+        let uart = unsafe { &mut cc26xx::uart::UART0 };
         if !self.initialized {
             self.initialized = true;
             uart.init(uart::UARTParams {

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -210,7 +210,7 @@ pub unsafe fn reset_handler() {
 
     let mut chip = cc26x2::chip::Cc26X2::new();
 
-    println!("Initialization complete. Entering main loop");
+    debug!("Initialization complete. Entering main loop\r");
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -210,7 +210,6 @@ pub unsafe fn reset_handler() {
 
     let mut chip = cc26x2::chip::Cc26X2::new();
 
-    debug!("Initialization complete. Entering main loop\r");
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -96,7 +96,7 @@ pub unsafe fn reset_handler() {
         capsules::led::LED::new(led_pins)
     );
 
-    // BUTTONs
+    // BUTTONS
     let button_pins = static_init!(
         [(&'static cc26xx::gpio::GPIOPin, capsules::button::GpioMode); 2],
         [
@@ -118,6 +118,7 @@ pub unsafe fn reset_handler() {
         btn.set_client(button);
     }
 
+    // UART
     cc26xx::uart::UART0.set_pins(3, 2);
     let console = static_init!(
         capsules::console::Console<cc26xx::uart::UART>,

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -14,7 +14,6 @@ extern crate kernel;
 
 use cc26xx::aon;
 use cc26xx::prcm;
-use cc26xx::uart::UART;
 
 #[macro_use]
 pub mod io;
@@ -25,9 +24,6 @@ const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultRes
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 2;
 static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None];
-
-// Initialize UART module with pin numbers for this particular board
-pub static mut UART0: UART = UART::new(3, 2);
 
 #[link_section = ".app_memory"]
 // Give half of RAM to be dedicated APP memory
@@ -122,16 +118,17 @@ pub unsafe fn reset_handler() {
         btn.set_client(button);
     }
 
+    cc26xx::uart::UART0.set_pins(3, 2);
     let console = static_init!(
         capsules::console::Console<cc26xx::uart::UART>,
         capsules::console::Console::new(
-            &UART0,
+            &cc26xx::uart::UART0,
             115200,
             &mut capsules::console::WRITE_BUF,
             kernel::Grant::create()
         )
     );
-    kernel::hil::uart::UART::set_client(&UART0, console);
+    kernel::hil::uart::UART::set_client(&cc26xx::uart::UART0, console);
     console.initialize();
 
     // Attach the kernel debug interface to this console

--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -3,6 +3,7 @@
 use cc26xx::gpio;
 use cc26xx::peripheral_interrupts::*;
 use cc26xx::rtc;
+use cc26xx::uart;
 use cortexm4::{self, nvic};
 use kernel;
 
@@ -39,6 +40,7 @@ impl kernel::Chip for Cc26X2 {
                 match interrupt {
                     GPIO => gpio::PORT.handle_interrupt(),
                     AON_RTC => rtc::RTC.handle_interrupt(),
+                    UART0 => uart::UART0.handle_interrupt(),
                     // AON Programmable interrupt
                     // We need to ignore JTAG events since some debuggers emit these
                     AON_PROG => (),

--- a/chips/cc26xx/src/ioc.rs
+++ b/chips/cc26xx/src/ioc.rs
@@ -105,6 +105,7 @@ impl IocfgPin {
         pin_ioc.modify(IoConfiguration::EDGE_IRQ_EN::CLEAR);
     }
 
+    /// Configures pin for UART receive (RX).
     pub fn enable_uart_rx(&self) {
         let regs: &IocRegisters = unsafe { &*IOC_BASE };
         let pin_ioc = &regs.iocfg[self.pin];
@@ -114,6 +115,7 @@ impl IocfgPin {
         self.enable_input();
     }
 
+    /// Configures pin for UART transmit (TX).
     pub fn enable_uart_tx(&self) {
         let regs: &IocRegisters = unsafe { &*IOC_BASE };
         let pin_ioc = &regs.iocfg[self.pin];

--- a/chips/cc26xx/src/ioc.rs
+++ b/chips/cc26xx/src/ioc.rs
@@ -31,7 +31,9 @@ register_bitfields![
             PullNone = 0b11
         ],
         PORT_ID     OFFSET(0) NUMBITS(6) [
-            GPIO = 0x00
+            GPIO = 0x00,
+            UART_RX = 0xF,
+            UART_TX = 0x10
             // Add more as needed from datasheet p.1028
         ]
     ]
@@ -101,6 +103,24 @@ impl IocfgPin {
         let regs: &IocRegisters = unsafe { &*IOC_BASE };
         let pin_ioc = &regs.iocfg[self.pin];
         pin_ioc.modify(IoConfiguration::EDGE_IRQ_EN::CLEAR);
+    }
+
+    pub fn enable_uart_rx(&self) {
+        let regs: &IocRegisters = unsafe { &*IOC_BASE };
+        let pin_ioc = &regs.iocfg[self.pin];
+
+        pin_ioc.modify(IoConfiguration::PORT_ID::UART_RX);
+        self.set_input_mode(hil::gpio::InputMode::PullNone);
+        self.enable_input();
+    }
+
+    pub fn enable_uart_tx(&self) {
+        let regs: &IocRegisters = unsafe { &*IOC_BASE };
+        let pin_ioc = &regs.iocfg[self.pin];
+
+        pin_ioc.modify(IoConfiguration::PORT_ID::UART_TX);
+        self.set_input_mode(hil::gpio::InputMode::PullNone);
+        self.enable_output();
     }
 }
 

--- a/chips/cc26xx/src/lib.rs
+++ b/chips/cc26xx/src/lib.rs
@@ -11,6 +11,7 @@ pub mod rtc;
 pub mod gpio;
 pub mod ioc;
 pub mod prcm;
+pub mod uart;
 pub mod ccfg;
 pub mod trng;
 pub mod peripheral_interrupts;

--- a/chips/cc26xx/src/prcm.rs
+++ b/chips/cc26xx/src/prcm.rs
@@ -157,4 +157,13 @@ impl Clock {
 
         prcm_commit();
     }
+
+    pub fn enable_uart_run() {
+        let regs: &PrcmRegisters = unsafe { &*PRCM_BASE };
+        regs.uart_clk_gate_run.modify(ClockGate::CLK_EN::SET);
+        regs.uart_clk_gate_sleep.modify(ClockGate::CLK_EN::SET);
+        regs.uart_clk_gate_deep_sleep.modify(ClockGate::CLK_EN::SET);
+
+        prcm_commit();
+    }
 }

--- a/chips/cc26xx/src/prcm.rs
+++ b/chips/cc26xx/src/prcm.rs
@@ -158,7 +158,8 @@ impl Clock {
         prcm_commit();
     }
 
-    pub fn enable_uart_run() {
+    /// Enables UART clocks for run, sleep and deep sleep mode.
+    pub fn enable_uart() {
         let regs: &PrcmRegisters = unsafe { &*PRCM_BASE };
         regs.uart_clk_gate_run.modify(ClockGate::CLK_EN::SET);
         regs.uart_clk_gate_sleep.modify(ClockGate::CLK_EN::SET);

--- a/chips/cc26xx/src/uart.rs
+++ b/chips/cc26xx/src/uart.rs
@@ -1,0 +1,210 @@
+//! UART driver, cc26xx family
+use kernel::common::regs::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::hil::gpio::Pin;
+use kernel::hil::uart;
+use core::cell::Cell;
+use kernel;
+
+use prcm;
+use gpio;
+use ioc;
+
+pub const UART_BASE: usize = 0x4000_1000;
+pub const MCU_CLOCK: u32 = 48_000_000;
+
+#[repr(C)]
+struct Registers {
+    dr: ReadWrite<u32>,
+    rsr_ecr: ReadWrite<u32>,
+    _reserved0: [u8; 0x10],
+    fr: ReadOnly<u32, Flags::Register>,
+    _reserved1: [u8; 0x8],
+    ibrd: ReadWrite<u32, IntDivisor::Register>,
+    fbrd: ReadWrite<u32, FracDivisor::Register>,
+    lcrh: ReadWrite<u32, LineControl::Register>,
+    ctl: ReadWrite<u32, Control::Register>,
+    ifls: ReadWrite<u32>,
+    imsc: ReadWrite<u32, Interrupts::Register>,
+    ris: ReadOnly<u32, Interrupts::Register>,
+    mis: ReadOnly<u32, Interrupts::Register>,
+    icr: WriteOnly<u32, Interrupts::Register>,
+    dmactl: ReadWrite<u32>,
+}
+
+register_bitfields![
+    u32,
+    Control [
+        UART_ENABLE OFFSET(0) NUMBITS(1) [],
+        TX_ENABLE OFFSET(8) NUMBITS(1) [],
+        RX_ENABLE OFFSET(9) NUMBITS(1) []
+    ],
+    LineControl [
+        FIFO_ENABLE OFFSET(4) NUMBITS(1) [],
+        WORD_LENGTH OFFSET(5) NUMBITS(2) [
+            Len5 = 0x0,
+            Len6 = 0x1,
+            Len7 = 0x2,
+            Len8 = 0x3
+        ]
+    ],
+    IntDivisor [
+        DIVISOR OFFSET(0) NUMBITS(16) []
+    ],
+    FracDivisor [
+        DIVISOR OFFSET(0) NUMBITS(6) []
+    ],
+    Flags [
+        TX_FIFO_FULL OFFSET(5) NUMBITS(1) []
+    ],
+    Interrupts [
+        ALL_INTERRUPTS OFFSET(0) NUMBITS(12) []
+    ]
+];
+
+pub struct UART {
+    regs: *const Registers,
+    client: Cell<Option<&'static uart::Client>>,
+    tx_pin: Cell<Option<u8>>,
+    rx_pin: Cell<Option<u8>>,
+}
+
+pub static mut UART0: UART = UART::new();
+
+impl UART {
+    pub const fn new() -> UART {
+        UART {
+            regs: UART_BASE as *mut Registers,
+            client: Cell::new(None),
+            tx_pin: Cell::new(None),
+            rx_pin: Cell::new(None),
+        }
+    }
+
+    pub fn set_pins(&self, tx_pin: u8, rx_pin: u8) {
+        self.tx_pin.set(Some(tx_pin));
+        self.rx_pin.set(Some(rx_pin));
+    }
+
+    pub fn configure(&self, params: kernel::hil::uart::UARTParams) {
+        let tx_pin = match self.tx_pin.get() {
+            Some(pin) => pin,
+            None => panic!("Tx pin not configured for UART")
+        };
+
+        let rx_pin = match self.rx_pin.get() {
+            Some(pin) => pin,
+            None => panic!("Rx pin not configured for UART")
+        };
+
+        unsafe {
+            /*
+            * Make sure the TX pin is output/high before assigning it to UART control
+            * to avoid falling edge glitches
+            */
+            gpio::PORT[tx_pin as usize].make_output();
+            gpio::PORT[tx_pin as usize].set();
+
+            // Map UART signals to IO pin
+            ioc::IOCFG[tx_pin as usize].enable_uart_tx();
+            ioc::IOCFG[rx_pin as usize].enable_uart_rx();
+        }
+
+        // Disable the UART before configuring
+        self.disable();
+
+        self.set_baud_rate(params.baud_rate);
+
+        // Set word length
+        let regs = unsafe { &*self.regs };
+        regs.lcrh.write(LineControl::WORD_LENGTH::Len8);
+
+        self.fifo_enable();
+
+        // Enable UART, RX and TX
+        regs.ctl.write(Control::UART_ENABLE::SET
+            + Control::RX_ENABLE::SET
+            + Control::TX_ENABLE::SET
+        );
+    }
+
+    fn power_and_clock(&self) {
+        prcm::Power::enable_domain(prcm::PowerDomain::Serial);
+        while !prcm::Power::is_enabled(prcm::PowerDomain::Serial) { };
+        prcm::Clock::enable_uart_run();
+    }
+
+    fn set_baud_rate(&self, baud_rate: u32) {
+        // Fractional baud rate divider
+        let div = (((MCU_CLOCK * 8) / baud_rate) + 1) / 2;
+        // Set the baud rate
+        let regs = unsafe { &*self.regs };
+        regs.ibrd.write(IntDivisor::DIVISOR.val(div / 64));
+        regs.fbrd.write(FracDivisor::DIVISOR.val(div % 64));
+    }
+
+    fn fifo_enable(&self) {
+        let regs = unsafe { &*self.regs };
+        regs.lcrh.modify(LineControl::FIFO_ENABLE::SET);
+    }
+
+    fn fifo_disable(&self) {
+        let regs = unsafe { &*self.regs };
+        regs.lcrh.modify(LineControl::FIFO_ENABLE::CLEAR);
+    }
+
+    pub fn disable(&self) {
+        self.fifo_disable();
+        let regs = unsafe { &*self.regs };
+        regs.ctl.modify(Control::UART_ENABLE::CLEAR
+            + Control::TX_ENABLE::CLEAR
+            + Control::RX_ENABLE::CLEAR);
+    }
+
+    pub fn disable_interrupts(&self) {
+        // Disable all UART interrupts
+        let regs = unsafe { &*self.regs };
+        regs.imsc.modify(Interrupts::ALL_INTERRUPTS::CLEAR);
+        // Clear all UART interrupts
+        regs.icr.write(Interrupts::ALL_INTERRUPTS::SET);
+    }
+
+    pub fn send_byte(&self, c: u8) {
+        // Wait for space in FIFO
+        while !self.tx_ready() {}
+        // Put byte in data register
+        let regs = unsafe { &*self.regs };
+        regs.dr.set(c as u32);
+    }
+
+    pub fn tx_ready(&self) -> bool {
+        let regs = unsafe { &*self.regs };
+        !regs.fr.is_set(Flags::TX_FIFO_FULL)
+    }
+}
+
+impl kernel::hil::uart::UART for UART {
+    fn set_client(&self, client: &'static kernel::hil::uart::Client) {
+        self.client.set(Some(client));
+    }
+
+    fn init(&self, params: kernel::hil::uart::UARTParams) {
+        self.power_and_clock();
+        self.disable_interrupts();
+        self.configure(params);
+    }
+
+    fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {
+        if tx_len == 0 { return; }
+
+        for i in 0..tx_len {
+            self.send_byte(tx_data[i]);
+        }
+
+        self.client.get().map(move |client| {
+            client.transmit_complete(tx_data, kernel::hil::uart::Error::CommandComplete);
+        });
+    }
+
+    #[allow(unused)]
+    fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize) {}
+}

--- a/chips/cc26xx/src/uart.rs
+++ b/chips/cc26xx/src/uart.rs
@@ -72,7 +72,7 @@ pub struct UART {
 impl UART {
     const fn new() -> UART {
         UART {
-            regs: UART_BASE as *mut Registers,
+            regs: UART_BASE as *const Registers,
             client: Cell::new(None),
             tx_pin: Cell::new(None),
             rx_pin: Cell::new(None),

--- a/chips/cc26xx/src/uart.rs
+++ b/chips/cc26xx/src/uart.rs
@@ -96,10 +96,8 @@ impl UART {
         };
 
         unsafe {
-            /*
-             * Make sure the TX pin is output/high before assigning it to UART control
-             * to avoid falling edge glitches
-             */
+            // Make sure the TX pin is output/high before assigning it to UART control
+            // to avoid falling edge glitches
             gpio::PORT[tx_pin as usize].make_output();
             gpio::PORT[tx_pin as usize].set();
 

--- a/chips/cc26xx/src/uart.rs
+++ b/chips/cc26xx/src/uart.rs
@@ -15,9 +15,9 @@ pub const MCU_CLOCK: u32 = 48_000_000;
 struct Registers {
     dr: ReadWrite<u32>,
     rsr_ecr: ReadWrite<u32>,
-    _reserved0: [u8; 0x10],
+    _reserved0: [u32; 0x4],
     fr: ReadOnly<u32, Flags::Register>,
-    _reserved1: [u8; 0x8],
+    _reserved1: [u32; 0x2],
     ibrd: ReadWrite<u32, IntDivisor::Register>,
     fbrd: ReadWrite<u32, FracDivisor::Register>,
     lcrh: ReadWrite<u32, LineControl::Register>,

--- a/chips/cc26xx/src/uart.rs
+++ b/chips/cc26xx/src/uart.rs
@@ -68,15 +68,13 @@ pub struct UART {
     rx_pin: Cell<Option<u8>>,
 }
 
-pub static mut UART0: UART = UART::new();
-
 impl UART {
-    pub const fn new() -> UART {
+    pub const fn new(tx_pin: u8, rx_pin: u8) -> UART {
         UART {
             regs: UART_BASE as *mut Registers,
             client: Cell::new(None),
-            tx_pin: Cell::new(None),
-            rx_pin: Cell::new(None),
+            tx_pin: Cell::new(Some(tx_pin)),
+            rx_pin: Cell::new(Some(rx_pin)),
         }
     }
 

--- a/chips/cc26xx/src/uart.rs
+++ b/chips/cc26xx/src/uart.rs
@@ -170,9 +170,6 @@ impl UART {
     /// Clears all interrupts related to UART.
     pub fn handle_interrupt(&self) {
         let regs = unsafe { &*self.regs };
-        // Get status bits
-        #[allow(unused)]
-        let flags: u32 = regs.fr.get();
         // Clear interrupts
         regs.icr.write(Interrupts::ALL_INTERRUPTS::SET);
     }

--- a/chips/cc26xx/src/uart.rs
+++ b/chips/cc26xx/src/uart.rs
@@ -8,8 +8,8 @@ use kernel::hil::gpio::Pin;
 use kernel::hil::uart;
 use prcm;
 
-pub const UART_BASE: usize = 0x4000_1000;
-pub const MCU_CLOCK: u32 = 48_000_000;
+const UART_BASE: usize = 0x4000_1000;
+const MCU_CLOCK: u32 = 48_000_000;
 
 #[repr(C)]
 struct Registers {
@@ -70,7 +70,7 @@ pub struct UART {
 }
 
 impl UART {
-    pub const fn new() -> UART {
+    const fn new() -> UART {
         UART {
             regs: UART_BASE as *mut Registers,
             client: Cell::new(None),
@@ -84,7 +84,7 @@ impl UART {
         self.rx_pin.set(Some(rx_pin));
     }
 
-    pub fn configure(&self, params: kernel::hil::uart::UARTParams) {
+    fn configure(&self, params: kernel::hil::uart::UARTParams) {
         let tx_pin = match self.tx_pin.get() {
             Some(pin) => pin,
             None => panic!("Tx pin not configured for UART"),
@@ -147,7 +147,7 @@ impl UART {
         regs.lcrh.modify(LineControl::FIFO_ENABLE::CLEAR);
     }
 
-    pub fn disable(&self) {
+    fn disable(&self) {
         self.fifo_disable();
         let regs = unsafe { &*self.regs };
         regs.ctl.modify(
@@ -155,7 +155,7 @@ impl UART {
         );
     }
 
-    pub fn disable_interrupts(&self) {
+    fn disable_interrupts(&self) {
         // Disable all UART interrupts
         let regs = unsafe { &*self.regs };
         regs.imsc.modify(Interrupts::ALL_INTERRUPTS::CLEAR);


### PR DESCRIPTION
### Pull Request Overview

This pull request adds basic UART support for the launchxl. Only supports transmission as of now.

### Testing Strategy

Everything was tested using the debug macro and a serial reader on an external computer.

### TODO or Help Wanted

- Add RX support
- Enable interrupts at specific events and handle them accordingly

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [x] Ran `make formatall`.
