### PR TITLE
nrf52: convert register matches to is_set

### DIFF
--- a/chips/nrf52/src/radio.rs
+++ b/chips/nrf52/src/radio.rs
@@ -661,24 +661,24 @@ impl Radio {
         let regs = unsafe { &*self.regs };
         self.disable_all_interrupts();
 
-        if regs.event_ready.matches(Event::READY::SET) {
+        if regs.event_ready.is_set(Event::READY) {
             regs.event_ready.write(Event::READY::CLEAR);
             regs.event_end.write(Event::READY::CLEAR);
             regs.task_start.write(Task::ENABLE::SET);
         }
 
-        if regs.event_address.matches(Event::READY::SET) {
+        if regs.event_address.is_set(Event::READY) {
             regs.event_address.write(Event::READY::CLEAR);
         }
-        if regs.event_payload.matches(Event::READY::SET) {
+        if regs.event_payload.is_set(Event::READY) {
             regs.event_payload.write(Event::READY::CLEAR);
         }
 
         // tx or rx finished!
-        if regs.event_end.matches(Event::READY::SET) {
+        if regs.event_end.is_set(Event::READY) {
             regs.event_end.write(Event::READY::CLEAR);
 
-            let result = if regs.crcstatus.matches(Event::READY::SET) {
+            let result = if regs.crcstatus.is_set(Event::READY) {
                 ReturnCode::SUCCESS
             } else {
                 ReturnCode::FAIL

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -308,7 +308,7 @@ impl Uarte {
     /// Check if the UART tranmission is done
     pub fn tx_ready(&self) -> bool {
         let regs = unsafe { &*self.regs };
-        regs.event_endtx.matches(Event::READY::SET)
+        regs.event_endtx.is_set(Event::READY)
     }
 
     fn set_dma_pointer_to_buffer(&self) {


### PR DESCRIPTION
### Pull Request Overview

In #827, we changed `matches` to `matches_all`. As these are really
just checking one bit, convert them to `is_set`.

Fixes #835.

### Testing Strategy

Compile-tested only, but fixes broken build and is pretty 1:1 change.

### Documentation Updated

- [x] ~~Kernel: Updated the relevant files in `/docs`, or no updates are required.~~
- [X] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [X] Ran `make formatall`.
