### PR TITLE
Grant remove un-necessary `unwrap`

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -35,7 +35,7 @@ impl<T> AppliedGrant<T> {
         R: Copy,
     {
         let mut allocator = Allocator {
-            app: unsafe { Some(process::PROCS[self.appid].as_mut().unwrap()) },
+            app: unsafe { process::PROCS[self.appid].as_mut() },
             app_id: self.appid,
         };
         let mut root = unsafe { Owned::new(self.grant, self.appid) };


### PR DESCRIPTION
### Pull Request Overview

This pull request removes an un-necessary `unwrap` and it looks dangerous to me but I don't know the piece of codebase that well. However, if the allocator is `None` I think the closure should handle it right?

If this is wrong, I think this requires some explanation or simply use `expect` with some explanation which makes this easier to debug! 

### Testing Strategy

This pull request was tested by it compiles 


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

~- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.~
~- [ ] Userland: Added/updated the application README, if needed.~

### Formatting

- [x] Ran `make formatall`.
