### PR TITLE
Use portable invocation of bash in shell scripts

### DIFF
--- a/userland/libc++/build.sh
+++ b/userland/libc++/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GCC_SRC_DIR=$1
 

--- a/userland/newlib/build.sh
+++ b/userland/newlib/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NEWLIB_SRC_DIR=$1
 

--- a/userland/tools/check_unstaged.sh
+++ b/userland/tools/check_unstaged.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script checks whether there are any unstaged changes. If clean,
 # return zero, otherwise warn the user that there are unstaged changes

--- a/userland/tools/uncrustify/uncrustify.sh
+++ b/userland/tools/uncrustify/uncrustify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
### Pull Request Overview

"/bin/bash" is not actually standard unix, and _some_ UNIXs don't have
it (e.g. my new NixOS laptop :) ) instead, use "/usr/bin/env bash" in
shebang commands, which is standard.
This pull request adds/changes/fixes...

### Testing Strategy

I ran the shell scripts

### TODO or Help Wanted

N/A

### Documentation Updated

- ~~Kernel: Updated the relevant files in `/docs`, or no updates are required.~~
- ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [X] Ran `make formatall`.
