### PR TITLE
[nrf52-ficr] `fix warnings and suppress overflow warnings in the register interface`

### DIFF
--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -127,7 +127,8 @@ register_bitfields! [u32,
             /// nRF52838
             N52832 = 0x52832,
             /// Unspecified
-            Unspecified = 0xFFFFFFFF
+            #[allow(overflowing_literals)]
+            Unspecified = 0xffffffff
         ]
     ],
     /// Part Variant, Hardware version and Production configuration
@@ -148,7 +149,8 @@ register_bitfields! [u32,
             /// AAE0
             AAE0 = 0x41414530,
             /// Unspecified
-            Unspecified = 0xFFFFFFFF
+            #[allow(overflowing_literals)]
+            Unspecified = 0xffffffff
         ]
     ],
     /// Package option
@@ -164,7 +166,8 @@ register_bitfields! [u32,
             /// CKxx - 7x8 WLCSP 56 balls with backside coating for light protection
             CK = 0x2005,
             /// Unspecified
-            Unspecified = 0xFFFFFFFF
+            #[allow(overflowing_literals)]
+            Unspecified = 0xffffffff
         ]
     ],
     /// RAM variant
@@ -176,7 +179,9 @@ register_bitfields! [u32,
             K32 = 0x20,
             /// 64 kByte RAM
             K64 = 0x40,
-            Unspecified = 0xFFFFFFFF
+            #[allow(overflowing_literals)]
+            Unspecified = 0xffffffff
+
         ]
     ],
     /// Flash 
@@ -189,7 +194,8 @@ register_bitfields! [u32,
             /// 512 kByte FLASH
             K512 = 0x200,
             /// Unspecified
-            Unspecified = 0xFFFFFFFF
+            #[allow(overflowing_literals)]
+            Unspecified = 0xffffffff
         ]
     ]
 ];
@@ -208,34 +214,38 @@ enum Variant {
 }
 
 #[derive(PartialEq, Debug)]
+#[repr(u32)]
 enum Part {
     N52832 = 0x52832,
     Unspecified = 0xffffffff,
 }
 
 #[derive(PartialEq, Debug)]
+#[repr(u32)]
 enum Package {
     QF = 0x2000,
     CH = 0x2001,
     CI = 0x2002,
     CK = 0x2005,
-    Unspecified = 0xFFFFFFFF,
+    Unspecified = 0xffffffff,
 }
 
 #[derive(PartialEq, Debug)]
+#[repr(u32)]
 enum Ram {
     K16 = 0x10,
     K32 = 0x20,
     K64 = 0x40,
-    Unspecified = 0xFFFFFFFF,
+    Unspecified = 0xffffffff,
 }
 
 #[derive(Debug)]
+#[repr(u32)]
 enum Flash {
     K128 = 0x80,
     K256 = 0x100,
     K512 = 0x200,
-    Unspecified = 0xFFFFFFFF,
+    Unspecified = 0xffffffff,
 }
 
 pub struct Ficr {


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes compiler warnings that makes CI fail!

### Testing Strategy

This pull request was tested by: compiles with errors!

### TODO or Help Wanted

N/A

### Documentation Updated

~- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.~
~- [ ] Userland: Added/updated the application README, if needed.~

### Formatting

- [x] Ran `make formatall`.
