### PR TITLE
userland: add check for correct usage of override

### DIFF
--- a/userland/AppMakefile.mk
+++ b/userland/AppMakefile.mk
@@ -296,6 +296,10 @@ $(BUILDDIR)/format/%.uncrustify: %.cxx | _format_check_unstaged
 	$(Q)cmp -s $< $@ || (if [ "$$CI" = "true" ]; then diff -y $< $@; rm $@; exit 1; else cp $@ $<; fi)
 
 
+# Rules to help validate build configuration
+fmt format::
+	$(Q)$(TOCK_USERLAND_BASE_DIR)/tools/check_override.sh
+
 
 #########################################################################################
 # Include dependency rules for picking up header changes (by convention at bottom of makefile)

--- a/userland/tools/check_override.sh
+++ b/userland/tools/check_override.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+bad=$(find . | grep Makefile | xargs grep -E 'C.*FLAGS[\ +:]*=' | grep -v override)
+
+if [ -n "$bad" ]; then
+  echo "Found flags variable assignment without override directive."
+  echo
+  echo "The Tock build system uses the override directive on all flags variables."
+  echo "This lets users add runtime flags without inadvertently trampling flags"
+  echo "that are required to build correctly, however it means that any flags set"
+  echo "without override will be ignored. To fix, simply prefix your flags assignment"
+  echo "with 'override', as in 'override CFLAGS += -DMY_FLAG=1'".
+  echo
+  echo "For more on the override directive, see the make documentation:"
+  echo "https://www.gnu.org/software/make/manual/html_node/Override-Directive.html"
+  echo
+  echo "The following lines set flags without override:"
+  echo "$bad"
+  echo
+  exit 1
+fi


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a check that userland Makefiles remember to add `override`, as the build system will trample their flags otherwise.

### Testing Strategy

This pull request was tested by building apps in various configurations to make sure it reports when it should.

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
