### PR TITLE
cc26xx: correct the selection of LF clock source

### DIFF
--- a/chips/cc26xx/src/ccfg.rs
+++ b/chips/cc26xx/src/ccfg.rs
@@ -10,7 +10,7 @@ pub static CCFG_CONF: [u32; 22] = [
     0x01800000,
     0xFF820010,
     0x0058FFFD,
-    0xF3BFFF3A,
+    0xF3FFFF3A, //0xF3BFFF3A,
     0xFFFFFFFF,
     0xFFFFFFFF,
     0xFFFFFFFF,


### PR DESCRIPTION
### Pull Request Overview
This changes the clock source of the LF clock to use the RCOSC
derived clock instead of using the XOSC (external oscillator). When
switching to only running the LF clock (eg. during deep sleep) you need
to use the internally derived clock and not an clock with another power
source - this ensures that we default to the clock using the internal
power source (RCOSC) instead of the external.

### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] ~~Kernel: Updated the relevant files in `/docs`, or no updates are required.~~
- [x] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [ ] Ran `make formatall`.