### PR TITLE
[nrf5x/gpio] new register interface

### DIFF
--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -4,16 +4,16 @@
 //! * Philip Levis <pal@cs.stanford.edu>
 //! * Date: August 18, 2016
 
-use core::cell::Cell;
-use core::ops::{Index, IndexMut};
-use kernel::common::VolatileCell;
-use kernel::hil;
-use peripheral_registers::{GPIO, GPIO_BASE};
+use core::{cell::Cell, ops::{Index, IndexMut}};
+use kernel::{hil, common::regs::ReadWrite};
 
 #[cfg(feature = "nrf51")]
 const NUM_GPIOTE: usize = 4;
 #[cfg(feature = "nrf52")]
 const NUM_GPIOTE: usize = 8;
+
+const GPIOTE_BASE: usize = 0x40006000;
+const GPIO_BASE: usize = 0x50000000;
 
 /// The nRF5x doesn't automatically provide GPIO interrupts. Instead, to receive
 /// interrupts from a GPIO line, you must allocate a GPIOTE (GPIO Task and
@@ -22,58 +22,294 @@ const NUM_GPIOTE: usize = 8;
 /// requesting an interrupt can fail, if they are all already allocated.
 #[repr(C)]
 struct GpioteRegisters {
-    out: [VolatileCell<u32>; NUM_GPIOTE], // 0x0
+    /// Task for writing to pin specified in CONFIG[n].PSEL.
+    /// Action on pin is configured in CONFIG[n].POLARITY
+    ///
+    /// Address: 0x000 - 0x010 (nRF51)
+    /// Address: 0x000 - 0x020 (nRF52)
+    task_out: [ReadWrite<u32, TaskOut::Register>; NUM_GPIOTE],
+    /// Reserved
+    // task_set and task_clear are not used on nRF52
     _reserved0: [u8; 0x100 - (0x0 + NUM_GPIOTE * 4)],
-    event_in: [VolatileCell<u32>; NUM_GPIOTE], // 0x100
+    /// Event generated from pin specified in CONFIG[n].PSEL
+    ///
+    /// Address: 0x100 - 0x110 (nRF51)
+    /// Address: 0x100 - 0x120 (nRF52)
+    event_in: [ReadWrite<u32, EventIn::Register>; NUM_GPIOTE],
+    /// Reserved
     _reserved1: [u8; 0x17C - (0x100 + NUM_GPIOTE * 4)],
-    port: VolatileCell<u32>, // 0x17C,
-    _reserved2: [u8; 0x180],
-    inten: VolatileCell<u32>,    // 0x300
-    intenset: VolatileCell<u32>, // 0x304
-    intenclr: VolatileCell<u32>, // 0x308
+    /// Event generated from multiple input GPIO pins
+    /// Address: 0x17C - 0x180
+    event_port: ReadWrite<u32, EventPort::Register>,
+    /// Reserved
+    // inten on nRF51 is ignored because intenset and intenclr provides the same functionality
+    _reserved2: [u8; 0x184],
+    /// Enable interrupt
+    /// Address: 0x304 - 0x308
+    intenset: ReadWrite<u32, Intenset::Register>,
+    /// Disable interrupt
+    /// Address: 0x308 - 0x30C
+    intenclr: ReadWrite<u32, Intenclr::Register>,
+    /// Reserved
     _reserved3: [u8; 0x204],
-    config: [VolatileCell<u32>; NUM_GPIOTE], // 0x510
+    /// Configuration for OUT[n], SET[n] and CLR[n] tasks and IN[n] event
+    ///
+    /// Adress: 0x510 - 0x520 (nRF51)
+    /// Adress: 0x510 - 0x530 (nRF52)
+    // Note, only IN[n] and OUT[n] are used in Tock
+    config: [ReadWrite<u32, Config::Register>; NUM_GPIOTE],
 }
 
-const GPIOTE_BASE: usize = 0x40006000;
-
-#[allow(non_snake_case)]
-fn GPIO() -> &'static GPIO {
-    unsafe { &*(GPIO_BASE as *const GPIO) }
+#[repr(C)]
+struct GpioRegisters {
+    /// Reserved
+    _reserved1: [u32; 321],
+    /// Write GPIO port
+    /// Address: 0x504 - 0x508
+    out: ReadWrite<u32, Out::Register>,
+    /// Set individual bits in GPIO port
+    /// Address: 0x508 - 0x50C
+    outset: ReadWrite<u32, OutSet::Register>,
+    /// Clear individual bits in GPIO port
+    /// Address: 0x50C - 0x510
+    outclr: ReadWrite<u32, OutClr::Register>,
+    /// Read GPIO Port
+    /// Address: 0x510 - 0x514
+    in_: ReadWrite<u32, In::Register>,
+    /// Direction of GPIO pins
+    /// Address: 0x514 - 0x518
+    dir: ReadWrite<u32, Dir::Register>,
+    /// DIR set register
+    /// Address: 0x518 - 0x51C
+    dirset: ReadWrite<u32, DirSet::Register>,
+    /// DIR clear register
+    /// Address: 0x51C - 0x520
+    dirclr: ReadWrite<u32, DirClr::Register>,
+    #[cfg(feature = "nrf51")]
+    /// Reserved
+    _reserved2: [u32; 120],
+    #[cfg(feature = "nrf52")]
+    /// Latch register indicating what GPIO pins that have met the criteria set in the
+    /// PIN_CNF[n].SENSE
+    /// Address: 0x520 - 0x524
+    #[cfg(feature = "nrf52")]
+    latch: ReadWrite<u32, Latch::Register>,
+    /// Select between default DETECT signal behaviour and LDETECT mode
+    /// Address: 0x524 - 0x528
+    #[cfg(feature = "nrf52")]
+    detect_mode: ReadWrite<u32, DetectMode::Register>,
+    #[cfg(feature = "nrf52")]
+    /// Reserved
+    _reserved2: [u32; 118],
+    pin_cnf: [ReadWrite<u32, PinConfig::Register>; 32],
 }
 
-// Access to the GPIO Task and Event (GPIOTE) registers, for setting
-// up interrupts through the nRF51822 task/event system, in chapter 10
-// of the reference manual (v3.0).
-#[allow(non_snake_case)]
-fn GPIOTE() -> &'static GpioteRegisters {
-    unsafe { &*(GPIOTE_BASE as *const GpioteRegisters) }
-}
+/// Gpio
+#[cfg_attr(rustfmt, rustfmt_skip)]
+register_bitfields! [u32,
+    /// Write GPIO port
+    Out [
+        /// 0 - Low
+        /// 1 - High
+        PIN OFFSET(0) NUMBITS(32)
+    ],
+    /// Set individual bits in GPIO port
+    OutSet [
+        /// 0 - Low
+        /// 1 - High
+        /// Writing a '1' sets the pin high
+        /// Writing a '0' has no effect
+        PIN OFFSET(0) NUMBITS(32)
+    ],
+    /// Clear individual bits in GPIO port
+    OutClr [
+        /// 0 - Low
+        /// 1 - High
+        /// Writing a '1' sets the pin low
+        /// Writing a '0' has no effect
+        PIN OFFSET(0) NUMBITS(32)
+    ],
+    /// Read GPIO port 
+    In [
+        /// 0 - Low
+        /// 1 - High
+        PIN OFFSET(0) NUMBITS(32) 
+    ],
+    /// Direction of GPIO pins
+    Dir [
+        /// 0 - Pin set as input
+        /// 1 - Pin set as output
+        PIN OFFSET(0) NUMBITS(32)
+    ],
+    /// Configure direction of individual GPIO pins as output
+    DirSet [
+        /// 0 - Pin set as input
+        /// 1 - Pin set as output
+        /// Write: writing a '1' sets pin to output
+        /// Writing a '0' has no effect
+        PIN OFFSET(0) NUMBITS(32)
+    ],
+    /// Configure direction of individual GPIO pins as input
+    DirClr [
+        /// 0 - Pin set as input
+        /// 1 - Pin set as output
+        /// Write: writing a '1' sets pin to input
+        /// Writing a '0' has no effect
+        PIN OFFSET(0) NUMBITS(32)
+    ],
+    /// Latch register indicating what GPIO pins that have met the criteria set in the
+    /// PIN_CNF[n].SENSE registers
+    Latch [
+        /// 0 - NotLatched
+        /// 1 - Latched
+        PIN OFFSET(0) NUMBITS(32)
+    ],
+    /// Select between default DETECT signal behaviour and LDETECT mode
+    DetectMode [
+        /// 0 - NotLatched
+        /// 1 - Latched
+        DETECTMODE OFFSET(0) NUMBITS(1) [
+            DEFAULT = 0,
+            LDDETECT = 1
+        ]
+    ],
+    /// Configuration of GPIO pins
+    PinConfig [
+        /// Pin direction. Same physical register as DIR register
+        DIR OFFSET(0) NUMBITS(1) [
+            Input = 0,
+            Output = 1
+        ],
+        /// Connect or disconnect input buffer
+        INPUT OFFSET(1) NUMBITS(1) [
+            Connect = 0,
+            Disconnect = 1
+        ],
+        /// Pull configuration
+        PULL OFFSET(2) NUMBITS(2) [
+            Disabled = 0,
+            Pulldown = 1,
+            Pullup = 3
+        ],
+        /// Drive configuration
+        DRIVE OFFSET(8) NUMBITS(3) [
+            /// Standard '0', standard '1'
+            S0S1 = 0,
+            /// High drive '0', standard '1'
+            H0S1 = 1,
+            /// Standard '0', high drive '1
+            S0H1 = 2,
+            /// High drive '0', high 'drive '1'
+            H0H1 = 3,
+            /// Disconnect '0' standard '1' (normally used for wired-or connections)
+            D0S1 = 4,
+            /// Disconnect '0', high drive '1' (normally used for wired-or connections)
+            D0H1 = 5,
+            /// Standard '0'. disconnect '1' (normally used for wired-and connections)
+            S0D1 = 6,
+            /// High drive '0', disconnect '1' (normally used for wired-and connections)
+            H0D1 = 7
+        ],
+        /// Pin sensing mechanism
+        SENSE OFFSET(16) NUMBITS(2) [
+            /// Disabled
+            Disabled = 0,
+            /// Sense for high level
+            High = 2,
+            /// Sense for low level
+            Low = 3
+        ]
+    ]
+];
 
-/// Allocate a GPIOTE channel
-fn allocate_channel() -> i8 {
-    for (i, ch) in GPIOTE().config.iter().enumerate() {
-        if ch.get() & 1 == 0 {
-            return i as i8;
-        }
-    }
-    return -1;
-}
+/// GpioTe
+#[cfg_attr(rustfmt, rustfmt_skip)]
+register_bitfields! [u32,
+    /// Task for writing to pin specified in CONFIG[n].PSEL. 
+    /// Action on pin is configured in CONFIG[n].POLARITY
+    TaskOut [
+        PIN OFFSET(0) NUMBITS(32)
+    ],
 
-/// Return which channel is allocated to a pin, or -1 if none.
-fn find_channel(pin: u8) -> i8 {
-    for (i, ch) in GPIOTE().config.iter().enumerate() {
-        if (ch.get() >> 8) & 0x1F == pin as u32 {
-            return i as i8;
-        }
-    }
-    return -1;
-}
+    /// Event generated from pin specified in CONFIG[n].PSEL
+    EventIn [
+        PIN OFFSET(0) NUMBITS(32)
+    ],
+    
+    /// Event generated from multiple input pins
+    EventPort [
+        PINS OFFSET(0) NUMBITS(1)
+    ],
+
+    /// Enable interrupt
+    Intenset [
+        // nRF51 has only 4 inputs
+        IN OFFSET(0) NUMBITS(8),
+        PORT OFFSET(31) NUMBITS(1)
+    ],
+
+    /// Disable interrupt
+    Intenclr [
+        // nRF51 has only 4 inputs
+        IN OFFSET(0) NUMBITS(8),
+        PORT OFFSET(31) NUMBITS(1)
+    ],
+
+    /// Configuration for OUT[n], SET[n] and CLR[n] tasks and IN[n] event
+    Config [
+        /// Mode
+        MODE OFFSET(0) NUMBITS(2) [
+            /// Disabled. Pin specified by PSEL will not be acquired by the
+            /// GPIOTE module
+            Disabled = 0,
+            /// The pin specified by PSEL will be configured as an input and the
+            /// IN[n] event will be generated if operation specified in POLARITY
+            /// occurs on the pin.
+            Event = 1,
+            ///The GPIO specified by PSEL will be configured as an output and
+            /// triggering the SET[n], CLR[n] or OUT[n] task will perform the
+            /// operation specified by POLARITY on the pin. When enabled as a
+            /// task the GPIOTE module will acquire the pin and the pin can no
+            /// longer be written as a regular output pin from the GPIO module.
+            Task = 3
+        ],
+        /// GPIO number associated with SET[n], CLR[n] and OUT[n] tasks
+        /// and IN[n] event
+        PSEL OFFSET(8) NUMBITS(4) [],
+        /// When In task mode: Operation to be performed on output
+        /// when OUT[n] task is triggered. When In event mode: Operation
+        /// on input that shall trigger IN[n] event
+        POLARITY OFFSET(16) NUMBITS(2) [
+            /// Task mode: No effect on pin from OUT[n] task. Event mode: no
+            /// IN[n] event generated on pin activity
+            None = 0,
+            /// Task mode: Set pin from OUT[n] task. Event mode: Generate
+            /// IN[n] event when rising edge on pin
+            LoToHi = 1,
+            /// Task mode: Clear pin from OUT[n] task. Event mode: Generate
+            /// IN[n] event when falling edge on pin
+            HiToLo = 2,
+            /// Task mode: Toggle pin from OUT[n]. Event mode: Generate
+            /// IN[n] when any change on pin
+            Toggle = 3
+        ],
+        /// When in task mode: Initial value of the output when the GPIOTE
+        /// channel is configured. When in event mode: No effect
+        OUTINIT OFFSET(20) NUMBITS(1) [
+            /// Task mode: Initial value of pin before task triggering is low
+            Low = 1,
+            /// Task mode: Initial value of pin before task triggering is high
+            High = 0
+        ]
+    ]
+];
 
 pub struct GPIOPin {
     pin: u8,
     client_data: Cell<usize>,
     client: Cell<Option<&'static hil::gpio::Client>>,
+    gpiote_register: *const GpioteRegisters,
+    gpio_register: *const GpioRegisters,
 }
 
 impl GPIOPin {
@@ -82,6 +318,8 @@ impl GPIOPin {
             pin: pin,
             client_data: Cell::new(0),
             client: Cell::new(None),
+            gpio_register: GPIO_BASE as *const GpioRegisters,
+            gpiote_register: GPIOTE_BASE as *const GpioteRegisters,
         }
     }
 
@@ -97,20 +335,22 @@ impl hil::gpio::PinCtl for GPIOPin {
             hil::gpio::InputMode::PullDown => 1,
             hil::gpio::InputMode::PullNone => 0,
         };
-        let pin_cnf = &GPIO().pin_cnf[self.pin as usize];
-        pin_cnf.set((pin_cnf.get() & !(0b11 << 2)) | (conf << 2));
+        let gpio_regs = unsafe { &*self.gpio_register };
+        gpio_regs.pin_cnf[self.pin as usize].write(PinConfig::PULL.val(conf));
     }
 }
 
 impl hil::gpio::Pin for GPIOPin {
+    #[no_mangle]
+    #[inline(never)]
     fn make_output(&self) {
-        GPIO().dirset.set(1 << self.pin);
+        unsafe { (&*self.gpio_register).dirset.set(1 << self.pin) };
     }
 
     // Configuration constants stolen from
     // mynewt/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51_bitfields.h
     fn make_input(&self) {
-        GPIO().dirclr.set(1 << self.pin);
+        unsafe { (&*self.gpio_register).dirclr.set(1 << self.pin) };
     }
 
     // Not clk
@@ -119,19 +359,21 @@ impl hil::gpio::Pin for GPIOPin {
     }
 
     fn set(&self) {
-        GPIO().outset.set(1 << self.pin);
+        unsafe { (&*self.gpio_register).outset.set(1 << self.pin) };
     }
 
     fn clear(&self) {
-        GPIO().outclr.set(1 << self.pin);
+        unsafe { (&*self.gpio_register).outclr.set(1 << self.pin) };
     }
 
     fn toggle(&self) {
-        GPIO().out.set((1 << self.pin) ^ GPIO().out.get());
+        let gpio_regs = unsafe { &*self.gpio_register };
+        gpio_regs.out.set((1 << self.pin) ^ gpio_regs.out.get());
     }
 
     fn read(&self) -> bool {
-        GPIO().in_.get() & (1 << self.pin) != 0
+        let gpio_regs = unsafe { &*self.gpio_register };
+        gpio_regs.in_.get() & (1 << self.pin) != 0
     }
 
     fn enable_interrupt(&self, client_data: usize, mode: hil::gpio::InterruptMode) {
@@ -144,25 +386,50 @@ impl hil::gpio::Pin for GPIOPin {
         };
         let pin = (self.pin & 0b11111) as u32;
         mode_bits |= pin << 8;
-        let channel = allocate_channel();
-        if channel >= 0 {
-            GPIOTE().config[channel as usize].set(mode_bits);
-            GPIOTE().intenset.set(1 << channel);
+
+        if let Ok(channel) = self.allocate_channel() {
+            let regs = unsafe { &*self.gpiote_register };
+            regs.config[channel as usize].set(mode_bits);
+            regs.intenset.set(1 << channel);
         } else {
-            panic!("No available GPIOTE interrupt channels");
+            debug!("No available GPIOTE interrupt channels");
         }
     }
 
     fn disable_interrupt(&self) {
-        let channel = find_channel(self.pin);
-        if channel >= 0 {
-            GPIOTE().config[channel as usize].set(0);
-            GPIOTE().intenclr.set(1 << channel);
+        if let Ok(channel) = self.find_channel(self.pin) {
+            let regs = unsafe { &*self.gpiote_register };
+            regs.config[channel as usize].set(0);
+            regs.intenclr.set(1 << channel);
         }
     }
 }
 
 impl GPIOPin {
+    /// Allocate a GPIOTE channel
+    /// Return the allocated if successful
+    /// else Error
+    fn allocate_channel(&self) -> Result<usize, ()> {
+        let regs = unsafe { &*self.gpiote_register };
+        for (i, ch) in regs.config.iter().enumerate() {
+            if ch.matches_any(Config::MODE::Event) {
+                return Ok(i);
+            }
+        }
+        Err(())
+    }
+
+    /// Return which channel is allocated to a pin, or Error
+    fn find_channel(&self, pin: u8) -> Result<usize, ()> {
+        let regs = unsafe { &*self.gpiote_register };
+        for (i, ch) in regs.config.iter().enumerate() {
+            if ch.read(Config::PSEL) == pin as u32 {
+                return Ok(i);
+            }
+        }
+        return Err(());
+    }
+
     pub fn handle_interrupt(&self) {
         self.client.get().map(|client| {
             client.fired(self.client_data.get());
@@ -189,13 +456,15 @@ impl IndexMut<usize> for Port {
 }
 
 impl Port {
-    /// GPIOTE interrupt: check each of 4 GPIOTE channels, if any has
+    /// GPIOTE interrupt: check each GPIOTE channel, if any has
     /// fired then trigger its corresponding pin's interrupt handler.
     pub fn handle_interrupt(&self) {
-        for (i, ev) in GPIOTE().event_in.iter().enumerate() {
+        let regs = unsafe { &*self.pins[0].gpiote_register };
+        for (i, ev) in regs.event_in.iter().enumerate() {
             if ev.get() != 0 {
                 ev.set(0);
-                let pin = (GPIOTE().config[i].get() >> 8 & 0x1F) as usize;
+                // get gpio number
+                let pin = regs.config[i].read(Config::PSEL) as usize;
                 self.pins[pin].handle_interrupt();
             }
         }

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -109,12 +109,14 @@ struct GpioRegisters {
 register_bitfields! [u32,
     /// Write GPIO port
     Out [
-        /// 0 - Low
-        /// 1 - High
+        /// Pin[n], each bit correspond to a pin 0 to 31
+        /// 0 - Low, Pin driver is low
+        /// 1 - High, Pin driver is high
         PIN OFFSET(0) NUMBITS(32)
     ],
     /// Set individual bits in GPIO port
     OutSet [
+        /// Pin[n], each bit correspond to a pin 0 to 31
         /// 0 - Low
         /// 1 - High
         /// Writing a '1' sets the pin high
@@ -123,6 +125,7 @@ register_bitfields! [u32,
     ],
     /// Clear individual bits in GPIO port
     OutClr [
+        /// Pin[n], each bit correspond to a pin 0 to 31
         /// 0 - Low
         /// 1 - High
         /// Writing a '1' sets the pin low
@@ -131,6 +134,7 @@ register_bitfields! [u32,
     ],
     /// Read GPIO port 
     In [
+        /// Pin[n], each bit correspond to a pin 0 to 31
         /// 0 - Low
         /// 1 - High
         PIN OFFSET(0) NUMBITS(32) 
@@ -143,6 +147,7 @@ register_bitfields! [u32,
     ],
     /// Configure direction of individual GPIO pins as output
     DirSet [
+        /// Pin[n], each bit correspond to a pin 0 to 31
         /// 0 - Pin set as input
         /// 1 - Pin set as output
         /// Write: writing a '1' sets pin to output
@@ -151,6 +156,7 @@ register_bitfields! [u32,
     ],
     /// Configure direction of individual GPIO pins as input
     DirClr [
+        /// Pin[n], each bit correspond to a pin 0 to 31
         /// 0 - Pin set as input
         /// 1 - Pin set as output
         /// Write: writing a '1' sets pin to input
@@ -160,6 +166,7 @@ register_bitfields! [u32,
     /// Latch register indicating what GPIO pins that have met the criteria set in the
     /// PIN_CNF[n].SENSE registers
     Latch [
+        /// Pin[n], each bit correspond to a pin 0 to 31
         /// 0 - NotLatched
         /// 1 - Latched
         PIN OFFSET(0) NUMBITS(32)
@@ -174,6 +181,7 @@ register_bitfields! [u32,
         ]
     ],
     /// Configuration of GPIO pins
+    /// Pin[n], each bit correspond to a pin 0 to 31
     PinConfig [
         /// Pin direction. Same physical register as DIR register
         DIR OFFSET(0) NUMBITS(1) [
@@ -284,7 +292,7 @@ register_bitfields! [u32,
         ],
         /// GPIO number associated with SET[n], CLR[n] and OUT[n] tasks
         /// and IN[n] event
-        PSEL OFFSET(8) NUMBITS(4) [],
+        PSEL OFFSET(8) NUMBITS(5) [],
         /// When In task mode: Operation to be performed on output
         /// when OUT[n] task is triggered. When In event mode: Operation
         /// on input that shall trigger IN[n] event
@@ -306,9 +314,9 @@ register_bitfields! [u32,
         /// channel is configured. When in event mode: No effect
         OUTINIT OFFSET(20) NUMBITS(1) [
             /// Task mode: Initial value of pin before task triggering is low
-            Low = 1,
+            Low = 0,
             /// Task mode: Initial value of pin before task triggering is high
-            High = 0
+            High = 1
         ]
     ]
 ];
@@ -416,7 +424,7 @@ impl GPIOPin {
     fn allocate_channel(&self) -> Result<usize, ()> {
         let regs = unsafe { &*self.gpiote_register };
         for (i, ch) in regs.config.iter().enumerate() {
-            if ch.matches_any(Config::MODE::Event) {
+            if ch.matches_all(Config::MODE::Disabled) {
                 return Ok(i);
             }
         }

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -341,8 +341,6 @@ impl hil::gpio::PinCtl for GPIOPin {
 }
 
 impl hil::gpio::Pin for GPIOPin {
-    #[no_mangle]
-    #[inline(never)]
     fn make_output(&self) {
         unsafe { (&*self.gpio_register).dirset.set(1 << self.pin) };
     }
@@ -407,8 +405,8 @@ impl hil::gpio::Pin for GPIOPin {
 
 impl GPIOPin {
     /// Allocate a GPIOTE channel
-    /// Return the allocated if successful
-    /// else Error
+    /// Returns the allocated channel if successful
+    /// Or else an Error
     fn allocate_channel(&self) -> Result<usize, ()> {
         let regs = unsafe { &*self.gpiote_register };
         for (i, ch) in regs.config.iter().enumerate() {
@@ -419,7 +417,8 @@ impl GPIOPin {
         Err(())
     }
 
-    /// Return which channel is allocated to a pin, or Error
+    /// Return which channel is allocated to a pin,
+    /// Or else return an error
     fn find_channel(&self, pin: u8) -> Result<usize, ()> {
         let regs = unsafe { &*self.gpiote_register };
         for (i, ch) in regs.config.iter().enumerate() {

--- a/chips/nrf5x/src/peripheral_registers.rs
+++ b/chips/nrf5x/src/peripheral_registers.rs
@@ -53,18 +53,3 @@ pub struct TIMER {
     _reserved6: [VolatileCell<u32>; 11], // 0x514
     pub cc: [VolatileCell<u32>; 4],      // 0x540
 }
-
-pub const GPIO_BASE: usize = 0x50000000;
-#[repr(C)]
-pub struct GPIO {
-    _reserved1: [u32; 321],
-    pub out: VolatileCell<u32>,
-    pub outset: VolatileCell<u32>,
-    pub outclr: VolatileCell<u32>,
-    pub in_: VolatileCell<u32>,
-    pub dir: VolatileCell<u32>,
-    pub dirset: VolatileCell<u32>,
-    pub dirclr: VolatileCell<u32>,
-    _reserved2: [u32; 120],
-    pub pin_cnf: [VolatileCell<u32>; 32],
-}


### PR DESCRIPTION
### Pull Request Overview

This pull request changes to the `gpio` driver to the new register interface with some minor tweaks

I introduced two register pointers i.e, one for the `gpio` and one for the `gpiote` and this could probably be done better to decouple the `gpio` and `gpiote` in different modules. I also used the `register macro` twice just for clarity I know these publicly exported doesn't make any difference!

### Testing Strategy

This pull request was tested by running the `blink` app and the `buttons` app both on `nRF52-DK` and `nRF51-DK`

### TODO or Help Wanted

BTW, we have no guard that the same `gpio` to allocate several `gpio channels`.

Should we? 

### Documentation Updated

~- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.~
~- [ ] Userland: Added/updated the application README, if needed.~

### Formatting

- [x] Ran `make formatall`.

/cc @phil-levis 