### PR TITLE
Fix typo in format_all.sh

### DIFF
--- a/userland/examples/format_all.sh
+++ b/userland/examples/format_all.sh
@@ -27,7 +27,7 @@ for mkfile in `find . -maxdepth 3 -name Makefile`; do
 
 	pushd $dir > /dev/null
 	echo ""
-	echo "Fromatting $dir"
+	echo "Formatting $dir"
 	make format || (echo "${bold} ⤤ Failure formatting $dir${normal}" ; opt_rebuild $dir; exit 1)
 	popd > /dev/null
 done


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a typo in ```format_all.sh```


### Testing Strategy

N/A

### TODO or Help Wanted

N/A


### Documentation Updated

~- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.~
~- [ ] Userland: Added/updated the application README, if needed.~

### Formatting

~- [ ] Ran `make formatall`.~
