### PR TITLE
Build the sensys course board file in travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ usage:
 .PHONY: allboards
 allboards:
 	@for f in `./tools/list_boards.sh -1`; do echo "$$(tput bold)Build $$f"; $(MAKE) -C "boards/$$f" || exit 1; done
+	@echo "$$(tput bold)Build course/sensys"; $(MAKE) -C "doc/courses/sensys/exercises/board" || exit 1;
 
 .PHONY: alldoc
 alldoc:


### PR DESCRIPTION
The sensys course is what I point people to for getting started, and we
should ensure that it keeps compiling by adding it to travis. I don't
think it is too much of a burden to keep it up to date since it is
basically the same as hail.

fixes #765


### Testing Strategy

This pull request was tested by running `make allboards`.


