### PR TITLE
sam4l::flashcalw: Improve diagnostics

### DIFF
--- a/capsules/src/nonvolatile_to_pages.rs
+++ b/capsules/src/nonvolatile_to_pages.rs
@@ -21,6 +21,7 @@
 //! -----
 //!
 //! ```
+//! sam4l::flashcalw::FLASH_CONTROLLER.configure();
 //! pub static mut PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
 //! let nv_to_page = static_init!(
 //!     capsules::nonvolatile_to_pages::NonvolatileToPages<'static, sam4l::flashcalw::FLASHCALW>,

--- a/userland/examples/tests/nonvolatile_storage/main.c
+++ b/userland/examples/tests/nonvolatile_storage/main.c
@@ -30,8 +30,7 @@ int main (void) {
   int r = test_all();
   if (r == 0) {
     printf("All tests succeeded\n");
-  }
-  else {
+  } else {
     printf("Failed with code %d\n", r);
   }
 
@@ -88,7 +87,7 @@ static int test(uint8_t *readbuf, uint8_t *writebuf, size_t size, size_t offset,
   }
 
   done = false;
-  ret = nonvolatile_storage_internal_write(offset, len);
+  ret  = nonvolatile_storage_internal_write(offset, len);
   if (ret != 0) {
     printf("\tERROR calling write\n");
     return ret;

--- a/userland/examples/tests/nonvolatile_storage/main.c
+++ b/userland/examples/tests/nonvolatile_storage/main.c
@@ -3,16 +3,16 @@
 
 #include <internal/nonvolatile_storage.h>
 
-uint8_t readbuf[256];
-uint8_t writebuf[256];
+static int test_all(void);
+static int test(uint8_t *readbuf, uint8_t *writebuf, size_t size, size_t offset, size_t len);
 
-bool done = false;
+static bool done = false;
 
 static void read_done(int length,
                       __attribute__ ((unused)) int arg1,
                       __attribute__ ((unused)) int arg2,
                       __attribute__ ((unused)) void* ud) {
-  printf("Finished read! %i\n", length);
+  printf("\tFinished read! %i\n", length);
   done = true;
 }
 
@@ -20,64 +20,94 @@ static void write_done(int length,
                        __attribute__ ((unused)) int arg1,
                        __attribute__ ((unused)) int arg2,
                        __attribute__ ((unused)) void* ud) {
-  printf("Finished write! %i\n", length);
+  printf("\tFinished write! %i\n", length);
   done = true;
 }
 
 int main (void) {
-  int ret;
-
   printf("[Nonvolatile Storage] Test App\n");
 
-  ret = nonvolatile_storage_internal_read_buffer(readbuf, 256);
-  if (ret != 0) printf("ERROR setting read buffer\n");
+  int r = test_all();
+  if (r == 0) {
+    printf("All tests succeeded\n");
+  }
+  else {
+    printf("Failed with code %d\n", r);
+  }
 
-  ret = nonvolatile_storage_internal_write_buffer(writebuf, 256);
-  if (ret != 0) printf("ERROR setting write buffer\n");
+  return r;
+}
 
-  // Setup callbacks
-  ret = nonvolatile_storage_internal_read_done_subscribe(read_done, NULL);
-  if (ret != 0) printf("ERROR setting read done callback\n");
-
-  ret = nonvolatile_storage_internal_write_done_subscribe(write_done, NULL);
-  if (ret != 0) printf("ERROR setting write done callback\n");
-
+static int test_all(void) {
   int num_bytes = nonvolatile_storage_internal_get_number_bytes();
   printf("Have %i bytes of nonvolatile storage\n", num_bytes);
 
-  writebuf[0] = 5;
-  writebuf[1] = 10;
-  writebuf[2] = 20;
-  writebuf[3] = 200;
-  writebuf[4] = 123;
-  writebuf[5] = 88;
+  int r;
+  uint8_t readbuf[512];
+  uint8_t writebuf[512];
+
+  if ((r = test(readbuf, writebuf, 256, 0,  14)) != 0) return r;
+  if ((r = test(readbuf, writebuf, 256, 20, 14)) != 0) return r;
+  if ((r = test(readbuf, writebuf, 512, 0, 512)) != 0) return r;
+
+  return 0;
+}
+
+static int test(uint8_t *readbuf, uint8_t *writebuf, size_t size, size_t offset, size_t len) {
+  int ret;
+
+  printf("Test with size %d ...\n", size);
+
+  ret = nonvolatile_storage_internal_read_buffer(readbuf, size);
+  if (ret != 0) {
+    printf("\tERROR setting read buffer\n");
+    return ret;
+  }
+
+  ret = nonvolatile_storage_internal_write_buffer(writebuf, size);
+  if (ret != 0) {
+    printf("\tERROR setting write buffer\n");
+    return ret;
+  }
+
+  // Setup callbacks
+  ret = nonvolatile_storage_internal_read_done_subscribe(read_done, NULL);
+  if (ret != 0) {
+    printf("\tERROR setting read done callback\n");
+    return ret;
+  }
+
+  ret = nonvolatile_storage_internal_write_done_subscribe(write_done, NULL);
+  if (ret != 0) {
+    printf("\tERROR setting write done callback\n");
+    return ret;
+  }
+
+  for (size_t i = 0; i < len; i++) {
+    writebuf[i] = i;
+  }
 
   done = false;
-  ret  = nonvolatile_storage_internal_write(0, 6);
-  if (ret != 0) printf("ERROR calling write\n");
-  yield_for(&done);
-
-  writebuf[0] = 33;
-  writebuf[1] = 3;
-  writebuf[2] = 66;
-  writebuf[3] = 6;
-  writebuf[4] = 99;
-  writebuf[5] = 9;
-  writebuf[6] = 100;
-  writebuf[7] = 101;
-
-  done = false;
-  ret  = nonvolatile_storage_internal_write(6, 8);
-  if (ret != 0) printf("ERROR calling write\n");
+  ret = nonvolatile_storage_internal_write(offset, len);
+  if (ret != 0) {
+    printf("\tERROR calling write\n");
+    return ret;
+  }
   yield_for(&done);
 
   done = false;
-  ret  = nonvolatile_storage_internal_read(0, 14);
-  if (ret != 0) printf("ERROR calling read\n");
+  ret  = nonvolatile_storage_internal_read(offset, len);
+  if (ret != 0) {
+    printf("\tERROR calling read\n");
+    return ret;
+  }
   yield_for(&done);
 
-  for (int i = 0; i < 14; i++) {
-    printf("got[%i]: %i\n", i, readbuf[i]);
+  for (size_t i = 0; i < len; i++) {
+    if (readbuf[i] != writebuf[i]) {
+      printf("\tInconsistency between data written and read at index %u\n", i);
+      return -1;
+    }
   }
 
   return 0;


### PR DESCRIPTION
### Pull Request Overview

Return FAIL when a read/write is requested before `configure()` is
called.  This should not change behavior where `configure()` is
properly called before other operations.

Previous behavior when `configure()` has not been called:

- `read_page()`: SUCCESS
- `write_page()`: EBUSY

Both cases are dangerous because the driver is not being used as
intended (the intended setup in `configure()` is omitted and the state
machine is incorrectly initialized), and the second case makes
debugging difficult because EBUSY can be returned by other layers
(e.g. `capsules::nonvolatile_to_pages`).

This commit also adds the call to `configure()` in some example-use
code in comments atop `nonvolatile_to_pages.rs`, so copy-paste users
will have a better chance of getting it right.

A second commit in this PR also adds a `nonvolatile_storage` driver to
imix, which is necessary for testing the above.  The code for setting
up such a driver is documented fairly well, so perhaps this is not
necessary.

### Testing Strategy

The `examples/tests/nonvolatile_storage` app has been expanded to
tickle the failure modes of an unconfigured flash controller.

### TODO or Help Wanted

I welcome comments on whether it makes sense to have the
`nonvolatile_storage` driver running on imix by default.

### Documentation Updated

- [X] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [X] Userland: Added/updated the application README, if needed.

### Formatting

- [X] Ran `make format`.
- [x] Ran `make formatall`.  (problems with uncrustify)
