### PR TITLE
kernel: actually move stack to the bottom of sram

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -189,6 +189,25 @@ SECTIONS
 
 
 
+    .stack (NOLOAD) :
+    {
+        /* Kernel stack.
+         *
+         * Tock places the kernel stack at the bottom of SRAM so that the
+         * kernel will trigger memory fault if it exceeds its stack depth,
+         * rather than silently overwriting valuable data.
+         */
+        . = ALIGN(8);
+         _sstack = .;
+
+        . = . + __stack_size__;
+
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
+
+
     /* Kernel data that must be relocated. This is program data that is
      * exepected to live in SRAM, but is initialized with a value. This data is
      * physically placed into flash and is copied into SRAM by Tock. The
@@ -213,21 +232,6 @@ SECTIONS
 
     .sram (NOLOAD) :
     {
-        /* Kernel stack.
-         *
-         * To keep all kernel memory contiguous (eases MPU protection of kernel
-         * data), Tock next places its own stack into SRAM.
-         */
-        . = ALIGN(8);
-         _sstack = .;
-
-        . = . + __stack_size__;
-
-        . = ALIGN(8);
-        _estack = .;
-
-
-
         /* Kernel BSS section. Memory that is expected to be initialized to
          * zero.
          *


### PR DESCRIPTION
### Overview

The arguments from #289 hold, but #627 didn't quite do this right.
This actually places the stack at the bottom of SRAM:

before:

    $ nm hail  | grep [es]stack
    20002a90 B _estack
    20001a90 B _sstack

after:

    $ nm hail  | grep [es]stack
    20001000 B _estack
    20000000 B _sstack

### Testing

Tested on hail with a few different mixings of apps.

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
