### PR TITLE
cc26xx: remove unnecessary dependency to cortex-m4 crate

### DIFF
--- a/boards/launchxl/Cargo.lock
+++ b/boards/launchxl/Cargo.lock
@@ -18,7 +18,6 @@ dependencies = [
 name = "cc26xx"
 version = "0.1.0"
 dependencies = [
- "cortexm4 0.1.0",
  "kernel 0.1.0",
 ]
 

--- a/chips/cc26xx/Cargo.toml
+++ b/chips/cc26xx/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 
 [dependencies]
-cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }


### PR DESCRIPTION
### Pull Request Overview
Removes a dependency between the cc26xx crate and the cortex-m4 arch crate. The cc26xx crate should not have any arch-specific dependencies since it works regardless of the MCU arch (eg. launchxl & sensortag)

### Testing Strategy

```bash
$> make buildall
```

### TODO or Help Wanted
This pull request still needs...

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [ ] Ran `make formatall`.
