### PR TITLE
[nrf5x] Enable debug_gpio macro

### DIFF
--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -50,7 +50,7 @@
 extern crate capsules;
 extern crate compiler_builtins;
 #[allow(unused_imports)]
-#[macro_use(debug, debug_gpio, static_init)]
+#[macro_use(debug, debug_verbose, debug_gpio, static_init)]
 extern crate kernel;
 extern crate nrf51;
 extern crate nrf5x;
@@ -212,6 +212,13 @@ pub unsafe fn reset_handler() {
             &nrf5x::gpio::PORT[12]  //
         ],
         4 * 11
+    );
+
+    // Configure kernel debug gpios as early as possible
+    kernel::debug::assign_gpios(
+        Some(&nrf5x::gpio::PORT[LED1_PIN]),
+        Some(&nrf5x::gpio::PORT[LED2_PIN]),
+        Some(&nrf5x::gpio::PORT[LED3_PIN]),
     );
 
     let gpio = static_init!(

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -68,7 +68,7 @@
 extern crate capsules;
 extern crate compiler_builtins;
 #[allow(unused_imports)]
-#[macro_use(debug, debug_gpio, static_init)]
+#[macro_use(debug, debug_verbose, debug_gpio, static_init)]
 extern crate kernel;
 extern crate nrf52;
 extern crate nrf5x;
@@ -183,6 +183,13 @@ pub unsafe fn reset_handler() {
             &nrf5x::gpio::PORT[23],
             &nrf5x::gpio::PORT[22] // -----
         ]
+    );
+
+    // Configure kernel debug gpios as early as possible
+    kernel::debug::assign_gpios(
+        Some(&nrf5x::gpio::PORT[LED1_PIN]),
+        Some(&nrf5x::gpio::PORT[LED2_PIN]),
+        Some(&nrf5x::gpio::PORT[LED3_PIN]),
     );
 
     let gpio = static_init!(

--- a/chips/nrf51/src/lib.rs
+++ b/chips/nrf51/src/lib.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![crate_name = "nrf51"]
 #![crate_type = "rlib"]
-#![warn(missing_docs)]
 
 extern crate cortexm0;
 extern crate nrf5x;

--- a/chips/nrf51/src/lib.rs
+++ b/chips/nrf51/src/lib.rs
@@ -2,11 +2,14 @@
 #![no_std]
 #![crate_name = "nrf51"]
 #![crate_type = "rlib"]
+#![warn(missing_docs)]
+
 extern crate cortexm0;
-#[allow(unused_imports)]
-#[macro_use(debug)]
-extern crate kernel;
 extern crate nrf5x;
+
+#[allow(unused_imports)]
+#[macro_use(debug, debug_verbose, debug_gpio)]
+extern crate kernel;
 
 pub mod clock;
 pub mod chip;

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -2,14 +2,17 @@
 #![no_std]
 #![crate_name = "nrf52"]
 #![crate_type = "rlib"]
-#[warn(missing_docs)]
+#![warn(missing_docs)]
+
 #[allow(unused_imports)]
 extern crate cortexm4;
 extern crate nrf5x;
 
 #[macro_use]
 extern crate bitfield;
-#[macro_use(debug, register_bitfields, register_bitmasks)]
+
+#[allow(unused)]
+#[macro_use(debug, debug_verbose, debug_gpio, register_bitfields, register_bitmasks)]
 extern crate kernel;
 
 mod peripheral_registers;

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![crate_name = "nrf52"]
 #![crate_type = "rlib"]
-#![warn(missing_docs)]
 
 #[allow(unused_imports)]
 extern crate cortexm4;

--- a/chips/nrf5x/src/lib.rs
+++ b/chips/nrf5x/src/lib.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 #[allow(unused_imports)]
-#[macro_use(debug, register_bitfields, register_bitmasks)]
+#[macro_use(debug, debug_verbose, debug_gpio, register_bitfields, register_bitmasks)]
 extern crate kernel;
 
 mod peripheral_registers;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds support for `debug_gpio!` macro

### Testing Strategy

Both boards blinked when I ran `debug_gpio!(0, toggle)`

### TODO or Help Wanted

N/A

### Documentation Updated

~- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.~
~- [ ] Userland: Added/updated the application README, if needed.~

### Formatting

- [x] Ran `make formatall`.
