### PR TITLE
kernel: double initial stack size

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1623,8 +1623,8 @@ unsafe fn load(tbf_header: TbfHeader,
         // own.
         let load_result = LoadResult {
             // Set the initial stack and process memory size to 64 bytes.
-            initial_stack_pointer: mem_base.offset(64),
-            initial_sbrk_pointer: mem_base.offset(64),
+            initial_stack_pointer: mem_base.offset(128),
+            initial_sbrk_pointer: mem_base.offset(128),
             header: tbf_header,
         };
 


### PR DESCRIPTION
Doubles the initial process stack size set by the kernel from 64 bytes to 128 bytes.

If a process is compiled with -O0 (no optimizations) it overflows the
initial stack and runs into a MPU fault.

Running without this commit with a blink app compiled with -O0 instead
of -Os:

```
Kernel panic at /Users/bradjc/git/tock/kernel/src/process.rs:752:
	"Process blink had a fault"
	Kernel version release-1.0-2018-02-319-g7877ec53

---| Fault Status |---
Data Access Violation:              true
Memory Management Stacking Fault:   true
Invalid State Usage Fault:          true
Forced Hard Fault:                  true
Faulting Memory Address:            0x20003FFC
Fault Status Register (CFSR):       0x00020092
Hard Fault Status Register (HFSR):  0x40000000

---| App Status |---
App: blink   -   [Fault]
 Events Queued: 0   Syscall Count: 0   Last Syscall: None

 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x20006000═╪══════════════════════════════════════════╝
             │ ▼ Grant         280 |    280
  0x20005EE8 ┼───────────────────────────────────────────
             │ Unused
  0x20004040 ┼───────────────────────────────────────────
             │ ▲ Heap       536887360 | 536895208               S
  0x00000000 ┼─────────────────────────────────────────── R
             │ Data              0 |      0               A
  0x00000000 ┼─────────────────────────────────────────── M
             │ ▼ Stack      3758080040 | 3758080000 EXCEEDED!
  0x20003FD8 ┼───────────────────────────────────────────
             │ Unused
  0x20004000 ┴───────────────────────────────────────────
             .....
  0x00031000 ┬─────────────────────────────────────────── F
             │ App Flash      4052                        L
  0x0003002C ┼─────────────────────────────────────────── A
             │ Protected        44                        S
  0x00030000 ┴─────────────────────────────────────────── H

  R0 : 0x00000000    R6 : 0x00000000
  R1 : 0x00000000    R7 : 0x20003FF8
  R2 : 0x00000000    R8 : 0x00000000
  R3 : 0x00000000    R10: 0x00000000
  R4 : 0x00000000    R11: 0x00000000
  R5 : 0x00000000    R12: 0x00000000
  R9 : 0x00000000 (Static Base Register)
  SP : 0x20003FD8 (Process Stack Pointer)
  LR : 0x00000000
  PC : 0x00000000
 YPC : 0x00030051

 APSR: N 0 Z 0 C 0 V 0 Q 0
       GE 0 0 0 0
 IPSR: Exception Type - Thread Mode
 EPSR: ICI.IT 0x00
       ThumbBit false !!ERROR - Cortex M Thumb only!
 To debug, run `make debug RAM_START=0x20004000 FLASH_INIT=0x30051`
 in the app's folder and open the .lst file.
 ```


### Testing Strategy

This pull request was tested by running sensors and blink on hail. 





### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
