### PR TITLE
crt0: move stack pointer last

### DIFF
--- a/userland/libtock/crt0.c
+++ b/userland/libtock/crt0.c
@@ -51,15 +51,6 @@ void _start(void* text_start,
   uint32_t stacktop = (uint32_t)mem_start + STACK_SIZE;
   struct hdr* myhdr = (struct hdr*)text_start;
 
-  {
-    uint32_t heap_size = myhdr->got_size + myhdr->data_size + myhdr->bss_size;
-    memop(0, stacktop + heap_size);
-    memop(11, stacktop + heap_size);
-    memop(10, stacktop);
-    asm volatile ("mov sp, %[stacktop]" :: [stacktop] "r" (stacktop) : "memory");
-    asm volatile ("mov r9, sp");
-  }
-
   // fix up GOT
   volatile uint32_t* got_start     = (uint32_t*)(myhdr->got_start + stacktop);
   volatile uint32_t* got_sym_start = (uint32_t*)(myhdr->got_sym_start + (uint32_t)text_start);
@@ -88,6 +79,15 @@ void _start(void* text_start,
     } else {
       *target = (*target ^ 0x80000000) + (uint32_t)text_start;
     }
+  }
+
+  {
+    uint32_t heap_size = myhdr->got_size + myhdr->data_size + myhdr->bss_size;
+    memop(0, stacktop + heap_size);
+    memop(11, stacktop + heap_size);
+    memop(10, stacktop);
+    asm volatile ("mov sp, %[stacktop]" :: [stacktop] "r" (stacktop) : "memory");
+    asm volatile ("mov r9, sp");
   }
 
   main();


### PR DESCRIPTION


### Pull Request Overview

This pull request changes crt0.c to change the stack pointer last.

If the compiler emits code based on the stack pointer not changing then that code is invalid.

### Testing Strategy

This pull request was tested by running the hail test app.



### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
