### PR TITLE
Simplify `make doc`

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -146,16 +146,7 @@ target:
 
 .PHONY: doc
 doc: | target
-	@# Need to make a wrapper script so we can pass flags to `rustdoc`.
-	@# This allows us to tell rustdoc to document internal functions and fields.
-	@#
-	@# The script needs an absolute path for rustc to invoke it, so use a temp dir
-	@# https://stackoverflow.com/a/14608500/358675
-	$(Q)DEST=$$(mktemp -d)/rustdoc-$$RANDOM; \
-	    trap 'rm -rf $$DEST' EXIT; \
-	    printf '#!/bin/bash\nexec rustdoc $$@ --document-private-items\n' > $$DEST; \
-	    chmod +x $$DEST; \
-	    RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) RUSTDOC=$$DEST $(XARGO) doc $(VERBOSE) --release --target=$(TARGET)
+	$(Q)RUSTDOCFLAGS=--document-private-items RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) $(XARGO) doc $(VERBOSE) --release --target=$(TARGET)
 
 target/$(TARGET)/release/$(PLATFORM).elf: target/$(TARGET)/release/$(PLATFORM)
 	$(Q)cp target/$(TARGET)/release/$(PLATFORM) target/$(TARGET)/release/$(PLATFORM).elf


### PR DESCRIPTION
### Pull Request Overview

This pull request simplifies how `-document-private-items` is passed to `xargo doc`. Turns out we didn't have to do all of the create-a-temporary-script stuff.


### Testing Strategy

This pull request was tested by running `make doc` and checking that the docs are the same before and after.



