### PR TITLE
cortex-m3: add scb to enable deep sleep

### DIFF
--- a/arch/cortex-m3/src/scb.rs
+++ b/arch/cortex-m3/src/scb.rs
@@ -1,0 +1,57 @@
+//! ARM System Control Block
+//!
+//! <http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CIHFDJCA.html>
+
+use kernel::common::VolatileCell;
+
+#[repr(C)]
+struct ScbRegisters {
+    cpuid: VolatileCell<u32>,
+    icsr: VolatileCell<u32>,
+    vtor: VolatileCell<u32>,
+    aircr: VolatileCell<u32>,
+    scr: VolatileCell<u32>,
+    ccr: VolatileCell<u32>,
+    shp: [VolatileCell<u32>; 12],
+    shcsr: VolatileCell<u32>,
+    cfsr: VolatileCell<u32>,
+    hfsr: VolatileCell<u32>,
+    dfsr: VolatileCell<u32>,
+    mmfar: VolatileCell<u32>,
+    bfar: VolatileCell<u32>,
+    afsr: VolatileCell<u32>,
+    pfr: [VolatileCell<u32>; 2],
+    dfr: VolatileCell<u32>,
+    adr: VolatileCell<u32>,
+    mmfr: [VolatileCell<u32>; 4],
+    isar: [VolatileCell<u32>; 5],
+    _reserved0: [u32; 5],
+    cpacr: VolatileCell<u32>,
+}
+
+const SCB_BASE: usize = 0xE000ED00;
+
+static mut SCB: *mut ScbRegisters = SCB_BASE as *mut ScbRegisters;
+
+/// Allow the core to go into deep sleep on WFI.
+///
+/// The specific definition of "deep sleep" is chip specific.
+pub unsafe fn set_sleepdeep() {
+    let scr = (*SCB).scr.get();
+    (*SCB).scr.set(scr | 1 << 2);
+}
+
+/// Do not allow the core to go into deep sleep on WFI.
+///
+/// The specific definition of "deep sleep" is chip specific.
+pub unsafe fn unset_sleepdeep() {
+    let scr = (*SCB).scr.get();
+    (*SCB).scr.set(scr & !(1 << 2));
+}
+
+/// Software reset using the ARM System Control Block
+pub unsafe fn reset() {
+    let aircr = (*SCB).aircr.get();
+    let reset = (0x5FA << 16) | (aircr & (0x7 << 8)) | (1 << 2);
+    (*SCB).aircr.set(reset);
+}


### PR DESCRIPTION
### Pull Request Overview
The System Control Block works the same on the Cortex-M3 as in the Cortex-M4. This PR just copies the implementation from the Cortex-M4 arch.

### Testing Strategy
Not tested yet (the memory addresses looks correct though)

### TODO or Help Wanted
This pull request still needs...

### Documentation Updated

- ~~[x] Kernel: Updated the relevant files in `/docs`, or no updates are required.~~
- ~~[x] Userland: Added/updated the application README, if needed.~~

### Formatting
- [x] Ran `make formatall`.
