### PR TITLE
Critical fix to Hail clock wakeup and minor overhaul of alarm virtualization stack

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -175,7 +175,7 @@ pub unsafe fn reset_handler() {
 
     sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {
         frequency: sam4l::pm::OscillatorFrequency::Frequency16MHz,
-        startup_mode: sam4l::pm::OscillatorStartup::FastStart,
+        startup_mode: sam4l::pm::OscillatorStartup::SlowStart,
     });
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -8,7 +8,7 @@ use kernel::process::Error;
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = 0x00000000;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 enum Expiration {
     Disabled,
     Abs(u32),
@@ -16,7 +16,6 @@ enum Expiration {
 
 #[derive(Copy, Clone)]
 pub struct AlarmData {
-    t0: u32,
     expiration: Expiration,
     callback: Option<Callback>,
 }
@@ -24,7 +23,6 @@ pub struct AlarmData {
 impl Default for AlarmData {
     fn default() -> AlarmData {
         AlarmData {
-            t0: 0,
             expiration: Expiration::Disabled,
             callback: None,
         }
@@ -35,6 +33,7 @@ pub struct AlarmDriver<'a, A: Alarm + 'a> {
     alarm: &'a A,
     num_armed: Cell<usize>,
     app_alarm: Grant<AlarmData>,
+    prev: Cell<u32>,
 }
 
 impl<'a, A: Alarm> AlarmDriver<'a, A> {
@@ -43,11 +42,12 @@ impl<'a, A: Alarm> AlarmDriver<'a, A> {
             alarm: alarm,
             num_armed: Cell::new(0),
             app_alarm: grant,
+            prev: Cell::new(0),
         }
     }
 
-    fn reset_active_alarm(&self) {
-        let now = self.alarm.now();
+    fn reset_active_alarm(&self, now: u32) -> Option<u32> {
+        self.prev.set(now);
         let mut next_alarm = u32::max_value();
         let mut next_dist = u32::max_value();
         for alarm in self.app_alarm.iter() {
@@ -64,6 +64,9 @@ impl<'a, A: Alarm> AlarmDriver<'a, A> {
         }
         if next_alarm != u32::max_value() {
             self.alarm.set_alarm(next_alarm);
+            Some(next_alarm)
+        } else {
+            None
         }
     }
 }
@@ -103,17 +106,17 @@ impl<'a, A: Alarm> Driver for AlarmDriver<'a, A> {
         // disabling the underlying alarm anyway, if the underlying alarm is
         // currently disabled and we're enabling the first alarm, or on an error
         // (i.e. no change to the alarms).
-        let (return_code, reset) = self.app_alarm
+        self.app_alarm
             .enter(caller_id, |td, _alloc| {
-                match cmd_type {
+                let now = self.alarm.now();
+                let (return_code, reset) = match cmd_type {
                     0 /* check if present */ => (ReturnCode::SuccessWithValue { value: 1 }, false),
                     1 /* Get clock frequency */ => {
                         let freq = <A::Frequency>::frequency() as usize;
-                        (ReturnCode::SuccessWithValue { value: freq }, true)
+                        (ReturnCode::SuccessWithValue { value: freq }, false)
                     },
                     2 /* capture time */ => {
-                        let curr_time: u32 = self.alarm.now();
-                        (ReturnCode::SuccessWithValue { value: curr_time as usize },
+                        (ReturnCode::SuccessWithValue { value: now as usize },
                          false)
                     },
                     3 /* Stop */ => {
@@ -129,15 +132,9 @@ impl<'a, A: Alarm> Driver for AlarmDriver<'a, A> {
                             },
                             _ => {
                                 td.expiration = Expiration::Disabled;
-                                td.t0 = 0;
                                 let new_num_armed = self.num_armed.get() - 1;
                                 self.num_armed.set(new_num_armed);
-                                if new_num_armed == 0 {
-                                    self.alarm.disable();
-                                    (ReturnCode::SUCCESS, false)
-                                } else {
-                                    (ReturnCode::SUCCESS, true)
-                                }
+                                (ReturnCode::SUCCESS, true)
                             }
                         }
                     },
@@ -148,43 +145,42 @@ impl<'a, A: Alarm> Driver for AlarmDriver<'a, A> {
                             self.num_armed.set(self.num_armed.get() + 1);
                         }
 
-
-                        let now = self.alarm.now();
-                        td.t0 = now;
                         td.expiration = Expiration::Abs(time as u32);
 
                         if self.alarm.is_armed() {
                             (ReturnCode::SuccessWithValue { value: time }, true)
                         } else {
-                            self.alarm.set_alarm(time as u32);
-                            (ReturnCode::SuccessWithValue { value: time}, false)
+                            //self.alarm.set_alarm(time as u32);
+                            (ReturnCode::SuccessWithValue { value: time}, true)
                         }
                     },
                     _ => (ReturnCode::ENOSUPPORT, false)
+                };
+                if reset {
+                    self.reset_active_alarm(now);
                 }
+                return_code
             })
             .unwrap_or_else(|err| {
-                let e = match err {
+                match err {
                     Error::OutOfMemory => ReturnCode::ENOMEM,
                     Error::AddressOutOfBounds => ReturnCode::EINVAL,
                     Error::NoSuchApp => ReturnCode::EINVAL,
-                };
-                (e, false)
-            });
-        if reset {
-            self.reset_active_alarm();
-        }
-        return_code
+                }
+            })
     }
+}
+
+fn past_from_base(cur: u32, now: u32, prev: u32) -> bool {
+    now.wrapping_sub(prev) >= cur.wrapping_sub(prev)
 }
 
 impl<'a, A: Alarm> time::Client for AlarmDriver<'a, A> {
     fn fired(&self) {
         let now = self.alarm.now();
-
         self.app_alarm.each(|alarm| {
             if let Expiration::Abs(exp) = alarm.expiration {
-                let expired = now.wrapping_sub(alarm.t0) >= exp.wrapping_sub(alarm.t0);
+                let expired = past_from_base(exp, now, self.prev.get());
                 if expired {
                     alarm.expiration = Expiration::Disabled;
                     self.num_armed.set(self.num_armed.get() - 1);
@@ -197,8 +193,13 @@ impl<'a, A: Alarm> time::Client for AlarmDriver<'a, A> {
 
         // If there are armed alarms left, reset the underlying alarm to the
         // nearest interval.  Otherwise, disable the underlying alarm.
-        if self.num_armed.get() > 0 {
-            self.reset_active_alarm();
+        if self.num_armed.get() == 0 {
+            self.alarm.disable();
+        } else if let Some(next_alarm) = self.reset_active_alarm(now) {
+            let new_now = self.alarm.now();
+            if past_from_base(next_alarm, new_now, now) {
+                self.fired();
+            }
         } else {
             self.alarm.disable();
         }

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -161,12 +161,10 @@ impl<'a, A: Alarm> Driver for AlarmDriver<'a, A> {
                 }
                 return_code
             })
-            .unwrap_or_else(|err| {
-                match err {
-                    Error::OutOfMemory => ReturnCode::ENOMEM,
-                    Error::AddressOutOfBounds => ReturnCode::EINVAL,
-                    Error::NoSuchApp => ReturnCode::EINVAL,
-                }
+            .unwrap_or_else(|err| match err {
+                Error::OutOfMemory => ReturnCode::ENOMEM,
+                Error::AddressOutOfBounds => ReturnCode::EINVAL,
+                Error::NoSuchApp => ReturnCode::EINVAL,
             })
     }
 }

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -261,9 +261,7 @@ impl<'a> Ast<'a> {
     /// Returns if an alarm is currently set
     pub fn is_alarm_enabled(&self) -> bool {
         while self.busy() {}
-        unsafe {
-            (*self.regs).sr.is_set(Status::ALARM0)
-        }
+        unsafe { (*self.regs).sr.is_set(Status::ALARM0) }
     }
 
     fn set_prescalar(&self, val: u8) {

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -179,11 +179,12 @@ impl<'a> Controller for Ast<'a> {
         self.callback.set(Some(client));
 
         pm::enable_clock(pm::Clock::PBD(PBDClock::AST));
+        self.disable();
+        self.disable_alarm_irq();
         self.select_clock(Clock::ClockOsc32);
         self.set_prescalar(0); // 32KHz / (2^(0 + 1)) = 16KHz
         self.enable_alarm_wake();
         self.clear_alarm();
-        self.enable();
     }
 }
 
@@ -372,6 +373,7 @@ impl<'a> Alarm for Ast<'a> {
         }
         self.clear_alarm();
         self.enable_alarm_irq();
+        self.enable();
     }
 
     fn get_alarm(&self) -> u32 {

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -179,9 +179,9 @@ impl<'a> Controller for Ast<'a> {
         self.callback.set(Some(client));
 
         pm::enable_clock(pm::Clock::PBD(PBDClock::AST));
+        self.select_clock(Clock::ClockOsc32);
         self.disable();
         self.disable_alarm_irq();
-        self.select_clock(Clock::ClockOsc32);
         self.set_prescalar(0); // 32KHz / (2^(0 + 1)) = 16KHz
         self.enable_alarm_wake();
         self.clear_alarm();

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -198,7 +198,7 @@ pub enum Clock {
 }
 
 impl<'a> Ast<'a> {
-    pub fn clock_busy(&self) -> bool {
+    fn clock_busy(&self) -> bool {
         unsafe { (*self.regs).sr.is_set(Status::CLKBUSY) }
     }
 
@@ -206,29 +206,22 @@ impl<'a> Ast<'a> {
         self.callback.set(Some(client));
     }
 
-    pub fn busy(&self) -> bool {
+    fn busy(&self) -> bool {
         unsafe { (*self.regs).sr.is_set(Status::BUSY) }
     }
 
-    // Clears the alarm bit in the status register (indicating the alarm value
-    // has been reached).
+    /// Clears the alarm bit in the status register (indicating the alarm value
+    /// has been reached).
     pub fn clear_alarm(&self) {
         while self.busy() {}
         unsafe {
             (*self.regs).scr.write(Interrupt::ALARM0::SET);
         }
-    }
-
-    // Clears the per0 bit in the status register (indicating the alarm value
-    // has been reached).
-    pub fn clear_periodic(&mut self) {
         while self.busy() {}
-        unsafe {
-            (*self.regs).scr.write(Interrupt::PER0::SET);
-        }
     }
 
-    pub fn select_clock(&self, clock: Clock) {
+    // Configure the clock to use to drive the AST
+    fn select_clock(&self, clock: Clock) {
         unsafe {
             // Disable clock by setting first bit to zero
             while self.clock_busy() {}
@@ -243,68 +236,53 @@ impl<'a> Ast<'a> {
 
             // Re-enable clock
             (*self.regs).clock.modify(ClockControl::CEN::SET);
+            while self.clock_busy() {}
         }
     }
 
+    /// Enables the AST registers
     pub fn enable(&self) {
         while self.busy() {}
         unsafe {
             (*self.regs).cr.modify(Control::EN::SET);
         }
-    }
-
-    pub fn is_enabled(&self) -> bool {
         while self.busy() {}
-        unsafe { (*self.regs).cr.is_set(Control::EN) }
     }
 
+    /// Disable the AST registers
     pub fn disable(&self) {
         while self.busy() {}
         unsafe {
             (*self.regs).cr.modify(Control::EN::CLEAR);
         }
+        while self.busy() {}
     }
 
-    pub fn set_prescalar(&self, val: u8) {
+    /// Returns if an alarm is currently set
+    pub fn is_alarm_enabled(&self) -> bool {
+        while self.busy() {}
+        unsafe {
+            (*self.regs).sr.is_set(Status::ALARM0)
+        }
+    }
+
+    fn set_prescalar(&self, val: u8) {
         while self.busy() {}
         unsafe {
             (*self.regs).cr.modify(Control::PSEL.val(val as u32));
         }
+        while self.busy() {}
     }
 
-    pub fn enable_alarm_irq(&self) {
+    fn enable_alarm_irq(&self) {
         unsafe {
             (*self.regs).ier.write(Interrupt::ALARM0::SET);
         }
     }
 
-    pub fn disable_alarm_irq(&self) {
+    fn disable_alarm_irq(&self) {
         unsafe {
             (*self.regs).idr.write(Interrupt::ALARM0::SET);
-        }
-    }
-
-    pub fn enable_ovf_irq(&mut self) {
-        unsafe {
-            (*self.regs).ier.write(Interrupt::OVF::SET);
-        }
-    }
-
-    pub fn disable_ovf_irq(&mut self) {
-        unsafe {
-            (*self.regs).idr.write(Interrupt::OVF::SET);
-        }
-    }
-
-    pub fn enable_periodic_irq(&mut self) {
-        unsafe {
-            (*self.regs).ier.write(Interrupt::PER0::SET);
-        }
-    }
-
-    pub fn disable_periodic_irq(&mut self) {
-        unsafe {
-            (*self.regs).idr.write(Interrupt::PER0::SET);
         }
     }
 
@@ -313,15 +291,7 @@ impl<'a> Ast<'a> {
         unsafe {
             (*self.regs).wer.modify(Event::ALARM0::SET);
         }
-    }
-
-    pub fn set_periodic_interval(&mut self, interval: u32) {
         while self.busy() {}
-        unsafe {
-            (*self.regs)
-                .pir0
-                .write(PeriodicInterval::INSEL.val(interval));
-        }
     }
 
     pub fn get_counter(&self) -> u32 {
@@ -334,6 +304,7 @@ impl<'a> Ast<'a> {
         unsafe {
             (*self.regs).cv.write(Value::VALUE.val(value));
         }
+        while self.busy() {}
     }
 
     pub fn handle_interrupt(&mut self) {
@@ -349,29 +320,30 @@ impl<'a> Time for Ast<'a> {
 
     fn disable(&self) {
         self.disable_alarm_irq();
+        self.clear_alarm();
     }
 
     fn is_armed(&self) -> bool {
-        self.is_enabled()
+        self.is_alarm_enabled()
     }
 }
 
 impl<'a> Alarm for Ast<'a> {
     fn now(&self) -> u32 {
-        while self.busy() {}
-        unsafe { (*self.regs).cv.read(Value::VALUE) }
+        self.get_counter()
     }
 
     fn set_alarm(&self, mut tics: u32) {
+        let now = self.get_counter();
+        if tics.wrapping_sub(now) <= ALARM0_SYNC_TICS {
+            tics = now.wrapping_add(ALARM0_SYNC_TICS);
+        }
+
         while self.busy() {}
         unsafe {
-            let now = (*self.regs).cv.read(Value::VALUE);
-            if tics.wrapping_sub(now) <= ALARM0_SYNC_TICS {
-                tics = now.wrapping_add(ALARM0_SYNC_TICS);
-            }
             (*self.regs).ar0.write(Value::VALUE.val(tics));
         }
-        self.clear_alarm();
+        while self.busy() {}
         self.enable_alarm_irq();
         self.enable();
     }

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -3,8 +3,10 @@
 pub trait Time {
     type Frequency: Frequency;
 
+    /// Disable any outstanding alarm or timer
     fn disable(&self);
 
+    /// Returns whether a timer or alarm is currently armed
     fn is_armed(&self) -> bool;
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a set of bugs that caused low duty cycle apps, such as "blink", to eventually block. These bugs don't seem to be _new_, but they do seem to be appearing now because the SAM4L is generally able to go into deep sleep, making these likely enough to manifest relatively reliably. 

- The Hail's crystal oscillator appears to take a while to calibrate and the "FastStart" setting we were using only allowed 0.5ms. As a result, when the core wakes up from deep sleep, it might switch from RCSYS driving the main clock to PLL _before_ the oscillator driving the PLL has had time to stabilize. An unstable oscillator seems to result in the core getting stuck. The solution (in 3cd5dd4) is to use the slow start setting, allowing the crystal ~8ms to stabilize.

- The SAM4L's AST is particular about waiting on the busy state bit before and after writing to certain registers in order to synchronize between the registers and the asynchronous domain. Most of the time this isn't an issue, but if writes or reads are done when synchronization is ongoing writes and be lost. This PR adds waits on the busy bit more meticulously, in particular just waiting at least on the same conditions the Atmel SDK does (high level this should be before and after every read/write from a synchronized registers).

- Simplifying the system call alarm driver virtualization to use a single `prev` value to help determine which alarms have elapsed rather than a different `t0` for each alarm. This allows the algorithm to more closely resemble the one in `virtual_alarm`.

- There were various corner cases in which both `virtual_alarm`  and `alarm` may have been missing virtual alarms that fired. Most glaringly, if a virtual alarm expired between the invocation of `fired` and setting the next alarm at the end of that invocation. This PR checks for that possibility explicitly and is more careful about when the next alarm is set.

The latter two problems manifested only when more than one virtual alarm was in use.

### Testing Strategy

* To test the fast start/slow start on Haill, I wrote a simple in-kernel blink app that used the AST driver directly, with no virtual alarms, and running no processes whatsoever, so the core goes to deep sleep immediately after each blink. Without the change, the board stops blinking after about 1000 cycles (I didn't measure, I'm just guessing, but would happen within 10 minutes or less every time). With the change, blink runs for as long as I tested (over 24 hours).

* I didn't test explicit failure of not synchronizing the AST properly, but tested several apps that use the AST. In particular, I couldn't identify that this was a failure case that ever manifested in a bug, but it's required by the datasheet.

* To test changes to the alarm stack, I ran two blink apps simultaneously. Originally they would eventually stop working until another event (e.g. a GPIO interrupt) woke the core up. With these changes these apps run continuously.

Still difficult to say if these fixes cover _all_ possible bugs in the alarm virtualization, but i believe my tests demonstrate they are at least strict improvements. My hope is also that the alarm virtualization code is a bit cleaner and easier to reason about now.

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [x] Ran `make formatall`.
