### PR TITLE
kernel: ld: change how relocate is put in flash

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -157,6 +157,7 @@ SECTIONS
       _sstorage = .;
       *(.storage* storage*)
       _estorage = .;
+      . = ALIGN(512);
     } > rom
     . = ALIGN(512);
 
@@ -209,14 +210,14 @@ SECTIONS
 
 
     /* Kernel data that must be relocated. This is program data that is
-     * exepected to live in SRAM, but is initialized with a value. This data is
+     * expected to live in SRAM, but is initialized with a value. This data is
      * physically placed into flash and is copied into SRAM by Tock. The
      * symbols here will be defined with addresses in SRAM.
      *
      * Tock assumes the relocation section follows all static elements and will
      * copy (_erelocate - _srelocate) bytes from _etext to _srelocate.
      */
-    .relocate : AT (_etext)
+    .relocate :
     {
         . = ALIGN(4);
         _srelocate = .;
@@ -225,7 +226,7 @@ SECTIONS
 
         . = ALIGN(4);
         _erelocate = .;
-    } > ram
+    } > ram AT > rom
 
 
 


### PR DESCRIPTION
This slight change to the linker file changes how the linker puts kernel relocate sections into flash. In particular, the linker will now include the relocation section in its overflow calculation so it will now correctly error if the flash section is too large.

fixes #847


### Testing Strategy

This pull request was tested by running hail and blink on hail.

I also changed the hail `chip_layout.ld` file to have a rom region 4 bytes smaller than the `.bin` file that is generated and saw that I got a linker error. This does not happen on master.




### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
