### PR TITLE
[nrf5x/rng] New register interface

### DIFF
--- a/chips/nrf5x/src/lib.rs
+++ b/chips/nrf5x/src/lib.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 #[allow(unused_imports)]
-#[macro_use(debug)]
+#[macro_use(debug, register_bitfields, register_bitmasks)]
 extern crate kernel;
 
 mod peripheral_registers;

--- a/chips/nrf5x/src/peripheral_registers.rs
+++ b/chips/nrf5x/src/peripheral_registers.rs
@@ -98,21 +98,3 @@ pub struct TEMP_REGS {
     pub _reserved3: [u32; 127],           // 0x30c - 0x508
     pub temp: VolatileCell<u32>,          // 0x508 - 0x50c
 }
-
-pub const RNG_BASE: usize = 0x4000D000;
-#[repr(C)]
-pub struct RNG_REGS {
-    pub task_start: VolatileCell<u32>,   // 0x000 - 0x004
-    pub task_stop: VolatileCell<u32>,    // 0x004 - 0x008
-    pub _reserved1: [u32; 62],           // 0x008 - 0x100
-    pub event_valrdy: VolatileCell<u32>, // 0x100 - 0x104
-    pub _reserved2: [u32; 63],           // 0x104 - 0x200
-    pub shorts: VolatileCell<u32>,       // 0x200 - 0x204
-    pub _reserved3: [u32; 63],           // 0x204 - 0x300
-    pub inten: VolatileCell<u32>,        // 0x300 - 0x304
-    pub intenset: VolatileCell<u32>,     // 0x304 - 0x308
-    pub intenclr: VolatileCell<u32>,     // 0x308 - 0x30c
-    pub _reserved4: [u32; 126],          // 0x30c - 0x504
-    pub config: VolatileCell<u32>,       // 0x504 - 0x508
-    pub value: VolatileCell<u32>,        // 0x508 - 0x50c
-}

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -21,11 +21,88 @@
 //! * Date: March 01, 2017
 
 use core::cell::Cell;
+use kernel::common::regs::{ReadOnly, ReadWrite, WriteOnly};
 use kernel::hil::rng::{self, Continue};
-use peripheral_registers::{RNG_BASE, RNG_REGS};
+
+const RNG_BASE: usize = 0x4000D000;
+
+#[repr(C)]
+pub struct RngRegisters {
+    /// Task starting the random number generator
+    /// Address: 0x000 - 0x004
+    pub task_start: WriteOnly<u32, Task::Register>,
+    /// Task stopping the random number generator
+    /// Address: 0x004 - 0x008
+    pub task_stop: WriteOnly<u32, Task::Register>,
+    /// Reserved
+    pub _reserved1: [u32; 62],
+    /// Event being generated for every new random number written to the VALUE register
+    /// Address: 0x100 - 0x104
+    pub event_valrdy: ReadWrite<u32, Event::Register>,
+    /// Reserved
+    pub _reserved2: [u32; 63],
+    /// Shortcut register
+    /// Address: 0x200 - 0x204
+    pub shorts: ReadWrite<u32, Shorts::Register>,
+    pub _reserved3: [u32; 64],
+    /// Enable interrupt
+    /// Address: 0x304 - 0x308
+    pub intenset: ReadWrite<u32, Intenset::Register>,
+    /// Disable interrupt
+    /// Address: 0x308 - 0x30c
+    pub intenclr: ReadWrite<u32, Intenclr::Register>,
+    pub _reserved4: [u32; 126],
+    /// Configuration register
+    /// Address: 0x504 - 0x508
+    pub config: ReadWrite<u32, Config::Register>,
+    /// Output random number
+    /// Address: 0x508 - 0x50c
+    pub value: ReadOnly<u32, Value::Register>,
+}
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+register_bitfields! [u32,
+    /// Start task
+    Task [
+        ENABLE OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Ready event
+    Event [
+        READY OFFSET(0) NUMBITS(1)
+    ],
+    
+    /// Shortcut register
+    Shorts [
+        /// Shortcut between VALRDY event and STOP task
+        VALRDY_STOP OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Enable interrupt
+    Intenset [
+        VALRDY OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Disable interrupt
+    Intenclr [
+        VALRDY OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Configuration register
+    Config [
+        /// Bias correction
+        DERCEN OFFSET(0) NUMBITS(32)
+    ],
+    
+    /// Output random number
+    Value [
+        /// Generated random number
+        VALUE OFFSET(0) NUMBITS(8)
+    ]
+];
 
 pub struct Trng<'a> {
-    regs: *const RNG_REGS,
+    regs: *const RngRegisters,
     client: Cell<Option<&'a rng::Client>>,
     index: Cell<usize>,
     randomness: Cell<u32>,
@@ -36,17 +113,17 @@ pub static mut TRNG: Trng<'static> = Trng::new();
 impl<'a> Trng<'a> {
     const fn new() -> Trng<'a> {
         Trng {
-            regs: RNG_BASE as *const RNG_REGS,
+            regs: RNG_BASE as *const RngRegisters,
             client: Cell::new(None),
             index: Cell::new(0),
             randomness: Cell::new(0),
         }
     }
 
-    // only VALRDY register can trigger the interrupt
+    /// RNG Interrupt handler
     pub fn handle_interrupt(&self) {
         let regs = unsafe { &*self.regs };
-        // disable interrupts
+
         self.disable_interrupts();
 
         match self.index.get() {
@@ -66,7 +143,7 @@ impl<'a> Trng<'a> {
                 self.index.set(e + 1);
                 self.start_rng()
             }
-            // fetched 4 bytes of data send to the capsule
+            // fetched 4 bytes of data generated, then notify the capsule
             4 => {
                 self.client.get().map(|client| {
                     let result = client.randomness_available(&mut TrngIter(self));
@@ -77,7 +154,7 @@ impl<'a> Trng<'a> {
                 });
             }
             // This should never happen if the logic is correct
-            // Restart randomness generation if the condition occurs
+            // Restart randomness generation if this condition occurs
             _ => {
                 self.index.set(0);
                 self.randomness.set(0);
@@ -85,33 +162,32 @@ impl<'a> Trng<'a> {
         }
     }
 
+    /// Configure client
     pub fn set_client(&self, client: &'a rng::Client) {
         self.client.set(Some(client));
     }
 
     fn enable_interrupts(&self) {
         let regs = unsafe { &*self.regs };
-        regs.inten.set(1);
-        regs.intenset.set(1);
+        regs.intenset.write(Intenset::VALRDY::SET);
     }
 
     fn disable_interrupts(&self) {
         let regs = unsafe { &*self.regs };
-        regs.intenclr.set(1);
-        regs.inten.set(0);
+        regs.intenclr.write(Intenclr::VALRDY::SET);
     }
 
     fn start_rng(&self) {
         let regs = unsafe { &*self.regs };
 
-        // clear registers
-        regs.event_valrdy.set(0);
+        // Reset `valrdy`
+        regs.event_valrdy.write(Event::READY::CLEAR);
 
-        // enable interrupts
+        // Enable interrupts
         self.enable_interrupts();
 
-        // start rng
-        regs.task_start.set(1);
+        // Start rng
+        regs.task_start.write(Task::ENABLE::SET);
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request moves the RNG registers to the new register interface

### Testing Strategy

Ran the [rng test](https://github.com/helena-project/tock/tree/master/userland/examples/tests/rng) successfully

### TODO or Help Wanted

N/A

### Documentation Updated

~- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.~
~- [ ] Userland: Added/updated the application README, if needed.~

### Formatting

- [x] Ran `make formatall`.
