### PR TITLE
Copy-paste ARM-error handeling for nrf52 + unify naming in arch-cortexm4

### DIFF
--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -107,13 +107,11 @@ _ggeneric_isr_no_stacking:
 }
 
 #[cfg(not(target_os = "none"))]
-#[allow(non_snake_case)]
-pub unsafe extern "C" fn SVC_Handler() {}
+pub unsafe extern "C" fn svc_handler() {}
 
 #[cfg(target_os = "none")]
 #[naked]
-#[allow(non_snake_case)]
-pub unsafe extern "C" fn SVC_Handler() {
+pub unsafe extern "C" fn svc_handler() {
     asm!(
         "
   cmp lr, #0xfffffff9

--- a/chips/cc26x2/src/crt1.rs
+++ b/chips/cc26x2/src/crt1.rs
@@ -1,4 +1,4 @@
-use cortexm4::{generic_isr, nvic, systick_handler, SVC_Handler};
+use cortexm4::{generic_isr, nvic, svc_handler, systick_handler};
 
 extern "C" {
     // Symbols defined in the linker file
@@ -38,7 +38,7 @@ pub static BASE_VECTORS: [unsafe extern fn(); 50] = [
     unhandled_interrupt, // Reserved
     unhandled_interrupt, // Reserved
     unhandled_interrupt, // Reserved
-    SVC_Handler, // SVC
+    svc_handler, // SVC
     unhandled_interrupt, // Debug monitor,
     unhandled_interrupt, // Reserved
     unhandled_interrupt, // PendSV

--- a/chips/nrf52/src/crt1.rs
+++ b/chips/nrf52/src/crt1.rs
@@ -1,19 +1,13 @@
-use cortexm4::{generic_isr, nvic, systick_handler, SVC_Handler};
+use cortexm4::{generic_isr, nvic, svc_handler, systick_handler};
 
 /*
  * Adapted from crt1.c which was relicensed by the original author from
  * GPLv3 to Apache 2.0.
  * The original version of the file, under GPL can be found at
- * https://github.com/SoftwareDefinedBuildings/
- *     stormport/blob/rebase0/tos/platforms/storm/stormcrt1.c
+ * https://github.com/SoftwareDefinedBuildings/stormport/blob/rebase0/tos/platforms/storm/stormcrt1.c
  *
  * Copyright 2016, Michael Andersen <m.andersen@eecs.berkeley.edu>
  */
-
-/* https://github.com/NordicSemiconductor/nrf52-hardware-startup-hands-on/blob/master/
-           pca10040/s132/arm5_no_packs/RTE/Device/nRF52832_xxAA/arm_startup_nrf52.s */
-/* https://github.com/NordicSemiconductor/nRF52-ble-app-lbs/blob/master/
-           pca10040/s132/arm5_no_packs/RTE/Device/nRF52832_xxAA/system_nrf52.c */
 
 extern "C" {
     // Symbols defined in the linker file
@@ -30,31 +24,247 @@ extern "C" {
 }
 
 unsafe extern "C" fn unhandled_interrupt() {
-    'loop0: loop {}
+    let mut interrupt_number: u32;
+
+    // IPSR[8:0] holds the currently active interrupt
+    asm!(
+        "mrs    r0, ipsr                    "
+        : "={r0}"(interrupt_number)
+        :
+        : "r0"
+        :
+        );
+
+    interrupt_number = interrupt_number & 0x1ff;
+    panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
 }
 
 unsafe extern "C" fn hard_fault_handler() {
-    'loop0: loop {}
+    use {core, kernel, core::intrinsics::offset};
+
+    let faulting_stack: *mut u32;
+    let kernel_stack: bool;
+
+    asm!(
+        "mov    r1, 0                       \n\
+         tst    lr, #4                      \n\
+         itte   eq                          \n\
+         mrseq  r0, msp                     \n\
+         addeq  r1, 1                       \n\
+         mrsne  r0, psp                     "
+        : "={r0}"(faulting_stack), "={r1}"(kernel_stack)
+        :
+        : "r0", "r1"
+        :
+        );
+
+    if kernel_stack {
+        let stacked_r0: u32 = *offset(faulting_stack, 0);
+        let stacked_r1: u32 = *offset(faulting_stack, 1);
+        let stacked_r2: u32 = *offset(faulting_stack, 2);
+        let stacked_r3: u32 = *offset(faulting_stack, 3);
+        let stacked_r12: u32 = *offset(faulting_stack, 4);
+        let stacked_lr: u32 = *offset(faulting_stack, 5);
+        let stacked_pc: u32 = *offset(faulting_stack, 6);
+        let stacked_xpsr: u32 = *offset(faulting_stack, 7);
+
+        let mode_str = "Kernel";
+
+        let shcsr: u32 = core::ptr::read_volatile(0xE000ED24 as *const u32);
+        let cfsr: u32 = core::ptr::read_volatile(0xE000ED28 as *const u32);
+        let hfsr: u32 = core::ptr::read_volatile(0xE000ED2C as *const u32);
+        let mmfar: u32 = core::ptr::read_volatile(0xE000ED34 as *const u32);
+        let bfar: u32 = core::ptr::read_volatile(0xE000ED38 as *const u32);
+
+        let iaccviol = (cfsr & 0x01) == 0x01;
+        let daccviol = (cfsr & 0x02) == 0x02;
+        let munstkerr = (cfsr & 0x08) == 0x08;
+        let mstkerr = (cfsr & 0x10) == 0x10;
+        let mlsperr = (cfsr & 0x20) == 0x20;
+        let mmfarvalid = (cfsr & 0x80) == 0x80;
+
+        let ibuserr = ((cfsr >> 8) & 0x01) == 0x01;
+        let preciserr = ((cfsr >> 8) & 0x02) == 0x02;
+        let impreciserr = ((cfsr >> 8) & 0x04) == 0x04;
+        let unstkerr = ((cfsr >> 8) & 0x08) == 0x08;
+        let stkerr = ((cfsr >> 8) & 0x10) == 0x10;
+        let lsperr = ((cfsr >> 8) & 0x20) == 0x20;
+        let bfarvalid = ((cfsr >> 8) & 0x80) == 0x80;
+
+        let undefinstr = ((cfsr >> 16) & 0x01) == 0x01;
+        let invstate = ((cfsr >> 16) & 0x02) == 0x02;
+        let invpc = ((cfsr >> 16) & 0x04) == 0x04;
+        let nocp = ((cfsr >> 16) & 0x08) == 0x08;
+        let unaligned = ((cfsr >> 16) & 0x100) == 0x100;
+        let divbysero = ((cfsr >> 16) & 0x200) == 0x200;
+
+        let vecttbl = (hfsr & 0x02) == 0x02;
+        let forced = (hfsr & 0x40000000) == 0x40000000;
+
+        let ici_it = (((stacked_xpsr >> 25) & 0x3) << 6) | ((stacked_xpsr >> 10) & 0x3f);
+        let thumb_bit = ((stacked_xpsr >> 24) & 0x1) == 1;
+        let exception_number = (stacked_xpsr & 0x1ff) as usize;
+
+        panic!(
+            "{} HardFault.\n\
+             \tKernel version {}\n\
+             \tr0  0x{:x}\n\
+             \tr1  0x{:x}\n\
+             \tr2  0x{:x}\n\
+             \tr3  0x{:x}\n\
+             \tr12 0x{:x}\n\
+             \tlr  0x{:x}\n\
+             \tpc  0x{:x}\n\
+             \tprs 0x{:x} [ N {} Z {} C {} V {} Q {} GE {}{}{}{} ; ICI.IT {} T {} ; Exc {}-{} ]\n\
+             \tsp  0x{:x}\n\
+             \ttop of stack     0x{:x}\n\
+             \tbottom of stack  0x{:x}\n\
+             \tSHCSR 0x{:x}\n\
+             \tCFSR  0x{:x}\n\
+             \tHSFR  0x{:x}\n\
+             \tInstruction Access Violation:       {}\n\
+             \tData Access Violation:              {}\n\
+             \tMemory Management Unstacking Fault: {}\n\
+             \tMemory Management Stacking Fault:   {}\n\
+             \tMemory Management Lazy FP Fault:    {}\n\
+             \tInstruction Bus Error:              {}\n\
+             \tPrecise Data Bus Error:             {}\n\
+             \tImprecise Data Bus Error:           {}\n\
+             \tBus Unstacking Fault:               {}\n\
+             \tBus Stacking Fault:                 {}\n\
+             \tBus Lazy FP Fault:                  {}\n\
+             \tUndefined Instruction Usage Fault:  {}\n\
+             \tInvalid State Usage Fault:          {}\n\
+             \tInvalid PC Load Usage Fault:        {}\n\
+             \tNo Coprocessor Usage Fault:         {}\n\
+             \tUnaligned Access Usage Fault:       {}\n\
+             \tDivide By Zero:                     {}\n\
+             \tBus Fault on Vector Table Read:     {}\n\
+             \tForced Hard Fault:                  {}\n\
+             \tFaulting Memory Address: (valid: {}) {:#010X}\n\
+             \tBus Fault Address:       (valid: {}) {:#010X}\n\
+             ",
+            mode_str,
+            env!("TOCK_KERNEL_VERSION"),
+            stacked_r0,
+            stacked_r1,
+            stacked_r2,
+            stacked_r3,
+            stacked_r12,
+            stacked_lr,
+            stacked_pc,
+            stacked_xpsr,
+            (stacked_xpsr >> 31) & 0x1,
+            (stacked_xpsr >> 30) & 0x1,
+            (stacked_xpsr >> 29) & 0x1,
+            (stacked_xpsr >> 28) & 0x1,
+            (stacked_xpsr >> 27) & 0x1,
+            (stacked_xpsr >> 19) & 0x1,
+            (stacked_xpsr >> 18) & 0x1,
+            (stacked_xpsr >> 17) & 0x1,
+            (stacked_xpsr >> 16) & 0x1,
+            ici_it,
+            thumb_bit,
+            exception_number,
+            kernel::process::ipsr_isr_number_to_str(exception_number),
+            faulting_stack as u32,
+            (_estack as *const ()) as u32,
+            (&_ezero as *const u32) as u32,
+            shcsr,
+            cfsr,
+            hfsr,
+            iaccviol,
+            daccviol,
+            munstkerr,
+            mstkerr,
+            mlsperr,
+            ibuserr,
+            preciserr,
+            impreciserr,
+            unstkerr,
+            stkerr,
+            lsperr,
+            undefinstr,
+            invstate,
+            invpc,
+            nocp,
+            unaligned,
+            divbysero,
+            vecttbl,
+            forced,
+            mmfarvalid,
+            mmfar,
+            bfarvalid,
+            bfar
+        );
+    } else {
+        // hard fault occurred in an app, not the kernel. The app should be
+        //  marked as in an error state and handled by the kernel
+        asm!(
+            "ldr r0, =SYSCALL_FIRED
+              mov r1, #1
+              str r1, [r0, #0]
+              ldr r0, =APP_FAULT
+              str r1, [r0, #0]
+              /* Read the SCB registers. */
+              ldr r0, =SCB_REGISTERS
+              ldr r1, =0xE000ED14
+              ldr r2, [r1, #0] /* CCR */
+              str r2, [r0, #0]
+              ldr r2, [r1, #20] /* CFSR */
+              str r2, [r0, #4]
+              ldr r2, [r1, #24] /* HFSR */
+              str r2, [r0, #8]
+              ldr r2, [r1, #32] /* MMFAR */
+              str r2, [r0, #12]
+              ldr r2, [r1, #36] /* BFAR */
+              str r2, [r0, #16]
+              /* Set thread mode to privileged */
+              mov r0, #0
+              msr CONTROL, r0
+              movw LR, #0xFFF9
+              movt LR, #0xFFFF"
+        );
+    }
 }
 
 #[link_section=".vectors"]
 #[cfg_attr(rustfmt, rustfmt_skip)]
-// no_mangle Ensures that the symbol is kept until the final binary
-#[no_mangle]
+#[no_mangle] // ensures that the symbol is kept until the final binary
+/// ARM Cortex M Vector Table
 pub static BASE_VECTORS: [unsafe extern fn(); 16] = [
-    _estack, reset_handler,
-    /* NMI */           unhandled_interrupt,
-    /* Hard Fault */    hard_fault_handler,
-    /* MemManage */     unhandled_interrupt,
-    /* BusFault */      unhandled_interrupt,
-    /* UsageFault*/     unhandled_interrupt,
-    unhandled_interrupt, unhandled_interrupt, unhandled_interrupt,
+    // Stack Pointer
+    _estack, 
+    // Reset Handler
+    reset_handler,
+    // NMI
     unhandled_interrupt,
-    /* SVC */           SVC_Handler,
-    /* DebugMon */      unhandled_interrupt,
+    // Hard Fault
+    hard_fault_handler,
+    // Memory Managment Fault
     unhandled_interrupt,
-    /* PendSV */        unhandled_interrupt,
-    /* SysTick */       systick_handler
+    // Bus Fault
+    unhandled_interrupt,
+    // Usage Fault
+    unhandled_interrupt,
+    // Reserved
+    unhandled_interrupt, 
+    // Reserved
+    unhandled_interrupt, 
+    // Reserved
+    unhandled_interrupt,
+    // Reserved
+    unhandled_interrupt,
+    // SVCall
+    svc_handler,
+    // Reserved for Debug
+    unhandled_interrupt,
+    // Reserved
+    unhandled_interrupt,
+    // PendSv
+    unhandled_interrupt,
+    // SysTick
+    systick_handler
 ];
 
 #[link_section = ".vectors"]

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm, concat_idents, const_fn, const_cell_new, try_from)]
+#![feature(asm, concat_idents, const_fn, const_cell_new, try_from, core_intrinsics)]
 #![no_std]
 #![crate_name = "nrf52"]
 #![crate_type = "rlib"]

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -38,7 +38,7 @@ pub mod dac;
 pub mod aes;
 pub mod usbc;
 
-use cortexm4::{generic_isr, systick_handler, SVC_Handler};
+use cortexm4::{generic_isr, svc_handler, systick_handler};
 
 unsafe extern "C" fn unhandled_interrupt() {
     let mut interrupt_number: u32;
@@ -85,7 +85,7 @@ pub static BASE_VECTORS: [unsafe extern fn(); 16] = [
     /* UsageFault*/     unhandled_interrupt,
     unhandled_interrupt, unhandled_interrupt, unhandled_interrupt,
     unhandled_interrupt,
-    /* SVC */           SVC_Handler,
+    /* SVC */           svc_handler,
     /* DebugMon */      unhandled_interrupt,
     unhandled_interrupt,
     /* PendSV */        unhandled_interrupt,


### PR DESCRIPTION
### Pull Request Overview

This pull request adds:
* Same error handling for `hard-faults` and `unhandled interupts` as `sam4l` (it is copy-pasted)
* s/SVC_Handler/svc_handler

### Testing Strategy

Tested the `buffer overflow` which hardfault and displays an error trace
and the BLE Advertising app still works!

### TODO or Help Wanted

N/A

### Documentation Updated

~- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.~
~- [ ] Userland: Added/updated the application README, if needed.~

### Formatting

- [x] Ran `make formatall`.
