### PR TITLE
Disable lps25hb interrupt after use.

### DIFF
--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -191,6 +191,7 @@ impl<'a> i2c::I2CClient for LPS25HB<'a> {
                 buffer[0] = Registers::CtrlReg1 as u8;
                 buffer[1] = 0;
                 self.i2c.write(buffer, 2);
+                self.interrupt_pin.disable_interrupt();
                 self.state.set(State::Done);
             }
             State::Done => {


### PR DESCRIPTION
### Pull Request Overview

This interrupt should be disabled for low power operation.
The SAM4L doesn't currently support low power GPIO interrupts.

### Testing Strategy

Tested on the signpost ambient board. Pressure sensor is still operational and the board now goes to sleep after using the pressure sensor.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
