### PR TITLE
cortex-m3: add scb to lib

### DIFF
--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -5,6 +5,7 @@ extern crate kernel;
 
 pub mod systick;
 pub mod nvic;
+pub mod scb;
 
 #[no_mangle]
 #[naked]


### PR DESCRIPTION
### Pull Request Overview

This is a blunder fix of me not adding the scb module to be exported
by the cortex-m3 crate.

### Testing Strategy

```bash
$> make allboards
```


### TODO or Help Wanted

This pull request still needs...

### Documentation Updated

- [x] ~~Kernel: Updated the relevant files in `/docs`, or no updates are required.~~
- [x] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [ ] Ran `make formatall`.