### PR TITLE
update getting started

### DIFF
--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -42,12 +42,18 @@ installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
 ```bash
-$ curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2018-03-07
+$ curl https://sh.rustup.rs -sSf | sh
 ```
 
 This will install `rustup` in your home directory, so you will need to
 source `~/.profile` or open a new shell to add the `.cargo/bin` directory
 to your `$PATH`.
+
+Then install the correct nightly version of Rust:
+
+```bash
+$ rustup install nightly-2018-03-07
+```
 
 #### Xargo
 

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -37,23 +37,17 @@ of installing some of these tools, but you can also install them yourself.
 
 #### Rust (nightly)
 
-We are using `rustc 1.24.0-nightly (8e7a609e6 2018-01-04)`. We recommend
+We are using `rustc 1.26.0-nightly (2789b067d 2018-03-06)`. We recommend
 installing it with [rustup](http://www.rustup.rs) so you can manage multiple
 versions of Rust and continue using stable versions for other Rust code:
 
 ```bash
-$ curl https://sh.rustup.rs -sSf | sh
+$ curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2018-03-07
 ```
 
 This will install `rustup` in your home directory, so you will need to
 source `~/.profile` or open a new shell to add the `.cargo/bin` directory
 to your `$PATH`.
-
-Then install the correct nightly version of Rust:
-
-```bash
-$ rustup install nightly-2018-03-07
-```
 
 #### Xargo
 


### PR DESCRIPTION
### Pull Request Overview

This pull request changes:
* rustc to the current version
* modifies cURL command to enable nightly by default

### Testing Strategy
I thought first that it was an error that we use ```rustc 2018-03-06``` in the makefiles but actually it turns out that is correct:
```bash
rustup override set nightly-2018-03-07
info: using existing install for 'nightly-2018-03-07-x86_64-unknown-linux-gnu'
info: override toolchain for '/home/niklasad1/GitHub/tock' set to 'nightly-2018-03-07-x86_64-unknown-linux-gnu'

  nightly-2018-03-07-x86_64-unknown-linux-gnu unchanged - rustc 1.26.0-nightly (2789b067d 2018-03-06)
```

### TODO or Help Wanted
We should probably figure out a way of auto-generate this stuff because it's painful to update every time we bump `rustc`

### Documentation Updated

~- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.~
~- [ ] Userland: Added/updated the application README, if needed.~

### Formatting

~- [ ] Ran `make formatall`.~
