### PR TITLE
hail: add scripts for j-link+gdb debugging

### DIFF
--- a/boards/hail/README.md
+++ b/boards/hail/README.md
@@ -159,6 +159,14 @@ cd tock/boards/hail
 make program
 ```
 
+### Debugging the Kernel
+
+You can use gdb to debug a running kernel. The `jlink/` folder has some scripts
+designed to work with the [J-Link Debugger](https://www.segger.com/products/debug-probes/j-link/).
+In one terminal run `jlink_gdbserver.sh`, and in another terminal `./gdb_session.sh`.
+
+You may also find the `make lst` target helpful. It will generate a listings file
+with disassembly of the kernel image at `target/thumbv7em-none-eabi/release/hail.lst`.
 
 
 [tockloader]: https://github.com/tock/tockloader

--- a/boards/hail/jlink/gdb_session.sh
+++ b/boards/hail/jlink/gdb_session.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+arm-none-eabi-gdb -x hail.gdb

--- a/boards/hail/jlink/hail.gdb
+++ b/boards/hail/jlink/hail.gdb
@@ -1,0 +1,18 @@
+target remote localhost:2331
+monitor speed 30
+file ../target/thumbv7em-none-eabi/release/hail
+monitor reset
+#
+# CPU core initialization (to be done by user)
+#
+# Set the processor mode
+# monitor reg cpsr = 0xd3
+# Set auto JTAG speed
+monitor speed auto
+# Setup GDB FOR FASTER DOWNLOADS
+set remote memory-write-packet-size 1024
+set remote memory-write-packet-size fixed
+# tui enable
+# layout split
+# layout service_pending_interrupts
+b reset_handler

--- a/boards/hail/jlink/jlink_gdbserver.sh
+++ b/boards/hail/jlink/jlink_gdbserver.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+JLinkGDBServer -device ATSAM4LC8C -speed 1200 -if swd -AutoConnect 1 -port 2331


### PR DESCRIPTION
### Pull Request Overview

This pull request adds documentation and support scripts for using gdb with hail for debugging the kernel.

### Testing Strategy

This pull request was tested by debugging a hail :)

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
