### PR TITLE
Set sleep to be chip-specific, default to wfi

### DIFF
--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -6,6 +6,7 @@ use cc26xx::rtc;
 use cc26xx::uart;
 use cortexm4::{self, nvic};
 use kernel;
+use kernel::support;
 
 pub struct Cc26X2 {
     mpu: cortexm4::mpu::MPU,
@@ -55,5 +56,11 @@ impl kernel::Chip for Cc26X2 {
 
     fn has_pending_interrupts(&self) -> bool {
         unsafe { nvic::has_pending() }
+    }
+
+    fn sleep(&self) {
+        unsafe {
+            support::wfi();
+        }
     }
 }

--- a/chips/nrf51/src/chip.rs
+++ b/chips/nrf51/src/chip.rs
@@ -1,5 +1,6 @@
 use cortexm0::nvic;
 use kernel;
+use kernel::support;
 use nrf5x;
 use nrf5x::peripheral_interrupts::*;
 use radio;
@@ -50,5 +51,11 @@ impl kernel::Chip for NRF51 {
 
     fn has_pending_interrupts(&self) -> bool {
         unsafe { nvic::has_pending() }
+    }
+
+    fn sleep(&self) {
+        unsafe {
+            support::wfi();
+        }
     }
 }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -1,6 +1,7 @@
 use cortexm4::{self, nvic};
 use i2c;
 use kernel;
+use kernel::support;
 use nrf5x;
 use nrf5x::peripheral_interrupts::*;
 use radio;
@@ -89,5 +90,11 @@ impl kernel::Chip for NRF52 {
 
     fn has_pending_interrupts(&self) -> bool {
         unsafe { nvic::has_pending() }
+    }
+
+    fn sleep(&self) {
+        unsafe {
+            support::wfi();
+        }
     }
 }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -12,6 +12,7 @@ use gpio;
 use helpers::{DeferredCall, Task};
 use i2c;
 use kernel::Chip;
+use kernel::support;
 use pm;
 use spi;
 use trng;
@@ -161,7 +162,7 @@ impl Chip for Sam4l {
         &self.systick
     }
 
-    fn prepare_for_sleep(&self) {
+    fn sleep(&self) {
         if pm::deep_sleep_ready() {
             unsafe {
                 cortexm4::scb::set_sleepdeep();
@@ -170,6 +171,10 @@ impl Chip for Sam4l {
             unsafe {
                 cortexm4::scb::unset_sleepdeep();
             }
+        }
+
+        unsafe {
+            support::wfi();
         }
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -75,8 +75,7 @@ pub fn main<P: Platform, C: Chip>(
 
             support::atomic(|| {
                 if !chip.has_pending_interrupts() && process::processes_blocked() {
-                    chip.prepare_for_sleep();
-                    support::wfi();
+                    chip.sleep();
                 }
             });
         };

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -21,7 +21,7 @@ pub trait Chip {
     fn has_pending_interrupts(&self) -> bool;
     fn mpu(&self) -> &Self::MPU;
     fn systick(&self) -> &Self::SysTick;
-    fn prepare_for_sleep(&self) {}
+    fn sleep(&self);
 }
 
 /// Generic operations that clock-like things are expected to support.


### PR DESCRIPTION
### Pull Request Overview
Changes the way sleep is managed - it is now directly invoked inside the trait implementation of kernel::Chip.

Different MCUs require different types of setup for each sleep mode, and often also setup after wakeup. This moves the sleep logic into the chip trait to allow more control on each chip (eg. to enable services after wakeup).

This allows more flexibility in regards to sleep modes and their affect on the chips. An example of when this is needed is during the sleep progression of the cc26xx family of chips, where you need to disable and enable certain services before and after deep sleep.

### Testing Strategy
Tested that it worked on a SensorTag device by running the blink app.

### TODO or Help Wanted
Feedback much appreciated, don't know if it's more preferrable to add another function to the trait named something along the lines of `after_wakeup` instead - and let the kernel default to WFI instead of invoking it inside of the chip implementation.

Could not find any documentation mentioning sleep, so I'll leave the box below unchecked.

### Documentation Updated

- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- ~~[x] Userland: Added/updated the application README, if needed.~~

### Formatting

- [x] Ran `make formatall`.