### PR TITLE
rustfmt: remove skips

### DIFF
--- a/chips/cc26x2/src/crt1.rs
+++ b/chips/cc26x2/src/crt1.rs
@@ -22,15 +22,14 @@ unsafe extern "C" fn hard_fault_handler() {
     'loop0: loop {}
 }
 
-#[link_section=".vectors"]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[link_section = ".vectors"]
 // no_mangle Ensures that the symbol is kept until the final binary
 #[no_mangle]
-pub static BASE_VECTORS: [unsafe extern fn(); 50] = [
+pub static BASE_VECTORS: [unsafe extern "C" fn(); 50] = [
     _estack,
     reset_handler,
     unhandled_interrupt, // NMI
-    hard_fault_handler, // Hard Fault
+    hard_fault_handler,  // Hard Fault
     unhandled_interrupt, // MPU fault
     unhandled_interrupt, // Bus fault
     unhandled_interrupt, // Usage fault
@@ -38,47 +37,47 @@ pub static BASE_VECTORS: [unsafe extern fn(); 50] = [
     unhandled_interrupt, // Reserved
     unhandled_interrupt, // Reserved
     unhandled_interrupt, // Reserved
-    svc_handler, // SVC
+    svc_handler,         // SVC
     unhandled_interrupt, // Debug monitor,
     unhandled_interrupt, // Reserved
     unhandled_interrupt, // PendSV
-    systick_handler, // Systick
-    generic_isr, // GPIO Int handler
-    generic_isr, // I2C
-    generic_isr, // RF Core Command & Packet Engine 1
-    generic_isr, // AON SpiSplave Rx, Tx and CS
-    generic_isr, // AON RTC
-    generic_isr, // UART0 Rx and Tx
-    generic_isr, // AUX software event 0
-    generic_isr, // SSI0 Rx and Tx
-    generic_isr, // SSI1 Rx and Tx
-    generic_isr, // RF Core Command & Packet Engine 0
-    generic_isr, // RF Core Hardware
-    generic_isr, // RF Core Command Acknowledge
-    generic_isr, // I2S
-    generic_isr, // AUX software event 1
-    generic_isr, // Watchdog timer
-    generic_isr, // Timer 0 subtimer A
-    generic_isr, // Timer 0 subtimer B
-    generic_isr, // Timer 1 subtimer A
-    generic_isr, // Timer 1 subtimer B
-    generic_isr, // Timer 2 subtimer A
-    generic_isr, // Timer 2 subtimer B
-    generic_isr, // Timer 3 subtimer A
-    generic_isr, // Timer 3 subtimer B
-    generic_isr, // Crypto Core Result available
-    generic_isr, // uDMA Software
-    generic_isr, // uDMA Error
-    generic_isr, // Flash controller
-    generic_isr, // Software Event 0
-    generic_isr, // AUX combined event
-    generic_isr, // AON programmable 0
-    generic_isr, // Dynamic Programmable interrupt
+    systick_handler,     // Systick
+    generic_isr,         // GPIO Int handler
+    generic_isr,         // I2C
+    generic_isr,         // RF Core Command & Packet Engine 1
+    generic_isr,         // AON SpiSplave Rx, Tx and CS
+    generic_isr,         // AON RTC
+    generic_isr,         // UART0 Rx and Tx
+    generic_isr,         // AUX software event 0
+    generic_isr,         // SSI0 Rx and Tx
+    generic_isr,         // SSI1 Rx and Tx
+    generic_isr,         // RF Core Command & Packet Engine 0
+    generic_isr,         // RF Core Hardware
+    generic_isr,         // RF Core Command Acknowledge
+    generic_isr,         // I2S
+    generic_isr,         // AUX software event 1
+    generic_isr,         // Watchdog timer
+    generic_isr,         // Timer 0 subtimer A
+    generic_isr,         // Timer 0 subtimer B
+    generic_isr,         // Timer 1 subtimer A
+    generic_isr,         // Timer 1 subtimer B
+    generic_isr,         // Timer 2 subtimer A
+    generic_isr,         // Timer 2 subtimer B
+    generic_isr,         // Timer 3 subtimer A
+    generic_isr,         // Timer 3 subtimer B
+    generic_isr,         // Crypto Core Result available
+    generic_isr,         // uDMA Software
+    generic_isr,         // uDMA Error
+    generic_isr,         // Flash controller
+    generic_isr,         // Software Event 0
+    generic_isr,         // AUX combined event
+    generic_isr,         // AON programmable 0
+    generic_isr,         // Dynamic Programmable interrupt
     // source (Default: PRCM)
     generic_isr, // AUX Comparator A
     generic_isr, // AUX ADC new sample or ADC DMA
     // done, ADC underflow, ADC overflow
-    generic_isr  // TRNG event
+    generic_isr, // TRNG event
 ];
 
 #[no_mangle]

--- a/chips/cc26xx/src/ccfg.rs
+++ b/chips/cc26xx/src/ccfg.rs
@@ -4,7 +4,6 @@
 //!
 //! Currently setup to use the default settings.
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
 #[no_mangle]
 #[link_section = ".ccfg"]
 pub static CCFG_CONF: [u32; 22] = [

--- a/chips/nrf51/src/crt1.rs
+++ b/chips/nrf51/src/crt1.rs
@@ -37,24 +37,26 @@ unsafe extern "C" fn hard_fault_handler() {
     'loop0: loop {}
 }
 
-#[link_section=".vectors"]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[link_section = ".vectors"]
 // no_mangle Ensures that the symbol is kept until the final binary
 #[no_mangle]
-pub static BASE_VECTORS: [unsafe extern fn(); 16] = [
-    _estack, reset_handler,
-    /* NMI */           unhandled_interrupt,
-    /* Hard Fault */    hard_fault_handler,
-    /* MemManage */     unhandled_interrupt,
-    /* BusFault */      unhandled_interrupt,
-    /* UsageFault*/     unhandled_interrupt,
-    unhandled_interrupt, unhandled_interrupt, unhandled_interrupt,
+pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
+    _estack,
+    reset_handler,
+    unhandled_interrupt, // NMI
+    hard_fault_handler,  // Hard Fault
+    unhandled_interrupt, // MemManage
+    unhandled_interrupt, // BusFault
+    unhandled_interrupt, // UsageFault
     unhandled_interrupt,
-    /* SVC */           SVC_Handler,
-    /* DebugMon */      unhandled_interrupt,
     unhandled_interrupt,
-    /* PendSV */        unhandled_interrupt,
-    /* SysTick */       unhandled_interrupt,
+    unhandled_interrupt,
+    unhandled_interrupt,
+    SVC_Handler,         // SVC
+    unhandled_interrupt, // DebugMon
+    unhandled_interrupt,
+    unhandled_interrupt, // PendSV
+    unhandled_interrupt, // SysTick
 ];
 
 #[link_section = ".vectors"]

--- a/chips/nrf52/Cargo.lock
+++ b/chips/nrf52/Cargo.lock
@@ -1,0 +1,35 @@
+[root]
+name = "nrf52"
+version = "0.1.0"
+dependencies = [
+ "bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+ "nrf5x 0.1.0",
+]
+
+[[package]]
+name = "bitfield"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cortexm4"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "kernel"
+version = "0.1.0"
+
+[[package]]
+name = "nrf5x"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
+
+[metadata]
+"checksum bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f989ae9b9fff3271a712a309fce47f0c46dd3476cb40074ddfcc06ad4a76cf6a"

--- a/chips/nrf52/src/crt1.rs
+++ b/chips/nrf52/src/crt1.rs
@@ -228,13 +228,12 @@ unsafe extern "C" fn hard_fault_handler() {
     }
 }
 
-#[link_section=".vectors"]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[link_section = ".vectors"]
 #[no_mangle] // ensures that the symbol is kept until the final binary
 /// ARM Cortex M Vector Table
-pub static BASE_VECTORS: [unsafe extern fn(); 16] = [
+pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
     // Stack Pointer
-    _estack, 
+    _estack,
     // Reset Handler
     reset_handler,
     // NMI
@@ -248,9 +247,9 @@ pub static BASE_VECTORS: [unsafe extern fn(); 16] = [
     // Usage Fault
     unhandled_interrupt,
     // Reserved
-    unhandled_interrupt, 
+    unhandled_interrupt,
     // Reserved
-    unhandled_interrupt, 
+    unhandled_interrupt,
     // Reserved
     unhandled_interrupt,
     // Reserved
@@ -264,7 +263,7 @@ pub static BASE_VECTORS: [unsafe extern fn(); 16] = [
     // PendSv
     unhandled_interrupt,
     // SysTick
-    systick_handler
+    systick_handler,
 ];
 
 #[link_section = ".vectors"]

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -69,7 +69,6 @@ struct FicrRegisters {
     info_flash: ReadOnly<u32, InfoFlash::Register>,
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
 register_bitfields! [u32,
     /// Code memory page size
     CodePageSize [
@@ -119,7 +118,7 @@ register_bitfields! [u32,
     /// Device address 2
     DeviceAddress1 [
         /// 16 MSB of 48 bit device address
-        DEVICEADDRESS OFFSET(0) NUMBITS(16)        
+        DEVICEADDRESS OFFSET(0) NUMBITS(16)
     ],
     /// Part code
     InfoPart [
@@ -184,7 +183,7 @@ register_bitfields! [u32,
 
         ]
     ],
-    /// Flash 
+    /// Flash
     InfoFlash [
         FLASH OFFSET(0) NUMBITS(32) [
             /// 128 kByte FLASH

--- a/chips/nrf52/src/nvmc.rs
+++ b/chips/nrf52/src/nvmc.rs
@@ -40,7 +40,6 @@ struct NvmcRegisters {
     pub imiss: ReadWrite<u32, CacheMiss::Register>,
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
 register_bitfields! [u32,
     /// Ready flag
     Ready [

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -67,7 +67,6 @@ struct UarteRegisters {
     pub config: ReadWrite<u32, Config::Register>,     // 0x56C-0x570
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
 register_bitfields! [u32,
     /// Start task
     Task [
@@ -78,7 +77,7 @@ register_bitfields! [u32,
     Event [
         READY OFFSET(0) NUMBITS(1)
     ],
-    
+
     /// Shortcuts
     Shorts [
         // Shortcut between ENDRX and STARTRX
@@ -99,7 +98,7 @@ register_bitfields! [u32,
         TXSTARTED OFFSET(20) NUMBITS(1),
         TXSTOPPED OFFSET(22) NUMBITS(1)
     ],
-    
+
     /// UART Errors
     ErrorSrc [
         OVERRUN OFFSET(0) NUMBITS(1),
@@ -107,7 +106,7 @@ register_bitfields! [u32,
         FRAMING OFFSET(2) NUMBITS(1),
         BREAK OFFSET(3) NUMBITS(1)
     ],
-    
+
     /// Enable UART
     Uart [
         ENABLE OFFSET(0) NUMBITS(4) [
@@ -115,7 +114,7 @@ register_bitfields! [u32,
             OFF = 0
         ]
     ],
-    
+
     /// Pin select
     Psel [
         // Pin number
@@ -123,22 +122,22 @@ register_bitfields! [u32,
         // Connect/Disconnect
         CONNECT OFFSET(31) NUMBITS(1)
     ],
-    
+
     /// Baudrate
     Baudrate [
         BAUDRAUTE OFFSET(0) NUMBITS(32)
     ],
-    
+
     /// DMA pointer
     Pointer [
         POINTER OFFSET(0) NUMBITS(32)
     ],
-    
+
     /// Counter value
     Counter [
         COUNTER OFFSET(0) NUMBITS(8)
     ],
-    
+
     /// Configuration of parity and flow control
     Config [
         HWFC OFFSET(0) NUMBITS(1),

--- a/chips/nrf52/src/uicr.rs
+++ b/chips/nrf52/src/uicr.rs
@@ -21,7 +21,6 @@ pub struct UicrRegisters {
     pub nfcpins: ReadWrite<u32, NfcPins::Register>,
 }
 
-// #[cfg_attr(rustfmt, rustfmt_skip)]
 register_bitfields! [u32,
     /// Task register 
     Pselreset [

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -87,7 +87,6 @@ struct AesEcbRegisters {
     pub ecbdataptr: ReadWrite<u32, EcbDataPointer::Register>,
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
 register_bitfields! [u32,
     /// Start task
     Task [

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -105,7 +105,6 @@ struct GpioRegisters {
 }
 
 /// Gpio
-#[cfg_attr(rustfmt, rustfmt_skip)]
 register_bitfields! [u32,
     /// Write GPIO port
     Out [
@@ -132,12 +131,12 @@ register_bitfields! [u32,
         /// Writing a '0' has no effect
         PIN OFFSET(0) NUMBITS(32)
     ],
-    /// Read GPIO port 
+    /// Read GPIO port
     In [
         /// Pin[n], each bit correspond to a pin 0 to 31
         /// 0 - Low
         /// 1 - High
-        PIN OFFSET(0) NUMBITS(32) 
+        PIN OFFSET(0) NUMBITS(32)
     ],
     /// Direction of GPIO pins
     Dir [
@@ -231,9 +230,8 @@ register_bitfields! [u32,
 ];
 
 /// GpioTe
-#[cfg_attr(rustfmt, rustfmt_skip)]
 register_bitfields! [u32,
-    /// Task for writing to pin specified in CONFIG[n].PSEL. 
+    /// Task for writing to pin specified in CONFIG[n].PSEL.
     /// Action on pin is configured in CONFIG[n].POLARITY
     TasksOut [
         TASK OFFSET(0) NUMBITS(1) [
@@ -249,7 +247,7 @@ register_bitfields! [u32,
             Ready = 1
         ]
     ],
-    
+
     /// Event generated from multiple input pins
     EventsPort [
         PINS OFFSET(0) NUMBITS(1) [

--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -60,7 +60,6 @@ struct TemperatureRegisters {
     pub t: [ReadWrite<u32, B::Register>; 5],
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
 register_bitfields! [u32,
     /// Start task
     Task [
@@ -86,12 +85,12 @@ register_bitfields! [u32,
     Temp [
         TEMP OFFSET(0) NUMBITS(32)
     ],
-    
+
     /// Slope of piece wise linear function
     A [
         SLOPE OFFSET(0) NUMBITS(12)
     ],
-    
+
     /// y-intercept of wise linear function
     B [
         INTERCEPT OFFSET(0) NUMBITS(14)
@@ -99,7 +98,7 @@ register_bitfields! [u32,
 
     /// End point of wise linear function
     T [
-       PIECE OFFSET(0) NUMBITS(8) 
+       PIECE OFFSET(0) NUMBITS(8)
     ]
 ];
 

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -60,7 +60,6 @@ pub struct RngRegisters {
     pub value: ReadOnly<u32, Value::Register>,
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
 register_bitfields! [u32,
     /// Start task
     Task [
@@ -71,7 +70,7 @@ register_bitfields! [u32,
     Event [
         READY OFFSET(0) NUMBITS(1)
     ],
-    
+
     /// Shortcut register
     Shorts [
         /// Shortcut between VALRDY event and STOP task
@@ -93,7 +92,7 @@ register_bitfields! [u32,
         /// Bias correction
         DERCEN OFFSET(0) NUMBITS(32)
     ],
-    
+
     /// Output random number
     Value [
         /// Generated random number

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -72,24 +72,26 @@ extern "C" {
     static mut _erelocate: u32;
 }
 
-#[link_section=".vectors"]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[link_section = ".vectors"]
 // no_mangle Ensures that the symbol is kept until the final binary
 #[no_mangle]
-pub static BASE_VECTORS: [unsafe extern fn(); 16] = [
-    _estack, reset_handler,
-    /* NMI */           unhandled_interrupt,
-    /* Hard Fault */    hard_fault_handler,
-    /* MemManage */     unhandled_interrupt,
-    /* BusFault */      unhandled_interrupt,
-    /* UsageFault*/     unhandled_interrupt,
-    unhandled_interrupt, unhandled_interrupt, unhandled_interrupt,
+pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
+    _estack,
+    reset_handler,
+    unhandled_interrupt, // NMI
+    hard_fault_handler,  // Hard Fault
+    unhandled_interrupt, // MemManage
+    unhandled_interrupt, // BusFault
+    unhandled_interrupt, // UsageFault
     unhandled_interrupt,
-    /* SVC */           svc_handler,
-    /* DebugMon */      unhandled_interrupt,
     unhandled_interrupt,
-    /* PendSV */        unhandled_interrupt,
-    /* SysTick */       systick_handler
+    unhandled_interrupt,
+    unhandled_interrupt,
+    svc_handler,         // SVC
+    unhandled_interrupt, // DebugMon
+    unhandled_interrupt,
+    unhandled_interrupt, // PendSV
+    systick_handler,     // SysTick
 ];
 
 #[link_section = ".vectors"]


### PR DESCRIPTION
### Pull Request Overview

This pull request removes a bunch of `rustfmt_skip`s that really aren't necessary.


### Testing Strategy

N/A




### Formatting

- [x] Ran `make formatall`.
