### PR TITLE
[nrf5x/temperature] Migrate to the new register interface

### DIFF
--- a/chips/nrf5x/src/lib.rs
+++ b/chips/nrf5x/src/lib.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 #[allow(unused_imports)]
-#[macro_use(debug)]
+#[macro_use(debug, register_bitfields, register_bitmasks)]
 extern crate kernel;
 
 mod peripheral_registers;

--- a/chips/nrf5x/src/peripheral_registers.rs
+++ b/chips/nrf5x/src/peripheral_registers.rs
@@ -84,21 +84,6 @@ pub struct GPIO {
     pub pin_cnf: [VolatileCell<u32>; 32],
 }
 
-pub const TEMP_BASE: usize = 0x4000C000;
-#[repr(C)]
-pub struct TEMP_REGS {
-    pub task_start: VolatileCell<u32>,    // 0x000 - 0x004
-    pub task_stop: VolatileCell<u32>,     // 0x004 - 0x008
-    pub _reserved1: [u32; 62],            // 0x008 - 0x100
-    pub event_datardy: VolatileCell<u32>, // 0x100 - 0x104
-    pub _reserved2: [u32; 127],           // 0x104 - 0x300
-    pub inten: VolatileCell<u32>,         // 0x300 - 0x304
-    pub intenset: VolatileCell<u32>,      // 0x304 - 0x308
-    pub intenclr: VolatileCell<u32>,      // 0x308 - 0x30c
-    pub _reserved3: [u32; 127],           // 0x30c - 0x508
-    pub temp: VolatileCell<u32>,          // 0x508 - 0x50c
-}
-
 pub const RNG_BASE: usize = 0x4000D000;
 #[repr(C)]
 pub struct RNG_REGS {

--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -10,16 +10,101 @@
 
 use core::cell::Cell;
 use kernel;
-use peripheral_registers;
+use kernel::common::regs::{ReadOnly, ReadWrite, WriteOnly};
 
-const NRF_TEMP_DATARDY_INTR: u32 = 1;
-const NRF_TEMP_ENABLE: u32 = 1;
-const NRF_TEMP_DISABLE: u32 = 0;
+const TEMP_BASE: usize = 0x4000C000;
 
-#[deny(no_mangle_const_items)]
-#[no_mangle]
+#[repr(C)]
+struct TemperatureRegisters {
+    /// Start temperature measurement
+    /// Address: 0x000 - 0x004
+    pub task_start: WriteOnly<u32, Task::Register>,
+    /// Stop temperature measurement
+    /// Address: 0x004 - 0x008
+    pub task_stop: WriteOnly<u32, Task::Register>,
+    /// Reserved
+    pub _reserved1: [u32; 62],
+    /// Temperature measurement complete, data ready
+    /// Address: 0x100 - 0x104
+    pub event_datardy: ReadWrite<u32, Event::Register>,
+    /// Reserved
+    // Note, `inten` register on nRF51 is ignored because it's not supported by nRF52
+    // And intenset and intenclr provide the same functionality
+    pub _reserved2: [u32; 128],
+    /// Enable interrupt
+    /// Address: 0x304 - 0x308
+    pub intenset: ReadWrite<u32, Intenset::Register>,
+    /// Disable interrupt
+    /// Address: 0x308 - 0x30c
+    pub intenclr: ReadWrite<u32, Intenclr::Register>,
+    /// Reserved
+    pub _reserved3: [u32; 127],
+    /// Temperature in °C (0.25° steps)
+    /// Address: 0x508 - 0x50c
+    pub temp: ReadOnly<u32, Temp::Register>,
+    /// Reserved
+    pub _reserved4: [u32; 5],
+    /// Slope of piece wise linear function (nRF52 only)
+    /// Address 0x520 - 0x534
+    #[cfg(feature = "nrf52")]
+    pub a: [ReadWrite<u32, A::Register>; 6],
+    pub _reserved5: [u32; 2],
+    /// y-intercept of 5th piece wise linear function (nRF52 only)
+    /// Address: 0x540 - 0x554
+    #[cfg(feature = "nrf52")]
+    pub b: [ReadWrite<u32, B::Register>; 6],
+    pub _reserved6: [u32; 2],
+    /// End point of 1st piece wise linear function (nRF52 only)
+    /// Address: 0x560 - 0x570
+    #[cfg(feature = "nrf52")]
+    pub t: [ReadWrite<u32, B::Register>; 5],
+}
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+register_bitfields! [u32,
+    /// Start task
+    Task [
+        ENABLE OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Read event
+    Event [
+        READY OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Enabled interrupt
+    Intenset [
+        DATARDY OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Disable interrupt
+    Intenclr [
+        DATARDY OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Temperature in °C (0.25° steps)
+    Temp [
+        TEMP OFFSET(0) NUMBITS(32)
+    ],
+    
+    /// Slope of piece wise linear function
+    A [
+        SLOPE OFFSET(0) NUMBITS(12)
+    ],
+    
+    /// y-intercept of wise linear function
+    B [
+        INTERCEPT OFFSET(0) NUMBITS(14)
+    ],
+
+    /// End point of wise linear function
+    T [
+       PIECE OFFSET(0) NUMBITS(8) 
+    ]
+];
+
 pub struct Temperature {
-    regs: *const peripheral_registers::TEMP_REGS,
+    regs: *const TemperatureRegisters,
     client: Cell<Option<&'static kernel::hil::sensors::TemperatureClient>>,
 }
 
@@ -28,12 +113,14 @@ pub static mut TEMP: Temperature = Temperature::new();
 impl Temperature {
     const fn new() -> Temperature {
         Temperature {
-            regs: peripheral_registers::TEMP_BASE as *const peripheral_registers::TEMP_REGS,
+            regs: TEMP_BASE as *const TemperatureRegisters,
             client: Cell::new(None),
         }
     }
 
-    // MEASUREMENT DONE
+    /// Temperature interrupt handler
+    #[no_mangle]
+    #[inline(never)]
     pub fn handle_interrupt(&self) {
         // disable interrupts
         self.disable_interrupts();
@@ -44,7 +131,7 @@ impl Temperature {
         let temp = (regs.temp.get() / 4) * 100;
 
         // stop measurement
-        regs.task_stop.set(NRF_TEMP_DISABLE);
+        regs.task_stop.write(Task::ENABLE::SET);
 
         // disable interrupts
         self.disable_interrupts();
@@ -57,12 +144,12 @@ impl Temperature {
 
     fn enable_interrupts(&self) {
         let regs = unsafe { &*self.regs };
-        regs.intenset.set(NRF_TEMP_DATARDY_INTR);
+        regs.intenset.write(Intenset::DATARDY::SET);
     }
 
     fn disable_interrupts(&self) {
         let regs = unsafe { &*self.regs };
-        regs.intenclr.set(NRF_TEMP_DATARDY_INTR);
+        regs.intenclr.write(Intenclr::DATARDY::SET);
     }
 }
 
@@ -70,8 +157,8 @@ impl kernel::hil::sensors::TemperatureDriver for Temperature {
     fn read_temperature(&self) -> kernel::ReturnCode {
         let regs = unsafe { &*self.regs };
         self.enable_interrupts();
-        regs.event_datardy.set(NRF_TEMP_DISABLE);
-        regs.task_start.set(NRF_TEMP_ENABLE);
+        regs.event_datardy.write(Event::READY::CLEAR);
+        regs.task_start.write(Task::ENABLE::SET);
         kernel::ReturnCode::SUCCESS
     }
 

--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -119,8 +119,6 @@ impl Temperature {
     }
 
     /// Temperature interrupt handler
-    #[no_mangle]
-    #[inline(never)]
     pub fn handle_interrupt(&self) {
         // disable interrupts
         self.disable_interrupts();


### PR DESCRIPTION

### Pull Request Overview
This pull request adds:
* Ported the old registers to the new register interface
* Added differences between nrf51 and nrf52 using features (conditional compilation)
* Added new registers for nrf52

### Testing Strategy

This pull request was tested by:
1. Running the [sensors](https://github.com/helena-project/tock/tree/master/userland/examples/sensors)
app successfully
2. New register configuration:
```bash
>>> p &self.regs.a                         
$1 = (kernel::common::regs::ReadWrite<u32, nrf5x::temperature::A::Register> (*)[6]) 0x4000c520                                                                              
>>> p &self.regs.b                         
$2 = (kernel::common::regs::ReadWrite<u32, nrf5x::temperature::B::Register> (*)[6]) 0x4000c540                                                                              
>>> p &self.regs.t                         
$3 = (kernel::common::regs::ReadWrite<u32, nrf5x::temperature::B::Register> (*)[5]) 0x4000c560 
```
3. Check that the features works correctly by trying to compile it for nRF51:
```bash
   Compiling nrf5x v0.1.0 (file:///home/niklasad1/GitHub/tock/chips/nrf5x)
error[E0609]: no field `a` on type `&temperature::TemperatureRegisters`
   --> /home/niklasad1/GitHub/tock/chips/nrf5x/src/temperature.rs:129:26
    |
129 |         let slope = regs.a[0].get();
    |                          ^

error[E0609]: no field `b` on type `&temperature::TemperatureRegisters`
   --> /home/niklasad1/GitHub/tock/chips/nrf5x/src/temperature.rs:130:26
    |
130 |         let slope = regs.b[0].get();
    |                          ^

error[E0609]: no field `t` on type `&temperature::TemperatureRegisters`
   --> /home/niklasad1/GitHub/tock/chips/nrf5x/src/temperature.rs:131:26
    |
131 |         let slope = regs.t[0].get();
    |  

```

### TODO or Help Wanted

The naming of registers A, B and T are from the datasheet and could probably renamed to something better.
### Documentation Updated

~- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.~
~- [ ] Userland: Added/updated the application README, if needed.~

### Formatting

- [x] Ran `make formatall`.
