### PR TITLE
Avoid concurrent PeripheralManager instances

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -322,7 +322,6 @@ pub unsafe fn reset_handler() {
 
     sam4l::spi::SPI.set_client(mux_spi);
     sam4l::spi::SPI.init();
-    sam4l::spi::SPI.enable();
 
     // Create a virtualized client for SPI system call interface
     // CS line is CS0

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -326,7 +326,6 @@ pub unsafe fn reset_handler() {
     );
     sam4l::spi::SPI.set_client(mux_spi);
     sam4l::spi::SPI.init();
-    sam4l::spi::SPI.enable();
 
     // Create a virtualized client for SPI system call interface,
     // then the system call capsule

--- a/boards/imix/src/spi_dummy.rs
+++ b/boards/imix/src/spi_dummy.rs
@@ -68,7 +68,6 @@ pub unsafe fn spi_dummy_test() {
     sam4l::spi::SPI.set_active_peripheral(sam4l::spi::Peripheral::Peripheral0);
     sam4l::spi::SPI.set_client(&SPICB);
     sam4l::spi::SPI.init();
-    sam4l::spi::SPI.enable();
     sam4l::spi::SPI.set_baud_rate(200000);
 
     let len = BUF2.len();

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -17,7 +17,6 @@ use kernel::common::regs::{self, ReadOnly, ReadWrite, WriteOnly};
 use kernel::hil::spi;
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
-use kernel::hil::spi::SpiMaster;
 use kernel::hil::spi::SpiMasterClient;
 use kernel::hil::spi::SpiSlaveClient;
 use pm;
@@ -211,8 +210,8 @@ impl PeripheralManagement<pm::Clock> for SpiHw {
         clock.enable();
     }
 
-    fn after_peripheral_access(&self, clock: &pm::Clock, _: &SpiRegisters) {
-        if !self.is_busy() {
+    fn after_peripheral_access(&self, clock: &pm::Clock, registers: &SpiRegisters) {
+        if !registers.sr.is_set(Status::SPIENS) {
             clock.disable();
         }
     }
@@ -240,13 +239,13 @@ impl SpiHw {
     fn init_as_role(&self, spi: &SpiRegisterManager, role: SpiRole) {
         self.role.set(role);
 
-        if self.role.get() == SpiRole::SpiMaster {
+        if role == SpiRole::SpiMaster {
             // Only need to set LASTXFER if we are master
             spi.registers.cr.write(Control::LASTXFER::SET);
         }
 
         // Sets bits per transfer to 8
-        let csr = self.get_active_csr();
+        let csr = self.get_active_csr(spi);
         csr.modify(ChipSelectParams::BITS::Eight);
 
         // Set mode to master or slave
@@ -259,7 +258,7 @@ impl SpiHw {
         spi.registers.mr.modify(mode + Mode::MODFDIS::SET);
     }
 
-    pub fn enable(&self) {
+    fn enable(&self) {
         let spi = &SpiRegisterManager::new(&self);
 
         spi.registers.cr.write(Control::SPIEN::SET);
@@ -269,8 +268,13 @@ impl SpiHw {
         }
     }
 
-    pub fn disable(&self) {
+    fn disable(&self) {
         let spi = &SpiRegisterManager::new(&self);
+
+        // TODO(alevy): we actually probably want to do this asynchrounously but
+        // because we're using DMA, a transfer may have completed with a byte
+        // still in the TX buffer.
+        while !spi.registers.sr.is_set(Status::TXEMPTY) {}
 
         self.dma_read.get().map(|read| read.disable());
         self.dma_write.get().map(|write| write.disable());
@@ -312,19 +316,22 @@ impl SpiHw {
         if clock % real_rate != 0 && scbr != 0xFF {
             scbr += 1;
         }
-        let csr = self.get_active_csr();
+        let spi = &SpiRegisterManager::new(&self);
+        let csr = self.get_active_csr(spi);
         csr.modify(ChipSelectParams::SCBR.val(scbr));
         clock / scbr
     }
 
     fn get_baud_rate(&self) -> u32 {
+        let spi = &SpiRegisterManager::new(&self);
         let clock = 48000000;
-        let scbr = self.get_active_csr().read(ChipSelectParams::SCBR);
+        let scbr = self.get_active_csr(spi).read(ChipSelectParams::SCBR);
         clock / scbr
     }
 
     fn set_clock(&self, polarity: ClockPolarity) {
-        let csr = self.get_active_csr();
+        let spi = &SpiRegisterManager::new(&self);
+        let csr = self.get_active_csr(spi);
         match polarity {
             ClockPolarity::IdleHigh => csr.modify(ChipSelectParams::CPOL::InactiveHigh),
             ClockPolarity::IdleLow => csr.modify(ChipSelectParams::CPOL::InactiveLow),
@@ -332,7 +339,8 @@ impl SpiHw {
     }
 
     fn get_clock(&self) -> ClockPolarity {
-        let csr = self.get_active_csr();
+        let spi = &SpiRegisterManager::new(&self);
+        let csr = self.get_active_csr(spi);
         if csr.matches_all(ChipSelectParams::CPOL::InactiveLow) {
             ClockPolarity::IdleLow
         } else {
@@ -341,7 +349,8 @@ impl SpiHw {
     }
 
     fn set_phase(&self, phase: ClockPhase) {
-        let csr = self.get_active_csr();
+        let spi = &SpiRegisterManager::new(&self);
+        let csr = self.get_active_csr(spi);
         match phase {
             ClockPhase::SampleLeading => csr.modify(ChipSelectParams::NCPHA::CaptureLeading),
             ClockPhase::SampleTrailing => csr.modify(ChipSelectParams::NCPHA::CaptureTrailing),
@@ -349,7 +358,8 @@ impl SpiHw {
     }
 
     fn get_phase(&self) -> ClockPhase {
-        let csr = self.get_active_csr();
+        let spi = &SpiRegisterManager::new(&self);
+        let csr = self.get_active_csr(spi);
         if csr.matches_all(ChipSelectParams::NCPHA::CaptureTrailing) {
             ClockPhase::SampleTrailing
         } else {
@@ -372,10 +382,8 @@ impl SpiHw {
     }
 
     /// Returns the currently active peripheral
-    fn get_active_peripheral(&self) -> Peripheral {
+    fn get_active_peripheral(&self, spi: &SpiRegisterManager) -> Peripheral {
         if self.role.get() == SpiRole::SpiMaster {
-            let spi = &SpiRegisterManager::new(&self);
-
             if spi.registers.mr.matches_all(Mode::PCS::PCS3) {
                 Peripheral::Peripheral3
             } else if spi.registers.mr.matches_all(Mode::PCS::PCS2) {
@@ -394,10 +402,11 @@ impl SpiHw {
 
     /// Returns the value of CSR0, CSR1, CSR2, or CSR3,
     /// whichever corresponds to the active peripheral
-    fn get_active_csr(&self) -> &regs::ReadWrite<u32, ChipSelectParams::Register> {
-        let spi = &SpiRegisterManager::new(&self);
-
-        match self.get_active_peripheral() {
+    fn get_active_csr<'a>(
+        &self,
+        spi: &'a SpiRegisterManager,
+    ) -> &'a regs::ReadWrite<u32, ChipSelectParams::Register> {
+        match self.get_active_peripheral(spi) {
             Peripheral::Peripheral0 => &spi.registers.csr[0],
             Peripheral::Peripheral1 => &spi.registers.csr[1],
             Peripheral::Peripheral2 => &spi.registers.csr[2],
@@ -477,6 +486,7 @@ impl SpiHw {
                 read.do_xfer(DMAPeripheral::SPI_RX, rbuf, count);
             });
         });
+
         ReturnCode::SUCCESS
     }
 }
@@ -543,9 +553,6 @@ impl spi::SpiMaster for SpiHw {
         read_buffer: Option<&'static mut [u8]>,
         len: usize,
     ) -> ReturnCode {
-        // TODO: Remove? Included in read_write_bytes call
-        self.enable();
-
         // If busy, don't start.
         if self.is_busy() {
             return ReturnCode::EBUSY;
@@ -579,12 +586,14 @@ impl spi::SpiMaster for SpiHw {
     }
 
     fn hold_low(&self) {
-        let csr = self.get_active_csr();
+        let spi = &SpiRegisterManager::new(&self);
+        let csr = self.get_active_csr(spi);
         csr.modify(ChipSelectParams::CSAAT::ActiveAfterTransfer);
     }
 
     fn release_low(&self) {
-        let csr = self.get_active_csr();
+        let spi = &SpiRegisterManager::new(&self);
+        let csr = self.get_active_csr(spi);
         csr.modify(ChipSelectParams::CSAAT::InactiveAfterTransfer);
     }
 
@@ -661,6 +670,7 @@ impl DMAClient for SpiHw {
             .set(self.transfers_in_progress.get() - 1);
 
         if self.transfers_in_progress.get() == 0 {
+            self.disable();
             let txbuf = self.dma_write.get().map_or(None, |dma| {
                 let buf = dma.abort_xfer();
                 dma.disable();

--- a/doc/courses/sensys/exercises/board/src/main.rs
+++ b/doc/courses/sensys/exercises/board/src/main.rs
@@ -317,7 +317,6 @@ pub unsafe fn reset_handler() {
 
     sam4l::spi::SPI.set_client(mux_spi);
     sam4l::spi::SPI.init();
-    sam4l::spi::SPI.enable();
 
     // Create a virtualized client for SPI system call interface
     // CS line is CS0


### PR DESCRIPTION
### Pull Request Overview

Fixes #899 

This commit modifies SPI to be careful about only creating new SpiRegisterManager in "top-level" functions and never to call a nested function that also might disable the clock.

Additionally, two smaller nits in the SPI driver:

-  Use the SPIEN bit in the status register, rather than the `transfers_in_progress` counter to determine when it's safe to disable the peripheral clock.
- Wait for TXEMPTY before disabling the SPI since there might be a byte left to transmit even though the DMA transaction has completed (since the DMA transaction completes when it finishes transfering bytes to the controller, not when the controller is done transmitting the last byte).


### Testing Strategy

I used the ip_sense app to test these changes, which uses the RF233 over SPI on imix. That app was not working, and it does with these changes.

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] ~~Kernel: Updated the relevant files in `/docs`, or no updates are required.~~
- [X] ~~Userland: Added/updated the application README, if needed.~~

### Formatting

- [X] Ran `make formatall`.
